### PR TITLE
Simplify OVAL in ensure_gpgcheck_globally_activated

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="ensure_gpgcheck_globally_activated" version="1">
     <metadata>
-      <title>Ensure Yum gpgcheck Globally Activated</title>
+      <title>Ensure {{{ pkg_manager }}} gpgcheck Globally Activated</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
@@ -9,28 +9,15 @@
       of an RPM package's signature always occurs prior to its
       installation.</description>
     </metadata>
-    <criteria operator="OR">
-      <criteria operator="AND">
-        <extend_definition comment="Fedora installed" definition_ref="installed_OS_is_fedora" />
-        <criterion comment="check value of gpgcheck in /etc/dnf/dnf.conf" test_ref="test_dnf_ensure_gpgcheck_globally_activated" />
-      </criteria>
-      <criterion comment="check value of gpgcheck in /etc/yum.conf" test_ref="test_yum_ensure_gpgcheck_globally_activated" />
+    <criteria operator="AND">
+     <criterion comment="check value of gpgcheck in {{{ pkg_manager_config_file }}}" test_ref="test_ensure_gpgcheck_globally_activated" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of gpgcheck in /etc/yum.conf" id="test_yum_ensure_gpgcheck_globally_activated" version="1">
-    <ind:object object_ref="object_yum_ensure_gpgcheck_globally_activated" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of gpgcheck in {{{ pkg_manager_config_file }}}" id="test_ensure_gpgcheck_globally_activated" version="1">
+    <ind:object object_ref="object_ensure_gpgcheck_globally_activated" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_yum_ensure_gpgcheck_globally_activated" comment="gpgcheck set in /etc/yum.conf" version="1">
-    <ind:filepath>/etc/yum.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*1\s*$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of gpgcheck in /etc/dnf/dnf.conf" id="test_dnf_ensure_gpgcheck_globally_activated" version="1">
-    <ind:object object_ref="object_dnf_ensure_gpgcheck_globally_activated" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_dnf_ensure_gpgcheck_globally_activated" comment="gpgcheck set in /etc/dnf/dnf.conf" version="1">
-    <ind:filepath>/etc/dnf/dnf.conf</ind:filepath>
+  <ind:textfilecontent54_object id="object_ensure_gpgcheck_globally_activated" comment="gpgcheck set in {{{ pkg_manager_config_file }}}" version="1">
+    <ind:filepath>{{{ pkg_manager_config_file }}}</ind:filepath>
     <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*1\s*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
#### Description:

This OVAL is much simpler thanks to Jinja macros. Platform check
is not needed anymore.

#### Rationale:

This rule is a part of Fedora OSPP profile.
