### PR TITLE
Fix misleading description of syscalls checked on audit_rules_kernel_module_loading

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -9,7 +9,11 @@ description: |-
     -w /usr/sbin/insmod -p x -k modules
     -w /usr/sbin/rmmod -p x -k modules
     -w /usr/sbin/modprobe -p x -k modules
+{{% if product == "rhel6" %}}
     -a always,exit -F arch=<i>ARCH</i> -S init_module,delete_module -F key=modules
+{{% else %}}
+    -a always,exit -F arch=<i>ARCH</i> -S init_module,finit_module,create_module,delete_module -F key=modules
+{{% endif %}}
     </pre>
 
     The place to add the lines depends on a way <tt>auditd</tt> daemon is configured. If it is configured

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/default.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/default.fail.sh
@@ -4,4 +4,3 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_multiple_per_arg.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_multiple_per_arg.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+# Use auditctl, on RHEL7, default is to use augenrules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+rm -f /etc/audit/rules.d/*
+
+# cut out irrelevant rules for this test
+sed '1,10d' test_audit.rules > /etc/audit/audit.rules
+sed -i '5,8d' /etc/audit/audit.rules
+cat /etc/audit/audit.rules
+true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_multiple_per_arg.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_multiple_per_arg.pass.sh
@@ -10,5 +10,3 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '1,10d' test_audit.rules > /etc/audit/audit.rules
 sed -i '5,8d' /etc/audit/audit.rules
-cat /etc/audit/audit.rules
-true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_arg.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_arg.pass.sh
@@ -9,5 +9,3 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '1,14d' test_audit.rules > /etc/audit/audit.rules
-cat /etc/audit/audit.rules
-true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_arg.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_arg.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+# Use auditctl, on RHEL7, default is to use augenrules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+rm -f /etc/audit/rules.d/*
+
+# cut out irrelevant rules for this test
+sed '1,14d' test_audit.rules > /etc/audit/audit.rules
+cat /etc/audit/audit.rules
+true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_line.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_line.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+# Use auditctl, on RHEL7, default is to use augenrules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+rm -f /etc/audit/rules.d/*
+
+# cut out irrelevant rules for this test
+sed '11,18d' test_audit.rules > /etc/audit/audit.rules
+cat /etc/audit/audit.rules
+true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_line.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/syscalls_one_per_line.pass.sh
@@ -9,5 +9,3 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '11,18d' test_audit.rules > /etc/audit/audit.rules
-cat /etc/audit/audit.rules
-true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/test_audit.rules
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_kernel_module_loading/rule_audit_rules_kernel_module_loading/test_audit.rules
@@ -1,0 +1,21 @@
+# one per line
+-a always,exit -F arch=b32 -S init_module -k modules
+-a always,exit -F arch=b64 -S init_module -k modules
+-a always,exit -F arch=b32 -S delete_module -k modules
+-a always,exit -F arch=b64 -S delete_module -k modules
+-a always,exit -F arch=b32 -S create_module -k modules
+-a always,exit -F arch=b64 -S create_module -k modules
+-a always,exit -F arch=b32 -S finit_module -k modules
+-a always,exit -F arch=b64 -S finit_module -k modules
+
+# multiple per arg
+-a always,exit -F arch=b32 -S init_module,delete_module,create_module,finit_module -k modules
+-a always,exit -F arch=b64 -S init_module,delete_module,create_module,finit_module -k modules
+
+# one per arg
+-a always,exit -F arch=b32 -S init_module -S delete_module -S create_module -S finit_module -k modules
+-a always,exit -F arch=b64 -S init_module -S delete_module -S create_module -S finit_module -k modules
+
+-w /usr/sbin/insmod -p x -k modules
+-w /usr/sbin/rmmod -p x -k modules
+-w /usr/sbin/modprobe -p x -k modules


### PR DESCRIPTION
#### Description:

- Update description of rule `audit_rules_kernel_module_loading`
- Add tests for various syscall arrangements within the audit rule

#### Rationale:

- Description of the rule is misleading for non-rhel6 systems. On rhel6 system, OVAL check for this rule requires audit rule for `init_module` and `delete_module` syscalls. The OVAL check for other systems will also require rules for `finit_module` and `create_module` syscalls.

- Related to #3210
