### PR TITLE
Filter out swap files

### DIFF
--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -24,7 +24,9 @@ def iterate_over_rules():
         leaf_dir = os.path.basename(dir_name)
         rel_dir = '.' + dir_name[len(_DIR):]
         if leaf_dir.startswith('rule_'):
-            result = Rule(rel_dir, _SSG_PREFIX + leaf_dir, files)
+            # use only .sh files
+            scripts = filter(lambda x: x.endswith(".sh"), files)
+            result = Rule(rel_dir, _SSG_PREFIX + leaf_dir, scripts)
             yield result
 
 

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -19,13 +19,13 @@ def iterate_over_rules():
             directory -- absolute path to the rule directory
             id -- full rule id as it is present in datastream
             files -- list of executable .sh files in the
-            directory containing the test cases in Bash
+            directory containing the test scenarios in Bash
     """
     for dir_name, directories, files in os.walk(_DIR):
         leaf_dir = os.path.basename(dir_name)
         rel_dir = '.' + dir_name[len(_DIR):]
         if leaf_dir.startswith('rule_'):
-            # Filter out everything except the shell test cases.
+            # Filter out everything except the shell test scenarios.
             # Other files in rule directories are editor swap files
             # or other content than a test case.
             scripts = filter(lambda x: x.endswith(".sh"), files)

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -24,7 +24,12 @@ def iterate_over_rules():
         leaf_dir = os.path.basename(dir_name)
         rel_dir = '.' + dir_name[len(_DIR):]
         if leaf_dir.startswith('rule_'):
-            # use only .sh files
+            # Use only .sh files
+            # We care only about '.sh' files because only these files
+            # are supposed to contain bash scripts with test cases
+            # and we can expect them to be executable.
+            # Other files in rule directories are editor swap files
+            # or other content than a test case.
             scripts = filter(lambda x: x.endswith(".sh"), files)
             result = Rule(rel_dir, _SSG_PREFIX + leaf_dir, scripts)
             yield result

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -18,16 +18,14 @@ def iterate_over_rules():
         Named tuple having these fields:
             directory -- absolute path to the rule directory
             id -- full rule id as it is present in datastream
-            files -- list of files in the directory
+            files -- list of executable .sh files in the
+            directory containing the test cases in Bash
     """
     for dir_name, directories, files in os.walk(_DIR):
         leaf_dir = os.path.basename(dir_name)
         rel_dir = '.' + dir_name[len(_DIR):]
         if leaf_dir.startswith('rule_'):
-            # Use only .sh files
-            # We care only about '.sh' files because only these files
-            # are supposed to contain bash scripts with test cases
-            # and we can expect them to be executable.
+            # Filter out everything except the shell test cases.
             # Other files in rule directories are editor swap files
             # or other content than a test case.
             scripts = filter(lambda x: x.endswith(".sh"), files)


### PR DESCRIPTION
This prevents SSG test suite from trying to run vim swap files.
