### PR TITLE
Document existence of example product

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -379,6 +379,8 @@ When creating a new product, use the guidelines below for the directory layout:
 * If the content to be produced does not matter on versions, *do not* add version
 numbers. For example: `fedora`, `firefox`, etc.
 * In addition, use only a maxdepth of 3 directories.
+* See the the README inside the scap-security-guide/example folder for more
+information about the changes needed.
 
 Following these guidelines help with the usability and browsability of
 using and navigating the content.

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,20 @@
+# Example Product
+
+This product was introduced to show a few aspects:
+
+ - Serve a documentation on how to add a new product.
+    - [See commit bfe5a764](bfe5a76495973f5fc000645c68e3e6936543a09f) for the changes that were
+      necessary to add a new product.
+ - Create a profile that is quick to scan on RHEL-like distributions.
+
+To build this system, follow the steps for building regularly, but
+pass `-DSSG_PRODUCT_EXAMPLE=ON` to the CMake command:
+
+    cd scap-security-guide/build
+    cmake -DSSG_PRODUCT_EXAMPLE=ON ..
+    make example
+
+This will build only the example profile; this can then be used
+with [OpenSCAP](https://github.com/OpenSCAP/openscap) or
+[scap-workbench](https://github.com/OpenSCAP/scap-workbench) for
+testing purposes.


### PR DESCRIPTION
This adds:

 - A `README.md` to the Example product.
 - A message in CMake that the Example product is disabled, when it is disabled.
 - A line in the Developer documentation stating that these are examples for adding a new product + build system changes. 

This should resolve @yuumasato's comment on #3202. 