### PR TITLE
Ansible remediation fails setting file permissions if wildcard is used.

### DIFF
--- a/shared/templates/create_permissions.py
+++ b/shared/templates/create_permissions.py
@@ -101,7 +101,8 @@ class PermissionGenerator(FilesGenerator):
                 self.file_from_template(
                     "./template_ANSIBLE_file_permissions",
                     {
-                        "FILEPATH":      full_path,
+                        "FILEPATH":      dir_path,
+                        "FILENAME":      file_name,
                         "FILEMODE":      mode,
                     },
                     "./ansible/file_permissions{0}.yml", path_id

--- a/shared/templates/template_ANSIBLE_file_permissions
+++ b/shared/templates/template_ANSIBLE_file_permissions
@@ -3,12 +3,20 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-- name: Ensure permission {{{ FILEMODE }}} on {{{ FILEPATH }}}
+- name: Enumerate files for {{{ FILEPATH }}}{{{ FILENAME }}}
+  find:
+    paths: {{{ FILEPATH }}}
+    patterns: "{{{ FILENAME }}}"
+  register: files_for_permissions
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: Ensure permission {{{ FILEMODE }}} on {{{ FILEPATH }}}{{{ FILENAME }}}
   file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     mode: {{{ FILEMODE }}}
   with_items:
-    - {{{ FILEPATH }}}
+    - "{{ files_for_permissions.files }}"
   tags:
     @ANSIBLE_TAGS@
 


### PR DESCRIPTION
#### Description:

- Ansible remediation fails setting permissions if file path is provided with wildcard (i.e. /etc/ssh/*.pub).

#### Rationale:

- Altered variables to split file directory and file name in create_permission.py.  Ansible template now utilizes find and iterates through matched files to set file permissions.  Seems to work fine with individual files or path with wildcard.
