### PR TITLE
SSG Module: add setup.py for installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ CMakeLists.txt.user
 
 # Ignore pytest cache
 .pytest_cache/
+
+# Ignore Python egg for ssg when installing with pip
+ssg.egg-info/

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -519,6 +519,25 @@ An alternative is adding the directory where `testoval.py` resides to your PATH.
 $ export PATH=$PATH:/home/_username_/scap-security-guide/utils/
 ----
 
+== The SSG Python Module
+
+Locaated in the `ssg` directory are several useful Python modules for working with
+the content in SSG. Some of these utilities are of broader interest to the broader
+community working with OVAL content as well. However, the modules with prefix `build_`
+are only useful for building SSG. Contributions to this module are actively welcomed.
+
+By installing this in the user context from an active repository, as shown below, you
+can use the Python utilities in the `utils` directory without setting `PYTHONPATH`.
+
+To install the SSG Python module in a user scope:
+----
+$ pip install --user -e ./
+----
+
+Note that this module is not published on PyPI and is not obtainable from there.
+Further, we don't recommend installing this module in the system scope as it includes
+many utilities meant for development. Use of a virtualenv would be suggested instead.
+
 == Contributing with XCCDFs, OVALs and remediations
 
 There are three main types of content in SSG, they are rules, defined using the XCCDF standard, checks, usually written in link:https://oval.mitre.org/language/about/[OVAL] format, and remediations, that can be executed on ansible, bash, anaconda installer and puppet.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(name='ssg',
+      version='0.1',
+      description='SCAP Security Guide build and utilities module for generating compliance content',
+      url='http://github.com/OpenSCAP/scap-security-guide',
+      author='The OpenSCAP Team',
+      author_email='open-scap-list@redhat.com',
+      license='BSD',
+      packages=['ssg'],
+      install_requires=['jinja2', 'PyYAML'],
+      zip_safe=False)


### PR DESCRIPTION
Per @redhatrises's [comment](https://github.com/OpenSCAP/scap-security-guide/pull/2949#discussion_r195463466) on #2949, this creates the `ssg` Python module by adding a `setup.py` file.

The suggested usage is to avoid the necessity of `.pyenv.sh` usage, and allow `ssg` to be found more easily on non-*nix systems. Further, we add a call to contributions for others to contribute useful features.

Questions:
 - Can anyone verify that `license='BSD'` does refer to the BSD-3 clause? I was not able to verify this immediately.
 - Are the `author` and `author_email` ok?
