### PR TITLE
[RHEL/6, RHEL/7] Fix Limit Password Reuse remediation script

### DIFF
--- a/RHEL/7/input/profiles/rht-ccp.xml
+++ b/RHEL/7/input/profiles/rht-ccp.xml
@@ -18,7 +18,7 @@
 <refine-value idref="var_password_pam_ocredit" selector="2"/>
 <refine-value idref="var_password_pam_lcredit" selector="2"/>
 <refine-value idref="var_password_pam_difok" selector="3"/>
-<refine-value idref="var_password_history_retain_limit" selector="5"/>
+<refine-value idref="var_password_pam_unix_remember" selector="5"/>
 <refine-value idref="var_accounts_user_umask" selector="077"/>
 <refine-value idref="login_banner_text" selector="usgcb_default"/>
 

--- a/shared/fixes/bash/accounts_password_pam_unix_remember.sh
+++ b/shared/fixes/bash/accounts_password_pam_unix_remember.sh
@@ -4,5 +4,5 @@ populate var_password_pam_unix_remember
 if grep -q "remember=" /etc/pam.d/system-auth; then   
 	sed -i --follow-symlink "s/\(remember *= *\).*/\1$var_password_pam_unix_remember/" /etc/pam.d/system-auth
 else
-	sed -i --follow-symlink "/^password[\s]sufficient[\s]pam_unix.so/ s/$/ remember=$var_password_pam_unix_remember/" /etc/pam.d/system-auth
+	sed -i --follow-symlink "/^password[[:space:]]\+sufficient[[:space:]]\+pam_unix.so/ s/$/ remember=$var_password_pam_unix_remember/" /etc/pam.d/system-auth
 fi


### PR DESCRIPTION
It's broken currently, since /etc/pam.d/system-auth contains more than just one space in corresponding pam_unix.so row, e.g. has the form of:

```
password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
```

So current form replacing just one space between can't fix this. Besides that, it isn't using BRE syntax, which is required for sed (e.g. [\s] is invalid expression since:

```
$ echo "foo bar" | grep '[\s]' | wc -l
0
```

versus

```
$ echo "foo bar" | grep '\s' | wc -l
1
```

)

Yet since `+` character loses it's special meaning in BRE, we need to escape it with `\+` it to have the special meaning:
  https://www.gnu.org/software/sed/manual/html_node/Regular-Expressions.html#Regular-Expressions
## Testing report:

Tested on both of RHEL-6 & RHEL-7 and works fine (state before patch returns 'error' result, state after patch returns 'fixed' result & the remediation is applied into /etc/pam.d/system-auth{,-ac} as expected).

Please review.

Thanks, Jan.
