### PR TITLE
[bugfix] updating file permission templates to drop unused grub.conf check

### DIFF
--- a/RHEL/6/input/checks/templates/file_dir_permissions.csv
+++ b/RHEL/6/input/checks/templates/file_dir_permissions.csv
@@ -1,4 +1,3 @@
 /etc,shadow,0,0,0000
 /etc,gshadow,0,0,0000
 /etc,passwd,0,0,0644
-/boot/grub,grub.conf,0,0,0600


### PR DESCRIPTION
as reported by Paul, the OVAL templates were checking grub.conf information and this check was unused.
