### PR TITLE
[bugfix] [RHEL/6]  Whitelist /bin/cgclassify executable coming from libcgroup RPM to fix no_unpackaged_sgid_files false positive

### DIFF
--- a/RHEL/6/input/checks/file_permissions_unauthorized_sgid.xml
+++ b/RHEL/6/input/checks/file_permissions_unauthorized_sgid.xml
@@ -28,46 +28,45 @@
     <unix:sgid datatype="boolean">true</unix:sgid>
   </unix:file_state>
 
+  <!-- list of all setgid files included with base RHEL6 system -->
+  <unix:file_state id="state_sgid_whitelist" version="1">
+    <unix:filepath var_ref="var_sgid_whitelist" var_check="at least one" />
+  </unix:file_state>
 
-<!-- list of all setgid files included with base RHEL6 system -->
-    <unix:file_state id="state_sgid_whitelist" version="1">
-       <unix:filepath var_ref="var_sgid_whitelist" var_check="at least one" />
-    </unix:file_state>
-    <constant_variable id="var_sgid_whitelist" version="1" datatype="string" comment="sgid whitelist">
-                <value>/bin/cgexec</value>
-                <value>/sbin/netreport</value>
-                <value>/usr/bin/crontab</value>
-                <value>/usr/bin/gnomine</value>
-                <value>/usr/bin/iagno</value>
-                <value>/usr/bin/locate</value>
-                <value>/usr/bin/lockfile</value>
-                <value>/usr/bin/same-gnome</value>
-                <value>/usr/bin/screen</value>
-                <value>/usr/bin/ssh-agent</value>
-                <value>/usr/bin/wall</value>
-                <value>/usr/bin/write</value>
-                <value>/usr/lib64/vte/gnome-pty-helper</value>
-                <value>/usr/libexec/kde4/kdesud</value>
-                <value>/usr/libexec/utempter/utempter</value>
-                <value>/usr/lib/mailman/cgi-bin/admindb</value>
-                <value>/usr/lib/mailman/cgi-bin/admin</value>
-                <value>/usr/lib/mailman/cgi-bin/confirm</value>
-                <value>/usr/lib/mailman/cgi-bin/create</value>
-                <value>/usr/lib/mailman/cgi-bin/edithtml</value>
-                <value>/usr/lib/mailman/cgi-bin/listinfo</value>
-                <value>/usr/lib/mailman/cgi-bin/options</value>
-                <value>/usr/lib/mailman/cgi-bin/private</value>
-                <value>/usr/lib/mailman/cgi-bin/rmlist</value>
-                <value>/usr/lib/mailman/cgi-bin/roster</value>
-                <value>/usr/lib/mailman/cgi-bin/subscribe</value>
-                <value>/usr/lib/mailman/mail/mailman</value>
-                <value>/usr/lib/vte/gnome-pty-helper</value>
-                <value>/usr/sbin/lockdev</value>
-                <value>/usr/sbin/postdrop</value>
-                <value>/usr/sbin/postqueue</value>
-                <value>/usr/sbin/sendmail.sendmail</value>
-        </constant_variable>
-
-
+  <constant_variable id="var_sgid_whitelist" version="1" datatype="string" comment="sgid whitelist">
+    <value>/bin/cgclassify</value>
+    <value>/bin/cgexec</value>
+    <value>/sbin/netreport</value>
+    <value>/usr/bin/crontab</value>
+    <value>/usr/bin/gnomine</value>
+    <value>/usr/bin/iagno</value>
+    <value>/usr/bin/locate</value>
+    <value>/usr/bin/lockfile</value>
+    <value>/usr/bin/same-gnome</value>
+    <value>/usr/bin/screen</value>
+    <value>/usr/bin/ssh-agent</value>
+    <value>/usr/bin/wall</value>
+    <value>/usr/bin/write</value>
+    <value>/usr/lib64/vte/gnome-pty-helper</value>
+    <value>/usr/libexec/kde4/kdesud</value>
+    <value>/usr/libexec/utempter/utempter</value>
+    <value>/usr/lib/mailman/cgi-bin/admindb</value>
+    <value>/usr/lib/mailman/cgi-bin/admin</value>
+    <value>/usr/lib/mailman/cgi-bin/confirm</value>
+    <value>/usr/lib/mailman/cgi-bin/create</value>
+    <value>/usr/lib/mailman/cgi-bin/edithtml</value>
+    <value>/usr/lib/mailman/cgi-bin/listinfo</value>
+    <value>/usr/lib/mailman/cgi-bin/options</value>
+    <value>/usr/lib/mailman/cgi-bin/private</value>
+    <value>/usr/lib/mailman/cgi-bin/rmlist</value>
+    <value>/usr/lib/mailman/cgi-bin/roster</value>
+    <value>/usr/lib/mailman/cgi-bin/subscribe</value>
+    <value>/usr/lib/mailman/mail/mailman</value>
+    <value>/usr/lib/vte/gnome-pty-helper</value>
+    <value>/usr/sbin/lockdev</value>
+    <value>/usr/sbin/postdrop</value>
+    <value>/usr/sbin/postqueue</value>
+    <value>/usr/sbin/sendmail.sendmail</value>
+  </constant_variable>
 
 </def-group>


### PR DESCRIPTION
As can be seen in scan report coming from RHEL-6.6 x86_64 server:
  [1] https://jlieskov.fedorapeople.org/no_unpackaged_sgid_suid_files_report.html

the OVAL check for `Ensure All SGID Executables Are Authorized` returns failure (together with listing the following entry:

```
setgid files outside system RPMs
path                    type        UID         GID        size        permissions
/bin/cgclassify  regular        0           496      11984        rwxr-sr-x 
```

) as the one not meeting the requirement.

But further investigation of the RHEL-6's system situation / conditions returns:

```
[root@localhost ~]# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 6.6 (Santiago)
[root@localhost ~]# uname -i
x86_64
[root@localhost ~]# rpm -qf /bin/cgclassify
libcgroup-0.40.rc1-12.el6.x86_64
```

IOW the reported result is false positive, since as can be seen above, `/bin/cgclassify` isn't unauthorized / arbitrary SGID executable, but rather comes from `libcgroup-0.40.rc1-12.el6.x86_64` RPM package.

Thus fix this false positive case by whitelisting /bin/cgclassify executable in corresponding OVAL check's variable. Also, modify the indentation of that OVAL check, so it would be better readable (IOW child elements to be shifted by common 2 spaces, rather than shifted by random / varying count of spaces across different OVAL objects).
## Testing report:

Proposed PR has been tested on RHEL-6 system & works as expected (no false positive reported after the change).

Please review.

Thank you, Jan.
