### PR TITLE
Update for RHEL7 STIG disk partitioning

### DIFF
--- a/RHEL/7/input/profiles/common.xml
+++ b/RHEL/7/input/profiles/common.xml
@@ -1,9 +1,6 @@
 <Profile id="common">
 <title>Common Profile for General-Purpose Systems</title>
 <description>This profile contains items common to general-purpose desktop and server installations.</description>
-<select idref="partition_for_tmp" selected="true"/>
-<select idref="partition_for_var" selected="true"/>
 <select idref="partition_for_var_log" selected="true"/>
 <select idref="partition_for_var_log_audit" selected="true"/>
-<select idref="partition_for_home" selected="true"/>
 </Profile>


### PR DESCRIPTION
this PR resolves ticket #199

The RHEL7 STIG requirements do not mandate the legacy partitioning models of /home, /var, etc.
Updating the XCCDF profiles to reflect. Chose to update in common as it's unlikely other RHEL7 profiles will require legacy partitioning.
