### PR TITLE
Changed shell command

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = high
 # disruption = medium
 - name: "Read list of files with incorrect permissions"
-  shell: "rpm -Va | grep '^.M' | cut -d ' ' -f5- | sed -r 's;^.*\\s+(.+);\\1;g'"
+  shell: "rpm -Va | awk '/^.M/ {print $NF}'"
   register: files_with_incorrect_permissions
   failed_when: False
   changed_when: False


### PR DESCRIPTION

#### Description:

Changed the shell command per @cmattern-rht .  

#### Rationale:

Not all values returned with <code>rpm -Va | grep ^.M </code> have the same number of fields and so the <code>rpm --setperms</code> was failing on those empty values. This will take the last value which is always the path that is needed.

