### PR TITLE
Finish rule ensure_gpgcheck_local_packages in Fedora OSPP profile

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/rhel7.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/rhel7.sh
@@ -1,8 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-
-if grep --silent ^localpkg_gpgcheck /etc/yum.conf ; then
-        sed -i "s/^localpkg_gpgcheck.*/localpkg_gpgcheck=1/g" /etc/yum.conf
-else
-        echo -e "\n# Set localpkg_gpgcheck to 1 per security requirements" >> /etc/yum.conf
-        echo "localpkg_gpgcheck=1" >> /etc/yum.conf
-fi

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/shared.sh
@@ -1,0 +1,4 @@
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '{{{ pkg_manager_config_file }}}' '^localpkg_gpgcheck' '1' '@CCENUM@'

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Ensure gpgcheck Enabled for Local Packages</title>
       <affected family="unix">
+        <platform>multi_platform_fedora</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
       </affected>
       <description>The localpkg_gpgcheck option should be used to ensure that checking 
@@ -10,14 +11,14 @@
       installation.</description>
     </metadata>
     <criteria>
-      <criterion comment="check value of localpkg_gpgcheck in /etc/yum.conf" test_ref="test_yum_ensure_gpgcheck_local_packages" />
+      <criterion comment="check value of localpkg_gpgcheck in {{{ pkg_manager_config_file }}}" test_ref="test_yum_ensure_gpgcheck_local_packages" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of localpkg_gpgcheck in /etc/yum.conf" id="test_yum_ensure_gpgcheck_local_packages" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of localpkg_gpgcheck in {{{ pkg_manager_config_file }}}" id="test_yum_ensure_gpgcheck_local_packages" version="1">
     <ind:object object_ref="object_yum_ensure_gpgcheck_local_packages" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_yum_ensure_gpgcheck_local_packages" comment="localpkg_gpgcheck set in /etc/yum.conf" version="1">
-    <ind:filepath>/etc/yum.conf</ind:filepath>
+  <ind:textfilecontent54_object id="object_yum_ensure_gpgcheck_local_packages" comment="localpkg_gpgcheck set in {{{ pkg_manager_config_file }}}" version="1">
+    <ind:filepath>{{{ pkg_manager_config_file }}}</ind:filepath>
     <ind:pattern operation="pattern match">^\s*localpkg_gpgcheck\s*=\s*(1|True|yes)\s*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/tests/data/group_system/group_software/group_updating/group_updating_utils.sh
+++ b/tests/data/group_system/group_software/group_updating/group_updating_utils.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function find_config_file {
+	if which dnf >/dev/null ; then
+		config_file="/etc/dnf/dnf.conf"
+	else
+		config_file="/etc/yum.conf"
+	fi
+	echo $config_file
+}

--- a/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/comment.fail.sh
+++ b/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/comment.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../group_updating_utils.sh
+
+config_file="$(find_config_file)"
+
+if grep -q "^localpkg_gpgcheck" "$config_file" ; then
+	sed -i "s/^localpkg_gpgcheck.*/# localpkg_gpgcheck=1/" "$config_file"
+else
+	echo "# localpkg_gpgcheck=1" >> "$config_file"
+fi

--- a/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/correct_value.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../group_updating_utils.sh
+
+config_file="$(find_config_file)"
+
+if grep -q "^localpkg_gpgcheck" "$config_file"; then
+	sed -i "s/^localpkg_gpgcheck.*/localpkg_gpgcheck=1/" "$config_file"
+else
+	echo "localpkg_gpgcheck=1" >> "$config_file"
+fi

--- a/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/line_not_there.fail.sh
+++ b/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/line_not_there.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../group_updating_utils.sh
+
+config_file="$(find_config_file)"
+
+sed -i "/^localpkg_gpgcheck.*/d" "$config_file"

--- a/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_updating/rule_ensure_gpgcheck_local_packages/wrong_value.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../group_updating_utils.sh
+
+config_file="$(find_config_file)"
+
+if grep -q "^localpkg_gpgcheck" "$config_file" ; then
+	sed -i "s/^localpkg_gpgcheck.*/localpkg_gpgcheck=0/" "$config_file"
+else
+	echo "localpkg_gpgcheck=0" >> "$config_file"
+fi


### PR DESCRIPTION
#### Description:
This PR extends OVAL and Bash for rule ensure_gpgcheck_local_packages to Fedora.
Then, it adds test cases for this rule.

#### Rationale:

This rule is a part of Fedora OSPP profile.