### PR TITLE
Update no_shelllogin_for_systemaccounts.xml

### DIFF
--- a/shared/oval/no_shelllogin_for_systemaccounts.xml
+++ b/shared/oval/no_shelllogin_for_systemaccounts.xml
@@ -19,7 +19,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_shelllogin_for_systemaccounts" version="1">
     <ind:filepath>/etc/passwd</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!root).*:x:[\d]*:0*([0-9]{1,2}|[1-4][0-9]{2}):[^:]*:[^:]*:(?!\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!root).*:x:0*([0-9]{1,2}|[1-4][0-9]{2}):[\d]*:[^:]*:[^:]*:(?!\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
Regex matches gid < 500, instead of uid < 500 as it should.  

Changed the order of the uid and gid match regexes chunks so that it matches the accounts with uid < 500 instead of the current match of gid < 500.
