### PR TITLE
tests/ssg_test_suite: Fixed cases where IGNORE_KNOWN_HOSTS_OPTIONS must be a list

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -17,7 +17,7 @@ def run_cmd_local(command, verbose_path, env=None):
 
 def run_cmd_remote(command_string, domain_ip, verbose_path, env=None):
     machine = 'root@{0}'.format(domain_ip)
-    remote_cmd = ['ssh'] + IGNORE_KNOWN_HOSTS_OPTIONS + [machine, command_string]
+    remote_cmd = ['ssh'] + list(IGNORE_KNOWN_HOSTS_OPTIONS) + [machine, command_string]
     logging.debug('Running {}'.format(command_string))
     returncode, output = _run_cmd(remote_cmd, verbose_path, env)
     return returncode, output

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -63,7 +63,7 @@ def send_files_remote(verbose_path, remote_dir, domain_ip, *files):
 
     logging.debug('Uploading files {0} to {1}'.format(files_string,
                                                       destination))
-    command = ['scp'] + common.IGNORE_KNOWN_HOSTS_OPTIONS + list(files) + [destination]
+    command = ['scp'] + list(common.IGNORE_KNOWN_HOSTS_OPTIONS) + list(files) + [destination]
     if common.run_cmd_local(command, verbose_path)[0] != 0:
         logging.error('Failed to upload files {0}'.format(files_string))
         success = False
@@ -77,7 +77,7 @@ def get_file_remote(verbose_path, local_dir, domain_ip, remote_path):
     source = 'root@{0}:{1}'.format(domain_ip, remote_path)
     logging.debug('Downloading file {0} to {1}'
                   .format(source, local_dir))
-    command = ['scp'] + common.IGNORE_KNOWN_HOSTS_OPTIONS + [source, local_dir]
+    command = ['scp'] + list(common.IGNORE_KNOWN_HOSTS_OPTIONS) + [source, local_dir]
     if common.run_cmd_local(command, verbose_path)[0] != 0:
         logging.error('Failed to download file {0}'.format(remote_path))
         success = False


### PR DESCRIPTION
Test suite failed in case `--remediate-using ansible` was used because `IGNORE_KNOWN_HOSTS_OPTIONS` variable was expected to be a list - this PR converts this variable to list in such cases.