### PR TITLE
Rule sshd_enable_warning_banner for Fedora

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/bash/rhel7.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/bash/rhel7.sh
@@ -1,6 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-
-# Include source function library.
-. /usr/share/scap-security-guide/remediation_functions
-
-replace_or_append '/etc/ssh/sshd_config' '^Banner' '/etc/issue' '@CCENUM@' '%s %s'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/bash/shared.sh
@@ -1,4 +1,5 @@
-# platform = Red Hat Enterprise Linux 6
+# platform = multi_platform_all
+
 grep -q ^Banner /etc/ssh/sshd_config && \
   sed -i "s/Banner.*/Banner \/etc\/issue/g" /etc/ssh/sshd_config
 if ! [ $? -eq 0 ]; then

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/oval/shared.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Enable a Warning Banner</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_all</platform>
       </affected>
       <description>SSH warning banner should be enabled (and dependencies are
       met)</description>

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/comment.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/comment.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^Banner" /etc/ssh/sshd_config; then
+	sed -i "s|^Banner.*|# Banner /etc/issue/|" /etc/ssh/sshd_config
+else
+	echo "# Banner /etc/issue" >> /etc/ssh/sshd_config
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/correct_value.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^Banner" /etc/ssh/sshd_config; then
+	sed -i "s|^Banner.*|Banner /etc/issue|" /etc/ssh/sshd_config
+else
+	echo "Banner /etc/issue" >> /etc/ssh/sshd_config
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/line_not_there.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+sed -i "/^Banner.*/d" /etc/ssh/sshd_config

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/wrong_value.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_enable_warning_banner/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^Banner" /etc/ssh/sshd_config; then
+	sed -i "s/^Banner.*/Banner none/" /etc/ssh/sshd_config
+else
+	echo "Banner none" >> /etc/ssh/sshd_config
+fi


### PR DESCRIPTION
#### Description:

1. Extend OVAL and Bash for sshd_enable_warning_banner to all platforms
Unfortunately, I have discovered that we can't use replace_or_append functions if the value of key cotains a forward slash. If we don't escape the slash, the "replace" mode is broken, if we escape the slash, the "append" mode is broken.

2. Add tests for sshd_enable_warning_banner

#### Rationale:
This rule is a part of Fedora OSPP profile
