### PR TITLE
[bugfix] [RHEL/7, Fedora] Specify particular profile names rules of which should be displayed in the generated HTML guide

### DIFF
--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -35,10 +35,12 @@ checks:
 
 guide: shorthand2xccdf
 #       remove auxiliary Groups which are only for use in tables, and not guide output.
-#       specifying a nonexistent profile, "allrules," to make oscap print all Rules
 	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	oscap xccdf generate guide --profile allrules $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(ID)-$(PROD)-guide.html
+#       openscap-1.1.1 https://www.redhat.com/archives/open-scap-list/2014-September/msg00032.html expects
+#       exact profile name to be specified when generating guide (otherwise generated guide won't contain information
+#       about rules, just groups). Thus use 'common' as expected profile name for Fedora to see also rules
+	oscap xccdf generate guide --profile common $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(ID)-$(PROD)-guide.html
 
 content: shorthand2xccdf guide checks
 	$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -44,10 +44,12 @@ checks:
 
 guide: shorthand2xccdf
 #	remove auxiliary Groups which are only for use in tables, and not guide output.
-#	specifying a nonexistent profile, "allrules," to make oscap print all Rules
 	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile allrules $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-guide.html
+#       openscap-1.1.1 https://www.redhat.com/archives/open-scap-list/2014-September/msg00032.html expects
+#       exact profile name to be specified when generating guide (otherwise generated guide won't contain information
+#       about rules, just groups). Thus use 'rht-cpp' as expected profile name for RHEL-7 to see also rules
+	oscap xccdf generate guide --profile rht-ccp $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-guide.html
 	xsltproc -o $(OUT)/$(PROD)-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
 
 # example, if needed: for converting XCCDF into shorthand


### PR DESCRIPTION
OpenSCAP v1.1.1 with its new way of HTML report & HTML guide changed previous way how HTML guide is generated. Previously when specifying non-existing profile, it would list all rules (rules from all profiles) in the final guide. Now it's necessary:
  [1] https://www.redhat.com/archives/open-scap-list/2014-September/msg00032.html

to specify concrete profile name, rules of which should be displayed in the HTML guide (otherwise generated guide will contain just group sections, without rules).

Therefore use 'rht-ccp' as profile name for RHEL-7 & 'common' for Fedora products.
RHEL-6 Makefile doesn't require a change, since it's still using openscap-v1.0.8 (thus the old way for generation of HTML report & guide => nothing changed here).

Tested on both of RHEL-7 & Fedora & works fine for me [*].

Please review.

Thanks, Jan.

[*] &nbsp; A careful reader might notice in the newly generated guide that there are improperly rendered sections like: &nbsp; &nbsp; `$ sudo systemctl enable / disable ...`.
&nbsp; &nbsp; This will need fixing yet (planning to look tomorrow at that issue).
