### PR TITLE
Fail the build if an invalid PCI DSS ref is encountered

### DIFF
--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -159,6 +159,7 @@ def main():
                         "the Operating System level?",
                         rule.get("id"), ref.text
                     )
+                    sys.exit(1)
 
     if len(unused_rules) > 0:
         logging.warning(


### PR DESCRIPTION
Since we recently fixed the last invalid PCI-DSS ref I thought it would
be nice if we forbid adding any new invalid PCI-DSS refs.
