### PR TITLE
Fedora accounts_passwords_pam_faillock_deny_root rule and remediation fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/bash/shared.sh
@@ -1,10 +1,10 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_fedora
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
 
 # This script fixes absence of pam_faillock.so in PAM stack or the
-# absense of even_deny_root and deny=[0-9]+ in pam_faillock.so arguments
+# absense of even_deny_root in pam_faillock.so arguments
 # When inserting auth pam_faillock.so entries,
 # the entry with preauth argument will be added before pam_unix.so module
 # and entry with authfail argument will be added before pam_deny.so module.
@@ -12,30 +12,44 @@ AUTH_FILES[1]="/etc/pam.d/password-auth"
 # The placement of pam_faillock.so entries will not be changed
 # if they are already present
 
+# ensure, that pam.d folder exists
+mkdir -p "/etc/pam.d"
+
 for pamFile in "${AUTH_FILES[@]}"
 do
-	# pam_faillock.so already present?
-	if grep -q "^auth.*pam_faillock.so.*" $pamFile; then
+	# if auth file is missing, create it and add what this rule needs
+	if [ ! -f $pamFile ]; then
+		touch $pamFile
+		echo "
+auth required pam_faillock.so preauth silent even_deny_root deny=3 unlock_time=never fail_interval=900
+auth sufficient pam_unix.so
+auth [default=die] pam_faillock.so authfail silent even_deny_root deny=3 unlock_time=never fail_interval=900
+" >> $pamFile
+		# everything is set, don't check it again
+		continue
+	fi
 
-		# pam_faillock.so present, preauth even_deny_root directive present?
+	# is 'auth required' here?
+	if grep -q "^auth.*required.*pam_faillock.so.*" $pamFile; then
+		# has 'auth required' even_deny_root option?
 		if ! grep -q "^auth.*required.*pam_faillock.so.*preauth.*even_deny_root" $pamFile; then
 			# even_deny_root is not present
 			sed -i --follow-symlinks "s/\(^auth.*required.*pam_faillock.so.*preauth.*\).*/\1 even_deny_root/" $pamFile
 		fi
+	else
+		# no 'auth required', add it
+		sed -i --follow-symlinks "/^auth.*pam_unix.so.*/i auth required pam_faillock.so preauth silent even_deny_root" $pamFile
+	fi
 
-		# pam_faillock.so present, authfail even_deny_root directive present?
+	# is 'auth [default=die]' here?
+	if grep -q "^auth.*\[default=die\].*pam_faillock.so.*" $pamFile; then
+		# has 'auth [default=die]' even_deny_root option?
 		if ! grep -q "^auth.*\[default=die\].*pam_faillock.so.*authfail.*even_deny_root" $pamFile; then
 			# even_deny_root is not present
 			sed -i --follow-symlinks "s/\(^auth.*\[default=die\].*pam_faillock.so.*authfail.*\).*/\1 even_deny_root/" $pamFile
 		fi
-
-	# pam_faillock.so not present yet
 	else
-
-		# insert pam_faillock.so preauth row with proper value of the 'deny' option before pam_unix.so
-		sed -i --follow-symlinks "/^auth.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent even_deny_root" $pamFile
-		# insert pam_faillock.so authfail row with proper value of the 'deny' option before pam_deny.so, after all modules which determine authentication outcome.
-		sed -i --follow-symlinks "/^auth.*pam_deny.so.*/i auth        [default=die] pam_faillock.so authfail silent even_deny_root" $pamFile
+		# no 'auth [default=die]', add it
+		sed -i --follow-symlinks "/^auth.*pam_unix.so.*/a auth [default=die] pam_faillock.so authfail silent even_deny_root" $pamFile
 	fi
-
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Lock out the root account after failed login attempts</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The root account should be configured to deny access after the number of defined
       failed attempts has been reached.</description>
@@ -50,7 +51,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]+(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -85,7 +86,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <!-- Since order of PAM modules matters ensure pam_faillock.so in auth section is listed right after pam_unix.so auth row -->
-    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]+(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
+    <ind:pattern operation="pattern match">[\n][\s]*auth[\s]+(?:(?:sufficient)|(?:\[.*default=die.*\]))[\s]+pam_unix\.so[^\n]*(?s).*[\n][\s]*auth[\s]+\[default=die\][\s]+pam_faillock\.so[\s]+authfail[\s]+[^\n]*even_deny_root[^\n]*[\n]</ind:pattern>
     <!-- Check only the first instance -->
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/auth-config
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/auth-config
@@ -1,0 +1,29 @@
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        sufficient    pam_fprintd.so
+auth        [default=1 ignore=ignore success=ok] pam_succeed_if.so uid >= 1000 quiet
+auth        [default=1 ignore=ignore success=ok] pam_localuser.so
+auth        required      pam_faillock.so preauth silent even_deny_root deny=3 unlock_time=never fail_interval=900
+auth        sufficient    pam_unix.so
+auth        [default=die] pam_faillock.so authfail even_deny_root deny=3 unlock_time=never fail_interval=900
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        sufficient    pam_sss.so forward_pass
+auth        required      pam_deny.so
+
+account     required      pam_unix.so broken_shadow
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     [default=bad success=ok user_unknown=ignore] pam_sss.so
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    sufficient    pam_sss.so use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so
+session     optional      pam_sss.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/both-correct.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/both-correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+. set-up-pamd.sh
+
+set-up-pamd

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-default-die-pam_faillock.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-default-die-pam_faillock.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+. set-up-pamd.sh
+
+set-up-pamd
+sed -i '/auth[[:space:]]*\[default=die\][[:space:]]*pam_faillock\.so.*even_deny_root/d' /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-required-pam_faillock.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-required-pam_faillock.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+. set-up-pamd.sh
+
+set-up-pamd
+sed -i '/auth[[:space:]]*required[[:space:]]*pam_faillock\.so.*even_deny_root/d' /etc/pam.d/system-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-system-auth.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-system-auth.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+. set-up-pamd.sh
+
+set-up-pamd
+rm -f /etc/pam.d/system-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/set-up-pamd.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/set-up-pamd.sh
@@ -1,0 +1,5 @@
+function set-up-pamd {
+	mkdir -p /etc/pam.d
+	cp -rf auth-config /etc/pam.d/system-auth
+	cp -rf auth-config /etc/pam.d/password-auth
+}


### PR DESCRIPTION
#### Description:

- Add accounts_passwords_pam_faillock_deny_root rule for Fedora
- Fix OVAL (line with `pam_unix.so` can end right after `pam_unix.so`. Changing quantifier `+` to `*` fixes it)
- Fix bash remediation (it was fixing only cases when both tested lines were missing OR were here but wrong. It didn't work when one line was here but incorrect and other line was missing)
- Add tests

