### PR TITLE
Template bash and ansible remediations for mount_option rules

### DIFF
--- a/shared/templates/create_mount_options.py
+++ b/shared/templates/create_mount_options.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import re
 import sys
+import os
 
 from template_common import FilesGenerator, UnknownTargetError
 
@@ -89,9 +90,12 @@ class RemediationTarget(MountOptionTarget):
             self.template_file = "{0}_var".format(self.TEMPLATE_FILE_BASE)
             self._output_id_template = "{mount_option}_{point_id}"
         elif not mount_point.startswith("/"):  # no path, but not a variable either
+            self.template_file = "{0}_{1}".format(self.TEMPLATE_FILE_BASE, self._point_id)
+
+        template_path = os.path.join(self.generator.product_input_dir, self.template_file)
+        if not os.path.isfile(template_path):
             raise Skipped(
-                "Remediations are available only for for literal mount points, "
-                "or by mount points defined by variables, thus beginning with 'var_'."
+                "Template file {0} doesn't exist.".format(self.template_file)
             )
 
 

--- a/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
+++ b/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
@@ -1,0 +1,19 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+- name: "Get nfs and nfs4 mount points, that don't have {{{ MOUNTOPTION }}}"
+  shell: grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "{{{ MOUNTOPTION }}}" | awk '{print $2}'
+  register: points_register
+  check_mode: no
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: "Add {{{ MOUNTOPTION }}} to mount points"
+  shell: awk '$2=="{{ item }}"{$4=$4",{{{ MOUNTOPTION }}}"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
+  with_items:
+    - "{{ points_register.stdout_lines }}"
+  tags:
+    @ANSIBLE_TAGS@

--- a/shared/templates/template_BASH_mount_option_remote_filesystems
+++ b/shared/templates/template_BASH_mount_option_remote_filesystems
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+
+. /usr/share/scap-security-guide/remediation_functions
+include_mount_options_functions
+
+ensure_mount_option_for_vfstype "nfs[4]?" "{{{ MOUNTOPTION }}}"

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_all_noexec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_all_noexec.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i 's/,noexec//' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_noexec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_noexec.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i 's|\(.*nfs4.*\),noexec\(.*\)|\1\2|' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/no_nfs.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/no_nfs.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/
+sed -i '/nfs/d' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/noexec_set.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/noexec_set.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+
+cp ../fstab /etc/


### PR DESCRIPTION
#### Description:
Template mount_option_*_remote_filesystems remediations (except mount_option_krb_sec_remote_filesystems).

Based on already existing templating for `mount_option` rules. This templating uses same value for file name and option (e.g. mount_option_noexec_remote_filesystems rule uses `noexec` in file name and in rule implementation). That's why mount_option_krb_sec_remote_filesystems rule isn't created by template and is there separately now (it has `krb_sec` in filename, but `sec=krb5:krb5i:krb5p` in implementation).


And add tests for mount_option_noexec_rule which is one of templated rules