### PR TITLE
Add selinux_confinement_of_daemons for Fedora

### DIFF
--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
 	<platform>Wind River Linux 8</platform>
       </affected>
       <description>All pids in /proc should be assigned an SELinux security context other than 'initrc_t'.</description>


### PR DESCRIPTION
#### Description:

Adds `multi_platform_fedora` to OVAL for rule selinux_confinement_of_daemons.

#### Rationale:
This rule is a part of Fedora OSPP profile.
