### PR TITLE
[bugfix] update audit-syscall-check-macro for RHEL 6&7

### DIFF
--- a/RHEL/6/transforms/shorthand2xccdf.xslt
+++ b/RHEL/6/transforms/shorthand2xccdf.xslt
@@ -452,7 +452,7 @@ and the deprecated <xhtml:code>/etc/modprobe.conf</xhtml:code>:
 To determine if the system is configured to audit calls to
 the <xhtml:code><xsl:value-of select="@syscall"/></xhtml:code>
 system call, run the following command:
-<xhtml:pre xml:space="preserve"># auditctl -l | grep syscall | grep <xsl:value-of select="@syscall"/></xhtml:pre>
+<xhtml:pre xml:space="preserve">$ sudo grep "<xsl:value-of select="@syscall"/>" /etc/audit/audit.rules</xhtml:pre>
 If the system is configured to audit this activity, it will return a line.
   </xsl:template>
 

--- a/RHEL/7/transforms/shorthand2xccdf.xslt
+++ b/RHEL/7/transforms/shorthand2xccdf.xslt
@@ -456,7 +456,7 @@ and the deprecated <xhtml:code>/etc/modprobe.conf</xhtml:code>:
 To determine if the system is configured to audit calls to
 the <xhtml:code><xsl:value-of select="@syscall"/></xhtml:code>
 system call, run the following command:
-<xhtml:pre xml:space="preserve">$ sudo auditctl -l | grep syscall | grep <xsl:value-of select="@syscall"/></xhtml:pre>
+<xhtml:pre xml:space="preserve">$ sudo grep "<xsl:value-of select="@syscall"/>" /etc/audit/audit.rules</xhtml:pre>
 If the system is configured to audit this activity, it will return a line.
   </xsl:template>
 


### PR DESCRIPTION
Thank you to Jermaine Glass for reporting!

There was a change of auditctl output syntax between RHEL 6.5 and RHEL 6.6. Namely:
## RHEL 6.5

auditctl -l | grep syscall | grep adjtimex
LIST_RULES: exit,always arch=1073741827 (0x40000003) key=audit_time_rules
syscall=adjtimex
LIST_RULES: exit,always arch=3221225534 (0xc000003e) key=audit_time_rules
syscall=adjtimex
## RHEL 6.6

auditctl -l | grep syscall | grep adjtimex
  <==  No output

 auditctl -l | grep adjtimex | grep audit_time_rule
-a always,exit -F arch=i386 -S stime,settimeofday,adjtimex -F
key=audit_time_rules
-a always,exit -F arch=x86_64 -S adjtimex,settimeofday,clock_settime -F
key=audit_time_rules

Went to update the audit macro, then (as Steve Grubb outlined) auditctl checks the _runtime_ of the system, whereas the control
is meant to check static (/etc/audit/audit.rules). Updated macro to grep audit.rules vs use auditctl.
