### PR TITLE
Finish rule gnome_gdm_disable_automatic_login for Fedora

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 
 if rpm --quiet -q gdm
 then

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/comment.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/comment.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+if grep -q "^AutomaticLoginEnable=" /etc/gdm/custom.conf ; then
+	sed -i "s/^AutomaticLoginEnable=.*/#AutomaticLoginEnable=False/g" /etc/gdm/custom.conf
+else
+	sed -i "/^\[daemon\]/a \
+		#AutomaticLoginEnable=False" /etc/gdm/custom.conf
+fi

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/correct_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+if grep -q "^AutomaticLoginEnable=" /etc/gdm/custom.conf ; then
+	sed -i "s/^AutomaticLoginEnable=.*/AutomaticLoginEnable=False/g" /etc/gdm/custom.conf
+else
+	sed -i "/^\[daemon\]/a \
+		AutomaticLoginEnable=False" /etc/gdm/custom.conf
+fi

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/line_not_there.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/line_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+sed -i "/^AutomaticLoginEnable=.*/d" /etc/gdm/custom.conf

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_automatic_login/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+if grep -q "^AutomaticLoginEnable=" /etc/gdm/custom.conf ; then
+	sed -i "s/^AutomaticLoginEnable=.*/AutomaticLoginEnable=True/g" /etc/gdm/custom.conf
+else
+	sed -i "/^\[daemon\]/a \
+		AutomaticLoginEnable=True" /etc/gdm/custom.conf
+fi


### PR DESCRIPTION
#### Description:
This PR adds
* multi_platform_fedora to bash remediation 
* tests
for rule gnome_gdm_disable_automatic_login.

#### Rationale:
This rule is a part of Fedora OSPP profile.