### PR TITLE
[Enhancement] multi-platform variable for OVAL checks

### DIFF
--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -7,6 +7,7 @@ DIST = dist
 ID = ssg
 PROD = fedora
 
+OS := Fedora $(shell grep -oP '[0-9]*' /etc/redhat-release)
 OPENSCAP_SVG := $(shell $(TRANS)/oscapsupportssvg.py; echo $$?)
 
 all: shorthand2xccdf guide content dist
@@ -49,6 +50,8 @@ content: shorthand2xccdf guide checks
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-$(PROD)-xccdf-nodangles.xml > $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml
+	sed -i 's/multiplatform_oval/$(OS)/g' $(OUT)/unlinked-$(PROD)-oval.xml
+	sed -i 's/multiplatform_oval/$(OS)/g' $(OUT)/$(ID)-$(PROD)-oval.xml
 	oscap ds sds-compose $(OUT)/$(ID)-$(PROD)-xccdf-1.2.xml $(OUT)/$(ID)-$(PROD)-ds.xml
 #       Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-$(PROD)-cpe-dictionary.xml $(OUT)/$(ID)-$(PROD)-ds.xml

--- a/Fedora/transforms/.gitignore
+++ b/Fedora/transforms/.gitignore
@@ -1,0 +1,4 @@
+# files not to track in git
+*.pyc
+*.ini
+*.swp

--- a/RHEL/6/Makefile
+++ b/RHEL/6/Makefile
@@ -7,7 +7,9 @@ UTILS = utils
 DIST = dist
 
 ID = ssg
+PROD = rhel6
 
+OS := Red Hat Enterprise Linux $(shell grep -oP '[0-9]*(?=\.)' /etc/redhat-release)
 OPENSCAP_SVG := $(shell $(TRANS)/oscapsupportssvg.py; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
@@ -72,7 +74,6 @@ table-stigs: shorthand2xccdf table-srgmap checks
 	xsltproc -o $(OUT)/table-rhel5-stig.html $(TRANS)/xccdf2table-stig.xslt $(REFS)/disa-stig-rhel5-v1r0.6-xccdf.xml  
 	xsltproc -o $(OUT)/table-rhel5-stig-manual.html $(TRANS)/xccdf2table-stig.xslt $(REFS)/disa-stig-rhel5-v1r0.6-xccdf-manual.xml  
 #	xsltproc -stringparam notes "../$(IN)/auxiliary/transition_notes.xml" -o $(OUT)/table-rhel5-stig-manual-withnotes.html \
-	# asdasd
 #		$(TRANS)/xccdf2table-stig.xslt \
 #		$(REFS)/disa-stig-rhel5-v1r0.6-xccdf-manual.xml
 #	temporarily retain an output file showing the short titles as well
@@ -100,6 +101,8 @@ content: shorthand2xccdf guide checks
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-rhel6-xccdf-nodangles.xml > $(OUT)/$(ID)-rhel6-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-rhel6-xccdf-1.2.xml
+	sed -i 's/multiplatform_oval/$(OS)/g' $(OUT)/unlinked-$(PROD)-oval.xml
+	sed -i 's/multiplatform_oval/$(OS)/g' $(OUT)/$(ID)-$(PROD)-oval.xml
 	oscap ds sds-compose $(OUT)/$(ID)-rhel6-xccdf-1.2.xml $(OUT)/$(ID)-rhel6-ds.xml
 #	Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-rhel6-cpe-dictionary.xml $(OUT)/$(ID)-rhel6-ds.xml

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -7,7 +7,9 @@ UTILS = utils
 DIST = dist
 
 ID = ssg
+PROD = rhel7
 
+OS := Red Hat Enterprise Linux $(shell grep -oP '[0-9]*(?=\.)' /etc/redhat-release)
 OPENSCAP_SVG := $(shell $(TRANS)/oscapsupportssvg.py; echo $$?)
 
 all: shorthand2xccdf tables guide content dist
@@ -100,6 +102,8 @@ content: shorthand2xccdf guide checks
 	xsltproc --stringparam reverse_DNS org.ssgproject.content /usr/share/openscap/xsl/xccdf_1.1_to_1.2.xsl \
 		$(OUT)/$(ID)-rhel7-xccdf-nodangles.xml > $(OUT)/$(ID)-rhel7-xccdf-1.2.xml
 	sed -i '/idref="dangling reference to /d' $(OUT)/$(ID)-rhel7-xccdf-1.2.xml
+	sed -i 's/multiplatform_oval/$(OS)/g' $(OUT)/unlinked-$(PROD)-oval.xml
+	sed -i 's/multiplatform_oval/$(OS)/g' $(OUT)/$(ID)-$(PROD)-oval.xml
 	oscap ds sds-compose $(OUT)/$(ID)-rhel7-xccdf-1.2.xml $(OUT)/$(ID)-rhel7-ds.xml
 #       Add in CPE and OVAL content to datastream
 	oscap ds sds-add $(OUT)/$(ID)-rhel7-cpe-dictionary.xml $(OUT)/$(ID)-rhel7-ds.xml

--- a/shared/oval/no_empty_passwords.xml
+++ b/shared/oval/no_empty_passwords.xml
@@ -3,8 +3,7 @@
     <metadata>
       <title>No nullok Option in /etc/pam.d/system-auth</title>
       <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multiplatform_oval</platform>
       </affected>
       <description>The file /etc/pam.d/system-auth should not contain the nullok option</description>
       <reference source="swells" ref_id="20130918" ref_url="test_attestation" />


### PR DESCRIPTION
- Update Fedora, RHEL6, and RHEL7 Makefiles to change multi-platform variable in oval checks
