### PR TITLE
Add Fedora to Bash for sshd_disable_gssapi_auth

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_fedora
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions


### PR DESCRIPTION
#### Description:
Add Fedora to Bash for sshd_disable_gssapi_auth

#### Rationale:
This rule is a part of Fedora OSPP profile.

Note: Tests are already there.
