### PR TITLE
Audit rule to watch /etc/passwd for writes from open syscall

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -165,3 +165,4 @@ selections:
     - audit_rules_kernel_module_loading_insmod
     - audit_rules_kernel_module_loading_modprobe
     - audit_rules_kernel_module_loading_rmmod
+    - audit_rules_etc_passwd_open

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/oval/shared.xml
@@ -20,9 +20,7 @@
           <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules-->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
-          <criteria operator="AND">
-            <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_64bit_augenrules" />
-          </criteria>
+          <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_64bit_augenrules" />
         </criteria>
       </criteria>
 
@@ -35,10 +33,7 @@
           <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules -->
           <extend_definition comment="64-bit_system" definition_ref="system_info_architecture_64bit" negate="true" />
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
-          <criteria operator="AND">
-            <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_64bit_auditctl" />
-
-          </criteria>
+          <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_64bit_auditctl" />
         </criteria>
       </criteria>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/oval/shared.xml
@@ -1,0 +1,101 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_etc_passwd_open" version="1">
+    <metadata>
+      <title>Ensure auditd Collects Write Events to /etc/passwd</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Audit rules about the write events to /etc/passwd</description>
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_32bit_augenrules" />
+
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules-->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
+          <criteria operator="AND">
+            <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_64bit_augenrules" />
+          </criteria>
+        </criteria>
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_32bit_auditctl" />
+
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of the 32-bit version of the EACCES / EPERM rules -->
+          <extend_definition comment="64-bit_system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit versions of the rules -->
+          <criteria operator="AND">
+            <criterion comment="audit rule to record write events to /etc/passwd" test_ref="test_audit_rules_etc_passwd_open_64bit_auditctl" />
+
+          </criteria>
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Access to /var/log/audit rule regex-->
+  <constant_variable id="var_audit_rule_32bit_open_write_etc_passwd_regex" version="1" datatype="string" comment="audit rule arch and syscal">
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S(?:[\s]+open[\s]+|(?:[\s]+|[,])open(?:[\s]+|[,])))[\S]*[\s]*(?:-F[\s]+a2&amp;03)[\s]+(?:-F[\s]+path=/etc/passwd)[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+  </constant_variable>
+
+  <constant_variable id="var_audit_rule_64bit_open_write_etc_passwd_regex" version="1" datatype="string" comment="audit rule arch and syscal">
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S(?:[\s]+open[\s]+|(?:[\s]+|[,])open(?:[\s]+|[,])))[\S]*[\s]*(?:-F[\s]+a2&amp;03)[\s]+(?:-F[\s]+path=/etc/passwd)[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+  </constant_variable>
+
+  <!-- directory access /etc/passwd augenrule -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+ comment="defined audit rule must exist" id="test_audit_rules_etc_passwd_open_32bit_augenrules" version="1">
+    <ind:object object_ref="object_audit_rules_etc_passwd_open_32bit_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_etc_passwd_open_32bit_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rule_32bit_open_write_etc_passwd_regex" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+ comment="defined audit rule must exist" id="test_audit_rules_etc_passwd_open_64bit_augenrules" version="1">
+    <ind:object object_ref="object_audit_rules_etc_passwd_open_64bit_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_etc_passwd_open_64bit_augenrules" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rule_64bit_open_write_etc_passwd_regex" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+
+  <!-- directory access /etc/passwd augenrule -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+ comment="defined audit rule must exist" id="test_audit_rules_etc_passwd_open_32bit_auditctl" version="1">
+    <ind:object object_ref="object_audit_rules_etc_passwd_open_32bit_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_etc_passwd_open_32bit_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rule_32bit_open_write_etc_passwd_regex" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+ comment="defined audit rule must exist" id="test_audit_rules_etc_passwd_open_64bit_auditctl" version="1">
+    <ind:object object_ref="object_audit_rules_etc_passwd_open_64bit_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_etc_passwd_open_64bit_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rule_64bit_open_write_etc_passwd_regex" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Record Events that Modify User/Group Information via open syscall - /etc/passwd'
+
+description: |-
+    The audit system should collect write events to /etc/passwd file for all users and root.
+    If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F arch=b32 -S open -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F arch=b64 -S open -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify</pre>
+
+rationale: |-
+    Creation of users through direct edition of /etc/passwd could be an indicator of malicious activity on a system.
+    Auditing these events could serve as evidence of potential system compromise.
+
+severity: medium
+
+references:
+    ospp@rhel7: FAU_GEN.1.1.c
+
+{{{ complete_ocil_entry_audit_syscall(syscall="open") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping system calls related
+        to the same event is more efficient. See the following example:
+        <pre>-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify</pre>

--- a/rhel7/profiles/ospp42-draft.profile
+++ b/rhel7/profiles/ospp42-draft.profile
@@ -161,3 +161,4 @@ selections:
     - audit_rules_kernel_module_loading_modprobe
     - audit_rules_kernel_module_loading_rmmod
     - security_patches_up_to_date
+    - audit_rules_etc_passwd_open

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/auditctl_correct_rule.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/auditctl_correct_rule.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+# Use auditctl in RHEL7
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+echo "-a always,exit -F arch=b32 -S open -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/auditctl_multiple_syscalls.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/auditctl_multiple_syscalls.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+# Use auditctl in RHEL7
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+echo "-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/auditctl_wrong_dir.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/auditctl_wrong_dir.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+# Use auditctl in RHEL7
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+echo "-a always,exit -F arch=b32 -S open -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/augenrules_correct_rule.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/augenrules_correct_rule.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+echo "-a always,exit -F arch=b32 -S open -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/augenrules_wrong_dir.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/audit_path_syscall/rule_audit_rules_etc_passwd_open/augenrules_wrong_dir.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+echo "-a always,exit -F arch=b32 -S open -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules


### PR DESCRIPTION
#### Description:

- Add rule to watch for `write` operations with `open` syscall on `/etc/passwd`

#### Rationale:

- Creation of users through direct edition of /etc/passwd could be an indicator of malicious activity on a system.

