### PR TITLE
Audit rules unsuccesful file deletion

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -94,6 +94,10 @@ selections:
     - audit_rules_unsuccessful_file_modification_open
     - audit_rules_unsuccessful_file_modification_ftruncate
     - audit_rules_unsuccessful_file_modification_truncate
+    - audit_rules_unsuccessful_file_modification_unlink
+    - audit_rules_unsuccessful_file_modification_unlinkat
+    - audit_rules_unsuccessful_file_modification_rename
+    - audit_rules_unsuccessful_file_modification_renameat
     - audit_rules_file_deletion_events_renameat
     - audit_rules_file_deletion_events_rename
     - audit_rules_file_deletion_events_rmdir

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -26,9 +26,6 @@ rationale: |-
 
 severity: medium
 
-identifiers:
-    cce@rhel7: 80388-2
-
 references:
     cis: 5.2.10
     cui: 3.1.7
@@ -38,7 +35,6 @@ references:
     ospp@rhel7: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
-    stigid@rhel7: "030530"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="rename") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Delete Attempts to Files - rename'
+
+description: |-
+    The audit system should collect unsuccessful file deletion
+    attempts for all users and root. If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S rename -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S rename -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>
+    -a always,exit -F arch=b64 -S rename -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S rename -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 80388-2
+
+references:
+    cis: 5.2.10
+    cui: 3.1.7
+    disa: 172,2884
+    hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.312(b),164.312(d),164.312(e)
+    nist: AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5
+    ospp@rhel7: FAU_GEN.1.1.c
+    pcidss: Req-10.2.4,Req-10.2.1
+    srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
+    stigid@rhel7: "030530"
+
+{{{ complete_ocil_entry_audit_syscall(syscall="rename") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -26,9 +26,6 @@ rationale: |-
 
 severity: medium
 
-identifiers:
-    cce@rhel7: 80388-2
-
 references:
     cis: 5.2.10
     cui: 3.1.7
@@ -38,7 +35,6 @@ references:
     ospp@rhel7: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
-    stigid@rhel7: "030530"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="renameat") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Delete Attempts to Files - renameat'
+
+description: |-
+    The audit system should collect unsuccessful file deletion
+    attempts for all users and root. If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S renameat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S renameat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>
+    -a always,exit -F arch=b64 -S renameat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S renameat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 80388-2
+
+references:
+    cis: 5.2.10
+    cui: 3.1.7
+    disa: 172,2884
+    hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.312(b),164.312(d),164.312(e)
+    nist: AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5
+    ospp@rhel7: FAU_GEN.1.1.c
+    pcidss: Req-10.2.4,Req-10.2.1
+    srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
+    stigid@rhel7: "030530"
+
+{{{ complete_ocil_entry_audit_syscall(syscall="renameat") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -26,9 +26,6 @@ rationale: |-
 
 severity: medium
 
-identifiers:
-    cce@rhel7: 80388-2
-
 references:
     cis: 5.2.10
     cui: 3.1.7
@@ -38,7 +35,6 @@ references:
     ospp@rhel7: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
-    stigid@rhel7: "030530"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="unlink") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Delete Attempts to Files - unlink'
+
+description: |-
+    The audit system should collect unsuccessful file deletion
+    attempts for all users and root. If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>
+    -a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 80388-2
+
+references:
+    cis: 5.2.10
+    cui: 3.1.7
+    disa: 172,2884
+    hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.312(b),164.312(d),164.312(e)
+    nist: AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5
+    ospp@rhel7: FAU_GEN.1.1.c
+    pcidss: Req-10.2.4,Req-10.2.1
+    srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
+    stigid@rhel7: "030530"
+
+{{{ complete_ocil_entry_audit_syscall(syscall="unlink") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -26,9 +26,6 @@ rationale: |-
 
 severity: medium
 
-identifiers:
-    cce@rhel7: 80388-2
-
 references:
     cis: 5.2.10
     cui: 3.1.7
@@ -38,7 +35,6 @@ references:
     ospp@rhel7: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
-    stigid@rhel7: "030530"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="unlinkat") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Delete Attempts to Files - unlinkat'
+
+description: |-
+    The audit system should collect unsuccessful file deletion
+    attempts for all users and root. If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S unlinkat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S unlinkat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>
+    -a always,exit -F arch=b64 -S unlinkat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S unlinkat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete</pre>
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 80388-2
+
+references:
+    cis: 5.2.10
+    cui: 3.1.7
+    disa: 172,2884
+    hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.312(b),164.312(d),164.312(e)
+    nist: AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5
+    ospp@rhel7: FAU_GEN.1.1.c
+    pcidss: Req-10.2.4,Req-10.2.1
+    srg: SRG-OS-000064-GPOS-00033,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000392-GPOS-00172
+    stigid@rhel7: "030530"
+
+{{{ complete_ocil_entry_audit_syscall(syscall="unlinkat") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/rhel7/profiles/ospp42-draft.profile
+++ b/rhel7/profiles/ospp42-draft.profile
@@ -90,6 +90,10 @@ selections:
     - audit_rules_unsuccessful_file_modification_open
     - audit_rules_unsuccessful_file_modification_ftruncate
     - audit_rules_unsuccessful_file_modification_truncate
+    - audit_rules_unsuccessful_file_modification_unlink
+    - audit_rules_unsuccessful_file_modification_unlinkat
+    - audit_rules_unsuccessful_file_modification_rename
+    - audit_rules_unsuccessful_file_modification_renameat
     - audit_rules_file_deletion_events_renameat
     - audit_rules_file_deletion_events_rename
     - audit_rules_file_deletion_events_rmdir

--- a/shared/templates/csv/audit_rules_unsuccessful_file_modification.csv
+++ b/shared/templates/csv/audit_rules_unsuccessful_file_modification.csv
@@ -3,4 +3,8 @@ ftruncate
 open
 openat
 open_by_handle_at
+rename
+renameat
 truncate
+unlink
+unlinkat

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/default.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/default.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/empty.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/empty.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/only_eacces.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/only_eacces.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules


### PR DESCRIPTION
#### Description:

- Add rules to check audit rules to log for unsuccessful file deletion attempts. 
  - Rule prose was derived from existing unsuccessful file modification rule.
- OVALs are the same as generated by template [template_OVAL_audit_rules_unsuccessful_file_modification](https://github.com/ComplianceAsCode/content/blob/master/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification).
  - I'm basically abusing file modification to check for file deletion, which is kind of a file modification.
- Added basic test for `audit_rules_unsuccessful_file_modification_unlink`.
  - After #3244 they should be tested by template test scenarios.

#### Rationale:

- OSPP4.2 likes to audit unsuccessful events
