### PR TITLE
[bugfix] [RHEL/7] Update RHEL-7 service_*_disabled.sh remediation fixes (so they would have the form as expected by systemd)

### DIFF
--- a/RHEL/7/input/fixes/bash/service_abrtd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_abrtd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable abrtd for all run levels
+# Disable abrtd.service for all systemd targets
 #
-chkconfig --level 0123456 abrtd off
+systemctl disable abrtd.service
 
 #
-# Stop abrtd if currently running
+# Stop abrtd.service if currently running
 #
-service abrtd stop
+systemctl stop abrtd.service

--- a/RHEL/7/input/fixes/bash/service_acpid_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_acpid_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable acpid for all run levels
+# Disable acpid.service for all systemd targets
 #
-chkconfig --level 0123456 acpid off
+systemctl disable acpid.service
 
 #
-# Stop acpid if currently running
+# Stop acpid.service if currently running
 #
-service acpid stop
+systemctl stop acpid.service

--- a/RHEL/7/input/fixes/bash/service_atd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_atd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable atd for all run levels
+# Disable atd.service for all systemd targets
 #
-chkconfig --level 0123456 atd off
+systemctl disable atd.service
 
 #
-# Stop atd if currently running
+# Stop atd.service if currently running
 #
-service atd stop
+systemctl stop atd.service

--- a/RHEL/7/input/fixes/bash/service_autofs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_autofs_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable autofs for all run levels
+# Disable autofs.service for all systemd targets
 #
-chkconfig --level 0123456 autofs off
+systemctl disable autofs.service
 
 #
-# Stop autofs if currently running
+# Stop autofs.service if currently running
 #
-service autofs stop
+systemctl stop autofs.service

--- a/RHEL/7/input/fixes/bash/service_avahi-daemon_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_avahi-daemon_disabled.sh
@@ -1,9 +1,12 @@
 #
-# Disable avahi-daemon for all run levels
+# Disable avahi-daemon.service for all systemd targets
 #
-chkconfig --level 0123456 avahi-daemon off
+systemctl disable avahi-daemon.service
 
 #
-# Stop avahi-daemon if currently running
+# Stop avahi-daemon.service if currently running
+# and disable avahi-daemon.socket so the avahi-daemon.service
+# can't be activated
 #
-service avahi-daemon stop
+systemctl stop avahi-daemon.service
+systemctl disable avahi-daemon.socket

--- a/RHEL/7/input/fixes/bash/service_bluetooth_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_bluetooth_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable bluetooth for all run levels
+# Disable bluetooth.service for all systemd targets
 #
-chkconfig --level 0123456 bluetooth off
+systemctl disable bluetooth.service
 
 #
-# Stop bluetooth if currently running
+# Stop bluetooth.service if currently running
 #
-service bluetooth stop
+systemctl stop bluetooth.service

--- a/RHEL/7/input/fixes/bash/service_certmonger_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_certmonger_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable certmonger for all run levels
+# Disable certmonger.service for all systemd targets
 #
-chkconfig --level 0123456 certmonger off
+systemctl disable certmonger.service
 
 #
-# Stop certmonger if currently running
+# Stop certmonger.service if currently running
 #
-service certmonger stop
+systemctl stop certmonger.service

--- a/RHEL/7/input/fixes/bash/service_cgconfig_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_cgconfig_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable cgconfig for all run levels
+# Disable cgconfig.service for all systemd targets
 #
-chkconfig --level 0123456 cgconfig off
+systemctl disable cgconfig.service
 
 #
-# Stop cgconfig if currently running
+# Stop cgconfig.service if currently running
 #
-service cgconfig stop
+systemctl stop cgconfig.service

--- a/RHEL/7/input/fixes/bash/service_cgred_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_cgred_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable cgred for all run levels
+# Disable cgred.service for all systemd targets
 #
-chkconfig --level 0123456 cgred off
+systemctl disable cgred.service
 
 #
-# Stop cgred if currently running
+# Stop cgred.service if currently running
 #
-service cgred stop
+systemctl stop cgred.service

--- a/RHEL/7/input/fixes/bash/service_cpuspeed_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_cpuspeed_disabled.sh
@@ -1,9 +1,0 @@
-#
-# Disable cpuspeed for all run levels
-#
-chkconfig --level 0123456 cpuspeed off
-
-#
-# Stop cpuspeed if currently running
-#
-service cpuspeed stop

--- a/RHEL/7/input/fixes/bash/service_cups_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_cups_disabled.sh
@@ -1,9 +1,13 @@
 #
-# Disable cups for all run levels
+# Disable cups.service for all systemd targets
 #
-chkconfig --level 0123456 cups off
+systemctl disable cups.service
 
 #
-# Stop cups if currently running
+# Stop cups.service if currently running
+# and disable cups.path and cups.socket so
+# cups.service can't be activated
 #
-service cups stop
+systemctl stop cups.service
+systemctl disable cups.path
+systemctl disable cups.socket

--- a/RHEL/7/input/fixes/bash/service_dhcpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_dhcpd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable dhcpd for all run levels
+# Disable dhcpd.service for all systemd targets
 #
-chkconfig --level 0123456 dhcpd off
+systemctl disable dhcpd.service
 
 #
-# Stop dhcpd if currently running
+# Stop dhcpd.service if currently running
 #
-service dhcpd stop
+systemctl stop dhcpd.service

--- a/RHEL/7/input/fixes/bash/service_dovecot_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_dovecot_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable dovecot for all run levels
+# Disable dovecot.service for all systemd targets
 #
-chkconfig --level 0123456 dovecot off
+systemctl disable dovecot.service
 
 #
-# Stop dovecot if currently running
+# Stop dovecot.service if currently running
 #
-service dovecot stop
+systemctl stop dovecot.service

--- a/RHEL/7/input/fixes/bash/service_haldaemon_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_haldaemon_disabled.sh
@@ -1,9 +1,0 @@
-#
-# Disable haldaemon for all run levels
-#
-chkconfig --level 0123456 haldaemon off
-
-#
-# Stop haldaemon if currently running
-#
-service haldaemon stop

--- a/RHEL/7/input/fixes/bash/service_httpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_httpd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable httpd for all run levels
+# Disable httpd.service for all systemd targets
 #
-chkconfig --level 0123456 httpd off
+systemctl disable httpd.service
 
 #
-# Stop httpd if currently running
+# Stop httpd.service if currently running
 #
-service httpd stop
+systemctl stop httpd.service

--- a/RHEL/7/input/fixes/bash/service_kdump_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_kdump_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable kdump for all run levels
+# Disable kdump.service for all systemd targets
 #
-chkconfig --level 0123456 kdump off
+systemctl disable kdump.service
 
 #
-# Stop kdump if currently running
+# Stop kdump.service if currently running
 #
-service kdump stop
+systemctl stop kdump.service

--- a/RHEL/7/input/fixes/bash/service_mdmonitor_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_mdmonitor_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable mdmonitor for all run levels
+# Disable mdmonitor.service for all systemd targets
 #
-chkconfig --level 0123456 mdmonitor off
+systemctl disable mdmonitor.service
 
 #
-# Stop mdmonitor if currently running
+# Stop mdmonitor.service if currently running
 #
-service mdmonitor stop
+systemctl stop mdmonitor.service

--- a/RHEL/7/input/fixes/bash/service_messagebus_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_messagebus_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable messagebus for all run levels
+# Disable messagebus.service for all systemd targets
 #
-chkconfig --level 0123456 messagebus off
+systemctl disable messagebus.service
 
 #
-# Stop messagebus if currently running
+# Stop messagebus.service if currently running
 #
-service messagebus stop
+systemctl stop messagebus.service

--- a/RHEL/7/input/fixes/bash/service_named_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_named_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable named for all run levels
+# Disable named.service for all systemd targets
 #
-chkconfig --level 0123456 named off
+systemctl disable named.service
 
 #
-# Stop named if currently running
+# Stop named.service if currently running
 #
-service named stop
+systemctl stop named.service

--- a/RHEL/7/input/fixes/bash/service_netfs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_netfs_disabled.sh
@@ -1,9 +1,0 @@
-#
-# Disable netfs for all run levels
-#
-chkconfig --level 0123456 netfs off
-
-#
-# Stop netfs if currently running
-#
-service netfs stop

--- a/RHEL/7/input/fixes/bash/service_nfs_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_nfs_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable nfs for all run levels
+# Disable nfs.service for all systemd targets
 #
-chkconfig --level 0123456 nfs off
+systemctl disable nfs.service
 
 #
-# Stop nfs if currently running
+# Stop nfs.service if currently running
 #
-service nfs stop
+systemctl stop nfs.service

--- a/RHEL/7/input/fixes/bash/service_nfslock_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_nfslock_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable nfslock for all run levels
+# Disable nfs-lock.service for all systemd targets
 #
-chkconfig --level 0123456 nfslock off
+systemctl disable nfs-lock.service
 
 #
-# Stop nfslock if currently running
+# Stop nfs-lock.service if currently running
 #
-service nfslock stop
+systemctl stop nfs-lock.service

--- a/RHEL/7/input/fixes/bash/service_oddjobd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_oddjobd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable oddjobd for all run levels
+# Disable oddjobd.service for all systemd targets
 #
-chkconfig --level 0123456 oddjobd off
+systemctl disable oddjobd.service
 
 #
-# Stop oddjobd if currently running
+# Stop oddjobd.service if currently running
 #
-service oddjobd stop
+systemctl stop oddjobd.service

--- a/RHEL/7/input/fixes/bash/service_portreserve_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_portreserve_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable portreserve for all run levels
+# Disable portreserve.service for all systemd targets
 #
-chkconfig --level 0123456 portreserve off
+systemctl disable portreserve.service
 
 #
-# Stop portreserve if currently running
+# Stop portreserve.service if currently running
 #
-service portreserve stop
+systemctl stop portreserve.service

--- a/RHEL/7/input/fixes/bash/service_qpidd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_qpidd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable qpidd for all run levels
+# Disable qpidd.service for all systemd targets
 #
-chkconfig --level 0123456 qpidd off
+systemctl disable qpidd.service
 
 #
-# Stop qpidd if currently running
+# Stop qpidd.service if currently running
 #
-service qpidd stop
+systemctl stop qpidd.service

--- a/RHEL/7/input/fixes/bash/service_quota_nld_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_quota_nld_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable quota_nld for all run levels
+# Disable quota_nld.service for all systemd targets
 #
-chkconfig --level 0123456 quota_nld off
+systemctl disable quota_nld.service
 
 #
-# Stop quota_nld if currently running
+# Stop quota_nld.service if currently running
 #
-service quota_nld stop
+systemctl stop quota_nld.service

--- a/RHEL/7/input/fixes/bash/service_rdisc_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rdisc_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable rdisc for all run levels
+# Disable rdisc.service for all systemd targets
 #
-chkconfig --level 0123456 rdisc off
+systemctl disable rdisc.service
 
 #
-# Stop rdisc if currently running
+# Stop rdisc.service if currently running
 #
-service rdisc stop
+systemctl stop rdisc.service

--- a/RHEL/7/input/fixes/bash/service_rhsmcertd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rhsmcertd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable rhsmcertd for all run levels
+# Disable rhsmcertd.service for all systemd targets
 #
-chkconfig --level 0123456 rhsmcertd off
+systemctl disable rhsmcertd.service
 
 #
-# Stop rhsmcertd if currently running
+# Stop rhsmcertd.service if currently running
 #
-service rhsmcertd stop
+systemctl stop rhsmcertd.service

--- a/RHEL/7/input/fixes/bash/service_rpcgssd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rpcgssd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable rpcgssd for all run levels
+# Disable nfs-secure.service (rpcgssd) for all systemd targets
 #
-chkconfig --level 0123456 rpcgssd off
+systemctl disable nfs-secure.service
 
 #
-# Stop rpcgssd if currently running
+# Stop nfs-secure.service (rpcgssd) if currently running
 #
-service rpcgssd stop
+systemctl stop nfs-secure.service

--- a/RHEL/7/input/fixes/bash/service_rpcidmapd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rpcidmapd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable rpcidmapd for all run levels
+# Disable nfs-idmap.service (rpcidmapd) for all systemd targets
 #
-chkconfig --level 0123456 rpcidmapd off
+systemctl disable nfs-idmap.service
 
 #
-# Stop rpcidmapd if currently running
+# Stop nfs-idmap.service (rpcidmapd) if currently running
 #
-service rpcidmapd stop
+systemctl stop nfs-idmap.service

--- a/RHEL/7/input/fixes/bash/service_rpcsvcgssd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rpcsvcgssd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable rpcsvcgssd for all run levels
+# Disable nfs-secure-server.service (rpcsvcgssd) for all systemd targets
 #
-chkconfig --level 0123456 rpcsvcgssd off
+systemctl disable nfs-secure-server.service
 
 #
-# Stop rpcsvcgssd if currently running
+# Stop nfs-secure-server.service (rpcsvcgssd) if currently running
 #
-service rpcsvcgssd stop
+systemctl stop nfs-secure-server.service

--- a/RHEL/7/input/fixes/bash/service_saslauthd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_saslauthd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable saslauthd for all run levels
+# Disable saslauthd.service for all systemd targets
 #
-chkconfig --level 0123456 saslauthd off
+systemctl disable saslauthd.service
 
 #
-# Stop saslauthd if currently running
+# Stop saslauthd.service if currently running
 #
-service saslauthd stop
+systemctl stop saslauthd.service

--- a/RHEL/7/input/fixes/bash/service_smartd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_smartd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable smartd for all run levels
+# Disable smartd.service for all systemd targets
 #
-chkconfig --level 0123456 smartd off
+systemctl disable smartd.service
 
 #
-# Stop smartd if currently running
+# Stop smartd.service if currently running
 #
-service smartd stop
+systemctl stop smartd.service

--- a/RHEL/7/input/fixes/bash/service_smb_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_smb_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable smb for all run levels
+# Disable smb.service for all systemd targets
 #
-chkconfig --level 0123456 smb off
+systemctl disable smb.service
 
 #
-# Stop smb if currently running
+# Stop smb.service if currently running
 #
-service smb stop
+systemctl stop smb.service

--- a/RHEL/7/input/fixes/bash/service_snmpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_snmpd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable snmpd for all run levels
+# Disable snmpd.service for all systemd targets
 #
-chkconfig --level 0123456 snmpd off
+systemctl disable snmpd.service
 
 #
-# Stop snmpd if currently running
+# Stop snmpd.service if currently running
 #
-service snmpd stop
+systemctl stop snmpd.service

--- a/RHEL/7/input/fixes/bash/service_squid_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_squid_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable squid for all run levels
+# Disable squid.service for all systemd targets
 #
-chkconfig --level 0123456 squid off
+systemctl disable squid.service
 
 #
-# Stop squid if currently running
+# Stop squid.service if currently running
 #
-service squid stop
+systemctl stop squid.service

--- a/RHEL/7/input/fixes/bash/service_sshd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_sshd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable sshd for all run levels
+# Disable sshd.service for all systemd targets
 #
-chkconfig --level 0123456 sshd off
+systemctl disable sshd.service
 
 #
-# Stop sshd if currently running
+# Stop sshd.service if currently running
 #
-service sshd stop
+systemctl stop sshd.service

--- a/RHEL/7/input/fixes/bash/service_sysstat_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_sysstat_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable sysstat for all run levels
+# Disable sysstat.service for all systemd targets
 #
-chkconfig --level 0123456 sysstat off
+systemctl disable sysstat.service
 
 #
-# Stop sysstat if currently running
+# Stop sysstat.service if currently running
 #
-service sysstat stop
+systemctl stop sysstat.service

--- a/RHEL/7/input/fixes/bash/service_tftp_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_tftp_disabled.sh
@@ -1,9 +1,0 @@
-#
-# Disable tftp for all run levels
-#
-chkconfig --level 0123456 tftp off
-
-#
-# Stop tftp if currently running
-#
-service tftp stop

--- a/RHEL/7/input/fixes/bash/service_vsftpd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_vsftpd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable vsftpd for all run levels
+# Disable vsftpd.service for all systemd targets
 #
-chkconfig --level 0123456 vsftpd off
+systemctl disable vsftpd.service
 
 #
-# Stop vsftpd if currently running
+# Stop vsftpd.service if currently running
 #
-service vsftpd stop
+systemctl stop vsftpd.service

--- a/RHEL/7/input/fixes/bash/service_xinetd_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_xinetd_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable xinetd for all run levels
+# Disable xinetd.service for all systemd targets
 #
-chkconfig --level 0123456 xinetd off
+systemctl disable xinetd.service
 
 #
-# Stop xinetd if currently running
+# Stop xinetd.service if currently running
 #
-service xinetd stop
+systemctl stop xinetd.service

--- a/RHEL/7/input/fixes/bash/service_ypbind_disabled.sh
+++ b/RHEL/7/input/fixes/bash/service_ypbind_disabled.sh
@@ -1,9 +1,9 @@
 #
-# Disable ypbind for all run levels
+# Disable ypbind.service for all systemd targets
 #
-chkconfig --level 0123456 ypbind off
+systemctl disable ypbind.service
 
 #
-# Stop ypbind if currently running
+# Stop ypbind.service if currently running
 #
-service ypbind stop
+systemctl stop ypbind.service


### PR DESCRIPTION
This change updates the RHEL/7/input/fixes/bash/service_*_disabled.sh remediation scripts to the form so they would work against RHEL7's systemd. The changes performed can be split into four groups:

<ul>
<li> case when <pre>chkconfig --level 0..6 service_name off</pre> to <pre>systemctl disable service_name.service</pre> was sufficient </li> <br/>
<li> case when original <pre>chkconfig --level 0..6 service_name off</pre> would still work on RHEL-7 (for example case of <b>rhnsd</b> or <b>netconsole</b> services) </li> <br/>
<li> case when particular service isn't present in RHEL-7 anymore (for example case of <b>cpuspeed</b> or <b>haldaemon</b>) -- deleted particular remediations in this case </li> <br/>
<li> and finally case when "something changed" in RHEL-7 causing original <pre>chkconfig</pre> script wouldn't work on RHEL-7 (example is tftp service which is now handled via xinetd and therefore needs itself dedicated / specific remediation script of the form edit /etc/xinet.d/tftp & change <pre>disabled=no</pre> to <pre>disabled=yes</pre> -- in this case deleted the original chkconfig based remediation script too, since it wouldn't work & needs rewrite / reimplementation </li> <br/>
</ul>

## Testing status:

None of the proposed changes is included without proper testing (IOW that I would just blindly replace old form with the new one). But rather each of the script changes form has been first checked on RHEL-7's Server's command line for proper work & performed only then.

Please review.

Thank you && Regards, Jan.

P.S.: Intend to create same remediation scripts update for RHEL-7 service___enabled.sh scripts (since they are displayed in the scan report), but decided to split these into two pull requests since the service___disabled.sh change is massive enough for review.
