### PR TITLE
Replace occurences of yum in rules

### DIFF
--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -5,9 +5,8 @@ prodtype: rhel6,rhel7
 title: 'Uninstall bind Package'
 
 description: |-
-    To remove the <tt>bind</tt> package, which contains the
-    <tt>named</tt> service, run the following command:
-    <pre>$ sudo yum erase bind</pre>
+    The <tt>named</tt> service is provided by the <tt>bind</tt> package.
+    {{{ describe_package_remove(package="bind") }}}
 
 rationale: |-
     If there is no need to make DNS server software available,

--- a/linux_os/guide/services/ftp/ftp_use_vsftpd/package_vsftpd_installed/rule.yml
+++ b/linux_os/guide/services/ftp/ftp_use_vsftpd/package_vsftpd_installed/rule.yml
@@ -6,7 +6,7 @@ title: 'Install vsftpd Package'
 
 description: |-
     If this system must operate as an FTP server, install the <tt>vsftpd</tt> package via the standard channels.
-    <pre>$ sudo yum install vsftpd</pre>
+    {{{ describe_package_install(package="vsftpd") }}}
 
 rationale: |-
     After Red Hat Enterprise Linux 2.1, Red Hat switched from distributing wu-ftpd with Red Hat Enterprise Linux to distributing vsftpd. For security

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_security/httpd_install_mod_security/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_security/httpd_install_mod_security/rule.yml
@@ -6,7 +6,7 @@ title: 'Install mod_security'
 
 description: |-
     Install the <tt>security</tt> module:
-    <pre>$ sudo yum install mod_security</pre>
+    {{{ describe_package_install(package="mod_security") }}}
 
 rationale: |-
     <tt>mod_security</tt> provides an additional level of protection for the web server by

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/httpd_install_mod_ssl/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/httpd_install_mod_ssl/rule.yml
@@ -6,7 +6,7 @@ title: 'Install mod_ssl'
 
 description: |-
     Install the <tt>mod_ssl</tt> module:
-    <pre>$ sudo yum install mod_ssl</pre>
+    {{{ describe_package_install(package="mod_ssl") }}}
 
 rationale: |-
     <tt>mod_ssl</tt> provides encryption capabilities for the <tt>httpd</tt> Web server. Unencrypted

--- a/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
@@ -5,9 +5,7 @@ prodtype: rhel6,rhel7
 title: 'Uninstall dovecot Package'
 
 description: |-
-    The <tt>dovecot</tt> package can be uninstalled
-    with the following command:
-    <pre>$ sudo yum erase dovecot</pre>
+    {{{ describe_package_remove(package="dovecot") }}}
 
 rationale: |-
     If there is no need to make the Dovecot software available,

--- a/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
@@ -7,7 +7,7 @@ title: 'Uninstall openldap-servers Package'
 description: |-
     The <tt>openldap-servers</tt> package should be removed if not in use.
     Is this system the OpenLDAP server? If not, remove the package.
-    <pre>$ sudo yum erase openldap-servers</pre>
+    {{{ describe_package_remove(package="openldap-servers") }}}
     The openldap-servers RPM is not installed by default on a {{{ full_name }}}
     system. It is needed only by the OpenLDAP server, not by the
     clients which use LDAP for authentication. If the system is not

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
@@ -5,8 +5,7 @@ prodtype: rhel6,rhel7
 title: 'Uninstall xinetd Package'
 
 description: |-
-    The <tt>xinetd</tt> package can be uninstalled with the following command:
-    <pre>$ sudo yum erase xinetd</pre>
+    {{{ describe_package_remove(package="xinetd") }}}
 
 rationale: |-
     Removing the <tt>xinetd</tt> package decreases the risk of the

--- a/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
@@ -5,9 +5,7 @@ prodtype: rhel6,rhel7,ol7
 title: 'Uninstall ypserv Package'
 
 description: |-
-    The <tt>ypserv</tt> package can be uninstalled with
-    the following command:
-    <pre>$ sudo yum erase ypserv</pre>
+    {{{ describe_package_remove(package="ypserv") }}}
 
 rationale: "The NIS service provides an unencrypted authentication service which does not\nprovide for the confidentiality and integrity of user passwords or the remote session.\n\nRemoving the <tt>ypserv</tt> package decreases the risk of the accidental (or intentional) \nactivation of NIS or NIS+ services."
 

--- a/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
@@ -5,9 +5,7 @@ prodtype: rhel6,rhel7
 title: 'Uninstall rsh-server Package'
 
 description: |-
-    The <tt>rsh-server</tt> package can be uninstalled with
-    the following command:
-    <pre>$ sudo yum erase rsh-server</pre>
+    {{{ describe_package_remove(package="rsh-server") }}}
 
 rationale: |-
     The <tt>rsh-server</tt> service provides unencrypted remote access service which does not

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
@@ -5,9 +5,7 @@ prodtype: rhel6,rhel7
 title: 'Uninstall telnet-server Package'
 
 description: |-
-    The <tt>telnet-server</tt> package can be uninstalled with
-    the following command:
-    <pre>$ sudo yum erase telnet-server</pre>
+    {{{ describe_package_remove(package="telnet-server") }}}
 
 rationale: "It is detrimental for operating systems to provide, or install by default, functionality exceeding\nrequirements or mission objectives. These unnecessary capabilities are often overlooked and therefore\nmay remain unsecure. They increase the risk to the platform by providing additional attack vectors.\n<br />\nThe telnet service provides an unencrypted remote access service which does not provide for the \nconfidentiality and integrity of user passwords or the remote session. If a privileged user were\nto login using this service, the privileged user password could be compromised.\n<br />\nRemoving the <tt>telnet-server</tt> package decreases the risk of the telnet service's accidental \n(or intentional) activation."
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_screen_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_screen_installed/rule.yml
@@ -5,8 +5,8 @@ prodtype: rhel6,rhel7,fedora
 title: 'Install the screen Package'
 
 description: |-
-    To enable console screen locking, install the <tt>screen</tt> package:
-    <pre>$ sudo yum install screen</pre>
+    To enable console screen locking, install the <tt>screen</tt> package.
+    {{{ describe_package_install(package="screen") }}}
     Instruct users to begin new terminal sessions with the following command:
     <pre>$ screen</pre>
     The console can now be locked with the following key combination:

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -7,7 +7,7 @@ title: 'Install Smart Card Packages For Multifactor Authentication'
 description: |-
     Configure the operating system to implement multifactor authentication by
     installing the required packages with the following command:
-    <pre>$ sudo yum install esc pam_pkcs11 authconfig-gtk</pre>
+    {{{ describe_package_install(package="esc pam_pkcs11 authconfig-gtk") }}}
 
 rationale: |-
     Using an authentication device, such as a CAC or token that is separate from

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -5,8 +5,7 @@ prodtype: rhel7
 title: 'Install firewalld'
 
 description: |-
-    Install the firewalld package with the command:
-    <pre>$ sudo yum install firewalld</pre>
+    {{{ describe_package_install(package="firewalld") }}}
 
 rationale: 'The firewalld package should be installed to provide access control methods.'
 

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
@@ -10,8 +10,8 @@ description: |-
     x86 kernel already includes this support. However, if the system is
     32-bit and also supports the PAE and NX features as
     determined in the previous section, the kernel-PAE package should
-    be installed to enable XD or NX support:
-    <pre>$ sudo yum install kernel-PAE</pre>
+    be installed to enable XD or NX support.
+    {{{ describe_package_install(package="kernel-PAE") }}}
     The installation process should also have configured the
     bootloader to load the new kernel at boot. Verify this after reboot
     {{% if product == "rhel6" %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -5,8 +5,7 @@ prodtype: rhel6,rhel7,fedora,ol7
 title: 'Install AIDE'
 
 description: |-
-    Install the AIDE package with the command:
-    <pre>$ sudo yum install aide</pre>
+    {{{ describe_package_install(package="aide") }}}
 
 rationale: 'The AIDE package must be installed if it is to be available for integrity checking.'
 

--- a/linux_os/guide/system/software/sap/package_glibc_installed/rule.yml
+++ b/linux_os/guide/system/software/sap/package_glibc_installed/rule.yml
@@ -8,8 +8,7 @@ description: |-
     The package <tt>glibc</tt> is installed on Linux by default, but the
     <tt>glibc</tt> version might not be sufficient for SAP. Please refer to
     SAP note of your Linux version for the minimum requirement on <tt>glibc</tt>.
-    Use the following command to install and/or update the package:
-    <pre>$ sudo yum install glibc</pre>
+    {{{ describe_package_install(package="glibc") }}}
 
 rationale: |-
     The <tt>glibc</tt> package contains standard C and math libraries used by

--- a/linux_os/guide/system/software/sap/package_uuidd_installed/rule.yml
+++ b/linux_os/guide/system/software/sap/package_uuidd_installed/rule.yml
@@ -11,8 +11,7 @@ description: |-
     with SAP where massive UUIDs are created in a short time period, it is
     important to install the package <tt>uuidd</tt>. More information can be
     found in SAP note 1391070.
-    Using the following command to install and/or update the package:
-    <pre>$ sudo yum install uuidd</pre>
+    {{{ describe_package_install(package="uuidd") }}}
 
 rationale: |-
     The <tt>uuidd</tt> package contains a userspace daemon (uuidd) which is 

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: rhel7
 
-title: 'Ensure YUM Removes Previous Package Versions'
+title: 'Ensure {{{ pkg_manager }}} Removes Previous Package Versions'
 
 description: |-
-    <tt>Yum</tt> should be configured to remove previous software components after
-    previous versions have been installed. To configure <tt>yum</tt> to remove the
+    <tt>{{{ pkg_manager }}}</tt> should be configured to remove previous software components after
+    previous versions have been installed. To configure <tt>{{{ pkg_manager }}}</tt> to remove the
     previous software components after updating, set the <tt>clean_requirements_on_remove</tt>
-    to <tt>1</tt> in <tt>/etc/yum.conf</tt>.
+    to <tt>1</tt> in <tt>{{{ pkg_manager_config_file }}}</tt>.
 
 rationale: |-
     Previous versions of software components that are not removed from the information
@@ -31,6 +31,6 @@ ocil_clause: 'clean_requirements_on_remove is not enabled or configured correctl
 ocil: |-
     To verify that <tt>clean_requirements_on_remove</tt> is configured properly, run the
     following command:
-    <pre>$ grep clean_requirements_on_remove /etc/yum.conf</pre>
+    <pre>$ grep clean_requirements_on_remove {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:
     <pre>clean_requirements_on_remove=1</pre>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
@@ -4,10 +4,30 @@ prodtype: rhel7
 
 title: 'Ensure gpgcheck Enabled for Repository Metadata'
 
-description: "Verify the operating system prevents the installation of patches, service packs, device\ndrivers, or operating system components of local packages without verification of the \nrepository metadata.\n<br /><br />\nCheck that <tt>yum</tt> verifies the repository metadata prior to install with the\nfollowing command. This should be configured by setting <tt>repo_gpgcheck</tt> to <tt>1</tt>\nin <tt>/etc/yum.conf</tt>."
+description: |-
+    Verify the operating system prevents the installation of patches,
+    service packs, device drivers, or operating system components of
+    local packages without verification of the repository metadata.
+    Check that <tt>{{{ pkg_manager }}}</tt> verifies the repository
+    metadata prior to install with the following command.
+    This should be configured by setting <tt>repo_gpgcheck</tt> to <tt>1</tt>
+    in <tt>{{{ pkg_manager_config_file }}}</tt>.
 
-rationale: "Changes to any software components can have significant effects to the overall security\nof the operating system. This requirement ensures the software has not been tampered and\nhas been provided by a trusted vendor.\n<br /><br />\nAccordingly, patches, service packs, device drivers, or operating system components must\nbe signed with a certificate recognized and approved by the organization.\n<br /><br />\nVerifying the authenticity of the software prior to installation validates the integrity\nof the patch or upgrade received from a vendor. This ensures the software has not been\ntampered with and that it has been provided by a trusted vendor. Self-signed certificates\nare disallowed by this requirement. The operating system should not have to verify the software\nagain.\n<br /><br />\nNOTE: For U.S. Military systems, this requirement does not mandate DoD certificates for\nthis purpose; however, the certificate used to verify the software must be from an \napproved Certificate\
-    \ Authority."
+rationale: |-
+    Changes to any software components can have significant effects to the
+    overall security of the operating system. This requirement ensures the
+    software has not been tampered and has been provided by a trusted vendor.
+    Accordingly, patches, service packs, device drivers, or operating system
+    components must be signed with a certificate recognized and approved by
+    the organization. Verifying the authenticity of the software prior to
+    installation validates the integrity of the patch or upgrade received from
+    a vendor. This ensures the software has not been tampered with and that it
+    has been provided by a trusted vendor. Self-signed certificates are
+    disallowed by this requirement. The operating system should not have
+    to verify the software again. NOTE: For U.S. Military systems, this
+    requirement does not mandate DoD certificates for this purpose; however,
+    the certificate used to verify the software must be from an approved
+    Certificate Authority.
 
 severity: high
 
@@ -26,6 +46,6 @@ ocil_clause: 'gpgcheck is not enabled or configured correctly to verify reposito
 ocil: |-
     To verify that <tt>repo_gpgcheck</tt> is configured properly, run the following
     command:
-    <pre>$ grep repo_gpgcheck /etc/yum.conf</pre>
+    <pre>$ grep repo_gpgcheck {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:
     <pre>repo_gpgcheck=1</pre>


### PR DESCRIPTION
#### Description:
Replace occurrences of yum in rules by Jinja macros

#### Rationale:
We should use already defined Jinja macros to add package-related
commands instead of hard coding them. This will enable to easily
include these rules into Fedora and other products
that use different package managers.
