### PR TITLE
Fixed grep usage.

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_all
 
-if `grep -q ^log_group /etc/audit/auditd.conf` ; then
+if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
   if ! [ "${GROUP}" == 'root' ] ; then
     chown root.${GROUP} /var/log/audit

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 
-if `grep -q ^log_group /etc/audit/auditd.conf` ; then
+if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
   if ! [ "${GROUP}" == 'root' ] ; then
     chmod 0640 /var/log/audit/audit.log

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
@@ -6,7 +6,7 @@ package_install aide
 aide_conf="/etc/aide.conf"
 forbidden_hashes=(sha1 rmd160 sha256 whirlpool tiger haval gost crc32)
 
-groups=$(grep "^[A-Z]\+" $aide_conf | cut -f1 -d ' ' | tr -d ' ' | sort -u)
+groups=$(LC_ALL=C grep "^[A-Z]\+" $aide_conf | cut -f1 -d ' ' | tr -d ' ' | sort -u)
 
 for group in $groups
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
@@ -5,7 +5,7 @@ package_install aide
 
 aide_conf="/etc/aide.conf"
 
-groups=$(grep "^[A-Z]\+" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
+groups=$(LC_ALL=C grep "^[A-Z]\+" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
 
 for group in $groups
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
@@ -5,7 +5,7 @@ package_install aide
 
 aide_conf="/etc/aide.conf"
 
-groups=$(grep "^[A-Z]\+" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
+groups=$(LC_ALL=C grep "^[A-Z]\+" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
 
 for group in $groups
 do

--- a/shared/bash_remediation_functions/firefox_cfg_setting.sh
+++ b/shared/bash_remediation_functions/firefox_cfg_setting.sh
@@ -45,7 +45,7 @@ function firefox_cfg_setting {
       fi
 
       # If the key exists, change it. Otherwise, add it to the config_file.
-      if `grep -q "^lockPref(\"${key}\", " "${firefox_dir}/${firefox_cfg}"` ; then
+      if LC_ALL=C grep -m 1 -q "^lockPref(\"${key}\", " "${firefox_dir}/${firefox_cfg}"; then
         sed -i "s/lockPref(\"${key}\".*/lockPref(\"${key}\", ${value});/g" "${firefox_dir}/${firefox_cfg}"
       else
         echo "lockPref(\"${key}\", ${value});" >> "${firefox_dir}/${firefox_cfg}"

--- a/shared/bash_remediation_functions/firefox_js_setting.sh
+++ b/shared/bash_remediation_functions/firefox_js_setting.sh
@@ -57,7 +57,7 @@ function firefox_js_setting {
       fi
 
       # If the key exists, change it. Otherwise, add it to the config_file.
-      if `grep -q "^pref(\"${key}\", " "${firefox_pref_dir}/${firefox_js}"` ; then
+      if LC_ALL=C grep -m 1 -q "^pref(\"${key}\", " "${firefox_pref_dir}/${firefox_js}"; then
         sed -i "s/pref(\"${key}\".*/pref(\"${key}\", ${value});/g" "${firefox_pref_dir}/${firefox_js}"
       else
         echo "pref(\"${key}\", ${value});" >> "${firefox_pref_dir}/${firefox_js}"

--- a/shared/fixes/bash/directory_permissions_var_log_audit.xml
+++ b/shared/fixes/bash/directory_permissions_var_log_audit.xml
@@ -1,6 +1,6 @@
 # platform = multi_platform_rhel
 
-if `grep -q ^log_group /etc/audit/auditd.conf` ; then
+if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
   if ! [ "${GROUP}" == 'root' ] ; then
     chmod 0750 /var/log/audit


### PR DESCRIPTION
Made improvements to `grep` invocations that fix a class of Shellcheck warnings, improves performance and fixes possible bugs caused by `grep` ranges being influenced by locale.

* Removed redundant backticks in conditions.
* Added LC_ALL=C as we are interested in ASCII content and `[A-Z]` can be interpreted differently depending on locale setting.
* Added -m 1 to stop searching after one match is found if applicable.