### PR TITLE
Ansible remediation fails on ensure group owner if cron.allow doesn't exist.

### DIFF
--- a/shared/templates/template_ANSIBLE_file_groupowner
+++ b/shared/templates/template_ANSIBLE_file_groupowner
@@ -3,11 +3,17 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+- name: Test for existence {{{ FILEPATH }}}
+  stat:
+    path: {{{ FILEPATH }}}
+  register: file_exists
+
 - name: Ensure group owner {{{ FILEGID }}} on {{{ FILEPATH }}}
   file:
     path: "{{ item }}"
     group: {{{ FILEGID }}}
   with_items:
     - {{{ FILEPATH }}}
+  when: file_exists.stat.exists
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
… exist.

#### Description:

- Ansible remediation fails on trying to set group owner of /etc/cron.allow if cron.allow doesn't exist but existence of file is not required.  

#### Rationale:

- Added to ansible template to only attempt to set group owner of file if the file exists.  Will duplicate changes for setting owner remediation and create another pull request if this looks ok.


