### PR TITLE
[WIP] Inconsistent memcache_timeout, ssh_known_hosts_timeout wrt man sssd.conf

### DIFF
--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
@@ -20,13 +20,24 @@
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
-  comment="tests the value of memcache_timeoutsetting in the /etc/sssd/sssd.conf file"
+  comment="tests the value of memcache_timeout setting in the /etc/sssd/sssd.conf file"
   id="test_sssd_memcache_timeout" version="1">
     <ind:object object_ref="obj_sssd_memcache_timeout" />
+    <ind:state state_ref="state_sssd_memcache_timeout" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_memcache_timeout" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\[nss]([^\n]*\n+)+?memcache_timeout[\s]+=[\s]+300$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[nss]([^\n]*\n+)+?memcache_timeout[\s]+=[\s]+(\d+)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state comment="value of memcache_timeout setting"
+  id="state_sssd_memcache_timeout" version="1">
+    <ind:subexpression datatype="int" operation="less than or equal" var_check="all"
+    var_ref="var_sssd_memcache_timeout" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="memcache_timeout value" datatype="int"
+  id="var_sssd_memcache_timeout" version="1" />
+
 </def-group>

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
@@ -26,7 +26,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_memcache_timeout" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\[nss]([^\n]*\n+)+?memcache_timeout[\s]+=[\s]+86400$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[nss]([^\n]*\n+)+?memcache_timeout[\s]+=[\s]+300$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
@@ -5,12 +5,15 @@ prodtype: rhel6,rhel7
 title: 'Configure SSSD''s Memory Cache to Expire'
 
 description: |-
-    SSSD's memory cache should be configured to set to expire records after 1 day.
+    SSSD's memory cache should be configured to set to expire records after
+    <tt><sub idref="var_sssd_memcache_timeout" /></tt> seconds.
     To configure SSSD to expire memory cache, set <tt>memcache_timeout</tt> to
-    <tt>86400</tt> under the <tt>[nss]</tt> section in <tt>/etc/sssd/sssd.conf</tt>.
-    For example:
+    <tt><sub idref="var_sssd_memcache_timeout" /></tt> under the
+    <tt>[nss]</tt> section in <tt>/etc/sssd/sssd.conf</tt>.
+
+    For example, if the timeout is 300 seconds:
     <pre>[nss]
-    memcache_timeout = 86400
+    memcache_timeout = 300
     </pre>
 
 rationale: |-
@@ -33,4 +36,4 @@ ocil_clause: 'it does not exist or is not configured properly'
 ocil: |-
     To verify that SSSD's in-memory cache expires after a day, run the following command:
     <pre>$ sudo grep memcache_timeout /etc/sssd/sssd.conf</pre>
-    If configured properly, output should be <pre>memcache_timeout = 86400</pre>.
+    If configured properly, output should be <pre>memcache_timeout = <sub idref="var_sssd_memcache_timeout" /></pre>.

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
@@ -11,9 +11,9 @@ description: |-
     <tt><sub idref="var_sssd_memcache_timeout" /></tt> under the
     <tt>[nss]</tt> section in <tt>/etc/sssd/sssd.conf</tt>.
 
-    For example, if the timeout is 300 seconds:
+    For example:
     <pre>[nss]
-    memcache_timeout = 300
+    memcache_timeout = <sub idref="var_sssd_memcache_timeout" />
     </pre>
 
 rationale: |-

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
@@ -18,14 +18,26 @@
       test_ref="test_sssd_ssh_known_hosts_timeout" />
     </criteria>
   </definition>
+
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="tests the value of ssh_known_hosts_timeout setting in the /etc/sssd/sssd.conf file"
   id="test_sssd_ssh_known_hosts_timeout" version="1">
     <ind:object object_ref="obj_sssd_ssh_known_hosts_timeout" />
+    <ind:state state_ref="state_sssd_ssh_known_hosts_timeout" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_ssh_known_hosts_timeout" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\[ssh]([^\n]*\n+)+?ssh_known_hosts_timeout[\s]+=[\s]+180$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[ssh]([^\n]*\n+)+?ssh_known_hosts_timeout[\s]+=[\s]+(\d+)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state comment="value of ssh_known_hosts_timeout setting"
+  id="state_sssd_ssh_known_hosts_timeout" version="1">
+    <ind:subexpression datatype="int" operation="less than or equal" var_check="all"
+    var_ref="var_sssd_ssh_known_hosts_timeout" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="var_sssd_ssh_known_hosts_timeout value" datatype="int"
+  id="var_sssd_ssh_known_hosts_timeout" version="1" />
+
 </def-group>

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
@@ -25,7 +25,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_ssh_known_hosts_timeout" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\[ssh]([^\n]*\n+)+?ssh_known_hosts_timeout[\s]+=[\s]+86400$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[ssh]([^\n]*\n+)+?ssh_known_hosts_timeout[\s]+=[\s]+180$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
@@ -5,12 +5,14 @@ prodtype: rhel6,rhel7
 title: 'Configure SSSD to Expire SSH Known Hosts'
 
 description: |-
-    SSSD should be configured to expire keys from known SSH hosts after 1 day.
+    SSSD should be configured to expire keys from known SSH hosts after
+    <tt><sub idref="var_sssd_ssh_known_hosts_timeout" /></tt> seconds.
     To configure SSSD to known SSH hosts, set <tt>ssh_known_hosts_timeout</tt>
-    to <tt>86400</tt> under the <tt>[ssh]</tt> section in
-    <tt>/etc/sssd/sssd.conf</tt>. For example:
+    to <tt><sub idref="var_sssd_ssh_known_hosts_timeout" /></tt> under the
+    <tt>[ssh]</tt> section in <tt>/etc/sssd/sssd.conf</tt>. For example, if the
+    timeout is 300 seconds:
     <pre>[ssh]
-    ssh_known_hosts_timeout = 86400
+    ssh_known_hosts_timeout = 300
     </pre>
 
 rationale: |-
@@ -33,4 +35,4 @@ ocil: |-
     To verify that SSSD expires known SSH host keys, run the following command:
     <pre>$ sudo grep ssh_known_hosts_timeout /etc/sssd/sssd.conf</pre>
     If configured properly, output should be
-    <pre>ssh_known_hosts_timeout = 86400</pre>
+    <pre>ssh_known_hosts_timeout = <sub idref="var_sssd_ssh_known_hosts_timeout" /></pre>

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
@@ -9,10 +9,9 @@ description: |-
     <tt><sub idref="var_sssd_ssh_known_hosts_timeout" /></tt> seconds.
     To configure SSSD to known SSH hosts, set <tt>ssh_known_hosts_timeout</tt>
     to <tt><sub idref="var_sssd_ssh_known_hosts_timeout" /></tt> under the
-    <tt>[ssh]</tt> section in <tt>/etc/sssd/sssd.conf</tt>. For example, if the
-    timeout is 300 seconds:
+    <tt>[ssh]</tt> section in <tt>/etc/sssd/sssd.conf</tt>. For example:
     <pre>[ssh]
-    ssh_known_hosts_timeout = 300
+    ssh_known_hosts_timeout = <sub idref="var_sssd_ssh_known_hosts_timeout" />
     </pre>
 
 rationale: |-

--- a/linux_os/guide/services/sssd/var_sssd_memcache_timeout.var
+++ b/linux_os/guide/services/sssd/var_sssd_memcache_timeout.var
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'SSSD [nss] memcache_timeout option'
+
+description: |-
+    Value of the memcache_timeout option in the [nss] section
+    of SSSD config /etc/sssd/sssd.conf.
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    3_minutes: 180
+    5_minutes: 300
+    10_minutes: 600
+    15_minutes: 900
+    30_minutes: 1800
+    1_day: 86400
+    default: 300

--- a/linux_os/guide/services/sssd/var_sssd_memcache_timeout.var
+++ b/linux_os/guide/services/sssd/var_sssd_memcache_timeout.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'SSSD [nss] memcache_timeout option'
+title: 'SSSD memcache_timeout option'
 
 description: |-
     Value of the memcache_timeout option in the [nss] section

--- a/linux_os/guide/services/sssd/var_sssd_ssh_known_hosts_timeout.var
+++ b/linux_os/guide/services/sssd/var_sssd_ssh_known_hosts_timeout.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'SSSD [ssh] ssh_known_hosts_timeout option'
+title: 'SSSD ssh_known_hosts_timeout option'
 
 description: |-
     Value of the ssh_known_hosts_timeout option in the [ssh] section

--- a/linux_os/guide/services/sssd/var_sssd_ssh_known_hosts_timeout.var
+++ b/linux_os/guide/services/sssd/var_sssd_ssh_known_hosts_timeout.var
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'SSSD [ssh] ssh_known_hosts_timeout option'
+
+description: |-
+    Value of the ssh_known_hosts_timeout option in the [ssh] section
+    of SSSD configuration file /etc/sssd/sssd.conf.
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    3_minutes: 180
+    5_minutes: 300
+    10_minutes: 600
+    15_minutes: 900
+    30_minutes: 1800
+    1_day: 86400
+    default: 180

--- a/rhel7/profiles/stig-rhel7-disa.profile
+++ b/rhel7/profiles/stig-rhel7-disa.profile
@@ -17,6 +17,7 @@ description: "This profile contains configuration checks that align to the \n
 selections:
     - login_banner_text=dod_banners
     - inactivity_timeout_value=15_minutes
+    - var_sssd_ssh_known_hosts_timeout=5_minutes
     - var_screensaver_lock_delay=5_seconds
     - sshd_idle_timeout_value=10_minutes
     - var_accounts_fail_delay=4


### PR DESCRIPTION
ssg-rhel7-ds.xml reports inconsistent values wrt sssd.conf
ssg-rhel7-ds.xml recommends:

```
memcache_timeout = 86400
ssh_known_hosts_timeout = 86400
```

sssd.conf default

```
memcache_timeout = 300
ssh_known_hosts_timeout = 180
```

PR changes memcache_timeout,ssh_known_hosts_timeout values as defined in sssd.conf

PLEASE VERIFY THIS WITH SSSD DEVELOPERS PRIOR TO MERGE.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>
