### PR TITLE
[RHEL/6] Fix destination port typo (s/25/22/) in the iptables_sshd_disabled OVAL check

### DIFF
--- a/RHEL/6/input/checks/iptables_sshd_disabled.xml
+++ b/RHEL/6/input/checks/iptables_sshd_disabled.xml
@@ -8,6 +8,7 @@
       </affected>
       <description>If inbound SSH access is not needed, the firewall should disallow or reject access to
       the SSH port (22).</description>
+      <reference source="JL" ref_id="RHEL6_20140827" ref_url="test_attestation"/>
     </metadata>
     <criteria operator="AND">
       <criterion comment="Test ipv4 port 22 Deny" test_ref="test_iptables_sshd_disabled_ipv4" />
@@ -21,9 +22,8 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="Test for port 22 access over ipv4"
   id="obj_iptables_sshd_disabled_ipv4" version="1">
-    <ind:path>/etc/sysconfig</ind:path>
-    <ind:filename>iptables</ind:filename>
-    <ind:pattern operation="pattern match">^-A INPUT -m state --state NEW -m tcp -p tcp --dport 25 -j ACCEPT$</ind:pattern>
+    <ind:filepath>/etc/sysconfig/iptables</ind:filepath>
+    <ind:pattern operation="pattern match">^-A INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all"
@@ -33,8 +33,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="Test for port 22 access over ipv6"
   id="obj_iptables_sshd_disabled_ipv6" version="1">
-    <ind:path>/etc/sysconfig</ind:path>
-    <ind:filename>ip6tables</ind:filename>
+    <ind:filepath>/etc/sysconfig/ip6tables</ind:filepath>
     <ind:pattern operation="pattern match">^-A INPUT -m state --state NEW -m tcp -p tcp --dport 22 -j ACCEPT$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
Current IPv4 case test (/etc/sysconfig/iptables) contains a typo in the dest. port number (should be 22 -- SSH, rather than 25 -- SMTP). Besides that add test_attestation & replace path+filename OVAL elements with filepath element.

Tested on RHEL-6, works fine. Please review.

Thanks, Jan.
