### PR TITLE
Not all checks require sudo to check settings

### DIFF
--- a/RHEL/6/input/services/dns.xml
+++ b/RHEL/6/input/services/dns.xml
@@ -226,7 +226,7 @@ disabled to avoid the potential for abuse.</rationale>
 <description>If it is necessary for a secondary nameserver to receive zone data
 via zone transfer from the primary server, follow the instructions here.  Use
 dnssec-keygen to create a symmetric key file in the current directory:
-<pre>$ sudo cd /tmp
+<pre>$ cd /tmp
 $ sudo dnssec-keygen -a HMAC-MD5 -b 128 -n HOST dns.example.com
 Kdns.example.com .+aaa +iiiii</pre>
 This output is the name of a file containing the new key. Read the file to find

--- a/RHEL/6/input/services/ftp.xml
+++ b/RHEL/6/input/services/ftp.xml
@@ -89,8 +89,8 @@ Find if logging is applied to the FTP daemon.
 Procedures:
 <br/><br/>
 If vsftpd is started by xinetd the following command will indicate the xinetd.d startup file:
-<pre>$ sudo grep vsftpd /etc/xinetd.d/*</pre>
-<pre>$ sudo grep server_args <i>vsftpd xinetd.d startup file</i></pre>
+<pre>$ grep vsftpd /etc/xinetd.d/*</pre>
+<pre>$ grep server_args <i>vsftpd xinetd.d startup file</i></pre>
 This will indicate the vsftpd config file used when starting through xinetd.
 If the <i>server_args</i> line is missing or does not include the vsftpd configuration file, then the default config file (/etc/vsftpd/vsftpd.conf) is used.
 <pre>$ sudo grep xferlog_enable <i>vsftpd config file</i></pre>

--- a/RHEL/6/input/services/ldap.xml
+++ b/RHEL/6/input/services/ldap.xml
@@ -56,7 +56,7 @@ Then review the LDAP server and ensure TLS has been configured.
 </description>
 <ocil clause="there is no output, or the lines are commented out">
 To ensure TLS is configured with trust certificates, run the following command:
-<pre>$ sudo grep cert /etc/pam_ldap.conf</pre>
+<pre>$ grep cert /etc/pam_ldap.conf</pre>
 </ocil>
 <rationale>The tls_cacertdir or tls_cacertfile directives are required when
 tls_checkpeer is configured (which is the default for openldap versions 2.1 and

--- a/RHEL/6/input/services/nfs.xml
+++ b/RHEL/6/input/services/nfs.xml
@@ -69,7 +69,7 @@ this service should be disabled.
 <title>Disable netfs if Possible</title>
 <description>To determine if any network filesystems handled by netfs are
 currently mounted on the system execute the following command:
-<pre>$ sudo mount -t nfs,nfs4,smbfs,cifs,ncpfs</pre>
+<pre>$ mount -t nfs,nfs4,smbfs,cifs,ncpfs</pre>
 If the command did not return any output then disable netfs.
 </description>
 <Rule id="service_netfs_disabled">
@@ -283,7 +283,7 @@ server.</description>
 </description>
 <ocil clause="the setting does not show">
 To verify the <tt>nodev</tt> option is configured for all NFS mounts, run the following command:
-<pre>$ mount  | grep nfs</pre>
+<pre>$ mount | grep nfs</pre>
 All NFS mounts should show the <tt>nodev</tt> setting in parentheses.  This is not applicable if NFS is 
 not implemented.
 </ocil>
@@ -301,7 +301,7 @@ should not present device files to users.</rationale>
 </description>
 <ocil clause="the setting does not show">
 To verify the <tt>nosuid</tt> option is configured for all NFS mounts, run the following command:
-<pre>$ mount  | grep nfs</pre>
+<pre>$ mount | grep nfs</pre>
 All NFS mounts should show the <tt>nosuid</tt> setting in parentheses.  This is not applicable if NFS is 
 not implemented.
 </ocil>
@@ -410,7 +410,7 @@ Remove any instances of the
 </description>
 <ocil clause="there is output">
 To verify insecure file locking has been disabled, run the following command:
-<pre>$ sudo grep insecure_locks /etc/exports</pre>
+<pre>$ grep insecure_locks /etc/exports</pre>
 </ocil>
 <rationale>Allowing insecure file locking could allow for sensitive data to be
 viewed or edited by an unauthorized user.

--- a/RHEL/6/input/services/obsolete.xml
+++ b/RHEL/6/input/services/obsolete.xml
@@ -380,14 +380,14 @@ reduces the risk of sharing files which should remain private.
 <ocil clause="this flag is missing">
 If TFTP is not installed, this is not applicable.  To determine if TFTP is installed, 
 run the following command:
-<pre>$ sudo rpm -qa | grep tftp</pre>
+<pre>$ rpm -qa | grep tftp</pre>
 <br /><br />
 Verify <tt>tftp</tt> is configured by with the <tt>-s</tt> option by running the
 following command:
 <pre>grep "server_args" /etc/xinetd.d/tftp</pre>
 The output should indicate the <tt>server_args</tt> variable is configured with the <tt>-s</tt>
 flag, matching the example below:
-<pre> $ sudo grep "server_args" /etc/xinetd.d/tftp
+<pre> $ grep "server_args" /etc/xinetd.d/tftp
 server_args = -s /var/lib/tftpboot</pre>
 </ocil>
 <ident cce="27272-4" />

--- a/RHEL/6/input/services/smb.xml
+++ b/RHEL/6/input/services/smb.xml
@@ -109,7 +109,7 @@ only communicate with servers that support packet signing.
 </description>
 <ocil clause="it is not">
 To verify that Samba clients running smbclient must use packet signing, run the following command:
-<pre>$ sudo grep signing /etc/samba/smb.conf</pre>
+<pre>$ grep signing /etc/samba/smb.conf</pre>
 The output should show:
 <pre>client signing = mandatory</pre>
 </ocil>
@@ -136,7 +136,7 @@ packet signing.
 </description>
 <ocil clause="it does not">
 To verify that Samba clients using mount.cifs must use packet signing, run the following command:
-<pre>$ sudo grep sec /etc/fstab</pre>
+<pre>$ grep sec /etc/fstab</pre>
 The output should show either <tt>krb5i</tt> or <tt>ntlmv2i</tt> in use.
 </ocil>
 <rationale>

--- a/RHEL/6/input/services/xorg.xml
+++ b/RHEL/6/input/services/xorg.xml
@@ -22,7 +22,7 @@ features a <tt>3</tt> as shown:
 </description>
 <ocil clause="it does not">
 To verify the default runlevel is 3, run the following command:
-<pre>$ sudo grep initdefault /etc/inittab</pre>
+<pre>$ grep initdefault /etc/inittab</pre>
 The output should show the following:
 <pre>id:3:initdefault:</pre>
 </ocil>

--- a/RHEL/6/input/system/accounts/pam.xml
+++ b/RHEL/6/input/system/accounts/pam.xml
@@ -64,7 +64,7 @@ using <tt>pam_lastlog</tt>, add the following line immediately after <tt>session
 <ocil clause="that is not the case">
 To ensure that last logon/access notification is configured correctly, run
 the following command:
-<pre>$ sudo grep pam_lastlog.so /etc/pam.d/system-auth</pre>
+<pre>$ grep pam_lastlog.so /etc/pam.d/system-auth</pre>
 The output should show output <tt>showfailed</tt>.
 </ocil>
 <rationale>
@@ -482,7 +482,7 @@ both <tt>/etc/pam.d/system-auth</tt> and /etc/pam.d/password-auth:
 </description>
 <ocil clause="that is not the case">
 To ensure the failed password attempt policy is configured correctly, run the following command:
-<pre>$ sudo grep pam_faillock /etc/pam.d/system-auth</pre>
+<pre>$ grep pam_faillock /etc/pam.d/system-auth</pre>
 The output should show <tt>deny=3</tt>.
 </ocil>
 <rationale>
@@ -506,7 +506,7 @@ Add the following lines immediately below the <tt>pam_env.so</tt> statement in <
 </description>
 <ocil clause="that is not the case">
 To ensure the failed password attempt policy is configured correctly, run the following command:
-<pre>$ sudo grep pam_faillock /etc/pam.d/system-auth</pre>
+<pre>$ grep pam_faillock /etc/pam.d/system-auth</pre>
 The output should show <tt>unlock_time=&lt;some-large-number&gt;</tt>.
 </ocil>
 <rationale>
@@ -533,7 +533,7 @@ Add the following <tt>fail_interval</tt> directives to <tt>pam_faillock.so</tt> 
 </description>
 <ocil clause="that is not the case">
 To ensure the failed password attempt policy is configured correctly, run the following command:
-<pre>$ sudo grep pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>
+<pre>$ grep pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>
 For each file, the output should show <tt>fail_interval=&lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is 900 (15 minutes) or greater.  If the <tt>fail_interval</tt> parameter is not set, the default setting of 900 seconds is acceptable.
 </ocil>
 <rationale>

--- a/RHEL/6/input/system/accounts/physical.xml
+++ b/RHEL/6/input/system/accounts/physical.xml
@@ -84,7 +84,7 @@ parameters.
 <description>The grub boot loader should have password protection
 enabled to protect boot-time settings.
 To do so, select a password and then generate a hash from it by running the following command:
-<pre>$ sudo grub-crypt --sha-512</pre>
+<pre>$ grub-crypt --sha-512</pre>
 When prompted to enter a password, insert the following line into <tt>/etc/grub.conf</tt>
 immediately after the header comments. (Use the output from <tt>grub-crypt</tt> as the
 value of <b>password-hash</b>):

--- a/RHEL/6/input/system/accounts/restrictions/password_storage.xml
+++ b/RHEL/6/input/system/accounts/restrictions/password_storage.xml
@@ -26,7 +26,7 @@ prevent logins with empty passwords.
 </description>
 <ocil clause="NULL passwords can be used">
 To verify that null passwords cannot be used, run the following command:
-<pre>$ sudo grep nullok /etc/pam.d/system-auth</pre>
+<pre>$ grep nullok /etc/pam.d/system-auth</pre>
 If this produces any output, it may be possible to log into accounts
 with empty passwords.
 </ocil>
@@ -53,7 +53,7 @@ properly stored, or the account should be deleted entirely.
 <ocil clause="any stored hashes are found in /etc/passwd">
 To check that no password hashes are stored in
 <tt>/etc/passwd</tt>, run the following command:
-<pre>$ sudo awk -F: '($2 != "x") {print}' /etc/passwd</pre>
+<pre>$ awk -F: '($2 != "x") {print}' /etc/passwd</pre>
 If it produces any output, then a password hash is
 stored in <tt>/etc/passwd</tt>.
 </ocil>

--- a/RHEL/6/input/system/accounts/restrictions/root_logins.xml
+++ b/RHEL/6/input/system/accounts/restrictions/root_logins.xml
@@ -176,7 +176,7 @@ accounts other than root should be removed or have their UID changed.
 </description>
 <ocil clause="any account other than root has a UID of 0">
 To list all password file entries for accounts with UID 0, run the following command:
-<pre>$ sudo awk -F: '($3 == "0") {print}' /etc/passwd</pre>
+<pre>$ awk -F: '($3 == "0") {print}' /etc/passwd</pre>
 This should print only one line, for the user root.
 </ocil>
 <rationale>

--- a/RHEL/6/input/system/accounts/session.xml
+++ b/RHEL/6/input/system/accounts/session.xml
@@ -40,7 +40,7 @@ maliciously may result in an exceptional number of simultaneous login sessions.
 <ocil clause="it is not similar">
 Run the following command to ensure the <tt>maxlogins</tt> value is configured for all users
 on the system:
-<pre>$ sudo grep "maxlogins" /etc/security/limits.conf</pre>
+<pre>$ grep "maxlogins" /etc/security/limits.conf</pre>
 You should receive output similar to the following:
 <pre>*		hard	maxlogins	10</pre>
 </ocil>
@@ -219,9 +219,9 @@ written to by unauthorized users.</rationale>
 <ocil clause="the above command returns no output, or if the umask is configured incorrectly">
 Verify the <tt>umask</tt> setting is configured correctly in the <tt>/etc/bashrc</tt> file by
 running the following command:
-<pre>$ sudo grep "umask" /etc/bashrc</pre>
+<pre>$ grep "umask" /etc/bashrc</pre>
 All output must show the value of <tt>umask</tt> set to 077, as shown below:
-<pre>$ sudo grep "umask" /etc/bashrc
+<pre>$ grep "umask" /etc/bashrc
 umask 077
 umask 077</pre>
 </ocil>
@@ -244,9 +244,9 @@ written to by unauthorized users.</rationale>
 <ocil clause="the above command returns no output, or if the umask is configured incorrectly">
 Verify the <tt>umask</tt> setting is configured correctly in the <tt>/etc/csh.cshrc</tt> file by
 running the following command:
-<pre>$ sudo grep "umask" /etc/csh.cshrc</pre>
+<pre>$ grep "umask" /etc/csh.cshrc</pre>
 All output must show the value of <tt>umask</tt> set to 077, as shown in the below:
-<pre>$ sudo grep "umask" /etc/csh.cshrc
+<pre>$ grep "umask" /etc/csh.cshrc
 umask 077</pre>
 </ocil>
 <ident cce="27034-8" />
@@ -269,9 +269,9 @@ written to by unauthorized users.</rationale>
 <ocil clause="the above command returns no output, or if the umask is configured incorrectly">
 Verify the <tt>umask</tt> setting is configured correctly in the <tt>/etc/profile</tt> file by
 running the following command:
-<pre>$ sudo grep "umask" /etc/profile</pre>
+<pre>$ grep "umask" /etc/profile</pre>
 All output must show the value of <tt>umask</tt> set to 077, as shown in the below:
-<pre>$ sudo grep "umask" /etc/profile
+<pre>$ grep "umask" /etc/profile
 umask 077</pre>
 </ocil>
 <oval id="accounts_umask_etc_profile" value="var_accounts_user_umask" />
@@ -292,9 +292,9 @@ written to by unauthorized users.</rationale>
 <ocil clause="the above command returns no output, or if the umask is configured incorrectly">
 Verify the <tt>UMASK</tt> setting is configured correctly in the <tt>/etc/login.defs</tt> file by
 running the following command:
-<pre>$ sudo grep -i "UMASK" /etc/login.defs</pre>
+<pre>$ grep -i "UMASK" /etc/login.defs</pre>
 All output must show the value of <tt>umask</tt> set to 077, as shown in the below:
-<pre>$ sudo grep -i "UMASK" /etc/login.defs
+<pre>$ grep -i "UMASK" /etc/login.defs
 umask 077</pre>
 </ocil>
 <ident cce="26371-5" />

--- a/RHEL/6/input/system/network/wireless.xml
+++ b/RHEL/6/input/system/network/wireless.xml
@@ -44,12 +44,12 @@ to reboot the system first.
 normal usage of the wireless capability.
 <br /><br />
 First, identify the interfaces available with the command:
-<pre>$ sudo ifconfig -a</pre>
+<pre>$ ifconfig -a</pre>
 Additionally, the following command may be used to
 determine whether wireless support is included for a
 particular interface, though this may not always be a clear
 indicator:
-<pre>$ sudo iwconfig</pre>
+<pre>$ iwconfig</pre>
 After identifying any wireless interfaces (which may have
 names like <tt>wlan0</tt>, <tt>ath0</tt>, <tt>wifi0</tt>, <tt>em1</tt> or
 <tt>eth0</tt>), deactivate the interface with the command:

--- a/RHEL/6/input/system/permissions/execution.xml
+++ b/RHEL/6/input/system/permissions/execution.xml
@@ -37,7 +37,7 @@ a umask of 077 in their own init scripts.
 </description>
 <ocil clause="it does not">
 To check the value of the <tt>umask</tt>, run the following command:
-<pre>$ sudo grep umask /etc/init.d/functions</pre>
+<pre>$ grep umask /etc/init.d/functions</pre>
 The output should show either <tt>022</tt> or <tt>027</tt>.
 </ocil>
 <rationale>The umask influences the permissions assigned to files created by a
@@ -78,7 +78,7 @@ value of 0 is recommended.</description>
 </description>
 <ocil clause="it is not">
 To verify that core dumps are disabled for all users, run the following command:
-<pre>$ sudo grep core /etc/security/limits.conf</pre>
+<pre>$ grep core /etc/security/limits.conf</pre>
 The output should be:
 <pre>*     hard   core    0</pre>
 </ocil>

--- a/RHEL/6/input/system/permissions/mounting.xml
+++ b/RHEL/6/input/system/permissions/mounting.xml
@@ -10,7 +10,7 @@ allow an attacker to compromise the system.
 <br /><br />
 This command can be used to list the types of filesystems that are
 available to the currently executing kernel:
-<pre>$ sudo find /lib/modules/`uname -r`/kernel/fs -type f -name '*.ko'</pre>
+<pre>$ find /lib/modules/`uname -r`/kernel/fs -type f -name '*.ko'</pre>
 If these filesystems are not required then they can be explicitly disabled
 in a configuratio file in  <tt>/etc/modprobe.d</tt>.
 </description>

--- a/RHEL/6/input/system/permissions/partitions.xml
+++ b/RHEL/6/input/system/permissions/partitions.xml
@@ -64,7 +64,7 @@ untrusted media.
 the system to potential compromise.</rationale>
 <ocil clause="removable media partitions are present">
 To verify that binaries cannot be directly executed from removable media, run the following command:
-<pre>$ sudo grep -v noexec /etc/fstab</pre>
+<pre>$ grep -v noexec /etc/fstab</pre>
 The resulting output will show partitions which do not have the <tt>noexec</tt> flag. Verify all partitions
 in the output are not removable media.
 </ocil>

--- a/RHEL/6/input/system/software/integrity.xml
+++ b/RHEL/6/input/system/software/integrity.xml
@@ -98,7 +98,7 @@ AIDE can be executed periodically through other means; this is merely one exampl
 </description>
 <ocil clause="there is no output">
 To determine that periodic AIDE execution has been scheduled, run the following command:
-<pre>$ sudo grep aide /etc/crontab</pre>
+<pre>$ grep aide /etc/crontab</pre>
 </ocil>
 <rationale>
 By default, AIDE does not install itself for periodic execution. Periodically
@@ -119,7 +119,7 @@ package metadata stored in the RPM database. Although an attacker
 could corrupt the RPM database (analogous to attacking the AIDE
 database as described above), this check can still reveal
 modification of important files. To list which files on the system differ from what is expected by the RPM database:
-<pre>$ sudo rpm -qVa</pre>
+<pre>$ rpm -qVa</pre>
 See the man page for <tt>rpm</tt> to see a complete explanation of each column.
 </description>
 
@@ -130,7 +130,7 @@ The RPM package management system can check file access
 permissions of installed software packages, including many that are
 important to system security. 
 After locating a file with incorrect permissions, run the following command to determine which package owns it:
-<pre>$ sudo rpm -qf <i>FILENAME</i></pre>
+<pre>$ rpm -qf <i>FILENAME</i></pre>
 Next, run the following command to reset its permissions to 
 the correct values:
 <pre>$ sudo rpm --setperms <i>PACKAGENAME</i></pre>
@@ -138,7 +138,7 @@ the correct values:
 <ocil clause="there is output">
 The following command will list which files on the system have permissions different from what
 is expected by the RPM database:
-<pre>$ sudo rpm -Va | grep '^.M'</pre>
+<pre>$ rpm -Va | grep '^.M'</pre>
 </ocil>
 <rationale>
 Permissions on system binaries and configuration files that are too generous
@@ -156,13 +156,13 @@ this baseline should be investigated.</rationale>
 installed software packages, including many that are important to system
 security. Run the following command to list which files on the system
 have hashes that differ from what is expected by the RPM database:
-<pre>$ sudo rpm -Va | grep '^..5'</pre>
+<pre>$ rpm -Va | grep '^..5'</pre>
 A "c" in the second column indicates that a file is a configuration file, which
 may appropriately be expected to change.  If the file was not expected to
 change, investigate the cause of the change using audit logs or other means.
 The package can then be reinstalled to restore the file.
 Run the following command to determine which package owns the file:
-<pre>$ sudo rpm -qf <i>FILENAME</i></pre>
+<pre>$ rpm -qf <i>FILENAME</i></pre>
 The package can be reinstalled from a yum repository using the command:
 <pre>$ sudo yum reinstall <i>PACKAGENAME</i></pre>
 Alternatively, the package can be reinstalled from trusted media using the command:
@@ -170,7 +170,7 @@ Alternatively, the package can be reinstalled from trusted media using the comma
 </description>
 <ocil clause="there is output"> The following command will list which files on the system 
 have file hashes different from what is expected by the RPM database. 
-<pre>$ sudo rpm -Va | awk '$1 ~ /..5/ &amp;&amp; $2 != "c"'</pre> 
+<pre>$ rpm -Va | awk '$1 ~ /..5/ &amp;&amp; $2 != "c"'</pre> 
 </ocil>
 <rationale>
 The hashes of important files like system executables should match the


### PR DESCRIPTION
- Not all XCCDF commands require privileged access by default to check settings.
