### PR TITLE
Add fedora platform and test for selinux_state rule

### DIFF
--- a/linux_os/guide/system/selinux/selinux_state/bash/shared.sh
+++ b/linux_os/guide/system/selinux/selinux_state/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_fedora
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/selinux/selinux_state/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_state/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>SELinux Enforcing</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The SELinux state should be enforcing the local policy.</description>
     </metadata>

--- a/tests/data/group_system/group_selinux/rule_selinux_policytype/selinuxtype_targeted.pass.sh
+++ b/tests/data/group_system/group_selinux/rule_selinux_policytype/selinuxtype_targeted.pass.sh
@@ -4,7 +4,7 @@
 SELINUX_FILE='/etc/selinux/config'
 
 if grep -s '^[[:space:]]*SELINUXTYPE' $SELINUX_FILE; then
-	sed -i 's/^\([[:space:]]SELINUXTYPE[[:space:]]*=[[:space:]]*\).*/\1targeted/' $SELINUX_FILE
+	sed -i 's/^\([[:space:]]*SELINUXTYPE[[:space:]]*=[[:space:]]*\).*/\1targeted/' $SELINUX_FILE
 else
 	echo 'SELINUXTYPE=targeted' >> $SELINUX_FILE
 fi

--- a/tests/data/group_system/rule_selinux_state/selinux_enforcing.pass.sh
+++ b/tests/data/group_system/rule_selinux_state/selinux_enforcing.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_ospp
+
+SELINUX_FILE='/etc/selinux/config'
+
+if grep -s '^[[:space:]]*SELINUX' $SELINUX_FILE; then
+	sed -i 's/^\([[:space:]]*SELINUX[[:space:]]*=[[:space:]]*\).*/\1enforcing/' $SELINUX_FILE
+else
+	echo 'SELINUX=enforcing' >> $SELINUX_FILE
+fi


### PR DESCRIPTION
#### Description:
Changes platform at OVAL and bash remediation.
Adds test (only passing test added, because I've been trying failing tests - missing SELINUX or changing value - and all of them caused that my virtual machine stopped responding and test_suite didn't continue) for selinux_state.

And I find out, that regex in selinux_policytype test is missing quantifier, so this PR fixs it.