### PR TITLE
Fix regex for unauthorized syscall rule with one syscall and filter

### DIFF
--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -51,7 +51,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eacces_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -60,7 +60,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eperm_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -69,7 +69,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eacces_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -78,7 +78,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eperm_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">/etc/audit/rules\.d/.*\.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -87,7 +87,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eacces_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -96,7 +96,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_arufm_eperm_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -105,7 +105,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eacces_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EACCES[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -114,7 +114,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_arufm_eperm_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))[\S]*[\s]*(?!.*-F\s+a2&amp;)[\s]*(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,])))(?!.*-F\s+a2&amp;)(?:.*-F\s+exit=\-EPERM[\s]+)(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/one_sys_with_filter.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/one_sys_with_filter.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "-a always,exit -F arch=b32 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/two_sys_with_filter.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_unlink/two_sys_with_filter.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "-a always,exit -F arch=b32 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink,unlinkat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink,unlinkat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules


### PR DESCRIPTION
#### Description:

- Regular expression to rule that records unsuccessful syscall events without filter matched audit rules with one syscall and filter.

#### Rationale:

- Test `one_sys_with_filter.fail.sh` doesn't pass without this patch.