### PR TITLE
[bugfix] [RHEL/7] Drop service_haldaemon_disabled & service_cpuspeed_disabled XCCDF rules

### DIFF
--- a/RHEL/7/input/services/base.xml
+++ b/RHEL/7/input/services/base.xml
@@ -90,42 +90,6 @@ service is not necessary.
 <ref nist="CM-7" />
 </Rule>
 
-<Rule id="service_cpuspeed_disabled">
-<title>Disable CPU Speed (cpuspeed)</title>
-<description>The <tt>cpuspeed</tt> service can adjust the clock speed of supported CPUs based upon
-the current processing load thereby conserving power and reducing heat.
-<service-disable-macro service="cpuspeed" />
-</description>
-<ocil><service-disable-check-macro service="cpuspeed" /></ocil>
-<rationale>The <tt>cpuspeed</tt> service is only necessary if adjusting the CPU clock speed
-provides benefit. Traditionally this has included laptops (to enhance battery life),
-but may also apply to server or desktop environments where conserving power is
-highly desirable or necessary.
-</rationale>
-<ident cce="RHEL7-CCE-TBD" />
-<oval id="service_cpuspeed_disabled" />
-<ref nist="CM-7" />
-</Rule>
-
-<Rule id="service_haldaemon_disabled">
-<title>Disable Hardware Abstraction Layer Service (haldaemon)</title>
-<description>The Hardware Abstraction Layer Daemon (<tt>haldaemon</tt>) collects
-and maintains information about the system's hardware configuration. 
-This service is required on a workstation
-running a desktop environment, and may be necessary on any system which
-deals with removable media or devices.
-<service-disable-macro service="haldaemon" />
-</description>
-<ocil><service-disable-check-macro service="haldaemon" /></ocil>
-<rationale>The haldaemon provides essential functionality on systems
-that use removable media or devices, but can be disabled for systems
-that do not require these.
-</rationale>
-<ident cce="RHEL7-CCE-TBD" />
-<oval id="service_haldaemon_disabled" />
-<ref nist="CM-7" />
-</Rule>
-
 <Rule id="service_irqbalance_enabled">
 <title>Enable IRQ Balance (irqbalance)</title>
 <description>The <tt>irqbalance</tt> service optimizes the balance between


### PR DESCRIPTION
&nbsp;         \* HALdaemon was removed in Fedora-16:
&nbsp; &nbsp;         [1] https://ask.fedoraproject.org/en/question/8747/hal-daemon-gone-or-not/
&nbsp; &nbsp;         [2] http://fedoraproject.org/wiki/Features/HalRemoval

&nbsp;         \* cpuspeed was also removed in Fedora-16 (replaced with cpupowerutils from kernel-tools):
&nbsp; &nbsp;         [3] https://lists.fedoraproject.org/pipermail/test/2011-November/104448.html
&nbsp; &nbsp;         [4] https://fedoraproject.org/wiki/Fedora_16_Alpha_release_notes#What.27s_New_in_Fedora_16_Alpha
&nbsp; &nbsp;         [5] https://bugzilla.redhat.com/show_bug.cgi?id=713572
&nbsp; &nbsp;         [6] https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1158668

```
     Since these services can't run in RHEL-7, no point in recommending to disable them.
```

Please review.

Thanks, Jan.
