### PR TITLE
[bugfix] [RHEL/6] Fix OOM killer termination of oscap probe_file process due to excessive memory use when evaluating file_permissions_ungroupowned rule

### DIFF
--- a/RHEL/6/input/checks/file_permissions_ungroupowned.xml
+++ b/RHEL/6/input/checks/file_permissions_ungroupowned.xml
@@ -28,7 +28,11 @@
   </unix:file_state>
 
   <unix:file_object comment="all local files" id="object_file_permissions_ungroupowned" version="1">
-    <unix:behaviors recurse="symlinks and directories" recurse_direction="down" recurse_file_system="local" />
+    <!-- We can't traverse symlinks here since e.g. /sys file system might contain symlink loops
+         resulting into excessive memory use by the scanner process & possible subsequent OOM killer
+         termination of it. See e.g.: https://www.redhat.com/archives/open-scap-list/2014-May/msg00005.html
+         Therefore traverse only directories -->
+    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
     <unix:path>/</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
   </unix:file_object>


### PR DESCRIPTION
Today I got hit by the following issue:
  [1] https://www.redhat.com/archives/open-scap-list/2014-May/msg00005.html

When oscap process (probe_file child of it) was trying to evaluate file_permissions_ungroupowned RHEL-6 rule it got killed by OOM killer & ended up with the following error message:

```
# oscap oval eval --id oval:ssg:def:334 ssg-rhel6-oval.xml
Definition oval:ssg:def:334: not evaluated
OpenSCAP Error: Unable to close probe sd [oval_probe_ext.c:565]
No definition with ID: oval:ssg:def:334 in result model. [oval_agent.c:184]
```

The very same issue has been corrected for `no_files_unowned_by_user` OVAL check via patch:
  [2] https://github.com/OpenSCAP/scap-security-guide/commit/2eeeca75499f69adeb74f63e9f667c2460ae2435

But looks case [1] / case of `file_permissions_ungroupowned` RHEL-6 OVAL rule wasn't fixed yet.
Thus correct it.

Please review.

Thanks, Jan.
