### PR TITLE
[Bugfix] Add .gitignore to Fedora to ignore dist directory

### DIFF
--- a/Fedora/.gitignore
+++ b/Fedora/.gitignore
@@ -1,0 +1,2 @@
+dist
+!dist/README


### PR DESCRIPTION
- add .gitignore to to Fedora to ignore dist directory
