### PR TITLE
Ansible remediation fails on setting owner of file if cron.allow doesn't exist

### DIFF
--- a/shared/templates/template_ANSIBLE_file_owner
+++ b/shared/templates/template_ANSIBLE_file_owner
@@ -3,11 +3,17 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+- name: Test for existence {{{ FILEPATH }}}
+  stat:
+    path: {{{ FILEPATH }}}
+  register: file_exists
+
 - name: Ensure owner {{{ FILEUID }}} on {{{ FILEPATH }}}
   file:
     path: "{{ item }}"
     owner: {{{ FILEUID }}}
   with_items:
     - {{{ FILEPATH }}}
+  when: file_exists.stat.exists
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- Ansible remediation fails on set owner if cron.allow doesn't exist.

#### Rationale:

- Checks for existence of file before setting owner.
