### PR TITLE
Finish rule sssd_offline_cred_expiration

### DIFF
--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -1,6 +1,6 @@
 # platform = multi_platform_rhel, multi_platform_fedora
 # reboot = false
-# strategy = unknown
+# strategy = configure
 # complexity = low
 # disruption = medium
 - name: "Configure SSD to Expire Offline Credentials"

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
@@ -1,0 +1,24 @@
+# platform = multi_platform_rhel, multi_platform_fedora
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_OPT="offline_credentials_expiration"
+SSSD_OPT_VAL=1
+PAM_REGEX="[[:space:]]*\[pam]"
+PAM_OPT_REGEX="${PAM_REGEX}([^\n\[]*\n+)+?[[:space:]]*${SSSD_OPT}"
+
+# Try find [pam] and offline_credentials_expiration in sssd.conf, if it exists
+# set it to 1, if it doesn't exist add it, if [pam] section doesn't exist add
+# the section and the configuration option.
+if grep -qzosP $PAM_OPT_REGEX $SSSD_CONF; then
+	sed -i "s/${SSSD_OPT}[^(\n)]*/${SSSD_OPT} = ${SSSD_OPT_VAL}/" $SSSD_CONF
+elif grep -qs $PAM_REGEX $SSSD_CONF; then
+	sed -i "/$PAM_REGEX/a ${SSSD_OPT} = ${SSSD_OPT_VAL}" $SSSD_CONF
+else
+	mkdir -p /etc/sssd
+	touch $SSSD_CONF
+	echo -e "[pam]\n${SSSD_OPT} = ${SSSD_OPT_VAL}" >> $SSSD_CONF
+fi

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
@@ -25,7 +25,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_offline_cred_expiration" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\[pam]([^\n]*\n+)+?offline_credentials_expiration[\s]+=[\s]+1$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[pam](?:[^\n\[]*\n+)+?[\s]*offline_credentials_expiration[\s]*=[\s]*1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/comment.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+source common.sh
+
+echo -e "[pam]\n#offline_credentials_expiration = 1" >> $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/common.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/common.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+
+yum -y install sssd
+systemctl enable sssd
+mkdir -p /etc/sssd
+touch $SSSD_CONF
+truncate -s 0 $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/correct_value.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+source common.sh
+
+echo -e "[pam]\noffline_credentials_expiration = 1" >> $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/wrong_section.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+source common.sh
+
+echo -e "[pam]\ntest = 1" >> $SSSD_CONF
+echo -e "[sssd]\noffline_credentials_expiration = 1" >> $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/wrong_value.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/wrong_value.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+source common.sh
+
+echo -e "[pam]\noffline_credentials_expiration = 0" >> $SSSD_CONF


### PR DESCRIPTION
#### Description:

Added a bash remediation and test coverage for the rule sssd_offline_cred_expiration.

#### Rationale:

This rule is a part of Fedora OSPP profile.
