### PR TITLE
Audit rule to log access to /var/log/audit

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -144,6 +144,7 @@ selections:
     - audit_rules_privileged_commands_sudo
     - audit_rules_privileged_commands_su
     - audit_rules_session_events
+    - directory_access_var_log_audit
     - ensure_fedora_gpgkey_installed
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
@@ -1,0 +1,57 @@
+<def-group>
+  <definition class="compliance" id="directory_access_var_log_audit" version="1">
+    <metadata>
+      <title>Ensure auditd Collects Information Read Access to /var/log/audit</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Audit rules about the read events to /var/log/audit</description>
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit rule to record read access events to /var/log/audit" test_ref="test_directory_acccess_var_log_audit_augenrules" />
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit rule to record read access events to /var/log/audit" test_ref="test_directory_acccess_var_log_audit_auditctl" />
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Access to /var/log/audit rule regex-->
+  <constant_variable id="var_audit_rule_access_var_log_audit_regex" version="1" datatype="string" comment="audit rule arch and syscal">
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+dir=/var/log/audit/)[\s]+(?:-F[\s]+perm=r)[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+  </constant_variable>
+
+  <!-- 32bit EACCES augenrules objects -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+ comment="defined audit rule must exist" id="test_directory_acccess_var_log_audit_augenrules" version="1">
+    <ind:object object_ref="object_directory_acccess_var_log_audit_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_directory_acccess_var_log_audit_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_audit_regex" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <!-- 32bit EACCES auditctl objects -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+ comment="defined audit rule must exist" id="test_directory_acccess_var_log_audit_auditctl" version="1">
+    <ind:object object_ref="object_directory_acccess_var_log_audit_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_directory_acccess_var_log_audit_auditctl" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_audit_regex" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Record Access Events to Audit Log directory'
+
+description: |-
+    The audit system should collect access events to read audit log directory.
+    The following audit rule will assure that access to audit log directory are
+    collected.
+    <pre>-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+    program to read audit rules during daemon startup (the default), add the
+    rule to a file with suffix <tt>.rules</tt> in the directory
+    <tt>/etc/audit/rules.d</tt>.
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the rule to
+    <tt>/etc/audit/audit.rules</tt> file.
+
+rationale: |-
+    Attempts to read the logs should be recorded, suspicious access to audit log files could be an indicator of malicious activity on a system.
+    Auditing these events could serve as evidence of potential system compromise.'
+
+references:
+    ospp@rhel7: FAU_GEN.1.1.c
+
+severity: unknown
+
+ocil_clause: "no line is returned"
+
+ocil: |-
+    Run the following command to check the mode of the system audit logs:
+    <pre>$ ls -ld /var/log/audit</pre>
+    Audit log directories must be mode 0700 or less permissive.
+    To determine if the system is configured to audit accesses to
+    <code>/var/log/audit</code> directory, run the following command:
+    <pre space="preserve">$ sudo grep "dir=/var/log/audit" /etc/audit/audit.rules</pre>
+    If the system is configured to audit this activity, it will return a line.

--- a/rhel7/profiles/ospp42-draft.profile
+++ b/rhel7/profiles/ospp42-draft.profile
@@ -139,6 +139,7 @@ selections:
     - audit_rules_privileged_commands_sudo
     - audit_rules_privileged_commands_su
     - audit_rules_session_events
+    - directory_access_var_log_audit
     - ensure_redhat_gpgkey_installed
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/rule_directory_access_var_log_audit/correct_rule.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/rule_directory_access_var_log_audit/correct_rule.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/rule_directory_access_var_log_audit/wrong_dir.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/rule_directory_access_var_log_audit/wrong_dir.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/rule_directory_access_var_log_audit/wrong_perm.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/rule_directory_access_var_log_audit/wrong_perm.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules


### PR DESCRIPTION
#### Description:

- Add rule, check and tests for audit rules to log access events on `/var/log/audit`

#### Rationale:

- OSPP4.2 Profile would like people to know when their logs are accessed by someone
