### PR TITLE
Bump openscap-utils verision in spec file

### DIFF
--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -14,8 +14,8 @@ Source0:	http://repos.ssgproject.org/sources/%{name}-%{version}.tar.gz
 
 BuildArch:	noarch
 
-BuildRequires:	libxslt, expat, python, openscap-utils >= 0.9.1, python-lxml
-Requires:	xml-common, openscap-utils >= 0.9.1
+BuildRequires:	libxslt, expat, python, openscap-utils >= 1.0.8, python-lxml
+Requires:	xml-common, openscap-utils >= 1.0.8
 
 %description
 The scap-security-guide project provides a guide for configuration of the


### PR DESCRIPTION
This bumps the required version of openscap-utils to version equal to or greater than openscap-utils version 1.0.8. Bumping the version required helps to resolve SELinux OVAL check errors while checking the device context labels.
