### PR TITLE
Add password pam accounts rules to fedora

### DIFF
--- a/fedora/templates/csv/accounts_password.csv
+++ b/fedora/templates/csv/accounts_password.csv
@@ -4,7 +4,11 @@
 # - operation is the comparison operation to perform in OVAL check
 
 dcredit,less than or equal
+difok,greater than or equal
 lcredit,less than or equal
+maxclassrepeat,less than or equal
+maxrepeat,less than or equal
+minclass,greater than or equal
 minlen,greater than or equal
+ocredit,less than or equal
 ucredit,less than or equal
-

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_ocredit/ospp.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_ocredit/ospp.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "ocredit=-1" > /etc/security/pwquality.conf

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_ocredit/ospp_invalid.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_ocredit/ospp_invalid.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "ocredit=4" > /etc/security/pwquality.conf

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_ocredit/ospp_stricter.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_ocredit/ospp_stricter.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "ocredit=-2" > /etc/security/pwquality.conf


### PR DESCRIPTION
#### Description:

- Fill up csv file for `accounts_password_pam_` rules
- Add test for `accounts_password_pam_ocredit`

#### Rationale:

- These rules apply for Fedora, lets just generate them all.
