### PR TITLE
Updated installed_OS regex

### DIFF
--- a/shared/oval/installed_OS_is_rhel6.xml
+++ b/shared/oval/installed_OS_is_rhel6.xml
@@ -37,7 +37,7 @@
     <linux:state state_ref="state_rhel_workstation" />
   </linux:rpminfo_test>
   <linux:rpminfo_state id="state_rhel_workstation" version="1">
-    <linux:version operation="pattern match">^6\.\d+$</linux:version>
+    <linux:version operation="pattern match">^6.*$</linux:version>
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_rhel_workstation" version="1">
     <linux:name>redhat-release-workstation</linux:name>
@@ -48,7 +48,7 @@
     <linux:state state_ref="state_rhel_server" />
   </linux:rpminfo_test>
   <linux:rpminfo_state id="state_rhel_server" version="1">
-    <linux:version operation="pattern match">^6\.\d+$</linux:version>
+    <linux:version operation="pattern match">^6.*$</linux:version>
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_rhel_server" version="1">
     <linux:name>redhat-release-server</linux:name>

--- a/shared/oval/installed_OS_is_rhel7.xml
+++ b/shared/oval/installed_OS_is_rhel7.xml
@@ -37,7 +37,7 @@
     <linux:state state_ref="state_rhel_workstation" />
   </linux:rpminfo_test>
   <linux:rpminfo_state id="state_rhel_workstation" version="1">
-    <linux:version operation="pattern match">^7\.\d+$</linux:version>
+    <linux:version operation="pattern match">^7.*$</linux:version>
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_rhel_workstation" version="1">
     <linux:name>redhat-release-workstation</linux:name>
@@ -48,7 +48,7 @@
     <linux:state state_ref="state_rhel_server" />
   </linux:rpminfo_test>
   <linux:rpminfo_state id="state_rhel_server" version="1">
-    <linux:version operation="pattern match">^7\.\d+$</linux:version>
+    <linux:version operation="pattern match">^7.*$</linux:version>
   </linux:rpminfo_state>
   <linux:rpminfo_object id="obj_rhel_server" version="1">
     <linux:name>redhat-release-server</linux:name>


### PR DESCRIPTION
Slashes in old regex were escaping the ".", making it literally interpreted.

testing on rhel7

```
[shawnw@ssgdev-rhel7 oval]$ rpm -qv redhat-release-server
redhat-release-server-7.0-1.el7.x86_64

[shawnw@ssgdev-rhel7 oval]$ ./testcheck.py installed_OS_is_rhel6.xml 
Evaluating with OVAL tempfile : /tmp/installed_OS_is_rhel6t_Hp87.xml
Writing results to : /tmp/installed_OS_is_rhel6t_Hp87.xml-results
Definition oval:scap-security-guide.testing:def:100: false
Evaluation done.

[shawnw@ssgdev-rhel7 oval]$ ./testcheck.py installed_OS_is_rhel7.xml 
Evaluating with OVAL tempfile : /tmp/installed_OS_is_rhel7Dclx9j.xml
Writing results to : /tmp/installed_OS_is_rhel7Dclx9j.xml-results
Definition oval:scap-security-guide.testing:def:110: true
Evaluation done.
```
