### PR TITLE
[BugFix] [RHEL/6] Fix audit_rules_time_stime OVAL check to return appropriate result also on 64-bit architecture

### DIFF
--- a/RHEL/6/input/checks/audit_rules_time_stime.xml
+++ b/RHEL/6/input/checks/audit_rules_time_stime.xml
@@ -1,39 +1,37 @@
 <def-group>
-  <definition class="compliance"
-  id="audit_rules_time_stime" version="1">
+  <definition class="compliance" id="audit_rules_time_stime" version="1">
     <metadata>
       <title>Record Attempts to Alter Time Through Stime</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
       </affected>
-      <description>Record attempts to alter time through stime, note that this
- is only relevant on 32bit architecture.</description>
+      <description>Record attempts to alter time through stime. Note that on
+      64-bit architectures the stime system call is not defined in the audit
+      system calls lookup table.</description>
+      <reference source="JL" ref_id="RHEL6_20141201" ref_url="test_attestation"/>
     </metadata>
-    <criteria comment="Test for either..." operator="OR">
-      <criteria comment="both..." operator="AND">
-        <extend_definition comment="32bit and ..." 
+    <criteria comment="32-bit or 64-bit system and 32-bit arch stime line and key present" operator="AND">
+      <criteria comment="32-bit or 64-bit system" operator="OR">
+        <extend_definition comment="32-bit system"
         definition_ref="system_info_architecture_x86" />
-        <criterion comment="32bit line stime and key present"
-        test_ref="test_audit_rules_time_stime_x86" />
-      </criteria>
-      <criteria comment="both ...">
-        <extend_definition comment="64bit and ..." 
+        <extend_definition comment="64-bit system"
         definition_ref="system_info_architecture_x86_64" />
       </criteria>
+      <criterion comment="32-bit arch stime line and key present"
+      test_ref="test_audit_rules_time_stime_x86" />
     </criteria>
   </definition>
+
   <ind:textfilecontent54_test check="all"
   check_existence="at_least_one_exists"
   comment="Tests the for presence of 32bit -S stime and key"
   id="test_audit_rules_time_stime_x86" version="1">
     <ind:object object_ref="obj_audit_rules_time_stime_x86" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_audit_rules_time_stime_x86"
-  version="1">
-    <ind:path>/etc/audit</ind:path>
-    <ind:filename>audit.rules</ind:filename>
-    <ind:pattern 
-    operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*-S[\s]+stime[\s]+.*-k[\s]+[\S]+[\s]*$</ind:pattern>
+
+  <ind:textfilecontent54_object id="obj_audit_rules_time_stime_x86" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*-S[\s]+stime[\s]+.*-k[\s]+[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
The existing `audit_rules_time_stime` OVAL check implementation is based on the observation that there isn't `stime` system call present in audit lookup table on 64-bit systems:

```
[root@localhost ~]# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 6.6 (Santiago)
[root@localhost ~]# ausyscall i386 stime
stime              25
[root@localhost ~]# ausyscall x86_64 stime
Unknown syscall stime using x86_64 lookup table
```

This is correct. Though the logic in other audit OVAL check (e.g. `audit_rules_time_adjtimex, audit_rules_time_settimeofday, audit_rules_dac_modification_chmod ...`) is as follows:
- when the system is 32-bit check just for -F arch=b32 version of a particular rule for given system call -S in /etc/audit/audit.rules,
- when the system is 64-bit check for presence of both (-F arch=b32 & -F arch=b64) versions of a particular rule for the given system call -S in /etc/audit/audit.rules.

Therefore in the case `stime` audit lookup table entry would be defined on 64-bit system, we would be checking for both (-F arch=b32 & -F arch=b64) versions of a particular rule for -S stime system call. But since it isn't we should be checking at least for -F arch=b32 case (for case a 32-bit application is running on 64-bit system that would be calling stime() system call).

But what current `audit_rules_time_stime` implementation is [doing](https://github.com/OpenSCAP/scap-security-guide/blob/master/RHEL/6/input/checks/audit_rules_time_stime.xml) is as follows:
- the main check https://github.com/OpenSCAP/scap-security-guide/blob/master/RHEL/6/input/checks/audit_rules_time_stime.xml#L12 is OR-ing of two subtests,
- the first subtest checks if the arch is 32-bit & if so if there's `-F arch=b32 ... -S stime` present in /etc/audit/audit.rules file -- https://github.com/OpenSCAP/scap-security-guide/blob/master/RHEL/6/input/checks/audit_rules_time_stime.xml#L13
- the second subtest https://github.com/OpenSCAP/scap-security-guide/blob/master/RHEL/6/input/checks/audit_rules_time_stime.xml#L19 when the system architecture is 64-bit effectively does nothing.

As a result this means that though this test will work on 32-bit architecture, it won't return proper results on 64-bit architecture (IOW it will always return PASS on 64-bit architecture even when `-F arch=b32 ... -S stime` audit rule isn't defined on 64-bit architecture).

But as already mentioned above even on 64-bit architecture it's possible to compile 32-bit application (e.g. via `-m32` compiler option) which would utilize the `stime()` system call & therefore should be audited (since as shown above in `ausyscall` command the 32-bit `stime` version is defined / supported also on 64-bit architecture). Sample output / audit entry created today this way:

```
[root@localhost ~]# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 6.6 (Santiago)
[root@localhost ~]# uname -m
x86_64
[root@localhost ~]# ausearch -k audit_time_rules
...
----
time->Mon Dec  1 05:25:04 2014
type=SYSCALL msg=audit(1417429504.882:199): arch=40000003 syscall=25 success=yes exit=0 a0=ffed05d0 a1=ffed05d4 a2=466ff4 a3=0 items=0 ppid=3435 pid=3507 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=1 comm="t_stime" exe="/root/t_stime" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="audit_time_rules"
```

where `t_stime` above is / was sample from:
  http://man7.org/tlpi/code/online/dist/time/t_stime.c.html

compiled as 32-bit application on 64-bit system.

Fix:
Therefore invert the logic of the check in the way it would:
- comply with the logic of other audit rules tests,
- check for presence of `-F arch=b32 -S stime` also on 64-bit architecture.
## Testing report:

The proposed change has been tested on RHEL-6 for both (32-bit & 64-bit) architectures & works as expected (returns pass on 64-bit arch really only in case there's `-F arch=b32 ... -S stime` present in audit.rules).

Please review.

Thanks, Jan.
