### PR TITLE
xccdf bugfix and bash scripts for file_ownership_binary_dirs

### DIFF
--- a/RHEL/6/input/fixes/bash/file_ownership_binary_dirs.sh
+++ b/RHEL/6/input/fixes/bash/file_ownership_binary_dirs.sh
@@ -1,0 +1,1 @@
+../../../../../shared/fixes/bash/file_ownership_binary_dirs.sh

--- a/RHEL/6/input/system/permissions/files.xml
+++ b/RHEL/6/input/system/permissions/files.xml
@@ -322,7 +322,7 @@ System executables are stored in the following directories by default:
 /usr/local/sbin</pre>
 To find system executables that are not owned by <tt>root</tt>,
 run the following command for each directory <i>DIR</i> which contains system executables:
-<pre>$ sudo find <i>DIR</i> \! -user root</pre>
+<pre>$ sudo find <i>DIR/</i> \! -user root</pre>
 </ocil>
 <rationale>System binaries are executed by privileged users as well as system services,
 and restrictive permissions are necessary to ensure that their

--- a/RHEL/7/input/fixes/bash/file_ownership_binary_dirs.sh
+++ b/RHEL/7/input/fixes/bash/file_ownership_binary_dirs.sh
@@ -1,0 +1,1 @@
+../../../../../shared/fixes/bash/file_ownership_binary_dirs.sh

--- a/RHEL/7/input/system/permissions/files.xml
+++ b/RHEL/7/input/system/permissions/files.xml
@@ -322,7 +322,7 @@ System executables are stored in the following directories by default:
 /usr/local/sbin</pre>
 To find system executables that are not owned by <tt>root</tt>,
 run the following command for each directory <i>DIR</i> which contains system executables:
-<pre>$ sudo find <i>DIR</i> \! -user root</pre>
+<pre>$ sudo find <i>DIR/</i> \! -user root</pre>
 </ocil>
 <rationale>System binaries are executed by privileged users as well as system services,
 and restrictive permissions are necessary to ensure that their

--- a/shared/fixes/bash/file_ownership_binary_dirs.sh
+++ b/shared/fixes/bash/file_ownership_binary_dirs.sh
@@ -1,0 +1,7 @@
+find /bin/ \
+/usr/bin/ \
+/usr/local/bin/ \
+/sbin/ \
+/usr/sbin/ \
+/usr/local/sbin/ \
+\! -user root -execdir chown root {} \;


### PR DESCRIPTION
- find command in XCCDF prose was inaccurate, needed a / on the DIR in the find command
- added bash remediation script
