### PR TITLE
[bugfix] [shared] Fix remediation script for 'Set Deny For Failed Password Attempts wrt to issue #304

### DIFF
--- a/shared/fixes/bash/accounts_passwords_pam_faillock_deny.sh
+++ b/shared/fixes/bash/accounts_passwords_pam_faillock_deny.sh
@@ -29,8 +29,8 @@ do
 	else
 
 		# insert pam_faillock.so preauth & authfail rows with proper value of the 'deny' option
-		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/i auth required pam_faillock.so preauth silent deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
-		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/a auth [default=die] pam_faillock.so authfail deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
-		sed -i --follow-symlink "/^account.*required.*pam_unix.so/i account required pam_faillock.so" $pamFile
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
+		sed -i --follow-symlink "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail deny=$var_accounts_passwords_pam_faillock_deny" $pamFile
+		sed -i --follow-symlink "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" $pamFile
 	fi
 done


### PR DESCRIPTION
Multiple issues with current implementation of this script:
- operating on one file name containing space, rather than on two separate files,
- hardcoded path in second case,
- wrong use of `[default=die]` option for `authsucc` option,
- inability to fix the state when pam_faillock.so wasn't present in the files yet,
- authsucc should be replaced with preauth + authfail combination.

See more details in:
  https://github.com/OpenSCAP/scap-security-guide/issues/304
and
  https://github.com/OpenSCAP/scap-security-guide/issues/302
