### PR TITLE
rule.yml and OVAL check tools

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -730,6 +730,36 @@ commands:
 
 This utility requires an up to date JSON tree created by `rule_dir_json.py`.
 
+===== `utils/mod_checks.py`
+
+This utility modifies the `<affected>` element of an OVAL check. It supports
+several commands on a given rule:
+
+   - `mod_checks.py <rule_id> list` - list all OVALs, their computed products,
+     and their actual platforms.
+   - `mod_checks.py <rule_id> delete <product>` - delete the OVAL for the
+     the specified product.
+   - `mod_checks.py <rule_id> make_shared <product>` - moves the product OVAL
+     to the shared OVAL (e.g., `rhel7.xml` to `shared.xml`).
+   - `mod_checks.py <rule_id> diff <product> <product>` - Performs a diff
+     between two OVALs (product can be `shared` to diff against the shared
+     OVAL).
+
+In addition, the `mod_checks.py` utility supports modifying the shared OVAL
+with the following commands:
+
+   - `mod_checks.py <rule_id> add <platform> [<platform> ...]` - adds the
+     specified platforms to the shared OVAL for the rule specified by
+     `rule_id`.
+   - `mod_checks.py <rule_id> remove <platform> [<platform> ...]` - removes
+     the specified platforms from the shared OVAL.
+   - `mod_checks.py <rule_id> replace <replacement> [<replacement ...]` - do
+     the specified replacement against the platforms in the shared OVAL. See
+     the description of `replace` under `mod_prodtype.py` for more
+     information about the format of a replacement.
+
+This utility requires an up to date JSON tree created by `rule_dir_json.py`.
+
 ==== Checks
 
 Checks are used to evaluate a Rule. They are written using a custom OVAL syntax and are stored as xml files inside the _checks/oval_ directory for the desired platform.

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -760,6 +760,36 @@ with the following commands:
 
 This utility requires an up to date JSON tree created by `rule_dir_json.py`.
 
+===== `utils/mod_fixes.py`
+
+This utility modifies the `<affected>` element of a remediation. It supports
+several commands on a given rule and for the specified remediation language:
+
+   - `mod_fixes.py <rule_id> <lang> list` - list all fixes, their computed
+     products, and their actual platforms.
+   - `mod_fixes.py <rule_id> <lang> delete <product>` - delete the fix for
+     the specified product.
+   - `mod_fixes.py <rule_id> <lang> make_shared <product>` - moves the product
+     fix to the shared fix (e.g., `rhel7.sh` to `shared.sh`).
+   - `mod_fixes.py <rule_id> <lang> diff <product> <product>` - Performs a
+     diff between two fixes (product can be `shared` to diff against the
+     shared fix).
+
+In addition, the `mod_fixes.py` utility supports modifying the shared fixes
+with the following commands:
+
+   - `mod_fixes.py <rule_id> <lang> add <platform> [<platform> ...]` - adds
+     the specified platforms to the shared fix for the rule specified by
+     `rule_id`.
+   - `mod_fixes.py <rule_id> <lang> remove <platform> [<platform> ...]` - removes
+     the specified platforms from the shared fix.
+   - `mod_fixes.py <rule_id> <lang> replace <replacement> [<replacement ...]` - do
+     the specified replacement against the platforms in the shared fix. See
+     the description of `replace` under `mod_prodtype.py` for more
+     information about the format of a replacement.
+
+This utility requires an up to date JSON tree created by `rule_dir_json.py`.
+
 ==== Checks
 
 Checks are used to evaluate a Rule. They are written using a custom OVAL syntax and are stored as xml files inside the _checks/oval_ directory for the desired platform.

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -707,6 +707,29 @@ modules have been created, as well as three utilities:
 
 For more information about these utilities, please see their help text.
 
+To interact with `rule.yml` files and the OVALs inside a rule directory, the
+following utilities are provided:
+
+===== `utils/mod_prodtype.py`
+
+This utility modifies the prodtype field of rules. It supports several
+commands:
+
+   - `mod_prodtype.py <rule_id> list` - list the computed and actual prodtype
+     of the rule specified by `rule_id`.
+   - `mod_prodtype.py <rule_id> add <product> [<product> ...]` - add additional
+     products to the prodtype of the rule specified by `rule_id`.
+   - `mod_prodtype.py <rule_id> remove <product> [<product> ...]` - remove products
+     to the prodtype of the rule specified by `rule_id`.
+   - `mod_prodtype.py <rule_id> replace <replacement> [<replacement> ...]` - do
+     the specified replacement transformations. A replacement transformation is
+     of the form `match~replace` where `match` and `replace` are a comma
+     separated list of products. If all of the products in `match` exist in the
+     original `prodtype` of the rule, they are removed and the products in
+     `replace` are added.
+
+This utility requires an up to date JSON tree created by `rule_dir_json.py`.
+
 ==== Checks
 
 Checks are used to evaluate a Rule. They are written using a custom OVAL syntax and are stored as xml files inside the _checks/oval_ directory for the desired platform.

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -171,6 +171,9 @@ def parse_from_file(file_path, env_yaml):
     we need a env_yaml context to process these. In practice, no remediations
     use jinja in the configuration, so for extracting only the configuration,
     env_yaml can be an abritrary product.yml dictionary.
+
+    If the logic of configuration parsing changes significantly, please also
+    update ssg.fixes.parse_platform(...).
     """
 
     mod_file = []

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -180,19 +180,21 @@ def parse_from_file(file_path, env_yaml):
 
     # Assignment automatically escapes shell characters for XML
     for line in fix_file_lines:
-        if line.startswith('#'):
-            try:
-                (key, value) = line.strip('#').split('=')
-                if key.strip() in REMEDIATION_CONFIG_KEYS:
-                    config[key.strip()] = value.strip()
-                else:
-                    if not line.startswith(FILE_GENERATED_HASH_COMMENT):
-                        mod_file.append(line)
-            except ValueError:
-                if not line.startswith(FILE_GENERATED_HASH_COMMENT):
-                    mod_file.append(line)
-        else:
-            mod_file.append(line)
+        if line.startswith(FILE_GENERATED_HASH_COMMENT):
+            continue
+
+        if line.startswith('#') and line.count('=') == 1:
+            (key, value) = line.strip('#').split('=')
+            if key.strip() in REMEDIATION_CONFIG_KEYS:
+                config[key.strip()] = value.strip()
+                continue
+
+        # If our parsed line wasn't a config item, add it to the
+        # returned file contents. This includes when the line
+        # begins with a '#' and contains an equals sign, but
+        # the "key" isn't one of the known keys from
+        # REMEDIATION_CONFIG_KEYS.
+        mod_file.append(line)
 
     remediation = namedtuple('remediation', ['contents', 'config'])
     return remediation(mod_file, config)

--- a/ssg/fixes.py
+++ b/ssg/fixes.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import re
+
+from .build_remediations import parse_from_file
+from .constants import XCCDF11_NS
+from .rule_yaml import parse_prodtype
+from .utils import read_file_list
+
+from .build_remediations import REMEDIATION_TO_EXT_MAP as REMEDIATION_MAP
+
+
+def get_fix_path(rule_obj, lang, fix_id):
+    """
+    For the given fix_id or product, return the full path to the fix of the
+    given language in the rule described by the given rule_obj.
+    """
+
+    if not fix_id.endswith(REMEDIATION_MAP[lang]):
+        fix_id += REMEDIATION_MAP[lang]
+
+    if ('dir' not in rule_obj or 'id' not in rule_obj or
+        'remediations' not in rule_obj or lang not in rule_obj['remediations']):
+        raise ValueError("Malformed rule_obj")
+
+    if fix_id not in rule_obj['remediations'][lang]:
+        raise ValueError("Unknown fix_id:%s for rule_id:%s and lang:%s" %
+                         (fix_id, rule_obj['id'], lang))
+
+    return os.path.join(rule_obj['dir'], lang, fix_id)
+
+
+def get_fix_contents(rule_obj, lang, fix_id):
+    """
+    Returns the tuple (path, contents) of the fix described by the given
+    fix_id or product.
+    """
+
+    fix_path = get_fix_path(rule_obj, lang, fix_id)
+    fix_contents = read_file_list(fix_path)
+
+    return fix_path, fix_contents
+
+
+def applicable_platforms(fix_path):
+    _, config = parse_from_file(fix_path, {})
+
+    if not 'platform' in config:
+        raise ValueError("Malformed fix: missing platform" % fix_path)
+
+    return parse_prodtype(config['platform'])
+
+
+def parse_platform(fix_contents):
+    """
+    Parses the platform configuration item to determine the line number that
+    the platforms configuration option is on. If this key is not found, None
+    is returned instead.
+
+    Note that this performs no validation on the contents of the file besides
+    this and does not return the current value of the platform.
+
+    If the configuration specification changes any, please update the
+    corresponding parsing in ssg.build_remediations.parse_from_file(...).
+    """
+
+    matched_line = None
+    for line_num in range(0, len(fix_contents)):
+        line = fix_contents[line_num]
+        if line.startswith('#') and '=' in line:
+            key, value = line.strip('#').split('=', 1)
+            if key.strip() == 'platform':
+                matched_line = line_num
+
+    return matched_line
+
+def set_applicable_platforms(fix_contents, new_platforms):
+    """
+    Returns a modified contents which updates the platforms to the new
+    platforms.
+    """
+
+    platform_line = parse_platform(fix_contents)
+    if platform_line is None:
+        raise ValueError("When parsing config file, unable to find platform "
+                         "line!\n\n%s" % "\n".join(fix_contents))
+
+    new_platforms_str = "# platform = " + ",".join(sorted(new_platforms))
+
+    new_contents = fix_contents[0:platform_line]
+    new_contents.extend([new_platforms_str])
+    new_contents.extend(fix_contents[platform_line+1:])
+
+    return new_contents

--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -101,6 +101,87 @@ def applicable_platforms(oval_file):
     return platforms
 
 
+def parse_affected(oval_contents):
+    """
+    Returns the tuple (start_affected, end_affected, platform_indents) for
+    the passed oval file contents. start_affected is the line number of
+    starting tag of the <affected> element, end_affected is the line number of
+    the closing tag of the </affected> element, and platform_indents is a
+    string containing the indenting characters before the contents of the
+    <affected> element.
+    """
+
+    start_affected = list(filter(lambda x: "<affected" in oval_contents[x],
+                                 range(0, len(oval_contents))))
+    if len(start_affected) != 1:
+        raise ValueError("OVAL file does not contain a single <affected> "
+                         "element; counted %d in:\n%s\n\n" %
+                         (len(start_affected), "\n".join(oval_contents)))
+
+    start_affected = start_affected[0]
+
+    end_affected = list(filter(lambda x: "</affected" in oval_contents[x],
+                               range(0, len(oval_contents))))
+    if len(end_affected) != 1:
+        raise ValueError("Malformed OVAL file does not contain a single "
+                         "closing </affected>; counted %d in:\n%s\n\n" %
+                         (len(start_affected), "\n".join(oval_contents)))
+    end_affected = end_affected[0]
+
+    if start_affected >= end_affected:
+        raise ValueError("Malformed OVAL file: start affected tag begins "
+                         "on the same line or after ending affected tag: "
+                         "start:%d vs end:%d:\n%s\n\n" %
+                         (start_affected, end_affected, oval_contents))
+
+    # Validate that start_affected contains only a starting <affected> tag;
+    # otherwise, using this information to update the <platform> subelements
+    # would fail.
+    start_line = oval_contents[start_affected]
+    start_line = start_line.strip()
+
+    if not start_line.startswith('<affected'):
+        raise ValueError("Malformed OVAL file: line with starting affected "
+                         "tag contains other elements: line:%s\n%s\n\n" %
+                         (start_line, oval_contents))
+    if '<' in start_line[1:]:
+        raise ValueError("Malformed OVAL file: line with starting affected "
+                         "tag contains other elements: line:%s\n%s\n\n" %
+                         (start_line, oval_contents))
+
+    # Validate that end_affected contains only an ending </affected> tag;
+    # otherwise, using this information to update the <platform> subelements
+    # would fail.
+    end_line = oval_contents[end_affected]
+    end_line = end_line.strip()
+
+    if not end_line.startswith('</affected>'):
+        raise ValueError("Malformed OVAL file: line with ending affected "
+                         "tag contains other elements: line:%s\n%s\n\n" %
+                         (end_line, oval_contents))
+    if '<' in end_line[1:]:
+        raise ValueError("Malformed OVAL file: line with ending affected "
+                         "tag contains other elements: line:%s\n%s\n\n" %
+                         (end_line, oval_contents))
+
+    indents = ""
+    if start_affected+1 == end_affected:
+        # Since the affected element is present but empty, the indents should
+        # be two more spaces than that of the starting <affected> element.
+        start_index = oval_contents[start_affected].index('<')
+        indents = oval_contents[start_affected][0:start_index]
+        indents += "  "
+    else:
+        # Otherwise, grab the indents off the next line unmodified, as this is
+        # likely a platform element tag. We don't validate here that this is
+        # indeed the case, as other parts of the build infrastructure will
+        # validate this for us.
+        start_index = oval_contents[start_affected+1].index('<')
+        indents = oval_contents[start_affected+1][0:start_index]
+
+    return start_affected, end_affected, indents
+
+
 def replace_external_vars(tree):
     """Replace external_variables with local_variables, so the definition can be
        tested independently of an XCCDF file"""

--- a/ssg/rule_yaml.py
+++ b/ssg/rule_yaml.py
@@ -12,29 +12,7 @@ from collections import namedtuple
 import yaml
 
 from .rules import get_rule_dir_yaml
-
-
-def read_file_list(path):
-    """
-    Reads the given file path and returns the contents as a list.
-    """
-
-    file_contents = open(path, 'r').read().split("\n")
-    if file_contents[-1] == '':
-        file_contents = file_contents[:-1]
-    return file_contents
-
-
-def write_list_file(path, contents):
-    """
-    Writes the given contents to path.
-    """
-
-    _contents = "\n".join(contents) + "\n"
-    _f = open(path, 'w')
-    _f.write(_contents)
-    _f.flush()
-    _f.close()
+from .utils import read_file_list
 
 
 def find_section_lines(file_contents, sec):

--- a/ssg/rule_yaml.py
+++ b/ssg/rule_yaml.py
@@ -1,0 +1,199 @@
+"""
+The rule_yaml module provides various utility functions for handling YAML files
+containing Jinja macros, without having to parse the macros.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+from collections import namedtuple
+import yaml
+
+from .rules import get_rule_dir_yaml
+
+
+def read_file_list(path):
+    """
+    Reads the given file path and returns the contents as a list.
+    """
+
+    file_contents = open(path, 'r').read().split("\n")
+    if file_contents[-1] == '':
+        file_contents = file_contents[:-1]
+    return file_contents
+
+
+def write_list_file(path, contents):
+    """
+    Writes the given contents to path.
+    """
+
+    _contents = "\n".join(contents) + "\n"
+    _f = open(path, 'w')
+    _f.write(_contents)
+    _f.flush()
+    _f.close()
+
+
+def find_section_lines(file_contents, sec):
+    """
+    Parses the given file_contents as YAML to find the section with the given identifier.
+    Note that this does not call into the yaml library and thus correctly handles jinja
+    macros at the expense of not being a strictly valid yaml parsing.
+
+    Returns a list of namedtuples (start, end) of the lines where section exists.
+    """
+
+    # Hack to find a global key ("section"/sec) in a YAML-like file.
+    # All indented lines until the next global key are included in the range.
+    # For example:
+    #
+    # 0: not_it:
+    # 1:     - value
+    # 2: this_one:
+    # 3:      - 2
+    # 4:      - 5
+    # 5:
+    # 6: nor_this:
+    #
+    # for the section "this_one", the result [(2, 5)] will be returned.
+    # Note that multiple sections may exist in a file and each will be
+    # identified and returned.
+    section = namedtuple('section', ['start', 'end'])
+
+    sec_ranges = []
+    sec_id = sec + ":"
+    sec_len = len(sec_id)
+    end_num = len(file_contents)
+    line_num = 0
+
+    while line_num < end_num:
+        if len(file_contents[line_num]) >= sec_len:
+            if file_contents[line_num][0:sec_len] == sec_id:
+                begin = line_num
+                line_num += 1
+                while line_num < end_num:
+                    nonempty_line = file_contents[line_num]
+                    if nonempty_line and file_contents[line_num][0] != ' ':
+                        break
+                    line_num += 1
+
+                end = line_num - 1
+                sec_ranges.append(section(begin, end))
+        line_num += 1
+
+    return sec_ranges
+
+
+def add_key_value(contents, key, start_line, new_value):
+    """
+    Adds a new key to contents with the given value after line start_line, returning
+    the result. Also adds a blank line afterwards.
+
+    Does not modify the value of contents.
+    """
+
+    new_contents = contents[:start_line]
+    new_contents.append("%s: %s" % (key, new_value))
+    new_contents.append("")
+    new_contents.extend(contents[start_line:])
+
+    return new_contents
+
+
+def update_key_value(contents, key, old_value, new_value):
+    """
+    Find key in the contents of a file and replace its value with the new value,
+    returning the resulting file. This validates that the old value is constant and
+    hasn't changed since parsing its value.
+
+    Raises a ValueError when the key cannot be found in the given contents.
+
+    Does not modify the value of contents.
+    """
+
+    new_contents = contents[:]
+    old_line = key + ": " + old_value
+    updated = False
+
+    for line_num in range(0, len(new_contents)):
+        line = new_contents[line_num]
+        if line == old_line:
+            new_contents[line_num] = key + ": " + new_value
+            updated = True
+            break
+
+    if not updated:
+        raise ValueError("For key:%s, cannot find the old value (%s) in the given "
+                         "contents." % (key, old_value))
+
+    return new_contents
+
+
+def remove_lines(contents, lines):
+    """
+    Remove the lines of the section from the parsed file, returning the new contents.
+
+    Does not modify the passed in contents.
+    """
+
+    new_contents = contents[:lines.start]
+    new_contents.extend(contents[lines.end+1:])
+    return new_contents
+
+
+def parse_from_yaml(file_contents, lines):
+    """
+    Parse the given line range as a yaml, returning the parsed object.
+    """
+
+    new_file_arr = file_contents[lines.start:lines.end + 1]
+    new_file = "\n".join(new_file_arr)
+    return yaml.load(new_file)
+
+
+def get_yaml_contents(rule_obj):
+    """
+    From a rule_obj description, return a namedtuple of (path, contents); where
+    path is the path to the rule YAML and contents is the list of lines in
+    the file.
+    """
+
+    file_description = namedtuple('file_description', ('path', 'contents'))
+
+    yaml_file = get_rule_dir_yaml(rule_obj['dir'])
+    if not os.path.exists(yaml_file):
+        raise ValueError("Error: yaml file does not exist for rule_id:%s" %
+                         rule_obj['id'], file=sys.stderr)
+
+    yaml_contents = read_file_list(yaml_file)
+
+    return file_description(yaml_file, yaml_contents)
+
+
+def parse_prodtype(prodtype):
+    """
+    From a prodtype line, returns the set of products listed.
+    """
+
+    return set(map(lambda x: x.strip(), prodtype.split(',')))
+
+
+def get_section_lines(file_path, file_contents, key_name):
+    """
+    From the given file_path and file_contents, find the lines describing the section
+    key_name and returns the line range of the section.
+    """
+
+    section = find_section_lines(file_contents, key_name)
+
+    if len(section) > 1:
+        raise ValueError("Multiple instances (%d) of %s in %s; refusing to modify file." %
+                         (len(section), key_name, file_path), file=sys.stderr)
+
+    elif len(section) == 1:
+        return section[0]
+
+    return None

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -60,3 +60,26 @@ def subset_dict(dictionary, keys):
             del result[original_key]
 
     return result
+
+
+def read_file_list(path):
+    """
+    Reads the given file path and returns the contents as a list.
+    """
+
+    file_contents = open(path, 'r').read().split("\n")
+    if file_contents[-1] == '':
+        file_contents = file_contents[:-1]
+    return file_contents
+
+
+def write_list_file(path, contents):
+    """
+    Writes the given contents to path.
+    """
+
+    _contents = "\n".join(contents) + "\n"
+    _f = open(path, 'w')
+    _f.write(_contents)
+    _f.flush()
+    _f.close()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,8 @@ add_test(
     NAME "validate-parse-affected"
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_parse_affected.py" "${CMAKE_SOURCE_DIR}"
 )
+
+add_test(
+    NAME "validate-parse-platform"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_parse_platform.py" "${CMAKE_SOURCE_DIR}"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,8 @@ add_test(
     NAME "max-path-len"
     COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/ensure_paths_are_short.py"
 )
+
+add_test(
+    NAME "validate-parse-affected"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_parse_affected.py" "${CMAKE_SOURCE_DIR}"
+)

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+import ssg.constants
+import ssg.oval
+import ssg.rules
+import ssg.utils
+import ssg.yaml
+
+
+def main():
+    """
+    Walk through all known products in the ssg root specified in sys.argv[1],
+    and ensure that all ovals in all rule directories are parsable under
+    ssg.oval.parse_affected(...).
+    """
+
+    if len(sys.argv) != 2:
+        print("Error! Must supply only path to root of ssg directory",
+              file=sys.stderr)
+        sys.exit(1)
+
+    ssg_root = sys.argv[1]
+
+    guide_dirs = set()
+    for product in ssg.constants.product_directories:
+        product_dir = os.path.join(ssg_root, product)
+        product_yaml_path = os.path.join(product_dir, "product.yml")
+        product_yaml = ssg.yaml.open_raw(product_yaml_path)
+
+        guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])
+        if guide_dir in guide_dirs:
+            continue
+
+        for rule_dir in ssg.rules.find_rule_dirs(guide_dir):
+            for oval in ssg.rules.get_rule_dir_ovals(rule_dir):
+                oval_contents = ssg.utils.read_file_list(oval)
+                results = ssg.oval.parse_affected(oval_contents)
+
+                assert len(results) == 3
+                assert isinstance(results[0], int)
+                assert isinstance(results[1], int)
+
+        guide_dirs.add(guide_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_parse_platform.py
+++ b/tests/test_parse_platform.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+import ssg.build_remediations
+import ssg.constants
+import ssg.fixes
+import ssg.rules
+import ssg.utils
+import ssg.yaml
+
+REMEDIATION_LANGS = list(ssg.build_remediations.REMEDIATION_TO_EXT_MAP)
+
+
+def main():
+    """
+    Walk through all known products in the ssg root specified in sys.argv[1],
+    and ensure that all fixes in all rule directories are parsable under
+    ssg.fixes.parse_platform(...).
+    """
+
+    if len(sys.argv) != 2:
+        print("Error! Must supply only path to root of ssg directory",
+              file=sys.stderr)
+        sys.exit(1)
+
+    ssg_root = sys.argv[1]
+
+    guide_dirs = set()
+    for product in ssg.constants.product_directories:
+        product_dir = os.path.join(ssg_root, product)
+        product_yaml_path = os.path.join(product_dir, "product.yml")
+        product_yaml = ssg.yaml.open_raw(product_yaml_path)
+
+        guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])
+        if guide_dir in guide_dirs:
+            continue
+
+        for rule_dir in ssg.rules.find_rule_dirs(guide_dir):
+            for lang in REMEDIATION_LANGS:
+                for fix in ssg.rules.get_rule_dir_remediations(rule_dir, lang):
+                    fix_contents = ssg.utils.read_file_list(fix)
+                    results = ssg.fixes.parse_platform(fix_contents)
+
+                    assert results is not None
+                    assert isinstance(results, int)
+
+        guide_dirs.add(guide_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/ssg-module/test_checks.py
+++ b/tests/unit/ssg-module/test_checks.py
@@ -1,6 +1,35 @@
+import os
+
 import pytest
 
 import ssg.checks
+
+
+def test_get_oval_path():
+    rule_obj = {
+        'id': 'some_id',
+        'dir': '/some/random/path/to/a/rule/called/some_id',
+        'ovals': {
+            'shared.xml': {}
+        }
+    }
+    correct_path = os.path.join(rule_obj['dir'], "oval", "shared.xml")
+
+    assert ssg.checks.get_oval_path(rule_obj, "shared") == correct_path
+    assert ssg.checks.get_oval_path(rule_obj, "shared.xml") == correct_path
+
+    with pytest.raises(ValueError):
+        ssg.checks.get_oval_path(rule_obj, "missing")
+
+    with pytest.raises(ValueError):
+        ssg.checks.get_oval_path({'id': 'something'}, "missing_dir")
+
+    with pytest.raises(ValueError):
+        ssg.checks.get_oval_path({}, "missing_id")
+
+    with pytest.raises(ValueError):
+        ssg.checks.get_oval_path({'id': 'present', 'dir': '/'},
+                                 "missing_ovals")
 
 
 def test_is_cce_valid():

--- a/tests/unit/ssg/data/ssg_rule_yaml.txt
+++ b/tests/unit/ssg/data/ssg_rule_yaml.txt
@@ -1,0 +1,1 @@
+testing

--- a/tests/unit/ssg/test_rule_yaml.py
+++ b/tests/unit/ssg/test_rule_yaml.py
@@ -1,0 +1,15 @@
+import pytest
+
+import os
+import ssg.rule_yaml
+
+data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
+
+
+def test_read_file_list():
+    path = os.path.join(data_dir, 'ssg_rule_yaml.txt')
+    contents = ssg.rule_yaml.read_file_list(path)
+
+    assert isinstance(contents, list)
+    assert len(contents) == 1
+    assert contents[0] == 'testing'

--- a/utils/mod_checks.py
+++ b/utils/mod_checks.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import argparse
+import subprocess
+import json
+
+import ssg.checks
+import ssg.oval
+import ssg.rule_yaml
+import ssg.utils
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-j", "--json", type=str, action="store", default="build/rule_dirs.json",
+                        help="File to read json output of rule_dir_json from (defaults "
+                             "to build/rule_dirs.json)")
+    parser.add_argument("rule_id", type=str, help="Rule to change, by id")
+    parser.add_argument("action", choices=['add', 'remove', 'list', 'replace', 'delete', 'make_shared', 'diff'],
+                        help="Rule to change, by id")
+    parser.add_argument("products", type=str, nargs='*',
+                        help="Products or platforms to perform action with on rule_id. For replace, "
+                             "the expected format is "
+                             "platform[,other_platform]~platform[,other_platform] "
+                             "where the first half is the platforms that are required to "
+                             "match, and are replaced by the platforms in the second half "
+                             "if all match. Add and remove require platforms and only apply "
+                             "to the shared OVAL; delete, make_shared, and diff require products.")
+    return parser.parse_args()
+
+
+def list_platforms(rule_obj):
+    print("Computed products:")
+    for oval_id in sorted(rule_obj.get('ovals', {})):
+        oval = rule_obj['ovals'][oval_id]
+
+        print(" - %s" % oval_id)
+        for product in sorted(oval.get('products', [])):
+            print("   - %s" % product)
+
+    print("")
+
+    print("Actual platforms:")
+    for oval_id in sorted(rule_obj.get('ovals', {})):
+        oval = rule_obj['ovals'][oval_id]
+        oval_file = ssg.checks.get_oval_path(rule_obj, oval_id)
+        platforms = ssg.oval.applicable_platforms(oval_file)
+
+        print(" - %s" % oval_id)
+        for platform in platforms:
+            print("   - %s" % platform)
+
+    print("")
+
+
+def add_platforms(rule_obj, platforms):
+    oval_file, oval_contents = ssg.checks.get_oval_contents(rule_obj, 'shared')
+    current_platforms = ssg.oval.applicable_platforms(oval_file)
+    new_platforms = set(current_platforms)
+    new_platforms.update(platforms)
+
+    print("Current platforms: %s" % ','.join(sorted(current_platforms)))
+    print("New platforms: %s" % ','.join(sorted(new_platforms)))
+
+    new_contents = ssg.checks.set_applicable_platforms(oval_contents,
+                                                       new_platforms)
+    ssg.utils.write_list_file(oval_file, new_contents)
+
+
+def remove_platforms(rule_obj, platforms):
+    oval_file, oval_contents = ssg.checks.get_oval_contents(rule_obj, 'shared')
+    current_platforms = ssg.oval.applicable_platforms(oval_file)
+    new_platforms = set(current_platforms).difference(platforms)
+
+    print("Current platforms: %s" % ','.join(sorted(current_platforms)))
+    print("New platforms: %s" % ','.join(sorted(new_platforms)))
+
+    new_contents = ssg.checks.set_applicable_platforms(oval_contents,
+                                                       new_platforms)
+    ssg.utils.write_list_file(oval_file, new_contents)
+
+
+def replace_platforms(rule_obj, platforms):
+    oval_file, oval_contents = ssg.checks.get_oval_contents(rule_obj, 'shared')
+    current_platforms = ssg.oval.applicable_platforms(oval_file)
+    new_platforms = set(current_platforms)
+
+    for platform in platforms:
+        parsed_platform = platform.split('~')
+        if not len(parsed_platform) == 2:
+            print("Invalid platform replacement description: %s" % product,
+                  file=sys.stderr)
+            sys.exit(1)
+
+        match = ssg.rule_yaml.parse_prodtype(parsed_platform[0])
+        replacement = ssg.rule_yaml.parse_prodtype(parsed_platform[1])
+
+        if match.issubset(current_platforms):
+            new_platforms.difference_update(match)
+            new_platforms.update(replacement)
+
+    print("Current platforms: %s" % ','.join(sorted(current_platforms)))
+    print("New platforms: %s" % ','.join(sorted(new_platforms)))
+
+    new_contents = ssg.checks.set_applicable_platforms(oval_contents,
+                                                       new_platforms)
+    ssg.utils.write_list_file(oval_file, new_contents)
+
+
+def delete_ovals(rule_obj, products):
+    for product in products:
+        oval_file = ssg.checks.get_oval_path(rule_obj, product)
+        os.remove(oval_file)
+        print("Removed: %s" % oval_file)
+
+
+def make_shared_oval(rule_obj, products):
+    if not products or len(products) > 1:
+        raise ValueError("Must pass exactly one product for the make_shared option.")
+    if 'ovals' not in rule_obj:
+        raise ValueError("Rule is missing all ovals.")
+
+    if 'shared.xml' in rule_obj['ovals']:
+        raise ValueError("Already have shared oval for rule_id:%s; refusing "
+                         "to continue." % rule_obj['id'])
+
+    oval_file = ssg.checks.get_oval_path(rule_obj, products[0])
+    shared_oval_file = os.path.join(rule_obj['dir'], 'oval', 'shared.xml')
+    os.rename(oval_file, shared_oval_file)
+    print("Moved %s -> %s" % (oval_file, shared_oval_file))
+
+
+def diff_ovals(rule_obj, products):
+    if not products or len(products) != 2 or products[0] == products[1]:
+        raise ValueError("Must pass exactly two products for the diff option.")
+    if 'ovals' not in rule_obj:
+        raise ValueError("Rule is missing all ovals.")
+
+    left_oval_file = ssg.checks.get_oval_path(rule_obj, products[0])
+    right_oval_file = ssg.checks.get_oval_path(rule_obj, products[1])
+
+    subprocess.run(['diff', '--color=always', left_oval_file, right_oval_file])
+
+
+def main():
+    args = parse_args()
+
+    json_file = open(args.json, 'r')
+    known_rules = json.load(json_file)
+
+    if not args.rule_id in known_rules:
+        print("Error: rule_id:%s is not known!" % args.rule_id, file=sys.stderr)
+        print("If you think this is an error, try regenerating the JSON.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.action != "list" and not args.products:
+        print("Error: expected a list of products or replace transformations but "
+              "none given.", file=sys.stderr)
+        sys.exit(1)
+
+    rule_obj = known_rules[args.rule_id]
+    print("rule_id:%s\n" % args.rule_id)
+
+    if args.action == "list":
+        list_platforms(rule_obj)
+    elif args.action == "add":
+        add_platforms(rule_obj, args.products)
+    elif args.action == "remove":
+        remove_platforms(rule_obj, args.products)
+    elif args.action == "replace":
+        replace_platforms(rule_obj, args.products)
+    elif args.action == 'delete':
+        delete_ovals(rule_obj, args.products)
+    elif args.action == 'make_shared':
+        make_shared_oval(rule_obj, args.products)
+    elif args.action == 'diff':
+        diff_ovals(rule_obj, args.products)
+    else:
+        print("Unknown option: %s" % args.action)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mod_fixes.py
+++ b/utils/mod_fixes.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import argparse
+import subprocess
+import json
+
+import ssg.build_remediations
+import ssg.fixes
+import ssg.rule_yaml
+import ssg.utils
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+REMEDIATION_LANGS = list(ssg.build_remediations.REMEDIATION_TO_EXT_MAP)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-j", "--json", type=str, action="store", default="build/rule_dirs.json",
+                        help="File to read json output of rule_dir_json from (defaults "
+                             "to build/rule_dirs.json)")
+    parser.add_argument("rule_id", type=str, help="Rule to change, by id")
+    parser.add_argument("fix_lang", choices=REMEDIATION_LANGS, help="Remediation to change")
+    parser.add_argument("action", choices=['add', 'remove', 'list', 'replace', 'delete', 'make_shared', 'diff'],
+                        help="Rule to change, by id")
+    parser.add_argument("products", type=str, nargs='*',
+                        help="Products or platforms to perform action with on rule_id. For replace, "
+                             "the expected format is "
+                             "platform[,other_platform]~platform[,other_platform] "
+                             "where the first half is the platforms that are required to "
+                             "match, and are replaced by the platforms in the second half "
+                             "if all match. Add and remove require platforms and only apply "
+                             "to the shared OVAL; delete, make_shared, and diff require products.")
+    return parser.parse_args()
+
+
+def list_platforms(rule_obj, lang):
+    print("Computed products:")
+    for fix_id in sorted(rule_obj['remediations'].get(lang, {})):
+        fix = rule_obj['remediations'][lang][fix_id]
+
+        print(" - %s" % fix_id)
+        for product in sorted(fix.get('products', [])):
+            print("   - %s" % product)
+
+    print("")
+
+    print("Actual platforms:")
+    for rule_id in sorted(rule_obj['remediations'].get(lang, {})):
+        fix = rule_obj['remediations'][lang][rule_id]
+        fix_file = ssg.fixes.get_fix_path(rule_obj, lang, rule_id)
+        platforms = ssg.fixes.applicable_platforms(fix_file)
+
+        print(" - %s" % fix_id)
+        for platform in platforms:
+            print("   - %s" % platform)
+
+    print("")
+
+
+def add_platforms(rule_obj, lang, platforms):
+    fix_file, fix_contents = ssg.fixes.get_fix_contents(rule_obj, lang, 'shared')
+    current_platforms = ssg.fixes.applicable_platforms(fix_file)
+    new_platforms = set(current_platforms)
+    new_platforms.update(platforms)
+
+    print("Current platforms: %s" % ','.join(sorted(current_platforms)))
+    print("New platforms: %s" % ','.join(sorted(new_platforms)))
+
+    new_contents = ssg.fixes.set_applicable_platforms(fix_contents,
+                                                      new_platforms)
+    ssg.utils.write_list_file(fix_file, new_contents)
+
+
+def remove_platforms(rule_obj, lang, platforms):
+    fix_file, fix_contents = ssg.fixes.get_fix_contents(rule_obj, lang, 'shared')
+    current_platforms = ssg.fixes.applicable_platforms(fix_file)
+    new_platforms = set(current_platforms).difference(platforms)
+
+    print("Current platforms: %s" % ','.join(sorted(current_platforms)))
+    print("New platforms: %s" % ','.join(sorted(new_platforms)))
+
+    new_contents = ssg.fixes.set_applicable_platforms(fix_contents,
+                                                      new_platforms)
+    ssg.utils.write_list_file(fix_file, new_contents)
+
+
+def replace_platforms(rule_obj, lang, platforms):
+    fix_file, fix_contents = ssg.fixes.get_fix_contents(rule_obj, lang, 'shared')
+    current_platforms = ssg.fixes.applicable_platforms(fix_file)
+    new_platforms = set(current_platforms)
+
+    for platform in platforms:
+        parsed_platform = platform.split('~')
+        if not len(parsed_platform) == 2:
+            print("Invalid platform replacement description: %s" % product,
+                  file=sys.stderr)
+            sys.exit(1)
+
+        match = ssg.rule_yaml.parse_prodtype(parsed_platform[0])
+        replacement = ssg.rule_yaml.parse_prodtype(parsed_platform[1])
+
+        if match.issubset(current_platforms):
+            new_platforms.difference_update(match)
+            new_platforms.update(replacement)
+
+    print("Current platforms: %s" % ','.join(sorted(current_platforms)))
+    print("New platforms: %s" % ','.join(sorted(new_platforms)))
+
+    new_contents = ssg.fixes.set_applicable_platforms(fix_contents,
+                                                      new_platforms)
+    ssg.utils.write_list_file(fix_file, new_contents)
+
+
+def delete_fixes(rule_obj, lang, products):
+    for product in products:
+        fix_file = ssg.fixes.get_fix_path(rule_obj, lang, product)
+        os.remove(fix_file)
+        print("Removed: %s" % fix_file)
+
+
+def make_shared_fix(rule_obj, lang, products):
+    if not products or len(products) > 1:
+        raise ValueError("Must pass exactly one product for the make_shared option.")
+    if 'remediations' not in rule_obj or lang not in rule_obj['remediations']:
+        raise ValueError("Rule is missing fixes.")
+
+    lang_ext = ssg.build_remediations.REMEDIATION_TO_EXT_MAP[lang]
+    shared_name = "shared" + lang_ext
+    if shared_name in rule_obj['remediations'][lang]:
+        raise ValueError("Already have shared fix for rule_id:%s; refusing "
+                         "to continue." % rule_obj['id'])
+
+    fix_file = ssg.fixes.get_fix_path(rule_obj, lang, products[0])
+    shared_fix_file = os.path.join(rule_obj['dir'], lang, shared_name)
+    os.rename(fix_file, shared_fix_file)
+    print("Moved %s -> %s" % (fix_file, shared_fix_file))
+
+
+def diff_fixes(rule_obj, lang, products):
+    if not products or len(products) != 2 or products[0] == products[1]:
+        raise ValueError("Must pass exactly two products for the diff option.")
+    if 'remediations' not in rule_obj or lang not in rule_obj['remediations']:
+        raise ValueError("Rule is missing fixes.")
+
+    left_fix_file = ssg.fixes.get_fix_path(rule_obj, lang, products[0])
+    right_fix_file = ssg.fixes.get_fix_path(rule_obj, lang, products[1])
+
+    subprocess.run(['diff', '--color=always', left_fix_file, right_fix_file])
+
+
+def main():
+    args = parse_args()
+
+    json_file = open(args.json, 'r')
+    known_rules = json.load(json_file)
+
+    if not args.rule_id in known_rules:
+        print("Error: rule_id:%s is not known!" % args.rule_id, file=sys.stderr)
+        print("If you think this is an error, try regenerating the JSON.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.action != "list" and not args.products:
+        print("Error: expected a list of products or replace transformations but "
+              "none given.", file=sys.stderr)
+        sys.exit(1)
+
+    rule_obj = known_rules[args.rule_id]
+    print("rule_id:%s\n" % args.rule_id)
+
+    if args.action == "list":
+        list_platforms(rule_obj, args.fix_lang)
+    elif args.action == "add":
+        add_platforms(rule_obj, args.fix_lang, args.products)
+    elif args.action == "remove":
+        remove_platforms(rule_obj, args.fix_lang, args.products)
+    elif args.action == "replace":
+        replace_platforms(rule_obj, args.fix_lang, args.products)
+    elif args.action == 'delete':
+        delete_fixes(rule_obj, args.fix_lang, args.products)
+    elif args.action == 'make_shared':
+        make_shared_fix(rule_obj, args.fix_lang, args.products)
+    elif args.action == 'diff':
+        diff_fixes(rule_obj, args.fix_lang, args.products)
+    else:
+        print("Unknown option: %s" % args.action)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mod_prodtype.py
+++ b/utils/mod_prodtype.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import argparse
+import json
+
+import ssg.rules
+import ssg.rule_yaml
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-j", "--json", type=str, action="store", default="build/rule_dirs.json",
+                        help="File to read json output of rule_dir_json from (defaults "
+                             "to build/rule_dirs.json)")
+    parser.add_argument("rule_id", type=str, help="Rule to change, by id")
+    parser.add_argument("action", choices=['add', 'remove', 'list', 'replace'],
+                        help="Rule to change, by id")
+    parser.add_argument("products", type=str, nargs='*',
+                        help="Products to perform action with on rule_id. For replace, "
+                             "the expected format is "
+                             "product[,other_product]~product[,other_product] "
+                             "where the first half is the products that are required to "
+                             "match, and are replaced by the products in the second half "
+                             "if all match.")
+    return parser.parse_args()
+
+
+def list_products(rule_obj):
+    yaml_file, yaml_contents = ssg.rule_yaml.get_yaml_contents(rule_obj)
+    prodtype_section = ssg.rule_yaml.get_section_lines(yaml_file, yaml_contents, 'prodtype')
+
+    print("Computed products:")
+    for product in sorted(rule_obj.get('products', [])):
+        print(" - %s" % product)
+    print("")
+
+    if prodtype_section:
+        prodtype_contents = ssg.rule_yaml.parse_from_yaml(yaml_contents, prodtype_section)
+        prodtype = ssg.rule_yaml.parse_prodtype(prodtype_contents['prodtype'])
+        print("Listed products:")
+        for product in prodtype:
+            print(" - %s" % product)
+    else:
+        print("Empty listed prodtype in the file")
+
+
+def add_products(rule_obj, products):
+    yaml_file, yaml_contents = ssg.rule_yaml.get_yaml_contents(rule_obj)
+    prodtype_section = ssg.rule_yaml.get_section_lines(yaml_file, yaml_contents, 'prodtype')
+
+    if not prodtype_section:
+        new_prodtype = sorted(set(products))
+        new_prodtype_str = ','.join(new_prodtype)
+
+        doc_complete_section = ssg.rule_yaml.get_section_lines(yaml_file, yaml_contents,
+                                                               'documentation_complete')
+        if not doc_complete_section:
+            print("Cannot modify empty prodtype with missing documentation_complete... "
+                  "Are you sure this is a rule file? %s" % yaml_file, file=sys.stderr)
+            sys.exit(1)
+
+        start_line = doc_complete_section[1]+1
+
+        print("Current prodtype is empty")
+        print("New prodtype: %s" % new_prodtype_str)
+        yaml_contents = ssg.rule_yaml.add_key_value(yaml_contents, 'prodtype',
+                                                    start_line, new_prodtype_str)
+    else:
+        prodtype_contents = ssg.rule_yaml.parse_from_yaml(yaml_contents, prodtype_section)
+        prodtype = prodtype_contents['prodtype']
+
+        new_prodtype = ssg.rule_yaml.parse_prodtype(prodtype)
+        new_prodtype.update(products)
+        new_prodtype_str = ','.join(sorted(new_prodtype))
+
+        print("Current prodtype: %s" % prodtype)
+        print("New prodtype: %s" % new_prodtype_str)
+
+        yaml_contents = ssg.rule_yaml.update_key_value(yaml_contents, 'prodtype',
+                                                       prodtype, new_prodtype_str)
+
+    ssg.rule_yaml.write_list_file(yaml_file, yaml_contents)
+
+
+def remove_products(rule_obj, products):
+    yaml_file, yaml_contents = ssg.rule_yaml.get_yaml_contents(rule_obj)
+    prodtype_section = ssg.rule_yaml.get_section_lines(yaml_file, yaml_contents, 'prodtype')
+
+    if not prodtype_section:
+        print("Cannot modify empty prodtype to remove products from %s" %
+              yaml_file, file=sys.stderr)
+        sys.exit(1)
+
+    prodtype_contents = ssg.rule_yaml.parse_from_yaml(yaml_contents, prodtype_section)
+    prodtype = prodtype_contents['prodtype']
+
+    new_prodtype = ssg.rule_yaml.parse_prodtype(prodtype)
+    new_prodtype = new_prodtype.difference(products)
+    new_prodtype_str = ','.join(sorted(new_prodtype))
+
+    print("Current prodtype: %s" % prodtype)
+
+    if new_prodtype:
+        print("New prodtype: %s" % new_prodtype_str)
+        yaml_contents = ssg.rule_yaml.update_key_value(yaml_contents, 'prodtype',
+                                                       prodtype, new_prodtype_str)
+    else:
+        print("New prodtype is empty")
+        yaml_contents = ssg.rule_yaml.remove_lines(yaml_contents, prodtype_section)
+
+    ssg.rule_yaml.write_list_file(yaml_file, yaml_contents)
+
+
+def replace_products(rule_obj, products):
+    yaml_file, yaml_contents = ssg.rule_yaml.get_yaml_contents(rule_obj)
+    prodtype_section = ssg.rule_yaml.get_section_lines(yaml_file, yaml_contents, 'prodtype')
+
+    if not prodtype_section:
+        print("Cannot modify empty prodtype to replace products from %s" % yaml_file,
+              file=sys.stderr)
+        sys.exit(1)
+
+    parsed_changes = []
+    for product in products:
+        parsed_product = product.split('~')
+        if not len(parsed_product) == 2:
+            print("Invalid product replacement description: %s" % product,
+                  file=sys.stderr)
+            sys.exit(1)
+
+        change = {
+            'match': ssg.rule_yaml.parse_prodtype(parsed_product[0]),
+            'replacement': ssg.rule_yaml.parse_prodtype(parsed_product[1]),
+        }
+        parsed_changes.append(change)
+
+    prodtype_contents = ssg.rule_yaml.parse_from_yaml(yaml_contents, prodtype_section)
+    prodtype = prodtype_contents['prodtype']
+
+    current_prodtypes = ssg.rule_yaml.parse_prodtype(prodtype)
+    new_prodtypes = set(current_prodtypes)
+
+    for change in parsed_changes:
+        if change['match'].issubset(current_prodtypes):
+            new_prodtypes.difference_update(change['match'])
+            new_prodtypes.update(change['replacement'])
+
+    new_prodtype_str = ','.join(new_prodtypes)
+
+    print("Current prodtype: %s" % prodtype)
+    print("New prodtype: %s" % new_prodtype_str)
+
+    yaml_contents = ssg.rule_yaml.update_key_value(yaml_contents, 'prodtype',
+                                                   prodtype, new_prodtype_str)
+
+    ssg.rule_yaml.write_list_file(yaml_file, yaml_contents)
+
+
+def main():
+    args = parse_args()
+
+    json_file = open(args.json, 'r')
+    known_rules = json.load(json_file)
+
+    if not args.rule_id in known_rules:
+        print("Error: rule_id:%s is not known!" % args.rule_id, file=sys.stderr)
+        print("If you think this is an error, try regenerating the JSON.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.action != "list" and not args.products:
+        print("Error: expected a list of products or replace transformations but "
+              "none given.", file=sys.stderr)
+        sys.exit(1)
+
+    rule_obj = known_rules[args.rule_id]
+    print("rule_id:%s\n" % args.rule_id)
+
+    if args.action == "list":
+        list_products(rule_obj)
+    elif args.action == "add":
+        add_products(rule_obj, args.products)
+    elif args.action == "remove":
+        remove_products(rule_obj, args.products)
+    elif args.action == "replace":
+        replace_products(rule_obj, args.products)
+    else:
+        print("Unknown option: %s" % args.action)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mod_prodtype.py
+++ b/utils/mod_prodtype.py
@@ -6,6 +6,7 @@ import argparse
 import json
 
 import ssg.rules
+import ssg.utils
 import ssg.rule_yaml
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -83,7 +84,7 @@ def add_products(rule_obj, products):
         yaml_contents = ssg.rule_yaml.update_key_value(yaml_contents, 'prodtype',
                                                        prodtype, new_prodtype_str)
 
-    ssg.rule_yaml.write_list_file(yaml_file, yaml_contents)
+    ssg.utils.write_list_file(yaml_file, yaml_contents)
 
 
 def remove_products(rule_obj, products):
@@ -112,7 +113,7 @@ def remove_products(rule_obj, products):
         print("New prodtype is empty")
         yaml_contents = ssg.rule_yaml.remove_lines(yaml_contents, prodtype_section)
 
-    ssg.rule_yaml.write_list_file(yaml_file, yaml_contents)
+    ssg.utils.write_list_file(yaml_file, yaml_contents)
 
 
 def replace_products(rule_obj, products):
@@ -157,7 +158,7 @@ def replace_products(rule_obj, products):
     yaml_contents = ssg.rule_yaml.update_key_value(yaml_contents, 'prodtype',
                                                    prodtype, new_prodtype_str)
 
-    ssg.rule_yaml.write_list_file(yaml_file, yaml_contents)
+    ssg.utils.write_list_file(yaml_file, yaml_contents)
 
 
 def main():


### PR DESCRIPTION
# `utils/mod_prodtype.py`

Tool for performing operations on the `prodtype`s of a rule YAML. In particular, after generating the `rule_dirs.json` file (via `utils/rule_dir_json`), this will find the rule and either: 

 - Add a product to the `prodtype`
 - Remove a product from the `prodtype` 
 - Apply a transformation (e.g., renaming `rhel6~rhel7`)
 - Listing all prodtypes (computed or actual)

Example usage:

#### Listing
```
$ mod_prodtypes.py sshd_set_keepalive list
rule_id:sshd_set_keepalive

Computed products:
 - debian8
 - example
 - fedora
 - ocp3
 - ol7
 - opensuse
 - rhel-osp7
 - rhel6
 - rhel7
 - sle11
 - sle12
 - ubuntu1404
 - ubuntu1604
 - wrlinux

Empty listed prodtype in the file

$ mod_prodtype.py grub2_enable_fips_mode list
rule_id:grub2_enable_fips_mode

Computed products:
 - rhel7

Listed products:
 - rhel7
```

#### Adding

```
$ mod_prodtype.py sshd_set_keepalive add rhel7
rule_id:sshd_set_keepalive

Current prodtype is empty
New prodtype: rhel7

$ mod_prodtype.py grub2_enable_fips_mode add fedora
rule_id:grub2_enable_fips_mode

Current prodtype: rhel7
New prodtype: fedora,rhel7
```

#### Removing

```
$ mod_prodtype.py grub2_enable_fips_mode remove fedora
rule_id:grub2_enable_fips_mode

Current prodtype: fedora,rhel7
New prodtype: rhel7

$ mod_prodtype.py sshd_set_keepalive remove rhel7
rule_id:sshd_set_keepalive

Current prodtype: rhel7
New prodtype is empty
```

#### Replacing

Replacing is special as the left pattern has to match exactly for the replacement to apply. However, replacements can chained, but always apply to the original prodtype line in the file (so if the prodtype is empty, no replacements will apply).

```
$ mod_prodtype.py grub2_enable_fips_mode replace rhel7~rhel7,fedora
rule_id:grub2_enable_fips_mode

Current prodtype: rhel7
New prodtype: fedora,rhel7

$ mod_prodtype.py grub2_enable_fips_mode replace rhel7~rhel7,fedora fedora~ol7
rule_id:grub2_enable_fips_mode

Current prodtype: rhel7
New prodtype: rhel7,fedora

$ mod_prodtype.py grub2_enable_fips_mode replace rhel7~rhel7,fedora fedora~ol7
rule_id:grub2_enable_fips_mode

Current prodtype: rhel7,fedora
New prodtype: rhel7,ol7

$ mod_prodtype.py grub2_enable_fips_mode replace rhel7~ol7 rhel7~fedora rhel7~rhel7
rule_id:grub2_enable_fips_mode

Current prodtype: rhel7
New prodtype: rhel7,fedora,ol7
```

Note that for `computed products` to update in `list` mode, one must regen the JSON file. 

# `utils/mod_checks.py`

A similar utility to the above is also added, for modifying the platforms in OVAL files. In particular, it only modifies shared OVALs (as it doesn't make sense to modify platform-specific OVALs to include more platforms as the products behind those platforms won't have the OVALs included in the build artifacts...). It also adds commands for diffing / making a product OVAL shared.

See the developer documentation for more information.

# `utils/mod_fixes.py`

Same as `mod_checks.py`, except for modifying fixes. 