### PR TITLE
Enabled installed_OS_is_certified for Fedora, improved metadata

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -13,6 +13,7 @@ description: |-
     similar to the one mandated by US National Security Systems.
 
 selections:
+    - installed_OS_is_certified
     - grub2_audit_argument
     - service_auditd_enabled
     - grub2_enable_fips_mode

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/oval/shared.xml
@@ -6,6 +6,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_rhel-osp</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The operating system installed on the system is
       a certified vendor operating system and meets government
@@ -14,6 +15,8 @@
     <criteria comment="Installed operating system is a certified operating system" operator="OR">
       <extend_definition comment="Installed OS is RHEL6" definition_ref="installed_OS_is_rhel6" />
       <extend_definition comment="Installed OS is RHEL7" definition_ref="installed_OS_is_rhel7" />
+      <!-- DO NOT add operating systems here unless they adhere to government certifications
+           and the vendor provides professional security updates and support -->
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
+prodtype: rhel6,rhel7,fedora
 
 title: 'The Installed Operating System Is Vendor Supported and Certified'
 
@@ -9,6 +9,8 @@ description: |-
     Red Hat Enterprise Linux is supported by Red Hat, Inc. As the Red Hat Enterprise
     Linux vendor, Red Hat, Inc. is responsible for providing security patches as well
     as meeting and maintaining goverment certifications and standards.
+
+    There is no remediation besides switching to a different operating system.
 
 rationale: |-
     An operating system is considered "supported" if the vendor continues to provide
@@ -29,9 +31,11 @@ references:
 
 ocil_clause: 'the installed operating system is not supported or certified'
 
+{{% if product in ["rhel6", "rhel7"] %}}
 ocil: |-
     To verify that the installed operating system is supported or certified, run
     the following command:
     <pre>$ grep -i "red hat" /etc/redhat-release</pre>
     The output should contain something similar to:
     <pre>{{{ full_name }}}</pre>
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/rule.yml
@@ -10,13 +10,15 @@ description: |-
     Linux vendor, Red Hat, Inc. is responsible for providing security patches as well
     as meeting and maintaining goverment certifications and standards.
 
-    There is no remediation besides switching to a different operating system.
-
 rationale: |-
     An operating system is considered "supported" if the vendor continues to provide
     security patches for the product as well as maintain government certification requirements.
     With an unsupported release, it will not be possible to resolve security issue discovered in
     the system software as well as meet government certifications.
+
+warnings:
+    - general: |-
+        There is no remediation besides switching to a different operating system.
 
 severity: high
 


### PR DESCRIPTION
The rule will fail on Fedora but it's important that it's available there for profile completeness and other rules that depend on it.