### PR TITLE
namedtuple ended up being a bottleneck in ID linking code

### DIFF
--- a/ssg/id_translate.py
+++ b/ssg/id_translate.py
@@ -9,14 +9,13 @@ from .constants import OVALREFATTR_TO_TAG, OCILREFATTR_TO_TAG
 
 
 def _split_namespace(tag):
-    """
-    returns a namedtuple of (namespace, tag), removing any
-    fragment id from namespace
+    """returns a tuple of (namespace, tag),
+    removing any fragment id from namespace
     """
 
     if tag[0] == "{":
         namespace, name = tag[1:].split("}", 1)
-        return (namespace.split("#")[0], name)
+        return (namespace.split("#", 1)[0], name)
 
     return (None, tag)
 

--- a/ssg/id_translate.py
+++ b/ssg/id_translate.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-from collections import namedtuple
-
 from .xml import ElementTree
 from .constants import oval_namespace as oval_ns
 from .constants import ocil_namespace as ocil_ns
@@ -16,13 +14,11 @@ def _split_namespace(tag):
     fragment id from namespace
     """
 
-    element = namedtuple('element', ['namespace', 'tag'])
-
     if tag[0] == "{":
         namespace, name = tag[1:].split("}", 1)
-        return element(namespace.split("#")[0], name)
+        return (namespace.split("#")[0], name)
 
-    return element(None, tag)
+    return (None, tag)
 
 
 def _namespace_to_prefix(tag):


### PR DESCRIPTION
This function gets called ~35k times and constructing the namedtuple with the labeled elements is slow.

This change speeds up relabelids.py:
~12.5 seconds to ~1.8 seconds.

I tried constructing the namedtuple just once and reusing but that still makes it 1 second slower than with normal tuples..