### PR TITLE
[bugfix] [RHEL/6] Use full path to sysctl executable for sysctl remediation scripts to prevent errors on RHEL-6 Server when attempting remediation

### DIFF
--- a/RHEL/6/input/fixes/bash/sysctl_fs_suid_dumpable.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_fs_suid_dumpable.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for fs.suid_dumpable
 #
-sysctl -q -n -w fs.suid_dumpable=0
+/sbin/sysctl -q -n -w fs.suid_dumpable=0
 
 #
 # If fs.suid_dumpable present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_kernel_dmesg_restrict.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_kernel_dmesg_restrict.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for kernel.dmesg_restrict
 #
-sysctl -q -n -w kernel.dmesg_restrict=1
+/sbin/sysctl -q -n -w kernel.dmesg_restrict=1
 
 #
 # If kernel.dmesg_restrict present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_kernel_exec_shield.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_kernel_exec_shield.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for kernel.exec-shield
 #
-sysctl -q -n -w kernel.exec-shield=1
+/sbin/sysctl -q -n -w kernel.exec-shield=1
 
 #
 # If kernel.exec-shield present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_kernel_randomize_va_space.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_kernel_randomize_va_space.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for kernel.randomize_va_space
 #
-sysctl -q -n -w kernel.randomize_va_space=2
+/sbin/sysctl -q -n -w kernel.randomize_va_space=2
 
 #
 # If kernel.randomize_va_space present in /etc/sysctl.conf, change value to "2"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_redirects.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.all.accept_redirects
 #
-sysctl -q -n -w net.ipv4.conf.all.accept_redirects=0
+/sbin/sysctl -q -n -w net.ipv4.conf.all.accept_redirects=0
 
 #
 # If net.ipv4.conf.all.accept_redirects present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_source_route.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_accept_source_route.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.all.accept_source_route
 #
-sysctl -q -n -w net.ipv4.conf.all.accept_source_route=0
+/sbin/sysctl -q -n -w net.ipv4.conf.all.accept_source_route=0
 
 #
 # If net.ipv4.conf.all.accept_source_route present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_log_martians.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_log_martians.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.all.log_martians
 #
-sysctl -q -n -w net.ipv4.conf.all.log_martians=1
+/sbin/sysctl -q -n -w net.ipv4.conf.all.log_martians=1
 
 #
 # If net.ipv4.conf.all.log_martians present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_rp_filter.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_rp_filter.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.all.rp_filter
 #
-sysctl -q -n -w net.ipv4.conf.all.rp_filter=1
+/sbin/sysctl -q -n -w net.ipv4.conf.all.rp_filter=1
 
 #
 # If net.ipv4.conf.all.rp_filter present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_secure_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_secure_redirects.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.all.secure_redirects
 #
-sysctl -q -n -w net.ipv4.conf.all.secure_redirects=0
+/sbin/sysctl -q -n -w net.ipv4.conf.all.secure_redirects=0
 
 #
 # If net.ipv4.conf.all.secure_redirects present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_send_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_all_send_redirects.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.all.send_redirects
 #
-sysctl -q -n -w net.ipv4.conf.all.send_redirects=0
+/sbin/sysctl -q -n -w net.ipv4.conf.all.send_redirects=0
 
 #
 # If net.ipv4.conf.all.send_redirects present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_redirects.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.default.accept_redirects
 #
-sysctl -q -n -w net.ipv4.conf.default.accept_redirects=0
+/sbin/sysctl -q -n -w net.ipv4.conf.default.accept_redirects=0
 
 #
 # If net.ipv4.conf.default.accept_redirects present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_source_route.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_accept_source_route.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.default.accept_source_route
 #
-sysctl -q -n -w net.ipv4.conf.default.accept_source_route=0
+/sbin/sysctl -q -n -w net.ipv4.conf.default.accept_source_route=0
 
 #
 # If net.ipv4.conf.default.accept_source_route present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_rp_filter.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_rp_filter.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.default.rp_filter
 #
-sysctl -q -n -w net.ipv4.conf.default.rp_filter=1
+/sbin/sysctl -q -n -w net.ipv4.conf.default.rp_filter=1
 
 #
 # If net.ipv4.conf.default.rp_filter present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_secure_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_secure_redirects.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.default.secure_redirects
 #
-sysctl -q -n -w net.ipv4.conf.default.secure_redirects=0
+/sbin/sysctl -q -n -w net.ipv4.conf.default.secure_redirects=0
 
 #
 # If net.ipv4.conf.default.secure_redirects present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_send_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_send_redirects.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.conf.default.send_redirects
 #
-sysctl -q -n -w net.ipv4.conf.default.send_redirects=0
+/sbin/sysctl -q -n -w net.ipv4.conf.default.send_redirects=0
 
 #
 # If net.ipv4.conf.default.send_redirects present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_echo_ignore_broadcasts.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_echo_ignore_broadcasts.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.icmp_echo_ignore_broadcasts
 #
-sysctl -q -n -w net.ipv4.icmp_echo_ignore_broadcasts=1
+/sbin/sysctl -q -n -w net.ipv4.icmp_echo_ignore_broadcasts=1
 
 #
 # If net.ipv4.icmp_echo_ignore_broadcasts present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_ignore_bogus_error_responses.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_icmp_ignore_bogus_error_responses.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.icmp_ignore_bogus_error_responses
 #
-sysctl -q -n -w net.ipv4.icmp_ignore_bogus_error_responses=1
+/sbin/sysctl -q -n -w net.ipv4.icmp_ignore_bogus_error_responses=1
 
 #
 # If net.ipv4.icmp_ignore_bogus_error_responses present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_ip_forward.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_ip_forward.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.ip_forward
 #
-sysctl -q -n -w net.ipv4.ip_forward=0
+/sbin/sysctl -q -n -w net.ipv4.ip_forward=0
 
 #
 # If net.ipv4.ip_forward present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv4_tcp_syncookies.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv4_tcp_syncookies.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv4.tcp_syncookies
 #
-sysctl -q -n -w net.ipv4.tcp_syncookies=1
+/sbin/sysctl -q -n -w net.ipv4.tcp_syncookies=1
 
 #
 # If net.ipv4.tcp_syncookies present in /etc/sysctl.conf, change value to "1"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_ra.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv6.conf.default.accept_ra
 #
-sysctl -q -n -w net.ipv6.conf.default.accept_ra=0
+/sbin/sysctl -q -n -w net.ipv6.conf.default.accept_ra=0
 
 #
 # If net.ipv6.conf.default.accept_ra present in /etc/sysctl.conf, change value to "0"

--- a/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
+++ b/RHEL/6/input/fixes/bash/sysctl_net_ipv6_conf_default_accept_redirects.sh
@@ -1,7 +1,7 @@
 #
 # Set runtime for net.ipv6.conf.default.accept_redirects
 #
-sysctl -q -n -w net.ipv6.conf.default.accept_redirects=0
+/sbin/sysctl -q -n -w net.ipv6.conf.default.accept_redirects=0
 
 #
 # If net.ipv6.conf.default.accept_redirects present in /etc/sysctl.conf, change value to "0"


### PR DESCRIPTION
Today, when trying to perform remediation for the following sysctl rule `Disable Kernel Parameter for Sending ICMP Redirects by Default` on RHEL-6.5 Server [Red Hat Enterprise Linux Server release 6.5 (Santiago)] noticed the following behaviour:

```
# oscap xccdf eval --remediate --profile usgcb-rhel6-server_tailored --tailoring-file /root/usgcb_tailored.xml --oval-results --report /tmp/out ssg-rhel6-xccdf.xml 
Title   Disable Kernel Parameter for Sending ICMP Redirects by Default
Rule    sysctl_net_ipv4_conf_default_send_redirects
Ident   CCE-27001-7
Result  fail

 --- Starting Remediation ---
Title   Disable Kernel Parameter for Sending ICMP Redirects by Default
Rule    sysctl_net_ipv4_conf_default_send_redirects
Ident   CCE-27001-7
Result  error
```

Having openscap patched to be more verbose while trying the particular remediation (to see what's the reason for that error) retrieved the following:

```
# oscap xccdf eval --remediate --profile usgcb-rhel6-server_tailored --tailoring-file /root/usgcb_tailored.xml --oval-results --report /tmp/out ssg-rhel6-xccdf.xml 
Title   Disable Kernel Parameter for Sending ICMP Redirects by Default
Rule    sysctl_net_ipv4_conf_default_send_redirects
Ident   CCE-27001-7
Result  fail

 --- Starting Remediation ---
stdout_buf contains = /tmp/oscap.U86b04/fix-XXNuA7w2: line 4: sysctl: command not found

Title   Disable Kernel Parameter for Sending ICMP Redirects by Default
Rule    sysctl_net_ipv4_conf_default_send_redirects
Ident   CCE-27001-7
Result  error
```

As can be seen above oscap wasn't able to find the `sysctl` executable required by the remediation script:
  [1] https://github.com/OpenSCAP/scap-security-guide/blob/master/RHEL/6/input/fixes/bash/sysctl_net_ipv4_conf_default_send_redirects.sh#L4

so the runtime part of the remediation script wasn't executed => oscap after performing remediation & when checking again if the feature was corrected realized it wasn't corrected => returned error.

Strange thing is this happens only for some sysctl rules.

Therefore to prevent this behaviour from happening in the future modify RHEL-6 sysctl\* remediation fixes to start using full path (prefix) to the `sysctl` executable, so it's ensured the child oscap remediate process always finds it (& performs also the runtime part of the remediation fix).

Note: If some of the sysctl_\* remediation fixes is intended to be applied also for RHEL-7 product in the future, this should work there too, since there /sbin is just symlink to /usr/sbin (but the `sysctl` executable is at the same path).

Patch has been tested on RHEL-6 & works fine (remediation error doesn't occur anymore).

Please review.

Thank you, Jan.
