### PR TITLE
[bugfix] [RHEL/7, Fedora] Specify exact profile names when generating guides -- version #2

### DIFF
--- a/Fedora/Makefile
+++ b/Fedora/Makefile
@@ -35,10 +35,11 @@ checks:
 
 guide: shorthand2xccdf
 #       remove auxiliary Groups which are only for use in tables, and not guide output.
-#       specifying a nonexistent profile, "allrules," to make oscap print all Rules
 	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
-	oscap xccdf generate guide --profile allrules $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(ID)-$(PROD)-guide.html
+#       OpenSCAP-1.1.1 expects exact profile name in order to include also rules into guide
+#       Create guide for common profile
+	oscap xccdf generate guide --profile common $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(ID)-$(PROD)-common-guide.html
 
 content: shorthand2xccdf guide checks
 	$(TRANS)/cpe_generate.py $(OUT)/unlinked-$(PROD)-oval.xml $(IN)/checks/platform/$(PROD)-cpe-dictionary.xml $(ID)

--- a/RHEL/7/Makefile
+++ b/RHEL/7/Makefile
@@ -44,11 +44,12 @@ checks:
 
 guide: shorthand2xccdf
 #	remove auxiliary Groups which are only for use in tables, and not guide output.
-#	specifying a nonexistent profile, "allrules," to make oscap print all Rules
 	xsltproc -o $(OUT)/unlinked-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removeaux.xslt $(OUT)/unlinked-$(PROD)-xccdf.xml
 	xsltproc -o $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml $(TRANS)/xccdf-removetested.xslt $(OUT)/unlinked-$(PROD)-xccdf-guide.xml
-	oscap xccdf generate guide --profile allrules $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-guide.html
-	xsltproc -o $(OUT)/$(PROD)-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
+#       OpenSCAP-1.1.1 expects exact profile name in order to include also rules into guide
+#       Create guide for RHT-CCP profile
+	oscap xccdf generate guide --profile rht-ccp $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml > $(OUT)/$(PROD)-ccp-guide.html
+	xsltproc -o $(OUT)/$(PROD)-ccp-guide-custom.html $(TRANS)/xccdf2html.xslt $(OUT)/unlinked-notest-$(PROD)-xccdf-guide.xml
 
 # example, if needed: for converting XCCDF into shorthand
 #xccdf2shorthand:


### PR DESCRIPTION
Specify exact profile names when generating HTML guide(s) for RHEL-7 & Fedora products.
