### PR TITLE
[bugfix] [RHEL/7] Update RHEL-7 service_*_enabled.sh remediation fixes to start using # systemctl ... rather than # chkconfig ...

### DIFF
--- a/RHEL/7/input/fixes/bash/service_auditd_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_auditd_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable auditd for all run levels
+# Enable auditd.service for all systemd targets
 #
-chkconfig --level 0123456 auditd on
+systemctl enable auditd.service
 
 #
-# Start auditd if not currently running
+# Start auditd.service if not currently running
 #
-service auditd start
+systemctl start auditd.service

--- a/RHEL/7/input/fixes/bash/service_crond_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_crond_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable crond for all run levels
+# Enable crond.service for all systemd targets
 #
-chkconfig --level 0123456 crond on
+systemctl enable crond.service
 
 #
-# Start crond if not currently running
+# Start crond.service if not currently running
 #
-service crond start
+systemctl start crond.service

--- a/RHEL/7/input/fixes/bash/service_ip6tables_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_ip6tables_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable ip6tables for all run levels
+# Enable ip6tables.service for all systemd targets
 #
-chkconfig --level 0123456 ip6tables on
+systemctl enable ip6tables.service
 
 #
-# Start ip6tables if not currently running
+# Start ip6tables.service if not currently running
 #
-service ip6tables start
+systemctl start ip6tables.service

--- a/RHEL/7/input/fixes/bash/service_iptables_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_iptables_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable iptables for all run levels
+# Enable iptables.service for all systemd targets
 #
-chkconfig --level 0123456 iptables on
+systemctl enable iptables.service
 
 #
-# Start iptables if not currently running
+# Start iptables.service if not currently running
 #
-service iptables start
+systemctl start iptables.service

--- a/RHEL/7/input/fixes/bash/service_irqbalance_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_irqbalance_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable irqbalance for all run levels
+# Enable irqbalance.service for all systemd targets
 #
-chkconfig --level 0123456 irqbalance on
+systemctl enable irqbalance.service
 
 #
-# Start irqbalance if not currently running
+# Start irqbalance.service if not currently running
 #
-service irqbalance start
+systemctl start irqbalance.service

--- a/RHEL/7/input/fixes/bash/service_ntpd_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_ntpd_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable ntpd for all run levels
+# Enable ntpd.service for all systemd targets
 #
-chkconfig --level 0123456 ntpd on
+systemctl enable ntpd.service
 
 #
-# Start ntpd if not currently running
+# Start ntpd.service if not currently running
 #
-service ntpd start
+systemctl start ntpd.service

--- a/RHEL/7/input/fixes/bash/service_postfix_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_postfix_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable postfix for all run levels
+# Enable postfix.service for all systemd targets
 #
-chkconfig --level 0123456 postfix on
+systemctl enable postfix.service
 
 #
-# Start postfix if not currently running
+# Start postfix.service if not currently running
 #
-service postfix start
+systemctl start postfix.service

--- a/RHEL/7/input/fixes/bash/service_psacct_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_psacct_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable psacct for all run levels
+# Enable psacct.service for all systemd targets
 #
-chkconfig --level 0123456 psacct on
+systemctl enable psacct.service
 
 #
-# Start psacct if not currently running
+# Start psacct.service if not currently running
 #
-service psacct start
+systemctl start psacct.service

--- a/RHEL/7/input/fixes/bash/service_restorecond_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_restorecond_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable restorecond for all run levels
+# Enable restorecond.service for all systemd targets
 #
-chkconfig --level 0123456 restorecond on
+systemctl enable restorecond.service
 
 #
-# Start restorecond if not currently running
+# Start restorecond.service if not currently running
 #
-service restorecond start
+systemctl start restorecond.service

--- a/RHEL/7/input/fixes/bash/service_rsyslog_enabled.sh
+++ b/RHEL/7/input/fixes/bash/service_rsyslog_enabled.sh
@@ -1,9 +1,9 @@
 #
-# Enable rsyslog for all run levels
+# Enable rsyslog.service for all systemd targets
 #
-chkconfig --level 0123456 rsyslog on
+systemctl enable rsyslog.service
 
 #
-# Start rsyslog if not currently running
+# Start rsyslog.service if not currently running
 #
-service rsyslog start
+systemctl start rsyslog.service


### PR DESCRIPTION
Similarly like in previous service___disabled.sh remediation fixes case (which got actually merged already), update also the RHEL/7 service___enabled.sh remediation fixes to start using `# systemctl enable / start service_name` commands rather than / instead of their RHEL-6 `# chkconfig --level 0..6 service_name on | chkconfig start service_name` alternative which wouldn't work on RHEL-7.
## Testing status:

All of the changes have been first manually tested on RHEL-7 Server system for their proper work prior inclusion of the particular remediation fix change.

Please review.

Thanks, Jan.
