### PR TITLE
Add OVAL and remediation for auditd_audispd_configure_remote_server

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
+. /usr/share/scap-security-guide/remediation_functions
+populate var_audispd_remote_server
+
+AUDITCONFIG=/etc/audisp/audisp-remote.conf
+
+replace_or_append $AUDITCONFIG '^remote_server' "$var_audispd_remote_server" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="auditd_audispd_configure_remote_server" version="1">
+    <metadata>
+      <title>Configure audispd Plugin Remote Server IP address or Hostname</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>remote_server setting in /etc/audisp/audisp-remote.conf is set to a certain IP address or hostname</description>
+    </metadata>
+    <criteria>
+        <criterion comment="remote_server setting in /etc/audisp/audisp-remote.conf" test_ref="test_auditd_audispd_configure_remote_server" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="remote server to send audit records" id="test_auditd_audispd_configure_remote_server" version="1">
+    <ind:object object_ref="object_auditd_audispd_configure_remote_server" />
+    <ind:state state_ref="state_auditd_audispd_configure_remote_server" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_auditd_audispd_configure_remote_server" version="1">
+    <ind:filepath>/etc/audisp/audisp-remote.conf</ind:filepath>
+    <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
+    <!-- Require at least one space before and after the equal sign -->
+    <ind:pattern operation="pattern match">^[ ]*remote_server[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_auditd_audispd_configure_remote_server" version="1">
+    <ind:subexpression operation="equals" var_ref="var_audispd_remote_server" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="audispd remote_server setting" datatype="string" id="var_audispd_remote_server" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
@@ -19,7 +19,7 @@
 
   <ind:textfilecontent54_object id="object_auditd_audispd_configure_remote_server" version="1">
     <ind:filepath>/etc/audisp/audisp-remote.conf</ind:filepath>
-    <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
+    <!-- Allow only space (exactly) as delimiter -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*remote_server[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
@@ -6,7 +6,7 @@ description: 'The setting for remote_server in /etc/audisp/audisp-remote.conf'
 
 type: string
 
-interactive: false
+interactive: true
 
 options:
     default: myhost.mydomain.com

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_hostname.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_hostname.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment
-set_parameters_value /etc/audisp/audisp-remote.conf "remote_server" "some.hostname.com"
+set_parameters_value /etc/audisp/audisp-remote.conf "remote_server" "myhost.mydomain.com"

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_numeric_address.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/remote_server_numeric_address.pass.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
-
-. ../../auditd_utils.sh
-prepare_auditd_test_enviroment
-set_parameters_value /etc/audisp/audisp-remote.conf "remote_server" "10.10.10.10"


### PR DESCRIPTION
#### Description:
This adds:
- OVAL
- bash remediation
- fixes of SSG TS tests

 for Rule auditd_audispd_configure_remote_server

The referenced variable is already defined in `linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var`

#### Rationale:
This rule is part of Fedora OSPP profile.
