### PR TITLE
Provide checks and remediations for package_screen_installed

### DIFF
--- a/fedora/templates/csv/packages_installed.csv
+++ b/fedora/templates/csv/packages_installed.csv
@@ -10,4 +10,5 @@ ntp
 openssh-server
 vsftpd
 postfix
+screen
 sssd


### PR DESCRIPTION
Seems like an oversight that we didn't have it in the first place:
```
Name         : screen
Version      : 4.6.2
Release      : 3.fc28
Arch         : x86_64
Size         : 581 k
Source       : screen-4.6.2-3.fc28.src.rpm
Repo         : fedora
Summary      : A screen manager that supports multiple logins on one terminal
URL          : http://www.gnu.org/software/screen
License      : GPLv2+
Description  : The screen utility allows you to have multiple logins on just one
             : terminal. Screen is useful for users who telnet into a machine or are
             : connected via a dumb terminal, but want to use more than just one
             : login.
             : 
             : Install the screen package if you need a screen manager that can
             : support multiple logins on one terminal.

```