### PR TITLE
[bugfix] [RHEL/7] Update form of RHEL-7 service disable / enable check macros in shorthand2xccdf XSLT transformation

### DIFF
--- a/RHEL/7/input/services/obsolete.xml
+++ b/RHEL/7/input/services/obsolete.xml
@@ -75,7 +75,28 @@ actively working to migrate to a more secure protocol.</description>
 <Rule id="disable_telnet_service" severity="high">
 <title>Disable telnet Service</title>
 <description>
-<service-disable-macro service="telnet" />
+The <code>telnet</code> service configuration file <code>/etc/xinet.d/telnet</code>
+is not created automatically. If it was created manually, check the
+<code>/etc/xinet.d/telnet</code> file and ensure that <code>disable = no</code>
+is changed to read <code>disable = yes</code> as follows below:
+<pre>
+# description: The telnet server serves telnet sessions; it uses \\
+#       unencrypted username/password pairs for authentication.
+service telnet
+{
+        flags           = REUSE
+        socket_type     = stream
+
+        wait            = no
+        user            = root
+        server          = /usr/sbin/in.telnetd
+        log_on_failure  += USERID
+        disable         = yes
+}
+</pre>
+Then the activation of the <code>telnet</code> service on system boot can be disabled
+via the following command:
+<pre># systemctl disable telnet.socket</pre>
 </description>
 <ocil><xinetd-service-disable-check-macro service="telnet" /></ocil>
 <rationale>
@@ -88,7 +109,7 @@ subject to man-in-the-middle attacks.
 <ident cce="RHEL7-CCE-TBD" />
 <oval id="service_telnetd_disabled" />
 <ref nist="AC-17(8),CM-7,IA-5(1)(c)" disa="68,1436,197,877,888" />
-<tested by="DS" on="20121026"/>
+<tested by="JL" on="20140922"/>
 </Rule>
 
 <Rule id="uninstall_telnet_server" severity="high">

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -384,27 +384,26 @@
 
   <xsl:template match="service-disable-macro">
     The <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service can be disabled with the following command:
-    <xhtml:pre># chkconfig <xsl:value-of select="@service"/> off</xhtml:pre>
+    <xhtml:pre># systemctl disable <xsl:value-of select="@service"/></xhtml:pre>
   </xsl:template>
 
   <xsl:template match="service-enable-macro">
     The <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service can be enabled with the following command:
-    <xhtml:pre># chkconfig --level 2345 <xsl:value-of select="@service"/> on</xhtml:pre>
+    <xhtml:pre># systemctl enable <xsl:value-of select="@service"/></xhtml:pre>
   </xsl:template>
 
   <xsl:template match="service-disable-check-macro">
-    To check that the <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service is disabled in system boot configuration, run the following command: 
-    <xhtml:pre># chkconfig <xhtml:code><xsl:value-of select="@service"/></xhtml:code> --list</xhtml:pre>
-    Output should indicate the <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service has either not been installed, 
+    To check that the <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service is disabled in system boot configuration, run the following command:
+    <xhtml:pre># systemctl is-enabled <xhtml:code><xsl:value-of select="@service"/></xhtml:code></xhtml:pre>
+    Output should indicate the <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service has either not been installed,
     or has been disabled at all runlevels, as shown in the example below:
-    <xhtml:pre># chkconfig <xhtml:code><xsl:value-of select="@service"/></xhtml:code> --list
-<xhtml:code><xsl:value-of select="@service"/></xhtml:code>       0:off   1:off   2:off   3:off   4:off   5:off   6:off</xhtml:pre>
+    <xhtml:pre># systemctl is-enabled <xhtml:code><xsl:value-of select="@service"/></xhtml:code><xhtml:br/>disabled</xhtml:pre>
 
-    Run the following command to verify <xhtml:code><xsl:value-of select="@service"/></xhtml:code> is disabled through current runtime configuration:
-    <xhtml:pre># service <xsl:value-of select="@service"/> status</xhtml:pre>
+    Run the following command to verify <xhtml:code><xsl:value-of select="@service"/></xhtml:code> is not active (i.e. not running) through current runtime configuration:
+    <xhtml:pre># systemctl is-active <xsl:value-of select="@service"/></xhtml:pre>
 
-    If the service is disabled the command will return the following output:
-    <xhtml:pre><xsl:value-of select="@service"/> is stopped</xhtml:pre>
+    If the service is not running the command will return the following output:
+    <xhtml:pre>inactive</xhtml:pre>
   </xsl:template>
 
   <xsl:template match="xinetd-service-disable-check-macro">
@@ -412,24 +411,29 @@
           <xhtml:pre># chkconfig <xhtml:code><xsl:value-of select="@service"/></xhtml:code> --list</xhtml:pre>
               Output should indicate the <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service has either not been installed, or has been disabled, as shown in the example below:
               <xhtml:pre># chkconfig <xhtml:code><xsl:value-of select="@service"/></xhtml:code> --list
-<xhtml:code><xsl:value-of select="@service"/></xhtml:code>       off</xhtml:pre>
+
+                         Note: This output shows SysV services only and does not include native
+                         systemd services. SysV configuration data might be overridden by native
+                         systemd configuration.
+
+                         If you want to list systemd services use 'systemctl list-unit-files'.
+                         To see services enabled on particular target use
+                         'systemctl list-dependencies [target]'.
+
+                         <xhtml:code><xsl:value-of select="@service"/></xhtml:code>       off</xhtml:pre>
   </xsl:template>
-
-
-
 
   <xsl:template match="service-enable-check-macro">
     Run the following command to determine the current status of the
 <xhtml:code><xsl:value-of select="@service"/></xhtml:code> service:
-  <xhtml:pre># service <xsl:value-of select="@service"/> status</xhtml:pre>
-    If the service is enabled, it should return the following: <xhtml:pre><xsl:value-of select="@service"/> is running...</xhtml:pre>
+  <xhtml:pre># systemctl is-active <xsl:value-of select="@service"/></xhtml:pre>
+    If the service is running, it should return the following: <xhtml:pre>active</xhtml:pre>
   </xsl:template>
 
   <xsl:template match="package-check-macro">
     Run the following command to determine if the <xhtml:code><xsl:value-of select="@package"/></xhtml:code> package is installed:
     <xhtml:pre># rpm -q <xsl:value-of select="@package"/></xhtml:pre>
   </xsl:template>
-
 
   <xsl:template match="module-disable-macro">
 To configure the system to prevent the <xhtml:code><xsl:value-of select="@module"/></xhtml:code>


### PR DESCRIPTION
This change updates the form of:
- service-disable-macro,
- service-enable-macro,
- service-disable-check-macro,
- xinetd-service-disable-check-macro, and
- service-enable-check-macro

in order they to start using the form to read as `# systemctl ...` rather than `# chkconfig ...`

Also update the 'Disable telnet Service' XCCDF rule description not to use the service-disable-macro (since the default form can't be used for telnet service on RHEL-7. We need a custom one for telnet).

Tested on RHEL-7 & works as expected.

Please review.

Thanks, Jan.
