### PR TITLE
Fixed disable_ctrlaltdel_reboot to check for file existance and added remediation

### DIFF
--- a/RHEL/6/input/fixes/bash/disable_ctrlaltdel_reboot.sh
+++ b/RHEL/6/input/fixes/bash/disable_ctrlaltdel_reboot.sh
@@ -1,5 +1,0 @@
-GREP_SHUTDOWN=$(grep '^\s*exec\s*/sbin/shutdown\s*-r\s*now.*$' /etc/init/control-alt-delete.override | wc -l)
-# Remediate if the file contains /sbin/shutdown or if the override file does not exist
-if [ "$GREP_SHUTDOWN" -ne 0 -o ! -e /etc/init/control-alt-delete.override ]; then
-    echo 'exec /usr/bin/logger -p security.info "Ctrl-Alt-Delete pressed"' > /etc/init/control-alt-delete.override
-fi


### PR DESCRIPTION
The current check for disabling Ctrl-Alt-Del key sequence on the console is broken. The current check is that `none_exist` on a pattern in `control-alt-delete.override`. However the test should fail if _either_ the file does not exist or the pattern does match the file. The existing check will incorrectly pass if the file does not exist (and it does not exist by default). This change adds a second check to verify that the file exists. The current behavior was probably introduced in 89dae8b4e9eeba1573f6e8b1b2dea23a23b0738f.

Additionally, this change adds a remediation script to create the override file, configured to log the event.
