### PR TITLE
Enabled selinux_all_devicefiles_labeled OVAL check for Fedora

### DIFF
--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>All device files in /dev should be assigned an SELinux security context other than 'device_t'.</description>
     </metadata>


### PR DESCRIPTION
Pretty much the same as #3257 