### PR TITLE
Rule require_singleuser_auth for Fedora

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -2,20 +2,19 @@
 
 {{% if init_system == "systemd" -%}}
 
-{{% if product == "fedora" -%}}
 service_file="/usr/lib/systemd/system/rescue.service"
+
+{{% if product == "fedora" -%}}
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"
+{{%- else -%}}
+sulogin="/sbin/sulogin"
+{{%- endif %}}
+
 if grep "^ExecStart=.*" "$service_file" ; then
     sed -i "s%^ExecStart=.*%ExecStart=-$sulogin rescue%" "$service_file"
 else
     echo "ExecStart=-$sulogin rescue" >> "$service_file"
 fi
-{{%- else -%}}
-grep -q "^ExecStart=\-.*/sbin/sulogin" /usr/lib/systemd/system/rescue.service
-if ! [ $? -eq 0 ]; then
-    sed -i "s/ExecStart=-.*-c \"/&\/sbin\/sulogin; /g" /usr/lib/systemd/system/rescue.service
-fi
-{{%- endif -%}}
 
 {{%- else -%}}
 grep -q ^SINGLE /etc/sysconfig/init && \

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -1,10 +1,22 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_fedora
 
 {{% if init_system == "systemd" -%}}
+
+{{% if product == "fedora" -%}}
+service_file="/usr/lib/systemd/system/rescue.service"
+sulogin="/usr/lib/systemd/systemd-sulogin-shell"
+if grep "^ExecStart=.*" "$service_file" ; then
+    sed -i "s%^ExecStart=.*%ExecStart=-$sulogin rescue%" "$service_file"
+else
+    echo "ExecStart=-$sulogin rescue" >> "$service_file"
+fi
+{{%- else -%}}
 grep -q "^ExecStart=\-.*/sbin/sulogin" /usr/lib/systemd/system/rescue.service
 if ! [ $? -eq 0 ]; then
     sed -i "s/ExecStart=-.*-c \"/&\/sbin\/sulogin; /g" /usr/lib/systemd/system/rescue.service
 fi
+{{%- endif -%}}
+
 {{%- else -%}}
 grep -q ^SINGLE /etc/sysconfig/init && \
   sed -i "s/SINGLE.*/SINGLE=\/sbin\/sulogin/g" /etc/sysconfig/init

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -26,14 +26,24 @@
   </definition>
   {{%- if init_system == "systemd" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
-  comment="Tests that /sbin/sulogin was not removed from the default systemd rescue.service to ensure that a
+    comment="Tests that
+    {{% if product == "fedora" -%}}
+    /usr/lib/systemd/systemd-sulogin-shell
+    {{%- else -%}}
+    /sbin/sulogin
+    {{%- endif %}}
+    was not removed from the default systemd rescue.service to ensure that a
   password must be entered to access single user mode"
   id="test_require_rescue_service" version="1">
     <ind:object object_ref="obj_require_rescue_service" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
+    {{%- if product == "fedora" -%}}
+    <ind:pattern operation="pattern match">^ExecStart=\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
+    {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-.*/sbin/sulogin</ind:pattern>
+    {{%- endif -%}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -63,6 +63,11 @@ ocil: |-
     To check if authentication is required for single-user mode, run the following command:
     <pre>$ grep sulogin /usr/lib/systemd/system/rescue.service</pre>
     The output should be similar to the following, and the line must begin with
-    ExecStart and /sbin/sulogin:
-    <pre>ExecStart=-/sbin/sulogin</pre>
+    {{% if product == "fedora" -%}}
+        ExecStart and /usr/lib/systemd/systemd-sulogin-shell.
+        <pre>ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue</pre>
+    {{%- else -%}}
+        ExecStart and /sbin/sulogin.
+        <pre>ExecStart=-/sbin/sulogin</pre>
+    {{%- endif %}}
 {{% endif %}}

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/correct_value.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+service_file="/usr/lib/systemd/system/rescue.service"
+sulogin="/usr/lib/systemd/systemd-sulogin-shell"
+if grep "^ExecStart=.*" "$service_file" ; then
+    sed -i "s%^ExecStart=.*%ExecStart=-$sulogin rescue%" "$service_file"
+else
+    echo "ExecStart=-$sulogin rescue" >> "$service_file"
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/wrong_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+service_file="/usr/lib/systemd/system/rescue.service"
+sulogin="/bin/bash"
+if grep "^ExecStart=.*" "$service_file" ; then
+    sed -i "s%^ExecStart=.*%ExecStart=-$sulogin rescue%" "$service_file"
+else
+    echo "ExecStart=-$sulogin rescue" >> "$service_file"
+fi


### PR DESCRIPTION
#### Description:
Adjusts rule require_singleuser_auth for Fedora.

On Fedora, "/sbin/sulogin" has been superseded by "/usr/lib/systemd/systemd-sulogin-shell". We need to adjust the OVAL and Bash remediation accordingly.

Also adds 2 sceanrios to the test suite.

#### Rationale:
This rule is a part of Fedora OSPP profile.