### PR TITLE
Map service_auditd_enabled to PCI-DSS Req 10.1

### DIFF
--- a/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
@@ -34,7 +34,7 @@ references:
     disa: 126,131
     hipaa: 164.308(a)(1)(ii)(D),164.308(a)(5)(ii)(C),164.310(a)(2)(iv),164.310(d)(2)(iii),164.312(b)
     nist: AU-3,AC-17(1),AU-1(b),AU-10,AU-12(a),AU-12(c),AU-14(1),IR-5
-    pcidss: Req-10
+    pcidss: Req-10.1
     srg: SRG-OS-000038-GPOS-00016,SRG-OS-000039-GPOS-00017,SRG-OS-000042-GPOS-00021,SRG-OS-000254-GPOS-00095,SRG-OS-000255-GPOS-00096
     stigid@rhel7: "030000"
 


### PR DESCRIPTION
#### Description:

- Map service_auditd_enabled to PCI-DSS Req 10.1

#### Rationale:

- Fixes #3063
