### PR TITLE
Audit rules for unsuccessful file ownership change

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -115,9 +115,13 @@ selections:
     - audit_rules_execution_setsebool
     - audit_rules_mac_modification
     - audit_rules_dac_modification_chown
+    - audit_rules_unsuccessful_file_modification_chown
     - audit_rules_dac_modification_fchownat
+    - audit_rules_unsuccessful_file_modification_fchownat
     - audit_rules_dac_modification_fchown
+    - audit_rules_unsuccessful_file_modification_fchown
     - audit_rules_dac_modification_lchown
+    - audit_rules_unsuccessful_file_modification_lchown
     - audit_rules_privileged_commands_passwd
     - audit_rules_privileged_commands_unix_chkpwd
     - audit_rules_privileged_commands_userhelper

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Ownership Changes to Files - chown'
+
+description: |-
+    The audit system should collect unsuccessful file ownership change
+    attempts for all users and root.
+    If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S chown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S chown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>-a always,exit -F arch=b64 -S chown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S chown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+{{{ complete_ocil_entry_audit_syscall(syscall="chown") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
@@ -22,7 +22,7 @@ description: |-
 
 
 rationale: |-
-    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    Unsuccessful attempts to change ownership of files could be an indicator of malicious activity on a system. Auditing
     these events could serve as evidence of potential system compromise.
 
 severity: medium
@@ -32,6 +32,7 @@ severity: medium
 warnings:
     - general: |-
         Note that these rules can be configured in a
-        number of ways while still achieving the desired effect. Here the system calls
-        have been placed independent of other system calls. Grouping these system
-        calls with others as identifying earlier in this guide is more efficient.
+        number of ways while still achieving the desired effect. Here the audit rule checks a
+        system call independently of other system calls. Grouping system calls related
+        to the same event is more efficient. See the following example:
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
@@ -22,7 +22,7 @@ description: |-
 
 
 rationale: |-
-    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    Unsuccessful attempts to change ownership of files could be an indicator of malicious activity on a system. Auditing
     these events could serve as evidence of potential system compromise.
 
 severity: medium
@@ -32,6 +32,7 @@ severity: medium
 warnings:
     - general: |-
         Note that these rules can be configured in a
-        number of ways while still achieving the desired effect. Here the system calls
-        have been placed independent of other system calls. Grouping these system
-        calls with others as identifying earlier in this guide is more efficient.
+        number of ways while still achieving the desired effect. Here the audit rule checks a
+        system call independently of other system calls. Grouping system calls related
+        to the same event is more efficient. See the following example:
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Ownership Changes to Files - fchown'
+
+description: |-
+    The audit system should collect unsuccessful file ownership change
+    attempts for all users and root.
+    If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S fchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>-a always,exit -F arch=b64 -S fchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+{{{ complete_ocil_entry_audit_syscall(syscall="fchown") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Ownership Changes to Files - fchownat'
+
+description: |-
+    The audit system should collect unsuccessful file ownership change
+    attempts for all users and root.
+    If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>-a always,exit -F arch=b64 -S fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+{{{ complete_ocil_entry_audit_syscall(syscall="fchownat") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
@@ -22,7 +22,7 @@ description: |-
 
 
 rationale: |-
-    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    Unsuccessful attempts to change ownership of files could be an indicator of malicious activity on a system. Auditing
     these events could serve as evidence of potential system compromise.
 
 severity: medium
@@ -32,6 +32,7 @@ severity: medium
 warnings:
     - general: |-
         Note that these rules can be configured in a
-        number of ways while still achieving the desired effect. Here the system calls
-        have been placed independent of other system calls. Grouping these system
-        calls with others as identifying earlier in this guide is more efficient.
+        number of ways while still achieving the desired effect. Here the audit rule checks a
+        system call independently of other system calls. Grouping system calls related
+        to the same event is more efficient. See the following example:
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
@@ -22,7 +22,7 @@ description: |-
 
 
 rationale: |-
-    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    Unsuccessful attempts to change ownership of files could be an indicator of malicious activity on a system. Auditing
     these events could serve as evidence of potential system compromise.
 
 severity: medium
@@ -32,6 +32,7 @@ severity: medium
 warnings:
     - general: |-
         Note that these rules can be configured in a
-        number of ways while still achieving the desired effect. Here the system calls
-        have been placed independent of other system calls. Grouping these system
-        calls with others as identifying earlier in this guide is more efficient.
+        number of ways while still achieving the desired effect. Here the audit rule checks a
+        system call independently of other system calls. Grouping system calls related
+        to the same event is more efficient. See the following example:
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Unsuccessul Ownership Changes to Files - lchown'
+
+description: |-
+    The audit system should collect unsuccessful file ownership change
+    attempts for all users and root.
+    If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file.
+    <pre>-a always,exit -F arch=b32 -S lchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S lchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    If the system is 64 bit then also add the following lines:
+    <pre>-a always,exit -F arch=b64 -S lchown -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S lchown -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change</pre>
+
+
+rationale: |-
+    Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
+    these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+{{{ complete_ocil_entry_audit_syscall(syscall="lchown") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.

--- a/rhel7/profiles/ospp42-draft.profile
+++ b/rhel7/profiles/ospp42-draft.profile
@@ -110,9 +110,13 @@ selections:
     - audit_rules_execution_setsebool
     - audit_rules_mac_modification
     - audit_rules_dac_modification_chown
+    - audit_rules_unsuccessful_file_modification_chown
     - audit_rules_dac_modification_fchownat
+    - audit_rules_unsuccessful_file_modification_fchownat
     - audit_rules_dac_modification_fchown
+    - audit_rules_unsuccessful_file_modification_fchown
     - audit_rules_dac_modification_lchown
+    - audit_rules_unsuccessful_file_modification_lchown
     - audit_rules_privileged_commands_passwd
     - audit_rules_privileged_commands_unix_chkpwd
     - audit_rules_privileged_commands_userhelper

--- a/shared/templates/csv/audit_rules_unsuccessful_file_modification.csv
+++ b/shared/templates/csv/audit_rules_unsuccessful_file_modification.csv
@@ -1,5 +1,9 @@
 creat
+chown
+fchown
+fchownat
 ftruncate
+lchown
 open
 openat
 open_by_handle_at

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/default.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/default.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/empty.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/empty.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/empty.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/empty.fail.sh
@@ -4,4 +4,3 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-true

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/one_filter.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_chown/one_filter.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules


### PR DESCRIPTION
#### Description:

- Add rules to check audit rules to log for unsuccessful file ownership change attempts.
- OVALs are the same as generated by template [template_OVAL_audit_rules_unsuccessful_file_modification](https://github.com/ComplianceAsCode/content/blob/master/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification).
- Added basic test for `audit_rules_unsuccessful_file_modification_chown`.
  - Test `one_filter.fail.sh` is expected to fail until commit https://github.com/ComplianceAsCode/content/pull/3262/commits/34ed00125738b5dfef99199d57a3c8b47c272663 is merged.

#### Rationale:
- OSPP4.2 Profile would like you to have separate records for unsuccessful file ownership change attempts

