### PR TITLE
Rule  service_debug-shell_disabled for Fedora

### DIFF
--- a/fedora/templates/csv/packages_removed.csv
+++ b/fedora/templates/csv/packages_removed.csv
@@ -5,3 +5,4 @@ prelink
 setroubleshoot
 xorg-x11-server-common
 sssd
+systemd

--- a/fedora/templates/csv/services_disabled.csv
+++ b/fedora/templates/csv/services_disabled.csv
@@ -1,3 +1,4 @@
 # service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
 sshd,openssh-server,
 sssd,,
+debug-shell,systemd,

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_disabled.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_disabled.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+systemctl disable debug-shell.service

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_enabled.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_enabled.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+systemctl enable debug-shell.service


### PR DESCRIPTION
#### Description:


1. Add OVAL for service_debug-shell_disabled on Fedora

This rule is templated. We have to add `systemd` to a list of
removed packages because debug-shell is provided by `systemd`
package. If we forget about it, the respective OVAL definition
will be removed from the final datastream by our build system.

2.  Add tests for rule service_debug-shell_disabled 

#### Rationale:

This rule is a part of Fedora OSPP profile.
