### PR TITLE
Tests and bash for gnome_gdm_disable_guest_login

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 
 if rpm --quiet -q gdm
 then

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/comment.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/comment.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+if grep -q "^TimedLoginEnable=" /etc/gdm/custom.conf ; then
+	sed -i "s/^TimedLoginEnable=.*/#TimedLoginEnable=False/g" /etc/gdm/custom.conf
+else
+	sed -i "/^\[daemon\]/a \
+		#TimedLoginEnable=False" /etc/gdm/custom.conf
+fi

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/correct_value.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/correct_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+if grep -q "^TimedLoginEnable=" /etc/gdm/custom.conf ; then
+	sed -i "s/^TimedLoginEnable=.*/TimedLoginEnable=False/g" /etc/gdm/custom.conf
+else
+	sed -i "/^\[daemon\]/a \
+		TimedLoginEnable=False" /etc/gdm/custom.conf
+fi

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/line_not_there.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/line_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+sed -i "/^TimedLoginEnable=.*/d" /etc/gdm/custom.conf

--- a/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/group_gnome_login_screen/rule_gnome_gdm_disable_guest_login/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install gdm
+
+if grep -q "^TimedLoginEnable=" /etc/gdm/custom.conf ; then
+	sed -i "s/^TimedLoginEnable=.*/TimedLoginEnable=True/g" /etc/gdm/custom.conf
+else
+	sed -i "/^\[daemon\]/a \
+		TimedLoginEnable=True" /etc/gdm/custom.conf
+fi


### PR DESCRIPTION
#### Description:

Adds platform string into the bash remediation and renames the
script to be used in Fedora profile.
Adds tests to test suite.

#### Rationale:

This rule is a part of Fedora OSPP profile.
