### PR TITLE
fix faillock audit oval

### DIFF
--- a/shared/templates/csv/audit_rules_login_events.csv
+++ b/shared/templates/csv/audit_rules_login_events.csv
@@ -1,3 +1,3 @@
-/var/run/faillock/
+/var/run/faillock
 /var/log/lastlog
 /var/log/tallylog


### PR DESCRIPTION
#### Description:

Removes the trailing slash for the directory watch.

Fixes #2709 , #2710

#### Rationale:

It should not matter whether the audit watch on a directory is specified with or without a trailing slash.  The RHEL 7 STIG V1R4 shows it without a trailing slash.  This change mirrors the STIG.