### PR TITLE
[RHEL/6] Add remediations for requirements /dev/shm to be mounted with nodev, noexec, and nosuid mount options

### DIFF
--- a/RHEL/6/input/fixes/bash/mount_option_dev_shm_nodev.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_dev_shm_nodev.sh
@@ -15,7 +15,7 @@ IFS='#' read DEV_SHM_HEAD DEV_SHM_OPTS DEV_SHM_TAIL <<< "$DEV_SHM_FSTAB"
 DEV_SHM_OPTS=${DEV_SHM_OPTS//defaults/rw,suid,dev,exec,auto,nouser,async,relatime}
 
 # 'dev' option (not prefixed with 'no') present in the list?
-echo $DEV_SHM_OPTS | grep -P '(?<!no)dev'
+echo $DEV_SHM_OPTS | grep -q -P '(?<!no)dev'
 if [ $? -eq 0 ]
 then
         # 'dev' option found, replace with 'nodev'
@@ -23,7 +23,7 @@ then
 fi
 
 # at least one 'nodev' present in the options list?
-echo $DEV_SHM_OPTS | grep -v 'nodev'
+echo $DEV_SHM_OPTS | grep -q -v 'nodev'
 if [ $? -eq 0 ]
 then
         # 'nodev' not found yet, append it

--- a/RHEL/6/input/fixes/bash/mount_option_dev_shm_noexec.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_dev_shm_noexec.sh
@@ -15,7 +15,7 @@ IFS='#' read DEV_SHM_HEAD DEV_SHM_OPTS DEV_SHM_TAIL <<< "$DEV_SHM_FSTAB"
 DEV_SHM_OPTS=${DEV_SHM_OPTS//defaults/rw,suid,dev,exec,auto,nouser,async,relatime}
 
 # 'exec' option (not prefixed with 'no') present in the list?
-echo $DEV_SHM_OPTS | grep -P '(?<!no)exec'
+echo $DEV_SHM_OPTS | grep -q -P '(?<!no)exec'
 if [ $? -eq 0 ]
 then
         # 'exec' option found, replace with 'noexec'
@@ -23,7 +23,7 @@ then
 fi
 
 # at least one 'noexec' present in the options list?
-echo $DEV_SHM_OPTS | grep -v 'noexec'
+echo $DEV_SHM_OPTS | grep -q -v 'noexec'
 if [ $? -eq 0 ]
 then
         # 'noexec' not found yet, append it

--- a/RHEL/6/input/fixes/bash/mount_option_dev_shm_nosuid.sh
+++ b/RHEL/6/input/fixes/bash/mount_option_dev_shm_nosuid.sh
@@ -15,7 +15,7 @@ IFS='#' read DEV_SHM_HEAD DEV_SHM_OPTS DEV_SHM_TAIL <<< "$DEV_SHM_FSTAB"
 DEV_SHM_OPTS=${DEV_SHM_OPTS//defaults/rw,suid,dev,exec,auto,nouser,async,relatime}
 
 # 'suid' option (not prefixed with 'no') present in the list?
-echo $DEV_SHM_OPTS | grep -P '(?<!no)suid'
+echo $DEV_SHM_OPTS | grep -q -P '(?<!no)suid'
 if [ $? -eq 0 ]
 then
         # 'suid' option found, replace with 'nosuid'
@@ -23,7 +23,7 @@ then
 fi
 
 # at least one 'nosuid' present in the options list?
-echo $DEV_SHM_OPTS | grep -v 'nosuid'
+echo $DEV_SHM_OPTS | grep -q -v 'nosuid'
 if [ $? -eq 0 ]
 then
         # 'nosuid' not found yet, append it


### PR DESCRIPTION
This PR adds RHEL-6 specific [*] remediation fixes for:
- mount_option_dev_shm_nodev,
- mount_option_dev_shm_noexec, and
- mount_option_dev_shm_nosuid

rules. The three remediation fixes are analogous & are based on the following logic:
- load /etc/fstab's /dev/shm row content into local variable separating the 4-th field (the mount options) with the '#' character at the start and at the end
- split the aforementioned variable content into three variables (head, opts, & tail) according to the '#' character,
- further process the OPTS variable (mount options one):
  - replace 'defaults' keyword with the actual meaning (list of options) of that option at Red Hat Enterprise Linux 6 system
  - in each of nodev, noexec, nosuid particular cases replace any unprefixed 'no' version (e.g. dev, exec, suid) with the prefixed 'no' version (e.g. nodev, noexec, nosuid)
  - check the current OPTS variable content if it contains 'no' version for each of the dev, exec, & suid options on case-by-case basis (e.g. one concrete remediation fix would check just one option depending for which mount keyword / option it's intended for),
  - in case the 'no' version isn't there yet, append it
- finally reconstruct the final form of /dev/shm row (by concatenating original HEAD, modified OPTS & original TAIL variable values)
- and replace particular /etc/fstab's /dev/shm row with the newly constructed form.

[*] The need to be RHEL-6 specific wrt to the proposed form, because in RHEL-7 mounting of /dev/shm is handled by systemd in an automated way (based on udev discovery) so for RHEL-7 they will require to have different form.
## Testing report:

The proposed change has been tested on RHEL-6 Server system (for all three of the enhanced options - dev, exec, & suid) & work's as expected.

Important note wrt to testing: Having the proposed change applied & running remediations for either one of the three will return 'error' state. But this is expected state - explanation:
- oscap when doing online remediation performs:
  - system scan against that property. If it fails, perform remediation (when requested) & after that runs scan of tha property again. If the subsequent (post-remediation) scan returns failure, oscap returns 'error' as exit status / message.

But since the OVAL partition / mount options check is based on checking of `/proc/mounts` file content (partition probe internally checks /proc/mounts content), since the system hasn't been rebooted from the moment remediation was applied & subsequent OVAL check was run, /proc/mounts still contains original options (IOW /dev/shm hasn't been remounted with the new setting from /etc/fstab), that post-remediation OVAL check with return failure & thus error.

Therefore to actually check the proposed remediation fixes are working properly it's necessary:
- either have a look at new /etc/fstab /dev/shm form after remediation (e.g. ensure that the row in question contains nodev, noexec, nosuid depending on which remediation was performed), or
- reboot the system to force /proc/mounts content to be regenerated (& therefore particular OVAL check in question to return truly real results).

Please review.

Thank you, Jan.
