### PR TITLE
Add Fedora to rule accounts_tmout

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -45,6 +45,7 @@ selections:
     - dconf_gnome_screensaver_user_locks
     - dconf_gnome_session_idle_user_locks
     - accounts_tmout
+    - var_accounts_tmout=10_min
     - grub2_password
     - grub2_uefi_password
     - grub2_disable_interactive_boot

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_tmout
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Set Interactive Session Timeout</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>Checks interactive shell timeout</description>
     </metadata>


### PR DESCRIPTION
#### Description:

This adds platform element for Fedora on OVAL and remediation for rule accounts_tmout

The refine-value for var_accounts_tmout in Fedora OSPP profile is
set consistently with RHEL 7 OSPP profile.

#### Rationale:

This rule is a part of Fedora OSPP profile.
