### PR TITLE
Add bash and tests for rule grub2_audit_argument

### DIFF
--- a/linux_os/guide/system/auditing/grub2_audit_argument/bash/shared.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/bash/shared.sh
@@ -1,0 +1,13 @@
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+
+# Correct the form of default kernel command line in GRUB
+if grep -q '^GRUB_CMDLINE_LINUX=.*audit=.*"'  '/etc/default/grub' ; then
+	# modify the GRUB command-line if an audit= arg already exists
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit=[^[:space:]]*\(.*"\)/\1 audit=1 \2/'  '/etc/default/grub'
+else
+	# no audit=arg is present, append it
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 audit=1"/'  '/etc/default/grub'
+fi
+
+# Correct the form of kernel command line for each installed kernel in the bootloader
+grubby --update-kernel=ALL --args="audit=1"

--- a/tests/data/group_system/group_auditing/rule_grub2_audit_argument/arg_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/rule_grub2_audit_argument/arg_not_there.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# Correct the form of default kernel command line in GRUB
+if grep -q '^GRUB_CMDLINE_LINUX=.*audit=.*"'  '/etc/default/grub' ; then
+	# Remove the audit arg from the GRUB command-line if an audit arg already exists
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit=[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
+fi

--- a/tests/data/group_system/group_auditing/rule_grub2_audit_argument/arg_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/rule_grub2_audit_argument/arg_not_there.fail.sh
@@ -2,8 +2,7 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-# Correct the form of default kernel command line in GRUB
+# Removes audit argument from kernel command line
 if grep -q '^GRUB_CMDLINE_LINUX=.*audit=.*"'  '/etc/default/grub' ; then
-	# Remove the audit arg from the GRUB command-line if an audit arg already exists
 	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit=[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
 fi

--- a/tests/data/group_system/group_auditing/rule_grub2_audit_argument/correct_value.pass.sh
+++ b/tests/data/group_system/group_auditing/rule_grub2_audit_argument/correct_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# Correct the form of default kernel command line in GRUB
+if grep -q '^GRUB_CMDLINE_LINUX=.*audit=.*"'  '/etc/default/grub' ; then
+	# modify the GRUB command-line if an audit= arg already exists
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit=[^[:space:]]*\(.*"\)/\1 audit=1 \2/'  '/etc/default/grub'
+else
+	# no audit=arg is present, append it
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 audit=1"/'  '/etc/default/grub'
+fi

--- a/tests/data/group_system/group_auditing/rule_grub2_audit_argument/wrong_value.fail.sh
+++ b/tests/data/group_system/group_auditing/rule_grub2_audit_argument/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-# Correct the form of default kernel command line in GRUB
+# Break the audit argument in kernel command line
 if grep -q '^GRUB_CMDLINE_LINUX=.*audit=.*"'  '/etc/default/grub' ; then
 	# modify the GRUB command-line if an audit= arg already exists
 	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit=[^[:space:]]*\(.*"\)/\1 audit=0 \2/'  '/etc/default/grub'

--- a/tests/data/group_system/group_auditing/rule_grub2_audit_argument/wrong_value.fail.sh
+++ b/tests/data/group_system/group_auditing/rule_grub2_audit_argument/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# Correct the form of default kernel command line in GRUB
+if grep -q '^GRUB_CMDLINE_LINUX=.*audit=.*"'  '/etc/default/grub' ; then
+	# modify the GRUB command-line if an audit= arg already exists
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit=[^[:space:]]*\(.*"\)/\1 audit=0 \2/'  '/etc/default/grub'
+else
+	# no audit=arg is present, append it
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 audit=0"/'  '/etc/default/grub'
+fi


### PR DESCRIPTION
#### Description:
Add a bash remediation and basic test scenarios for rule grub2_audit_argument

#### Rationale:
This rule is a part of Fedora OSPP profile.
