### PR TITLE
Update file_permissions_ungroupowned to use updated unix-def behaviors

### DIFF
--- a/RHEL/6/input/checks/file_permissions_ungroupowned.xml
+++ b/RHEL/6/input/checks/file_permissions_ungroupowned.xml
@@ -28,7 +28,7 @@
   </unix:file_state>
 
   <unix:file_object comment="all local files" id="object_file_permissions_ungroupowned" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
+    <unix:behaviors recurse="symlinks and directories" recurse_direction="down" recurse_file_system="local" />
     <unix:path>/</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
   </unix:file_object>


### PR DESCRIPTION
Originally requested by pvrabec some time ago
https://fedorahosted.org/scap-security-guide/ticket/134

testing:

```
$ ./testcheck.py file_permissions_ungroupowned.xml
Evaluating with OVAL tempfile : /tmp/file_permissions_ungroupownedD0pQj8.xml
Writing results to : /tmp/file_permissions_ungroupownedD0pQj8.xml-results
Definition oval:scap-security-guide.testing:def:100: true
Evaluation done.
```
