### PR TITLE
Update rule accounts_password_pam_retry

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -1,8 +1,8 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_retry
 
-if grep -q "retry=" /etc/pam.d/system-auth; then   
+if grep -q "retry=" /etc/pam.d/system-auth ; then
 	sed -i --follow-symlinks "s/\(retry *= *\).*/\1$var_password_pam_retry/" /etc/pam.d/system-auth
 else
 	sed -i --follow-symlinks "/pam_pwquality.so/ s/$/ retry=$var_password_pam_retry/" /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -14,7 +14,6 @@
     </criteria>
   </definition>
 
-  <!-- BEGIN RHEL7 & Fedora CHECKS -->
   <ind:textfilecontent54_test check="all" comment="check the configuration of /etc/pam.d/system-auth" id="test_password_pam_pwquality_retry" version="1">
     <ind:object object_ref="obj_password_pam_pwquality_retry" />
     <ind:state state_ref="state_password_pam_retry" />
@@ -26,7 +25,6 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- The following state & variables are reused between the RHEL6/RHEL7 checks -->
   <ind:textfilecontent54_state id="state_password_pam_retry" version="1">
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_retry" />
   </ind:textfilecontent54_state>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -10,11 +10,6 @@
       <description>The password retry should meet minimum requirements</description>
     </metadata>
     <criteria operator="AND" comment="Conditions for retry are satisfied">
-      <criteria operator="OR" comment="OSes with pwquality primarily used">
-        <extend_definition comment="RHEL7 OS installed" definition_ref="installed_OS_is_rhel7" />
-        <extend_definition comment="CentOS7 OS installed" definition_ref="installed_OS_is_centos7" />
-        <extend_definition comment="Fedora OS installed" definition_ref="installed_OS_is_fedora" />
-      </criteria>
       <criterion comment="pam_pwquality" test_ref="test_password_pam_pwquality_retry" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -4,7 +4,12 @@ prodtype: rhel7,fedora
 
 title: 'Set Password Retry Prompts Permitted Per-Session'
 
-description: "To configure the number of retry prompts that are permitted per-session:\n<br /><br />\nEdit the <tt>pam_pwquality.so</tt> statement in <tt>/etc/pam.d/system-auth</tt> to \nshow <tt>retry=<sub idref=\"var_password_pam_retry\" /></tt>, or a lower value if site policy is more restrictive.\n<br /><br />\nThe DoD requirement is a maximum of 3 prompts per session."
+description: |-
+    To configure the number of retry prompts that are permitted per-session:
+    Edit the <tt>pam_pwquality.so</tt> statement in <tt>/etc/pam.d/system-auth</tt> to
+    show <tt>retry=<sub idref="var_password_pam_retry" /></tt>, or a lower value if
+    site policy is more restrictive.
+    The DoD requirement is a maximum of 3 prompts per session.
 
 rationale: |-
     Setting the password retry prompts that are permitted on a per-session basis to a low value

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_retry/argument_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_retry/argument_missing.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+config_file="/etc/pam.d/system-auth"
+
+if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
+	sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*//" $config_file
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_retry/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_retry/correct_value.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+retry_cnt=3
+config_file="/etc/pam.d/system-auth"
+
+if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
+	sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*/\1$retry_cnt/" $config_file
+else
+	sed -i --follow-symlinks "/pam_pwquality\.so/ s/$/ retry=$retry_cnt/" $config_file
+fi

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_retry/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_password_quality/group_password_quality_pwquality/rule_accounts_password_pam_retry/wrong_value.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+retry_cnt=7
+config_file="/etc/pam.d/system-auth"
+
+if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
+	sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*/\1$retry_cnt/" $config_file
+else
+	sed -i --follow-symlinks "/pam_pwquality\.so/ s/$/ retry=$retry_cnt/" $config_file
+fi


### PR DESCRIPTION
#### Description:


This PR fixes OVAL, enables Bash remediation fro Fedora and adds 3 basic test scenarios for rule `accounts_password_pam_retry`.

This rule checks PAM modules arguments in `/etc/pam.d/system-auth`. We have discussed with @yuumasato if it would be better to check configuration in ` /etc/security/pwquality.conf` instead. Other similar rules from this directory already check ` /etc/security/pwquality.conf` instead of   `/etc/pam.d/system-auth`. All other rules from this group are templated.

But I looked into that again and I have realized that the rule description in 
https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
speaks about "permitted per-session". The other rules doesn't mention that "per-session":
Instead, `/etc/security/pwquality.conf` specifies default password quality requirements for the system passwords.

Moreover, `man 5 pwquality.conf` doesn't mention `retry` option at all, whereas `man 8 pam_pwquality` mentions `retry`. From that it seems it isn't possible to set `retry` option in ` /etc/security/pwquality.conf`.

Hopefully the rule isn't templated on purpose.

#### Rationale:
This rule is a part of Fedora OSPP profile.