### PR TITLE
[Enhancement] [RHEL/6] Add initial USGCB profile kickstart suppport for Red Hat Enterprise Linux 6 Workstation

### DIFF
--- a/RHEL/6/kickstart/usgcb-workstation-ks.cfg
+++ b/RHEL/6/kickstart/usgcb-workstation-ks.cfg
@@ -1,0 +1,169 @@
+# SCAP Security Guide USGCB profile kickstart for Red Hat Enterprise Linux 6 Workstation
+# Version: 0.0.1
+# Date: 2014-10-19
+#
+# Based on:
+# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Install a fresh new system (optional)
+install
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+url --url=http://192.168.122.1/image
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: workstation
+# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$rhel6usgcb$iOfd.1XF22M1PsUbTdeIXaNmIc9MA7pMsSry6B10JyUrurfYctRCar/sSaIgUg75WXrGQksf/XM3tdOEKb6Lt/
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# encrypted password form for different plaintext password
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=ext4 --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=ext4 --name=LogVol06 --vgname=VolGroup --size=12288 --grow
+# CCE-26557-9: Ensure /home Located On Separate Partition
+logvol /home --fstype=ext4 --name=LogVol02 --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# CCE-26435-8: Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=ext4 --name=LogVol01 --vgname=VolGroup --size=1024 --fsoptions="nodev,noexec,nosuid"
+# CCE-26639-5: Ensure /var Located On Separate Partition
+logvol /var --fstype=ext4 --name=LogVol03 --vgname=VolGroup --size=2048 --fsoptions="nodev"
+# CCE-26215-4: Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=ext4 --name=LogVol04 --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=ext4 --name=LogVol05 --vgname=VolGroup --size=512 --fsoptions="nodev"
+logvol swap --name=lv_swap --vgname=VolGroup --size=2016
+
+# Packages selection (%packages section is required)
+# Packages from the following package groups are installed by default
+%packages
+@base
+@client-mgmt-tools
+@core
+@debugging
+@basic-desktop
+@desktop-debugging
+@desktop-platform
+@directory-client
+@fonts
+@general-desktop
+@graphical-admin-tools
+@input-methods
+@internet-applications
+@internet-browser
+@java-platform
+@legacy-x
+@network-file-system-client
+@office-suite
+@print-client
+@remote-desktop-clients
+@server-platform
+@workstation-policy
+@x11
+
+# Install selected additional packages (required by USGCB profile)
+# CCE-27024-9: Install AIDE
+aide
+
+# Uninstall selected packages (packages that depend on some package that USGCB profile
+# requires to be removed)
+# gnome-user-share depends on httpd, which is required to be uninstalled
+-gnome-user-share
+# hpijs depends on net-snmp, which is required to be uninstalled
+-hpijs
+
+# Install openscap-utils & scap-security-guide packages yet so it's possible to perform
+# remediation once the installation is complete
+openscap-utils
+scap-security-guide
+
+%end # End of %packages section
+
+%post --interpreter /bin/bash --log /root/oscap.log
+
+# Perform post installation system remediation according to the USGCB profile via the oscap tool
+# To create a system compliant against different RHEL-6 SCAP Security Guide profile specify selected
+# profile name after the --profile oscap tool option
+
+oscap xccdf eval --remediate --profile usgcb-rhel6-server --report /root/oscap_usgcb_remediation_report.html \
+/usr/share/xml/scap/ssg/content/ssg-rhel6-xccdf.xml
+
+%end # End of %post section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject


### PR DESCRIPTION
One of the steps for the corresponding SCAP content to become official is the requirement to provide kickstart support (ability when particular kickstart is applied the system once installed would comply with particular security profile). See issue: https://github.com/OpenSCAP/scap-security-guide/issues/306 for further details.

We will start with adding initial kickstart support for USGCB profile for Red Hat Enterprise Linux 6 Workstation product.

The attached kickstart doesn't install a fully-compliant USGCB profile Red Hat Enterprise Linux 6 Workstation instance yet (~74% of the rules pass past installation). But this is caused:
- either by the particular remediation script to modify runtime state,
- or the remediation script in question to fail / return with error (these will require further investigation within separated ticket, since those rules would need separate fixes).

Kickstart output:
Creates "~74%" compliant USGCB profile Red Hat Enterprise Linux 6 Workstation instance. Bootloader password is 'password' & root / privileged system user password is 'workstation'.

Testing:
Has been tested via virt-manager & works fine.

Own testing notes:
The kickstart assumes there's Red Hat Enterprise Linux 6 Workstation Update 6 ISO image mounted at / under:
&nbsp; &nbsp;  http://192.168.122.1/image
location.

Once this is done, the system can be installed e.g. via virt-manager by specifying particular system path to the kickstart file, e.g selecting `Network Install (HTTP, FTP, or NFS)` option for virt-manager, and using
`URL` of the value of http://192.168.122.1/image & `Kickstart URL` (in the URL Options menu) path to kickstart file e.g. http://192.168.122.1/usgcb-workstation-ks.cfg (under assumption that kickstart is placed in system's /var/www/html directory [Be sure you have firewall httpd exception enabled if using this]).

Please review.

Thanks, Jan.
