### PR TITLE
[RHEL/6] Use full path for 'chkconfig' & 'service' commands in RHEL-6 service related remediation scripts

### DIFF
--- a/RHEL/6/input/fixes/bash/service_abrtd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_abrtd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable abrtd for all run levels
 #
-chkconfig --level 0123456 abrtd off
+/sbin/chkconfig --level 0123456 abrtd off
 
 #
 # Stop abrtd if currently running
 #
-service abrtd stop
+/sbin/service abrtd stop

--- a/RHEL/6/input/fixes/bash/service_acpid_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_acpid_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable acpid for all run levels
 #
-chkconfig --level 0123456 acpid off
+/sbin/chkconfig --level 0123456 acpid off
 
 #
 # Stop acpid if currently running
 #
-service acpid stop
+/sbin/service acpid stop

--- a/RHEL/6/input/fixes/bash/service_atd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_atd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable atd for all run levels
 #
-chkconfig --level 0123456 atd off
+/sbin/chkconfig --level 0123456 atd off
 
 #
 # Stop atd if currently running
 #
-service atd stop
+/sbin/service atd stop

--- a/RHEL/6/input/fixes/bash/service_auditd_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_auditd_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable auditd for all run levels
 #
-chkconfig --level 0123456 auditd on
+/sbin/chkconfig --level 0123456 auditd on
 
 #
 # Start auditd if not currently running
 #
-service auditd start
+/sbin/service auditd start

--- a/RHEL/6/input/fixes/bash/service_autofs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_autofs_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable autofs for all run levels
 #
-chkconfig --level 0123456 autofs off
+/sbin/chkconfig --level 0123456 autofs off
 
 #
 # Stop autofs if currently running
 #
-service autofs stop
+/sbin/service autofs stop

--- a/RHEL/6/input/fixes/bash/service_avahi-daemon_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_avahi-daemon_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable avahi-daemon for all run levels
 #
-chkconfig --level 0123456 avahi-daemon off
+/sbin/chkconfig --level 0123456 avahi-daemon off
 
 #
 # Stop avahi-daemon if currently running
 #
-service avahi-daemon stop
+/sbin/service avahi-daemon stop

--- a/RHEL/6/input/fixes/bash/service_bluetooth_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_bluetooth_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable bluetooth for all run levels
 #
-chkconfig --level 0123456 bluetooth off
+/sbin/chkconfig --level 0123456 bluetooth off
 
 #
 # Stop bluetooth if currently running
 #
-service bluetooth stop
+/sbin/service bluetooth stop

--- a/RHEL/6/input/fixes/bash/service_certmonger_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_certmonger_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable certmonger for all run levels
 #
-chkconfig --level 0123456 certmonger off
+/sbin/chkconfig --level 0123456 certmonger off
 
 #
 # Stop certmonger if currently running
 #
-service certmonger stop
+/sbin/service certmonger stop

--- a/RHEL/6/input/fixes/bash/service_cgconfig_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cgconfig_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable cgconfig for all run levels
 #
-chkconfig --level 0123456 cgconfig off
+/sbin/chkconfig --level 0123456 cgconfig off
 
 #
 # Stop cgconfig if currently running
 #
-service cgconfig stop
+/sbin/service cgconfig stop

--- a/RHEL/6/input/fixes/bash/service_cgred_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cgred_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable cgred for all run levels
 #
-chkconfig --level 0123456 cgred off
+/sbin/chkconfig --level 0123456 cgred off
 
 #
 # Stop cgred if currently running
 #
-service cgred stop
+/sbin/service cgred stop

--- a/RHEL/6/input/fixes/bash/service_cpuspeed_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cpuspeed_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable cpuspeed for all run levels
 #
-chkconfig --level 0123456 cpuspeed off
+/sbin/chkconfig --level 0123456 cpuspeed off
 
 #
 # Stop cpuspeed if currently running
 #
-service cpuspeed stop
+/sbin/service cpuspeed stop

--- a/RHEL/6/input/fixes/bash/service_crond_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_crond_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable crond for all run levels
 #
-chkconfig --level 0123456 crond on
+/sbin/chkconfig --level 0123456 crond on
 
 #
 # Start crond if not currently running
 #
-service crond start
+/sbin/service crond start

--- a/RHEL/6/input/fixes/bash/service_cups_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_cups_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable cups for all run levels
 #
-chkconfig --level 0123456 cups off
+/sbin/chkconfig --level 0123456 cups off
 
 #
 # Stop cups if currently running
 #
-service cups stop
+/sbin/service cups stop

--- a/RHEL/6/input/fixes/bash/service_dhcpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_dhcpd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable dhcpd for all run levels
 #
-chkconfig --level 0123456 dhcpd off
+/sbin/chkconfig --level 0123456 dhcpd off
 
 #
 # Stop dhcpd if currently running
 #
-service dhcpd stop
+/sbin/service dhcpd stop

--- a/RHEL/6/input/fixes/bash/service_dovecot_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_dovecot_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable dovecot for all run levels
 #
-chkconfig --level 0123456 dovecot off
+/sbin/chkconfig --level 0123456 dovecot off
 
 #
 # Stop dovecot if currently running
 #
-service dovecot stop
+/sbin/service dovecot stop

--- a/RHEL/6/input/fixes/bash/service_haldaemon_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_haldaemon_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable haldaemon for all run levels
 #
-chkconfig --level 0123456 haldaemon off
+/sbin/chkconfig --level 0123456 haldaemon off
 
 #
 # Stop haldaemon if currently running
 #
-service haldaemon stop
+/sbin/service haldaemon stop

--- a/RHEL/6/input/fixes/bash/service_httpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_httpd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable httpd for all run levels
 #
-chkconfig --level 0123456 httpd off
+/sbin/chkconfig --level 0123456 httpd off
 
 #
 # Stop httpd if currently running
 #
-service httpd stop
+/sbin/service httpd stop

--- a/RHEL/6/input/fixes/bash/service_ip6tables_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_ip6tables_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable ip6tables for all run levels
 #
-chkconfig --level 0123456 ip6tables on
+/sbin/chkconfig --level 0123456 ip6tables on
 
 #
 # Start ip6tables if not currently running
 #
-service ip6tables start
+/sbin/service ip6tables start

--- a/RHEL/6/input/fixes/bash/service_iptables_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_iptables_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable iptables for all run levels
 #
-chkconfig --level 0123456 iptables on
+/sbin/chkconfig --level 0123456 iptables on
 
 #
 # Start iptables if not currently running
 #
-service iptables start
+/sbin/service iptables start

--- a/RHEL/6/input/fixes/bash/service_irqbalance_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_irqbalance_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable irqbalance for all run levels
 #
-chkconfig --level 0123456 irqbalance on
+/sbin/chkconfig --level 0123456 irqbalance on
 
 #
 # Start irqbalance if not currently running
 #
-service irqbalance start
+/sbin/service irqbalance start

--- a/RHEL/6/input/fixes/bash/service_kdump_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_kdump_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable kdump for all run levels
 #
-chkconfig --level 0123456 kdump off
+/sbin/chkconfig --level 0123456 kdump off
 
 #
 # Stop kdump if currently running
 #
-service kdump stop
+/sbin/service kdump stop

--- a/RHEL/6/input/fixes/bash/service_mdmonitor_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_mdmonitor_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable mdmonitor for all run levels
 #
-chkconfig --level 0123456 mdmonitor off
+/sbin/chkconfig --level 0123456 mdmonitor off
 
 #
 # Stop mdmonitor if currently running
 #
-service mdmonitor stop
+/sbin/service mdmonitor stop

--- a/RHEL/6/input/fixes/bash/service_messagebus_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_messagebus_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable messagebus for all run levels
 #
-chkconfig --level 0123456 messagebus off
+/sbin/chkconfig --level 0123456 messagebus off
 
 #
 # Stop messagebus if currently running
 #
-service messagebus stop
+/sbin/service messagebus stop

--- a/RHEL/6/input/fixes/bash/service_named_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_named_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable named for all run levels
 #
-chkconfig --level 0123456 named off
+/sbin/chkconfig --level 0123456 named off
 
 #
 # Stop named if currently running
 #
-service named stop
+/sbin/service named stop

--- a/RHEL/6/input/fixes/bash/service_netconsole_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_netconsole_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable netconsole for all run levels
 #
-chkconfig --level 0123456 netconsole off
+/sbin/chkconfig --level 0123456 netconsole off
 
 #
 # Stop netconsole if currently running
 #
-service netconsole stop
+/sbin/service netconsole stop

--- a/RHEL/6/input/fixes/bash/service_netfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_netfs_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable netfs for all run levels
 #
-chkconfig --level 0123456 netfs off
+/sbin/chkconfig --level 0123456 netfs off
 
 #
 # Stop netfs if currently running
 #
-service netfs stop
+/sbin/service netfs stop

--- a/RHEL/6/input/fixes/bash/service_nfs_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_nfs_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable nfs for all run levels
 #
-chkconfig --level 0123456 nfs off
+/sbin/chkconfig --level 0123456 nfs off
 
 #
 # Stop nfs if currently running
 #
-service nfs stop
+/sbin/service nfs stop

--- a/RHEL/6/input/fixes/bash/service_nfslock_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_nfslock_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable nfslock for all run levels
 #
-chkconfig --level 0123456 nfslock off
+/sbin/chkconfig --level 0123456 nfslock off
 
 #
 # Stop nfslock if currently running
 #
-service nfslock stop
+/sbin/service nfslock stop

--- a/RHEL/6/input/fixes/bash/service_ntpd_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_ntpd_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable ntpd for all run levels
 #
-chkconfig --level 0123456 ntpd on
+/sbin/chkconfig --level 0123456 ntpd on
 
 #
 # Start ntpd if not currently running
 #
-service ntpd start
+/sbin/service ntpd start

--- a/RHEL/6/input/fixes/bash/service_oddjobd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_oddjobd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable oddjobd for all run levels
 #
-chkconfig --level 0123456 oddjobd off
+/sbin/chkconfig --level 0123456 oddjobd off
 
 #
 # Stop oddjobd if currently running
 #
-service oddjobd stop
+/sbin/service oddjobd stop

--- a/RHEL/6/input/fixes/bash/service_portreserve_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_portreserve_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable portreserve for all run levels
 #
-chkconfig --level 0123456 portreserve off
+/sbin/chkconfig --level 0123456 portreserve off
 
 #
 # Stop portreserve if currently running
 #
-service portreserve stop
+/sbin/service portreserve stop

--- a/RHEL/6/input/fixes/bash/service_postfix_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_postfix_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable postfix for all run levels
 #
-chkconfig --level 0123456 postfix on
+/sbin/chkconfig --level 0123456 postfix on
 
 #
 # Start postfix if not currently running
 #
-service postfix start
+/sbin/service postfix start

--- a/RHEL/6/input/fixes/bash/service_psacct_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_psacct_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable psacct for all run levels
 #
-chkconfig --level 0123456 psacct on
+/sbin/chkconfig --level 0123456 psacct on
 
 #
 # Start psacct if not currently running
 #
-service psacct start
+/sbin/service psacct start

--- a/RHEL/6/input/fixes/bash/service_qpidd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_qpidd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable qpidd for all run levels
 #
-chkconfig --level 0123456 qpidd off
+/sbin/chkconfig --level 0123456 qpidd off
 
 #
 # Stop qpidd if currently running
 #
-service qpidd stop
+/sbin/service qpidd stop

--- a/RHEL/6/input/fixes/bash/service_quota_nld_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_quota_nld_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable quota_nld for all run levels
 #
-chkconfig --level 0123456 quota_nld off
+/sbin/chkconfig --level 0123456 quota_nld off
 
 #
 # Stop quota_nld if currently running
 #
-service quota_nld stop
+/sbin/service quota_nld stop

--- a/RHEL/6/input/fixes/bash/service_rdisc_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rdisc_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable rdisc for all run levels
 #
-chkconfig --level 0123456 rdisc off
+/sbin/chkconfig --level 0123456 rdisc off
 
 #
 # Stop rdisc if currently running
 #
-service rdisc stop
+/sbin/service rdisc stop

--- a/RHEL/6/input/fixes/bash/service_restorecond_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_restorecond_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable restorecond for all run levels
 #
-chkconfig --level 0123456 restorecond on
+/sbin/chkconfig --level 0123456 restorecond on
 
 #
 # Start restorecond if not currently running
 #
-service restorecond start
+/sbin/service restorecond start

--- a/RHEL/6/input/fixes/bash/service_rhnsd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rhnsd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable rhnsd for all run levels
 #
-chkconfig --level 0123456 rhnsd off
+/sbin/chkconfig --level 0123456 rhnsd off
 
 #
 # Stop rhnsd if currently running
 #
-service rhnsd stop
+/sbin/service rhnsd stop

--- a/RHEL/6/input/fixes/bash/service_rhsmcertd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rhsmcertd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable rhsmcertd for all run levels
 #
-chkconfig --level 0123456 rhsmcertd off
+/sbin/chkconfig --level 0123456 rhsmcertd off
 
 #
 # Stop rhsmcertd if currently running
 #
-service rhsmcertd stop
+/sbin/service rhsmcertd stop

--- a/RHEL/6/input/fixes/bash/service_rpcgssd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rpcgssd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable rpcgssd for all run levels
 #
-chkconfig --level 0123456 rpcgssd off
+/sbin/chkconfig --level 0123456 rpcgssd off
 
 #
 # Stop rpcgssd if currently running
 #
-service rpcgssd stop
+/sbin/service rpcgssd stop

--- a/RHEL/6/input/fixes/bash/service_rpcidmapd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rpcidmapd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable rpcidmapd for all run levels
 #
-chkconfig --level 0123456 rpcidmapd off
+/sbin/chkconfig --level 0123456 rpcidmapd off
 
 #
 # Stop rpcidmapd if currently running
 #
-service rpcidmapd stop
+/sbin/service rpcidmapd stop

--- a/RHEL/6/input/fixes/bash/service_rpcsvcgssd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rpcsvcgssd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable rpcsvcgssd for all run levels
 #
-chkconfig --level 0123456 rpcsvcgssd off
+/sbin/chkconfig --level 0123456 rpcsvcgssd off
 
 #
 # Stop rpcsvcgssd if currently running
 #
-service rpcsvcgssd stop
+/sbin/service rpcsvcgssd stop

--- a/RHEL/6/input/fixes/bash/service_rsyslog_enabled.sh
+++ b/RHEL/6/input/fixes/bash/service_rsyslog_enabled.sh
@@ -1,9 +1,9 @@
 #
 # Enable rsyslog for all run levels
 #
-chkconfig --level 0123456 rsyslog on
+/sbin/chkconfig --level 0123456 rsyslog on
 
 #
 # Start rsyslog if not currently running
 #
-service rsyslog start
+/sbin/service rsyslog start

--- a/RHEL/6/input/fixes/bash/service_saslauthd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_saslauthd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable saslauthd for all run levels
 #
-chkconfig --level 0123456 saslauthd off
+/sbin/chkconfig --level 0123456 saslauthd off
 
 #
 # Stop saslauthd if currently running
 #
-service saslauthd stop
+/sbin/service saslauthd stop

--- a/RHEL/6/input/fixes/bash/service_smartd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_smartd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable smartd for all run levels
 #
-chkconfig --level 0123456 smartd off
+/sbin/chkconfig --level 0123456 smartd off
 
 #
 # Stop smartd if currently running
 #
-service smartd stop
+/sbin/service smartd stop

--- a/RHEL/6/input/fixes/bash/service_smb_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_smb_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable smb for all run levels
 #
-chkconfig --level 0123456 smb off
+/sbin/chkconfig --level 0123456 smb off
 
 #
 # Stop smb if currently running
 #
-service smb stop
+/sbin/service smb stop

--- a/RHEL/6/input/fixes/bash/service_snmpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_snmpd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable snmpd for all run levels
 #
-chkconfig --level 0123456 snmpd off
+/sbin/chkconfig --level 0123456 snmpd off
 
 #
 # Stop snmpd if currently running
 #
-service snmpd stop
+/sbin/service snmpd stop

--- a/RHEL/6/input/fixes/bash/service_squid_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_squid_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable squid for all run levels
 #
-chkconfig --level 0123456 squid off
+/sbin/chkconfig --level 0123456 squid off
 
 #
 # Stop squid if currently running
 #
-service squid stop
+/sbin/service squid stop

--- a/RHEL/6/input/fixes/bash/service_sshd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_sshd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable sshd for all run levels
 #
-chkconfig --level 0123456 sshd off
+/sbin/chkconfig --level 0123456 sshd off
 
 #
 # Stop sshd if currently running
 #
-service sshd stop
+/sbin/service sshd stop

--- a/RHEL/6/input/fixes/bash/service_sysstat_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_sysstat_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable sysstat for all run levels
 #
-chkconfig --level 0123456 sysstat off
+/sbin/chkconfig --level 0123456 sysstat off
 
 #
 # Stop sysstat if currently running
 #
-service sysstat stop
+/sbin/service sysstat stop

--- a/RHEL/6/input/fixes/bash/service_tftp_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_tftp_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable tftp for all run levels
 #
-chkconfig --level 0123456 tftp off
+/sbin/chkconfig --level 0123456 tftp off
 
 #
 # Stop tftp if currently running
 #
-service tftp stop
+/sbin/service tftp stop

--- a/RHEL/6/input/fixes/bash/service_vsftpd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_vsftpd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable vsftpd for all run levels
 #
-chkconfig --level 0123456 vsftpd off
+/sbin/chkconfig --level 0123456 vsftpd off
 
 #
 # Stop vsftpd if currently running
 #
-service vsftpd stop
+/sbin/service vsftpd stop

--- a/RHEL/6/input/fixes/bash/service_xinetd_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_xinetd_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable xinetd for all run levels
 #
-chkconfig --level 0123456 xinetd off
+/sbin/chkconfig --level 0123456 xinetd off
 
 #
 # Stop xinetd if currently running
 #
-service xinetd stop
+/sbin/service xinetd stop

--- a/RHEL/6/input/fixes/bash/service_ypbind_disabled.sh
+++ b/RHEL/6/input/fixes/bash/service_ypbind_disabled.sh
@@ -1,9 +1,9 @@
 #
 # Disable ypbind for all run levels
 #
-chkconfig --level 0123456 ypbind off
+/sbin/chkconfig --level 0123456 ypbind off
 
 #
 # Stop ypbind if currently running
 #
-service ypbind stop
+/sbin/service ypbind stop


### PR DESCRIPTION
As noted in further detail in issue:
  [1] https://github.com/OpenSCAP/scap-security-guide/issues/313

oscap when running remediation script calls execve() with restricted environment. As a result the corresponding $PATH variable content is restricted to executables just from
   `/usr/local/bin, /usr/bin, /bin` directories.

Since `chkconfig` and `service` command live in `/sbin` directory on RHEL-6, attempt to perform:
- service \* enabled
- service \* disabled
  script will result with error, as can be seen e.g. at:

&nbsp; &nbsp; [2]  https://jlieskov.fedorapeople.org/oscap_usgcb_remediation_report.html

(see those 11 rules returning error)

Therefore modify RHEL-6 remediation scripts for `service * enabled` / `service * disabled` they to use full path when calling `chkconfig` and / or `service` commands respectively.
