### PR TITLE
Use implied properties to parametrize package manager configuration settings rules

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -632,6 +632,12 @@ Sometimes, a rule requires `ocil` and `ocil_clause` to be specified, and they de
 Macros that begin with `complete_ocil_entry_` were designed for exactly this purpose, as they make sure that OCIL and OCIL clauses are defined and consistent.
 Macros that begin with underscores are not meant to be used in descriptions.
 
+To parametrize rules and remediations as well as Jinja macros, you can use product-specific variables defined in `product.yml` in product root directory.
+Moreover, you can define *implied properties* which are variables inferred from them.
+For example, you can define a condition that checks if the system uses `yum` or `dnf` as a package manager and based on that populate a variable containing correct path to the configuration file.
+The inferring logic is implemented in `_get_implied_properties` in `ssg/yaml.py`.
+Constants and mappings used in implied properties should be defined in `ssg/constants.py`.
+
 Rules are unselected by default - even if the scanner reads rule definitions, they are effectively ignored during the scan or remediation.
 A rule may be selected by any number of profiles, so when the scanner is scanning using a profile the rule is included in, the rule is taken into account.
 For example, the rule identified by `partition_for_tmp` defined in `shared/xccdf/system/software/disk_partitioning.xml` is included in the `RHEL7 C2S` profile in `rhel7/profiles/C2S.xml`.

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
@@ -21,8 +21,8 @@ description: |-
     The package can then be reinstalled to restore the file.
     Run the following command to determine which package owns the file:
     <pre>$ rpm -qf <i>FILENAME</i></pre>
-    The package can be reinstalled from a yum repository using the command:
-    <pre>$ sudo yum reinstall <i>PACKAGENAME</i></pre>
+    The package can be reinstalled from a {{{ pkg_manager }}} repository using the command:
+    <pre>$ sudo {{{ pkg_manager }}} reinstall <i>PACKAGENAME</i></pre>
     Alternatively, the package can be reinstalled from trusted media using the command:
     <pre>$ sudo rpm -Uvh <i>PACKAGENAME</i></pre>
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel, multi_platform_ol, multi_platform_fedora
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/yum.conf' '^gpgcheck' '1' '@CCENUM@'
+replace_or_append "{{{ pkg_manager_config_file }}}" '^gpgcheck' '1' '@CCENUM@'

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora,ol7
 
-title: 'Ensure gpgcheck Enabled In Main Yum Configuration'
+title: 'Ensure gpgcheck Enabled In Main {{{ pkg_manager }}} Configuration'
 
 description: |-
     The <tt>gpgcheck</tt> option controls whether
     RPM packages' signatures are always checked prior to installation.
-    To configure yum to check package signatures before installing
-    them, ensure the following line appears in <tt>/etc/yum.conf</tt> in
+    To configure {{{ pkg_manager }}} to check package signatures before installing
+    them, ensure the following line appears in <tt>{{{ pkg_manager_config_file }}}</tt> in
     the <tt>[main]</tt> section:
     <pre>gpgcheck=1</pre>
 
@@ -38,8 +38,8 @@ references:
 ocil_clause: 'GPG checking is not enabled'
 
 ocil: |-
-    To determine whether <tt>yum</tt> is configured to use <tt>gpgcheck</tt>,
-    inspect <tt>/etc/yum.conf</tt> and ensure the following appears in the
+    To determine whether <tt>{{{ pkg_manager }}}</tt> is configured to use <tt>gpgcheck</tt>,
+    inspect <tt>{{{ pkg_manager_config_file }}}</tt> and ensure the following appears in the
     <tt>[main]</tt> section:
     <pre>gpgcheck=1</pre>
     A value of <tt>1</tt> indicates that <tt>gpgcheck</tt> is enabled. Absence of a

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -5,9 +5,9 @@ prodtype: rhel7,fedora
 title: 'Ensure gpgcheck Enabled for Local Packages'
 
 description: |-
-    <tt>Yum</tt> should be configured to verify the signature(s) of local packages
-    prior to installation. To configure <tt>yum</tt> to verify signatures of local
-    packages, set the <tt>localpkg_gpgcheck</tt> to <tt>1</tt> in <tt>/etc/yum.conf</tt>.
+    <tt>{{{ pkg_manager }}}</tt> should be configured to verify the signature(s) of local packages
+    prior to installation. To configure <tt>{{{ pkg_manager }}}</tt> to verify signatures of local
+    packages, set the <tt>localpkg_gpgcheck</tt> to <tt>1</tt> in <tt>{{{ pkg_manager_config_file }}}</tt>.
 
 rationale: |-
     Changes to any software components can have significant effects to the overall security
@@ -36,6 +36,6 @@ ocil_clause: 'gpgcheck is not enabled or configured correctly to verify local pa
 ocil: |-
     To verify that <tt>localpkg_gpgcheck</tt> is configured properly, run the following
     command:
-    <pre>$ grep localpkg_gpgcheck /etc/yum.conf</pre>
+    <pre>$ grep localpkg_gpgcheck {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:
     <pre>localpkg_gpgcheck=1</pre>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -4,13 +4,13 @@
 # complexity = low
 # disruption = medium
 #
-- name: Find All Yum Repositories
+- name: Find All {{{ pkg_manager }}} Repositories
   find:
     paths: "/etc/yum.repos.d/"
     patterns: "*.repo"
   register: yum_find
 
-- name: Ensure gpgcheck Enabled For All Yum Package Repositories
+- name: Ensure gpgcheck Enabled For All {{{ pkg_manager }}} Package Repositories
   with_items: "{{ yum_find.files }}"
   lineinfile:
     create: yes

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,fedora,ol7
 
-title: 'Ensure gpgcheck Enabled For All Yum Package Repositories'
+title: 'Ensure gpgcheck Enabled For All {{{ pkg_manager }}} Package Repositories'
 
 description: |-
     To ensure signature checking is not disabled for
@@ -33,7 +33,7 @@ references:
 ocil_clause: 'GPG checking is disabled'
 
 ocil: |-
-    To determine whether <tt>yum</tt> has been configured to disable
+    To determine whether <tt>{{{ pkg_manager }}}</tt> has been configured to disable
     <tt>gpgcheck</tt> for any repos,  inspect all files in
     <tt>/etc/yum.repos.d</tt> and ensure the following does not appear in any
     sections:

--- a/linux_os/guide/system/software/updating/group.yml
+++ b/linux_os/guide/system/software/updating/group.yml
@@ -3,17 +3,13 @@ documentation_complete: true
 title: 'Updating Software'
 
 description: |-
-    The <tt>yum</tt> command line tool is used to install and
+    The <tt>{{{ pkg_manager }}}</tt> command line tool is used to install and
     update software packages. The system also provides a graphical
     software update tool in the <b>System</b> menu, in the <b>Administration</b> submenu,
     called <b>Software Update</b>.
     <br /><br />
-    Red Hat Enterprise Linux systems contain an installed software catalog called
+    {{{ full_name }}} systems contain an installed software catalog called
     the RPM database, which records metadata of installed packages. Consistently using
-    <tt>yum</tt> or the graphical <b>Software Update</b> for all software installation
+    <tt>{{{ pkg_manager }}}</tt> or the graphical <b>Software Update</b> for all software installation
     allows for insight into the current inventory of installed software on the system.
     <br /><br />
-    Oracle Linux system contain an installed software catalog called
-    the RPM database, which records metadata of installed packages. Consistently using
-    <tt>yum</tt> or the graphical <b>Software Update</b> for all software installation
-    allows for insight into the current inventory of installed software on the system.

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -72,6 +72,11 @@ PKG_MANAGER_TO_SYSTEM = {
     "apt_get": "dpkg",
 }
 
+PKG_MANAGER_TO_CONFIG_FILE = {
+    "yum": "/etc/yum.conf",
+    "dnf": "/etc/dnf/dnf.conf",
+}
+
 RHEL_CENTOS_CPE_MAPPING = {
     "cpe:/o:redhat:enterprise_linux:6": "cpe:/o:centos:centos:6",
     "cpe:/o:redhat:enterprise_linux:7": "cpe:/o:centos:centos:7",

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -7,7 +7,9 @@ import sys
 
 from .jinja import extract_substitutions_dict_from_template, process_file
 from .constants import (PKG_MANAGER_TO_SYSTEM,
-                        JINJA_MACROS_BASE_DEFINITIONS, JINJA_MACROS_HIGHLEVEL_DEFINITIONS)
+                        PKG_MANAGER_TO_CONFIG_FILE,
+                        JINJA_MACROS_BASE_DEFINITIONS,
+                        JINJA_MACROS_HIGHLEVEL_DEFINITIONS)
 from .constants import DEFAULT_UID_MIN
 
 try:
@@ -55,10 +57,13 @@ def _open_yaml(stream, original_file=None, substitutions_dict={}):
 
 def _get_implied_properties(existing_properties):
     result = dict()
-    if ("pkg_manager" in existing_properties and
-            "pkg_system" not in existing_properties):
+    if "pkg_manager" in existing_properties:
         pkg_manager = existing_properties["pkg_manager"]
-        result["pkg_system"] = PKG_MANAGER_TO_SYSTEM[pkg_manager]
+        if "pkg_system" not in existing_properties:
+            result["pkg_system"] = PKG_MANAGER_TO_SYSTEM[pkg_manager]
+        if "pkg_manager_config_file" not in existing_properties:
+            if pkg_manager in PKG_MANAGER_TO_CONFIG_FILE:
+                result["pkg_manager_config_file"] = PKG_MANAGER_TO_CONFIG_FILE[pkg_manager]
 
     if "uid_min" not in existing_properties:
         result["uid_min"] = DEFAULT_UID_MIN


### PR DESCRIPTION
#### Description:

Some rules describe package manager configuration. However, on RHEL we use `yum` and we set configuration settings in `/etc/yum.conf`, but on Fedora we use `dnf`and we set configuration in `/etc/dnf/dnf.conf`.

We can use implied properties to customize the rules and remediations. These variables will be substituted in final output, so there will be "dnf" mentioned in Fedora content and "yum" mentioned in RHEL content. Also, the rules and remediations will contain correct path to the configuration file depending on the package manager used on target platform.

Since this is a radical change, I have used the new approach only in rule `ensure_gpgcheck_globally_activated`. If the feedback on this change will be positive, then I can do a similar changes in all other rules from this group.

#### Rationale:

This will prevent us from copying code.