### PR TITLE
Fixed ansible remediations for auditd_data_retention max_log_file and max_log_file_action opts

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: Configure auditd Max Log File Size
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "max_log_file {{ var_auditd_max_log_file }}"
+    line: "max_log_file = {{ var_auditd_max_log_file }}"
     state: present
   #notify: reload auditd
   tags:

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: Configure auditd max_log_file_action Upon Reaching Maximum Log Size
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "max_log_file_action {{ var_auditd_max_log_file_action }}"
+    line: "max_log_file_action = {{ var_auditd_max_log_file_action }}"
     state: present
   #notify: reload auditd
   tags:


### PR DESCRIPTION
#### Description:

- Fixed ansible remediations which were missing the `=` sign

#### Rationale:

- Fixes #3325
