### PR TITLE
[bugfix] [RHEL/7] Drop service_haldaemon_disabled XCCDF rule from RHEL-7 content.

### DIFF
--- a/RHEL/7/input/services/base.xml
+++ b/RHEL/7/input/services/base.xml
@@ -108,25 +108,6 @@ highly desirable or necessary.
 <ref nist="CM-7" />
 </Rule>
 
-<Rule id="service_haldaemon_disabled">
-<title>Disable Hardware Abstraction Layer Service (haldaemon)</title>
-<description>The Hardware Abstraction Layer Daemon (<tt>haldaemon</tt>) collects
-and maintains information about the system's hardware configuration. 
-This service is required on a workstation
-running a desktop environment, and may be necessary on any system which
-deals with removable media or devices.
-<service-disable-macro service="haldaemon" />
-</description>
-<ocil><service-disable-check-macro service="haldaemon" /></ocil>
-<rationale>The haldaemon provides essential functionality on systems
-that use removable media or devices, but can be disabled for systems
-that do not require these.
-</rationale>
-<ident cce="RHEL7-CCE-TBD" />
-<oval id="service_haldaemon_disabled" />
-<ref nist="CM-7" />
-</Rule>
-
 <Rule id="service_irqbalance_enabled">
 <title>Enable IRQ Balance (irqbalance)</title>
 <description>The <tt>irqbalance</tt> service optimizes the balance between


### PR DESCRIPTION
HAL daemon has been removed in Fedora-16:
&nbsp;          [1] https://ask.fedoraproject.org/en/question/8747/hal-daemon-gone-or-not/
&nbsp;           [2] http://fedoraproject.org/wiki/Features/HalRemoval#Release_Notes

and replaced / obsoleted by udisks / upower, as well as libudev for device
discovery (the service doesn't exist anymore in RHEL-7 => no point the recommendation
to disable it to be present there).

The particular `service_haldaemon_disabled.sh` remediation fix has been previously deleted within the commit:
&nbsp;  [3] https://github.com/OpenSCAP/scap-security-guide/commit/92f0963d78d297ac823f770e32334ddf8032de87

which was part of pull request #239 (which got already included as of today).

The `service_haldaemon_disabled.xml` RHEL-7 OVAL check didn't exist / wasn't created yet, therefore it's enough to delete just the XCCDF rule.

Please review.

Thanks, Jan.
