### PR TITLE
Update Developer Guide

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 == Introduction
 
-This document tries provides information useful for ComplianceAsCode/content project developers.
+This document tries provides information useful for ComplianceAsCode/content project contributors.
 We will guide you through the structure of the project.
 We will explain the directory layout, used formats and the build system.
 
@@ -943,22 +943,17 @@ The SSG build and templating system is mostly written in Python.
 == Legacy Notice
 
 This project has been created by renaming SCAP Security Guide Project (SSG).
-SSG was originally a project that provides security policies in SCAP format.
-Over the time, the scope of the SSG project has extended over SCAP.
-We started to develop in Bash, Ansible and we introduced a new universal YAML format for
-security content.
-The word SCAP in the project name started to limit our expansion, because people were afraid
-that SCAP is overkill for their needs.
+It was a project that provides security policies in SCAP format.
+Project outgrown former name SCAP Security Guide, and changed its name to imply broader scope than just SCAP.
 Therefore, the SCAP Security Guide has been transformed into ComplianceAsCode/content, which better
-described the aim of the project.
+describes the goal of the project.
 
 This git repository was created by simply renaming and moving the SCAP Security Guide (SSG)
 repository to a different GitHub organization.
 
-However, due to this history, the repository contains many mentions of SCAP Security Guide.
+Due to this history, the repository contains many mentions of SCAP Security Guide.
 These legacy mentions are continuously cleaned up as the project develops.
 Some of them are kept due to backwards compatibility.
 
 For example, the output files produced by our build system still start by `ssg-` prefix.
-The reason for this is that the various Linux distributions package ship these files
-and packages would have to rename them.
+Various Linux distributions still ship our files in `scap-security-guide` package.

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -10,6 +10,33 @@ toc::[]
 
 == Introduction
 
+This document tries provides information useful for ComplianceAsCode project developers.
+We will guide you through the structure of the project.
+We will explain the directory layout, used formats and the build system.
+
+== Legacy Notice
+
+This project has been created by renaming SCAP Security Guide Project (SSG).
+SSG was originally a project that provides security policies in SCAP format.
+Over the time, the scope of the SSG project has extended over SCAP.
+We started to develop in Bash, Ansible and we introduced a new universal YAML format for
+security content.
+The word SCAP in the project name started to limit our expansion, because people were afraid
+that SCAP is overkill for their needs.
+Therefore, the SCAP Security Guide has been transformed into ComplianceAsCode, which better
+described the aim of the project.
+
+This git repository was created by simply renaming and moving the SCAP Security Guide (SSG)
+repository to a different GitHub organization.
+
+However, due to this history, the repository contains many mentions of SCAP Security Guide.
+These legacy mentions are continuously cleaned up as the project develops.
+Some of them are kept due to backwards compatibility.
+
+For example, the output files produced by our build system still start by `ssg-` prefix.
+The reason for this is that the various Linux distributions package ship these files
+and packages would have to rename them.
+
 == Establishing Accounts
 
 === Mailing List

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 == Introduction
 
-This document tries provides information useful for ComplianceAsCode project developers.
+This document tries provides information useful for ComplianceAsCode/content project developers.
 We will guide you through the structure of the project.
 We will explain the directory layout, used formats and the build system.
 
@@ -949,7 +949,7 @@ We started to develop in Bash, Ansible and we introduced a new universal YAML fo
 security content.
 The word SCAP in the project name started to limit our expansion, because people were afraid
 that SCAP is overkill for their needs.
-Therefore, the SCAP Security Guide has been transformed into ComplianceAsCode, which better
+Therefore, the SCAP Security Guide has been transformed into ComplianceAsCode/content, which better
 described the aim of the project.
 
 This git repository was created by simply renaming and moving the SCAP Security Guide (SSG)

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -14,29 +14,6 @@ This document tries provides information useful for ComplianceAsCode project dev
 We will guide you through the structure of the project.
 We will explain the directory layout, used formats and the build system.
 
-== Legacy Notice
-
-This project has been created by renaming SCAP Security Guide Project (SSG).
-SSG was originally a project that provides security policies in SCAP format.
-Over the time, the scope of the SSG project has extended over SCAP.
-We started to develop in Bash, Ansible and we introduced a new universal YAML format for
-security content.
-The word SCAP in the project name started to limit our expansion, because people were afraid
-that SCAP is overkill for their needs.
-Therefore, the SCAP Security Guide has been transformed into ComplianceAsCode, which better
-described the aim of the project.
-
-This git repository was created by simply renaming and moving the SCAP Security Guide (SSG)
-repository to a different GitHub organization.
-
-However, due to this history, the repository contains many mentions of SCAP Security Guide.
-These legacy mentions are continuously cleaned up as the project develops.
-Some of them are kept due to backwards compatibility.
-
-For example, the output files produced by our build system still start by `ssg-` prefix.
-The reason for this is that the various Linux distributions package ship these files
-and packages would have to rename them.
-
 == Establishing Accounts
 
 === Mailing List
@@ -962,3 +939,26 @@ The SSG build and templating system is mostly written in Python.
 * The common pattern is to dynamically add the `shared/modules` to the import path. The `ssgcommon` module has many useful utility functions and predefined constants. See scripts at `./build-scripts` as an example of this practice.
 * Follow the link:https://www.python.org/dev/peps/pep-0008/[PEP8 standard].
 * Try to keep most of your lines length under 80 characters. Although the 99 character limit is within link:https://www.python.org/dev/peps/pep-0008/#maximum-line-length[PEP8 requirements], there is no reason for most lines to be that long.
+
+== Legacy Notice
+
+This project has been created by renaming SCAP Security Guide Project (SSG).
+SSG was originally a project that provides security policies in SCAP format.
+Over the time, the scope of the SSG project has extended over SCAP.
+We started to develop in Bash, Ansible and we introduced a new universal YAML format for
+security content.
+The word SCAP in the project name started to limit our expansion, because people were afraid
+that SCAP is overkill for their needs.
+Therefore, the SCAP Security Guide has been transformed into ComplianceAsCode, which better
+described the aim of the project.
+
+This git repository was created by simply renaming and moving the SCAP Security Guide (SSG)
+repository to a different GitHub organization.
+
+However, due to this history, the repository contains many mentions of SCAP Security Guide.
+These legacy mentions are continuously cleaned up as the project develops.
+Some of them are kept due to backwards compatibility.
+
+For example, the output files produced by our build system still start by `ssg-` prefix.
+The reason for this is that the various Linux distributions package ship these files
+and packages would have to rename them.


### PR DESCRIPTION
#### Description:

* Add a Legacy notice that explains why "ssg" can be seen in the repository.
* Add a short introduction
* Update mentions of SSG

#### Rationale:
Since this project has moved to ComplianceAsCode, some things have been renamed, but some of them still keep the SSG in their name or contents.
