### PR TITLE
[PoC] Template test scenarios

### DIFF
--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,3 +1,4 @@
 from data.utils import iterate_over_rules
 from data.utils import create_tarball
 from data.utils import _DIR as DATA_DIR
+from data.utils import get_template_rules

--- a/tests/data/group_system/group_logging/rule_package_rsyslog_installed/installed.pass.sh
+++ b/tests/data/group_system/group_logging/rule_package_rsyslog_installed/installed.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_common
+# profiles = xccdf_org.ssgproject.content_profile_standard
 
 yum install -y rsyslog

--- a/tests/data/group_system/group_logging/rule_package_rsyslog_installed/notinstalled.fail.sh
+++ b/tests/data/group_system/group_logging/rule_package_rsyslog_installed/notinstalled.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_common
+# profiles = xccdf_org.ssgproject.content_profile_standard
 
-yum remove -y rsyslog
+yum remove -y rsyslog || true

--- a/tests/data/templates/packages_installed/rule_package_aide_installed.fail.sh
+++ b/tests/data/templates/packages_installed/rule_package_aide_installed.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum remove -y aide || true

--- a/tests/data/templates/packages_installed/rule_package_aide_installed.pass.sh
+++ b/tests/data/templates/packages_installed/rule_package_aide_installed.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum install -y aide

--- a/tests/data/templates/packages_installed/rule_package_screen_installed.pass.sh
+++ b/tests/data/templates/packages_installed/rule_package_screen_installed.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum install -y screen

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -25,8 +25,12 @@ def iterate_over_rules():
     for dir_name, directories, files in os.walk(_DIR):
         leaf_dir = os.path.basename(dir_name)
         rel_dir = '.' + dir_name[len(_DIR):]
+        print(rel_dir)
         if leaf_dir.startswith('rule_'):
             result = Rule(rel_dir, _SSG_PREFIX + leaf_dir, files)
+            yield result
+        if rel_dir.startswith('./templates/'):
+            result = Rule(rel_dir, leaf_dir, files)
             yield result
 
 


### PR DESCRIPTION
#### Description:

- Adds a way to indicate that a Rule should be tested using  `template tests`.
- Rules marked to use `template tests` will also load scenarios defined in the `templates/template_csv_name`.
- It is possible for a Rule to define its own tests, and also load `template tests`.

#### Rationale:

- Aim is to avoid duplication of efforts to write many similar tests for templated rules (eg. package_installed)
- This assumes that all generated contents from a templated rules will be broken or all of them will be correct.

Example:
By running SSGTestSuite to check `rule_package_rsyslog_installed`, we can see that its own tests are run, `installed.pass` and `notinstalled.fail`, along with tests from `package_installed` template.
```
$ ./test_suite.py rule --libvirt qemu:///system rhel7.5-kicked --datastream ~/git/scap-security-guide/build/ssg-rhel7-ds.xml --xccdf-id scap_org.open-scap_cref_ssg-rhel7-xccdf-1.2.xml package_rsyslog_installed
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/wsato/git/scap-security-guide/tests/logs/rule-custom-2018-09-03-1331/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_package_rsyslog_installed
INFO - Script notinstalled.fail.sh using profile xccdf_org.ssgproject.content_profile_standard OK
INFO - Script rule_package_screen_installed.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script rule_package_aide_installed.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script rule_package_aide_installed.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script installed.pass.sh using profile xccdf_org.ssgproject.content_profile_standard OK
```
