### PR TITLE
[Enhancement] Add OVAL for GNOME Disable User List

### DIFF
--- a/RHEL/6/input/checks/disable_user_list.xml
+++ b/RHEL/6/input/checks/disable_user_list.xml
@@ -1,0 +1,40 @@
+<def-group>
+  <definition class="compliance" id="disable_user_list" version="1">
+    <metadata>
+      <title>Disable the User List</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 6</platform>
+      </affected>
+      <description>Disable the GUI listing of all known users on the login screen.</description>
+      <reference source="galford" ref_id="20140907" ref_url="test_attestation" />
+    </metadata>
+    <criteria operator="OR">
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
+      <criterion comment="check etc settings tree" test_ref="test_tree_disable_user_list" />
+      <criterion comment="check etc settings without tree" test_ref="test_no_tree_disable_user_list" />
+    </criteria>
+  </definition>
+
+<ind:xmlfilecontent_test check="all" comment="checks for gconf-tree file" id="test_tree_disable_user_list" version="1">
+    <ind:object object_ref="object_disable_user_list_tree" />
+    <ind:state state_ref="state_disable_user_list" />
+  </ind:xmlfilecontent_test>
+  <ind:xmlfilecontent_object id="object_disable_user_list_tree" version="1">
+    <ind:filepath>/etc/gconf/gconf.xml.mandatory/%gconf-tree.xml</ind:filepath>
+    <ind:xpath>/gconf/dir/dir/dir/entry[@name='disable_user_list']/@value</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+  <ind:xmlfilecontent_test check="all" comment="checks for absent gconf-tree file" id="test_no_tree_disable_user_list" version="1">
+    <ind:object object_ref="object_disable_user_list_no_tree" />
+    <ind:state state_ref="state_disable_user_list" />
+  </ind:xmlfilecontent_test>
+  <ind:xmlfilecontent_object id="object_disable_user_list_no_tree" version="1">
+    <ind:filepath>/etc/gconf/gconf.xml.mandatory/apps/gdm/simple-greeter/%gconf.xml</ind:filepath>
+    <ind:xpath>/gconf/entry[@name='disable_user_list']/@value</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+  <ind:xmlfilecontent_state id="state_disable_user_list" version="1">
+    <ind:value_of datatype="string">true</ind:value_of>
+  </ind:xmlfilecontent_state>
+
+</def-group>

--- a/RHEL/6/input/system/accounts/banners.xml
+++ b/RHEL/6/input/system/accounts/banners.xml
@@ -165,6 +165,7 @@ The output should be <tt>true</tt>.
 <rationale>Leaving the user list enabled is a security risk since it allows anyone
 with physical access to the system to quickly enumerate known user accounts
 without logging in.</rationale>
+<oval id="disable_user_list" />
 <ident cce="27230-2" />
 <ref nist="AC-23" />
 </Rule>


### PR DESCRIPTION
- Add OVAL check to determine if the known user list is disabled in the GUI login screen
