### PR TITLE
[RHEL/6] Start using <sub idref=""> variable substitution feature / ability that got introduced in openscap v1.0.8

### DIFF
--- a/RHEL/6/input/services/ssh.xml
+++ b/RHEL/6/input/services/ssh.xml
@@ -150,7 +150,7 @@ automatically logged out.
 <br /><br />
 To set an idle timeout interval, edit the following line in <tt>/etc/ssh/sshd_config</tt> as
 follows:
-<pre>ClientAliveInterval <b>interval</b></pre>
+<pre>ClientAliveInterval <b><sub idref="sshd_idle_timeout_value" /></b></pre>
 The timeout <b>interval</b> is given in seconds. To have a timeout
 of 15 minutes, set <b>interval</b> to 900.
 <br /><br />

--- a/RHEL/6/input/system/accounts/pam.xml
+++ b/RHEL/6/input/system/accounts/pam.xml
@@ -243,7 +243,7 @@ passwords</warning>
 <description>To configure the number of retry prompts that are permitted per-session:
 <br /><br />
 Edit the <tt>pam_cracklib.so</tt> statement in <tt>/etc/pam.d/system-auth</tt> to 
-show <tt>retry=3</tt>, or a lower value if site policy is more restrictive.
+show <tt>retry=<sub idref="var_password_pam_cracklib_retry" /></tt>, or a lower value if site policy is more restrictive.
 <br /><br />
 The DoD requirement is a maximum of 3 prompts per session.
 </description>
@@ -270,8 +270,8 @@ is different from account lockout, which is provided by the pam_faillock module.
 <title>Set Password to Maximum of Three Consecutive Repeating Characters</title>
 <description>The pam_cracklib module's <tt>maxrepeat</tt> parameter controls requirements for
 consecutive repeating characters. When set to a positive number, it will reject passwords
-which contain more than that number of consecutive characters. Add <tt>maxrepeat=3</tt>
-after pam_cracklib.so to prevent a run of four or more identical characters.
+which contain more than that number of consecutive characters. Add <tt>maxrepeat=<sub idref="var_password_pam_cracklib_maxrepeat" /></tt>
+after pam_cracklib.so to prevent a run of (<sub idref="var_password_pam_cracklib_maxrepeat" /> + 1) or more identical characters.
 </description>
 <ocil clause="maxrepeat is not found or not set to the required value">
 To check the maximum value for consecutive repeating characters, run the following command:
@@ -390,9 +390,8 @@ more difficult by ensuring a larger search space.
 <title>Set Password Strength Minimum Different Characters</title>
 <description>The pam_cracklib module's <tt>difok</tt> parameter controls requirements for
 usage of different characters during a password change.
-Add <tt>difok=<i>NUM</i></tt> after pam_cracklib.so to require differing
-characters when changing passwords, substituting <i>NUM</i> appropriately.
-The DoD requirement is <tt>4</tt>.
+Add <tt>difok=<i><sub idref="var_password_pam_cracklib_difok" /></i></tt> after pam_cracklib.so to require differing
+characters when changing passwords. The DoD requirement is <tt>4</tt>.
 </description>
 <ocil clause="difok is not found or not set to the required value">
 To check how many characters must differ during a password change, run the following command:
@@ -426,10 +425,10 @@ four categories available:
 * Digits
 * Special characters (for example, punctuation)
 </pre>
-Add <tt>minclass=<i>NUM</i></tt> after pam_cracklib.so entry into the
-<tt>/etc/pam.d/system-auth</tt> file in order to require differing categories of
-characters when changing passwords, substituting <i>NUM</i> appropriately (for example to
-require at least three character classes to be used in password, use <tt>minclass=3</tt>).
+Add <tt>minclass=<i><sub idref="var_password_pam_cracklib_minclass" /></i></tt> after pam_cracklib.so entry into the
+<tt>/etc/pam.d/system-auth</tt> file in order to require <sub idref="var_password_pam_cracklib_minclass" />  differing categories of
+characters when changing passwords.
+For example to require at least three character classes to be used in password, use <tt>minclass=3</tt>.
 </description>
 <ocil clause="minclass is not found or not set to the required value">
 To check how many categories of characters must be used in password during a password change,
@@ -477,8 +476,8 @@ attempts using <tt>pam_faillock.so</tt>:
 <br /><br />
 Add the following lines immediately below the <tt>pam_unix.so</tt> statement in <tt>AUTH</tt> section of
 both <tt>/etc/pam.d/system-auth</tt> and /etc/pam.d/password-auth:
-<pre>auth [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900</pre>
-<pre>auth required pam_faillock.so authsucc deny=3 unlock_time=604800 fail_interval=900</pre>
+<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=604800 fail_interval=900</pre>
+<pre>auth required pam_faillock.so authsucc deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=604800 fail_interval=900</pre>
 </description>
 <ocil clause="that is not the case">
 To ensure the failed password attempt policy is configured correctly, run the following command:
@@ -501,8 +500,8 @@ To configure the system to lock out accounts after a number of incorrect login
 attempts and require an administrator to unlock the account using <tt>pam_faillock.so</tt>:
 <br /><br />
 Add the following lines immediately below the <tt>pam_env.so</tt> statement in <tt>/etc/pam.d/system-auth</tt>:
-<pre>auth [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900</pre>
-<pre>auth required pam_faillock.so authsucc deny=3 unlock_time=604800 fail_interval=900</pre>
+<pre>auth [default=die] pam_faillock.so authfail deny=3 unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=900</pre>
+<pre>auth required pam_faillock.so authsucc deny=3 unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=900</pre>
 </description>
 <ocil clause="that is not the case">
 To ensure the failed password attempt policy is configured correctly, run the following command:
@@ -528,8 +527,8 @@ attempts.
 <br /><br />
 Add the following <tt>fail_interval</tt> directives to <tt>pam_faillock.so</tt> immediately below the <tt>pam_env.so</tt> statement in
 <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt>:
-<pre>auth [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=900</pre>
-<pre>auth required pam_faillock.so authsucc deny=3 unlock_time=604800 fail_interval=900</pre>
+<pre>auth [default=die] pam_faillock.so authfail deny=3 unlock_time=604800 fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre>
+<pre>auth required pam_faillock.so authsucc deny=3 unlock_time=604800 fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre>
 </description>
 <ocil clause="that is not the case">
 To ensure the failed password attempt policy is configured correctly, run the following command:
@@ -549,9 +548,9 @@ specific period of time prevents direct password guessing attacks.
 <title>Limit Password Reuse</title>
 <description>Do not allow users to reuse recent passwords. This can
 be accomplished by using the <tt>remember</tt> option for the <tt>pam_unix</tt> PAM
-module.  In the file <tt>/etc/pam.d/system-auth</tt>, append <tt>remember=24</tt> to the 
+module.  In the file <tt>/etc/pam.d/system-auth</tt>, append <tt>remember=<sub idref="var_password_pam_unix_remember" /></tt> to the
 line which refers to the <tt>pam_unix.so</tt> module, as shown:
-<pre>password sufficient pam_unix.so <i>existing_options</i> remember=24</pre>
+<pre>password sufficient pam_unix.so <i>existing_options</i> remember=<sub idref="var_password_pam_unix_remember" /></pre>
 The DoD and FISMA requirement is 24 passwords.</description>
 <ocil clause="it does not">
 To verify the password reuse setting is compliant, run the following command:

--- a/RHEL/6/input/system/accounts/physical.xml
+++ b/RHEL/6/input/system/accounts/physical.xml
@@ -257,12 +257,12 @@ the man page <tt>gconftool-2(1)</tt>.</description>
 <title>Set GNOME Login Inactivity Timeout</title>
 <description>
 Run the following command to set the idle time-out value for
-inactivity in the GNOME desktop to 15 minutes:
+inactivity in the GNOME desktop to <sub idref="inactivity_timeout_value" /> minutes:
 <pre>$ sudo gconftool-2 \
   --direct \
   --config-source xml:readwrite:/etc/gconf/gconf.xml.mandatory \
   --type int \
-  --set /desktop/gnome/session/idle_delay 15</pre>
+  --set /desktop/gnome/session/idle_delay <sub idref="inactivity_timeout_value" /></pre>
 </description>
 <ocil clause="it is not">
 To check the current idle time-out value, run the following command:

--- a/RHEL/6/input/system/accounts/restrictions/password_expiration.xml
+++ b/RHEL/6/input/system/accounts/restrictions/password_expiration.xml
@@ -81,9 +81,9 @@ age, and 7 day warning period with the following command:
 <description>To specify password length requirements for new accounts,
 edit the file <tt>/etc/login.defs</tt> and add or correct the following
 lines:
-<pre>PASS_MIN_LEN 14<!-- <sub idref="var_accounts_password_minlen_login_defs"> --></pre>
+<pre>PASS_MIN_LEN <sub idref="var_accounts_password_minlen_login_defs" /></pre>
 <br/><br/>
-The DoD requirement is <tt>14</tt>. 
+The DoD requirement is <tt>14</tt>.
 The FISMA requirement is <tt>12</tt>.
 If a program consults <tt>/etc/login.defs</tt> and also another PAM module
 (such as <tt>pam_cracklib</tt>) during a password change operation,
@@ -93,7 +93,7 @@ for more information about enforcing password quality requirements.
 <ocil clause="it is not set to the required value">
 To check the minimum password length, run the command:
 <pre>$ grep PASS_MIN_LEN /etc/login.defs</pre>
-The DoD requirement is <tt>14</tt>. 
+The DoD requirement is <tt>14</tt>.
 </ocil>
 <rationale>
 Requiring a minimum password length makes password
@@ -113,8 +113,8 @@ behavior that may result.
 <title>Set Password Minimum Age</title>
 <description>To specify password minimum age for new accounts,
 edit the file <tt>/etc/login.defs</tt>
-and add or correct the following line, replacing <i>DAYS</i> appropriately:
-<pre>PASS_MIN_DAYS <i>DAYS</i></pre>
+and add or correct the following line:
+<pre>PASS_MIN_DAYS <i><sub idref="var_accounts_minimum_age_login_defs" /></i></pre>
 A value of 1 day is considered for sufficient for many
 environments.
 The DoD requirement is 1. 
@@ -140,8 +140,8 @@ after satisfying the password reuse requirement.
 <title>Set Password Maximum Age</title>
 <description>To specify password maximum age for new accounts,
 edit the file <tt>/etc/login.defs</tt>
-and add or correct the following line, replacing <i>DAYS</i> appropriately:
-<pre>PASS_MAX_DAYS <i>DAYS</i></pre>
+and add or correct the following line:
+<pre>PASS_MAX_DAYS <i><sub idref="var_accounts_maximum_age_login_defs" /></i></pre>
 A value of 180 days is sufficient for many environments. 
 The DoD requirement is 60.
 </description>
@@ -168,10 +168,9 @@ location subject to physical compromise.</rationale>
 <description>To specify how many days prior to password
 expiration that a warning will be issued to users,
 edit the file <tt>/etc/login.defs</tt> and add or correct
- the following line, replacing <i>DAYS</i> appropriately:
-<pre>PASS_WARN_AGE <i>DAYS</i></pre>
+ the following line:
+<pre>PASS_WARN_AGE <i><sub idref="var_accounts_password_warn_age_login_defs" /></i></pre>
 The DoD requirement is 7.
-<!-- <sub idref="accounts_password_warn_age_login_defs_login_defs_value" /> -->
 </description>
 <ocil clause="it is not set to the required value">
 To check the password warning age, run the command:

--- a/RHEL/6/input/system/accounts/session.xml
+++ b/RHEL/6/input/system/accounts/session.xml
@@ -31,7 +31,7 @@ Limiting the number of allowed users and sessions per user can limit risks relat
 Service attacks. This addresses concurrent sessions for a single account and does not address 
 concurrent sessions by a single user via multiple accounts.  The DoD requirement is 10.   To set the number of concurrent
 sessions per user add the following line in <tt>/etc/security/limits.conf</tt>:
-<pre>* hard maxlogins 10</pre>
+<pre>* hard maxlogins <sub idref="var_accounts_max_concurrent_login_sessions" /></pre>
 </description>
 <rationale>Limiting simultaneous user logins can insulate the system from denial of service 
 problems caused by excessive logins. Automated login processes operating improperly or 
@@ -211,7 +211,7 @@ operator="equals" interactive="0">
 To ensure the default umask for users of the Bash shell is set properly,
 add or correct the <tt>umask</tt> setting in <tt>/etc/bashrc</tt> to read
 as follows:
-<pre>umask 077<!-- <sub idref="var_accounts_user_umask" /> --></pre>
+<pre>umask <sub idref="var_accounts_user_umask" /></pre>
 </description>
 <rationale>The umask value influences the permissions assigned to files when they are created.
 A misconfigured umask value could result in files with excessive permissions that can be read or
@@ -236,7 +236,7 @@ umask 077</pre>
 <description>
 To ensure the default umask for users of the C shell is set properly,
 add or correct the <tt>umask</tt> setting in <tt>/etc/csh.cshrc</tt> to read as follows:
-<pre>umask 077<!-- <sub idref="var_accounts_user_umask" /> --></pre>
+<pre>umask <sub idref="var_accounts_user_umask" /></pre>
 </description>
 <rationale>The umask value influences the permissions assigned to files when they are created.
 A misconfigured umask value could result in files with excessive permissions that can be read or
@@ -260,7 +260,7 @@ umask 077</pre>
 <description>
 To ensure the default umask controlled by <tt>/etc/profile</tt> is set properly,
 add or correct the <tt>umask</tt> setting in <tt>/etc/profile</tt> to read as follows:
-<pre>umask 077<!--<sub idref="var_accounts_user_umask" /> --></pre>
+<pre>umask <sub idref="var_accounts_user_umask" /></pre>
 </description>
 <rationale>The umask value influences the permissions assigned to files when they are created.
 A misconfigured umask value could result in files with excessive permissions that can be read or
@@ -284,7 +284,7 @@ umask 077</pre>
 <description>
 To ensure the default umask controlled by <tt>/etc/login.defs</tt> is set properly,
 add or correct the <tt>UMASK</tt> setting in <tt>/etc/login.defs</tt> to read as follows:
-<pre>UMASK 077<!-- <sub idref="var_accounts_user_umask" /> --></pre>
+<pre>UMASK <sub idref="var_accounts_user_umask" /></pre>
 </description>
 <rationale>The umask value influences the permissions assigned to files when they are created.
 A misconfigured umask value could result in files with excessive permissions that can be read and 

--- a/RHEL/6/input/system/auditing.xml
+++ b/RHEL/6/input/system/auditing.xml
@@ -232,7 +232,7 @@ normally.</i>
 <description>Determine how many log files
 <tt>auditd</tt> should retain when it rotates logs.
 Edit the file <tt>/etc/audit/auditd.conf</tt>. Add or modify the following
-line, substituting <i>NUMLOGS</i> with the correct value:
+line, substituting <i>NUMLOGS</i> with the correct value of <sub idref="var_auditd_num_logs" />:
 <pre>num_logs = <i>NUMLOGS</i></pre>
 Set the value to 5 for general-purpose systems. 
 Note that values less than 2 result in no log rotation.</description>
@@ -256,7 +256,7 @@ file size and the number of logs retained.</rationale>
 <description>Determine the amount of audit data (in megabytes)
 which should be retained in each log file. Edit the file
 <tt>/etc/audit/auditd.conf</tt>. Add or modify the following line, substituting
-the correct value for <i>STOREMB</i>:
+the correct value of <sub idref="var_auditd_max_log_file" /> for <i>STOREMB</i>:
 <pre>max_log_file = <i>STOREMB</i></pre>
 Set the value to <tt>6</tt> (MB) or higher for general-purpose systems.
 Larger values, of course,
@@ -402,7 +402,7 @@ is used, running low on space for audit records should never occur.
 a designated account in certain situations. Add or correct the following line
 in <tt>/etc/audit/auditd.conf</tt> to ensure that administrators are notified
 via email for those situations:
-<pre>action_mail_acct = root</pre>
+<pre>action_mail_acct = <sub idref="var_auditd_action_mail_acct" /></pre>
 </description>
 <ocil clause="auditd is not configured to send emails per identified actions">
 Inspect <tt>/etc/audit/auditd.conf</tt> and locate the following line to

--- a/RHEL/6/input/system/permissions/execution.xml
+++ b/RHEL/6/input/system/permissions/execution.xml
@@ -29,8 +29,8 @@ for system daemons.
 parameters for most or all daemons started at boot time.  The default umask of
 022 prevents creation of group- or world-writable files.  To set the default
 umask for daemons, edit the following line, inserting 022 or 027 for
-<i>UMASK</i> appropriately:
-<pre>umask <i>UMASK</i></pre>
+<i>umask</i> appropriately:
+<pre>umask <i><sub idref="var_umask_for_daemons" /></i></pre>
 Setting the umask to too restrictive a setting can cause serious errors at
 runtime.  Many daemons on the system already individually restrict themselves to
 a umask of 077 in their own init scripts.

--- a/RHEL/6/input/system/selinux.xml
+++ b/RHEL/6/input/system/selinux.xml
@@ -70,10 +70,10 @@ the chances that it will remain off during system operation.
 
 <Rule id="selinux_state" severity="medium">
 <title>Ensure SELinux State is Enforcing</title>
-<description>The SELinux state should be set to <tt>enforcing</tt> at
+<description>The SELinux state should be set to <tt><sub idref="var_selinux_state" /></tt> at
 system boot time.  In the file <tt>/etc/selinux/config</tt>, add or correct the
 following line to configure the system to boot into enforcing mode:
-<pre>SELINUX=enforcing</pre>
+<pre>SELINUX=<sub idref="var_selinux_state" /></pre>
 </description>
 <ocil clause="SELINUX is not set to enforcing">
 Check the file <tt>/etc/selinux/config</tt> and ensure the following line appears:
@@ -97,7 +97,7 @@ privileges.
 general-purpose desktops and servers, as well as systems in many other roles.
 To configure the system to use this policy, add or correct the following line
 in <tt>/etc/selinux/config</tt>:
-<pre>SELINUXTYPE=targeted</pre>
+<pre>SELINUXTYPE=<sub idref="var_selinux_policy_name" /></pre>
 Other policies, such as <tt>mls</tt>, provide additional security labeling
 and greater confinement but are not compatible with many general-purpose
 use cases.


### PR DESCRIPTION
OpenSCAP 1.0.8 (IIRC) introduced the ability to substitute / expand variable value present in <sub> 
element.

Start using this feature by calling expansion for appropriate variables within XCCDF 
descriptions where this is appropriate instead of using hard-coded values.

Tested on RHEL/6, works as expected.

Please review.

Thanks, Jan.
