### PR TITLE
Remove use of loops for single items in Ansible templates

### DIFF
--- a/shared/templates/template_ANSIBLE_audit_rules_dac_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_dac_modification
@@ -55,22 +55,18 @@
 #
 - name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/audit.rules when on x86
   lineinfile:
-    line: "{{ item }}"
+    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
     state: present
     dest: /etc/audit/audit.rules
-  with_items:
-    - "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
   tags:
     @ANSIBLE_TAGS@
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in audit.rules when on x86_64
   lineinfile:
-    line: "{{ item }}"
+    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-  with_items:
-    - "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>=1000 -F auid!=4294967295 -F key=perm_mod"
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
@@ -64,23 +64,19 @@
 #
 - name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules when on x86
   lineinfile:
-    line: "{{ item }}"
+    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
     state: present
     dest: /etc/audit/audit.rules
-  with_items:
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
   when: audit_arch == 'b32'
   tags:
     @ANSIBLE_TAGS@
 
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:
-    line: "{{ item }}"
+    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-  with_items:
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>=1000 -F auid!=4294967295 -F key=delete"
   when: audit_arch == 'b64'
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_login_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_login_events
@@ -47,10 +47,8 @@
 #
 - name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
   lineinfile:
-    line: "{{ item }}"
+    line: "-w {{{ PATH }}} -p wa -k logins"
     state: present
     dest: /etc/audit/audit.rules
-  with_items:
-    - "-w {{{ PATH }}} -p wa -k logins"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
@@ -47,10 +47,8 @@
 #
 - name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
   lineinfile:
-    line: "{{ item }}"
+    line: "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification"
     state: present
     dest: /etc/audit/audit.rules
-  with_items:
-    - "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification"
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_file_groupowner
+++ b/shared/templates/template_ANSIBLE_file_groupowner
@@ -10,10 +10,8 @@
 
 - name: Ensure group owner {{{ FILEGID }}} on {{{ FILEPATH }}}
   file:
-    path: "{{ item }}"
+    path: {{{ FILEPATH }}}
     group: {{{ FILEGID }}}
-  with_items:
-    - {{{ FILEPATH }}}
   when: file_exists.stat.exists
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_file_owner
+++ b/shared/templates/template_ANSIBLE_file_owner
@@ -10,10 +10,8 @@
 
 - name: Ensure owner {{{ FILEUID }}} on {{{ FILEPATH }}}
   file:
-    path: "{{ item }}"
+    path: {{{ FILEPATH }}}
     owner: {{{ FILEUID }}}
-  with_items:
-    - {{{ FILEPATH }}}
   when: file_exists.stat.exists
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_file_permissions
+++ b/shared/templates/template_ANSIBLE_file_permissions
@@ -5,10 +5,8 @@
 # disruption = low
 - name: Ensure permission {{{ FILEMODE }}} on {{{ FILEPATH }}}
   file:
-    path: "{{ item }}"
+    path: {{{ FILEPATH }}}
     mode: {{{ FILEMODE }}}
-  with_items:
-    - {{{ FILEPATH }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_kernel_module_disabled
+++ b/shared/templates/template_ANSIBLE_kernel_module_disabled
@@ -6,11 +6,9 @@
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is disabled
   lineinfile:
     create: yes
-    dest: "/etc/modprobe.d/{{item}}.conf"
-    regexp: '{{item}}'
-    line: "install {{item}} /bin/true"
-  with_items:
-    - {{{ KERNMODULE }}}
+    dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
+    regexp: '{{{ KERNMODULE }}}'
+    line: "install {{{ KERNMODULE }}} /bin/true"
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_package_installed
+++ b/shared/templates/template_ANSIBLE_package_installed
@@ -5,10 +5,8 @@
 # disruption = low
 - name: Ensure {{{ PKGNAME }}} is installed
   package:
-    name: "{{item}}"
+    name: {{{ PKGNAME }}}
     state: present
-  with_items:
-    - {{{ PKGNAME }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_package_removed
+++ b/shared/templates/template_ANSIBLE_package_removed
@@ -5,10 +5,8 @@
 # disruption = low
 - name: Ensure {{{ PKGNAME }}} is removed
   package:
-    name: "{{item}}"
+    name: {{{ PKGNAME }}}
     state: absent
-  with_items:
-    - {{{ PKGNAME }}}
   tags:
     @ANSIBLE_TAGS@
 

--- a/shared/templates/template_ANSIBLE_permissions
+++ b/shared/templates/template_ANSIBLE_permissions
@@ -5,7 +5,7 @@
 # disruption = low
 - name: Ensure permission {{{ FILEMODE }}}, owner {{{ FILEUID }}}, and group {{{ FILEGID }}} on {{{ FILEPATH }}}
   file:
-    path: "{{ item }}"
+    path: {{{ FILEPATH }}}
     {{% if FILEMODE != "" %}}
     mode: {{{ FILEMODE }}}
     {{% endif %}}
@@ -15,7 +15,5 @@
     {{% if FILEGID != "" %}}
     group: {{{ FILEGID }}}
     {{% endif %}}
-  with_items:
-    - {{{ FILEPATH }}}
   tags:
     @ANSIBLE_TAGS@

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -5,26 +5,22 @@
 # disruption = low
 - name: Disable service {{{ SERVICENAME }}}
   service:
-    name: "{{item}}"
+    name: {{{ DAEMONNAME }}}
     enabled: "no"
     state: "stopped"
   register: service_result
   failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
-  with_items:
-    - {{{ DAEMONNAME }}}
   tags:
     @ANSIBLE_TAGS@
 
 {{% if init_system == "systemd" %}}
 - name: Disable socket of service {{{ SERVICENAME }}} if applicable
   service:
-    name: "{{item}}"
+    name: {{{ DAEMONNAME }}}.socket
     enabled: "no"
     state: "stopped"
   register: socket_result
   failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
-  with_items:
-    - {{{ DAEMONNAME }}}.socket
   tags:
     @ANSIBLE_TAGS@
 {{% endif %}}

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -5,11 +5,9 @@
 # disruption = low
 - name: Enable service {{{ SERVICENAME }}}
   service:
-    name: "{{item}}"
+    name: {{{ DAEMONNAME }}}
     enabled: "yes"
     state: "started"
-  with_items:
-    - {{{ DAEMONNAME }}}
   tags:
     @ANSIBLE_TAGS@
 


### PR DESCRIPTION
- with_items loop was used for a single item list in many of the Ansible templates.
  This removes use of loops for single valued lists. In addition, with_items will
  be replaced by loop and flatten in the future.