### PR TITLE
[enhancement] [RHEL/6] Add initial USGCB kickstart for Red Hat Enteprise Linux 6 Server variant

### DIFF
--- a/RHEL/6/kickstart/usgcb-server-with-gui-ks.cfg
+++ b/RHEL/6/kickstart/usgcb-server-with-gui-ks.cfg
@@ -164,12 +164,11 @@ SSG_GIT_URI="https://github.com/OpenSCAP/scap-security-guide.git"
 
 # Retrieve the most recent SCAP Security Guide repository content & build
 # the RHEL-6 benchmark.
-#
-# NOTE: For now (2014-10-23) it is necessary to retrieve upstream Git repository content
-#       to be able to apply remediation scripts for all rules required by the
-#       usgcb-rhel6-server profile content. As the current upstream content gets propagated
-#       into native scap-security-guide package shipped within Red Hat Enterprise Linux 6 this
-#       git checkout will be replaced with the use of native scap-security-guide RPM package.
+
+# NOTE: Pointing to upstream SCAP Security Guide repository. Downstream/stable editions
+#       (e.g. those to ship natively with Red Hat Enterprise Linux 6) will be updated to
+#       point to natively included scap-security-guide RPM package.
+
 git clone $SSG_GIT_URI $SSG_GIT_CONTENT
 cd $SSG_GIT_RHEL6
 make


### PR DESCRIPTION
Add initial USGCB kickstart support for RHEL-6 Server variant.

Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/306
