### PR TITLE
Finish rule accounts_passwords_pam_faillock_interval for Fedora

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/bash/shared.sh
@@ -2,39 +2,12 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_passwords_pam_faillock_deny
 
+include_set_faillock_option
+
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
 
-# This script fixes absence of pam_faillock.so in PAM stack or the
-# absense of deny=[0-9]+ in pam_faillock.so arguments
-# When inserting auth pam_faillock.so entries,
-# the entry with preauth argument will be added before pam_unix.so module
-# and entry with authfail argument will be added before pam_deny.so module.
-
-# The placement of pam_faillock.so entries will not be changed
-# if they are already present
-
-
-# Invoke the function without args, so its body is substituded right here.
-set_faillock_option_to_value_in_pam_file
-
-
-function insert_lines_if_pam_faillock_so_not_present {
-	# insert pam_faillock.so preauth row with proper value of the 'deny' option before pam_unix.so
-	sed -i --follow-symlinks "/^auth.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent $_option=$_value" $_pamFile
-	# insert pam_faillock.so authfail row with proper value of the 'deny' option before pam_deny.so, after all modules which determine authentication outcome.
-	sed -i --follow-symlinks "/^auth.*pam_deny.so.*/i auth        [default=die] pam_faillock.so authfail $_option=$_value" $_pamFile
-}
-
-
-
-for pamFile in "${AUTH_FILES[@]}"
+for pam_file in "${AUTH_FILES[@]}"
 do
-	# 'true &&' has to be there due to build system limitation
-	true && set_faillock_option_to_value_in_pam_file "$pamFile" deny "$var_accounts_passwords_pam_faillock_deny" insert_lines_if_pam_faillock_so_not_present
-
-	# add pam_faillock.so into account phase
-	if ! grep -q "^account.*required.*pam_faillock.so" $pamFile; then
-		sed -i --follow-symlinks "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" $pamFile
-	fi
+	set_faillock_option "$pam_file" "deny" "$var_accounts_passwords_pam_faillock_deny"
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
@@ -10,41 +10,43 @@ AUTH_FILES[1]="/etc/pam.d/password-auth"
 
 function insert_preauth {
 	local pam_file="$1"
-	local fail_interval="$2"
+	local option="$2"
+	local value="$3"
 	# is auth required pam_faillock.so preauth present?
 	if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$" "$pam_file" ; then
-		# is the fail_interval option set?
-		if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$" "$pam_file" ; then
-			# just change the value of fail_interval option to a correct value
-			sed -i --follow-symlinks "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\(fail_interval *= *\).*/\1\2$fail_interval/" "$pam_file"
-		# fail_interval option is not set.
+		# is the option set?
+		if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$option=([0-9]*).*$" "$pam_file" ; then
+			# just change the value of option to a correct value
+			sed -i --follow-symlinks "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\($option *= *\).*/\1\2$value/" "$pam_file"
+		# the option is not set.
 		else
-			# append a fail_interval option
-			sed -i --follow-symlinks "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ fail_interval=$fail_interval/" "$_pamFile"
+			# append the option
+			sed -i --follow-symlinks "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ $option=$value/" "$_pamFile"
 		fi
 	# auth required pam_faillock.so preauth is not present, insert the whole line
 	else
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent fail_interval=$fail_interval" "$pam_file"
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent $option=$value" "$pam_file"
 	fi
 }
 
 function insert_authfail {
 	local pam_file="$1"
-	local fail_interval="$2"
+	local option="$2"
+	local value="$3"
 	# is auth default pam_faillock.so authfail present?
 	if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*$" "$pam_file" ; then
-		# is the fail_interval option set?
-		if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$" "$pam_file" ; then
-			# just change the value of fail_interval option to a correct value
-			sed -i --follow-symlinks "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\(fail_interval *= *\).*/\1\2$fail_interval/" "$pam_file"
-		# fail_interval option is not set.
+		# is the option set?
+		if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*$option=([0-9]*).*$" "$pam_file" ; then
+			# just change the value of option to a correct value
+			sed -i --follow-symlinks "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\($option *= *\).*/\1\2$value/" "$pam_file"
+		# the option is not set.
 		else
-			# append a fail_interval option
-			sed -i --follow-symlinks "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ fail_interval=$fail_interval/" "$_pamFile"
+			# append the option
+			sed -i --follow-symlinks "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ $option=$value/" "$_pamFile"
 		fi
 	# auth default pam_faillock.so authfail is not present, insert the whole line
 	else
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail fail_interval=$fail_interval" "$pam_file"
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail $option=$value" "$pam_file"
 	fi
 }
 
@@ -55,15 +57,16 @@ function insert_account {
 	fi
 }
 
-function set_faillock_in_pam_file {
+function set_faillock_option_in_pam_file {
 	local pam_file="$1"
-	local fail_interval="$2"
-	insert_preauth "$pam_file" "$fail_interval"
-	insert_authfail "$pam_file" "$fail_interval"
+	local option="$2"
+	local value="$3"
+	insert_preauth "$pam_file" "$option" "$value"
+	insert_authfail "$pam_file" "$option" "$value"
 	insert_account "$pam_file"
 }
 
 for pam_file in "${AUTH_FILES[@]}"
 do
-	set_faillock_in_pam_file "$pam_file" "$var_accounts_passwords_pam_faillock_fail_interval"
+	set_faillock_option_in_pam_file "$pam_file" "fail_interval" "$var_accounts_passwords_pam_faillock_fail_interval"
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
@@ -3,70 +3,14 @@
 # include our remediation functions library
 . /usr/share/scap-security-guide/remediation_functions
 
+include_set_faillock_option
+
 populate var_accounts_passwords_pam_faillock_fail_interval
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
 
-function insert_preauth {
-	local pam_file="$1"
-	local option="$2"
-	local value="$3"
-	# is auth required pam_faillock.so preauth present?
-	if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$" "$pam_file" ; then
-		# is the option set?
-		if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$option=([0-9]*).*$" "$pam_file" ; then
-			# just change the value of option to a correct value
-			sed -i --follow-symlinks "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\($option *= *\).*/\1\2$value/" "$pam_file"
-		# the option is not set.
-		else
-			# append the option
-			sed -i --follow-symlinks "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ $option=$value/" "$_pamFile"
-		fi
-	# auth required pam_faillock.so preauth is not present, insert the whole line
-	else
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent $option=$value" "$pam_file"
-	fi
-}
-
-function insert_authfail {
-	local pam_file="$1"
-	local option="$2"
-	local value="$3"
-	# is auth default pam_faillock.so authfail present?
-	if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*$" "$pam_file" ; then
-		# is the option set?
-		if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*$option=([0-9]*).*$" "$pam_file" ; then
-			# just change the value of option to a correct value
-			sed -i --follow-symlinks "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\($option *= *\).*/\1\2$value/" "$pam_file"
-		# the option is not set.
-		else
-			# append the option
-			sed -i --follow-symlinks "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ $option=$value/" "$_pamFile"
-		fi
-	# auth default pam_faillock.so authfail is not present, insert the whole line
-	else
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail $option=$value" "$pam_file"
-	fi
-}
-
-function insert_account {
-	local pam_file="$1"
-	if ! grep -qE "^\s*account\s+required\s+pam_faillock\.so.*$" "$pam_file" ; then
-		sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so" "$pam_file"
-	fi
-}
-
-function set_faillock_option_in_pam_file {
-	local pam_file="$1"
-	local option="$2"
-	local value="$3"
-	insert_preauth "$pam_file" "$option" "$value"
-	insert_authfail "$pam_file" "$option" "$value"
-	insert_account "$pam_file"
-}
-
 for pam_file in "${AUTH_FILES[@]}"
 do
-	set_faillock_option_in_pam_file "$pam_file" "fail_interval" "$var_accounts_passwords_pam_faillock_fail_interval"
+	set_faillock_option "$pam_file" "fail_interval" "$var_accounts_passwords_pam_faillock_fail_interval"
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
@@ -1,24 +1,69 @@
-# platform = multi_platform_rhel
-. /usr/share/scap-security-guide/remediation_functions
-populate var_accounts_passwords_pam_faillock_fail_interval
+# platform = multi_platform_rhel, multi_platform_fedora
 
-# Invoke the function without args, so its body is substituded right here.
-set_faillock_option_to_value_in_pam_file
+# include our remediation functions library
+. /usr/share/scap-security-guide/remediation_functions
+
+populate var_accounts_passwords_pam_faillock_fail_interval
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
 
-
-function insert_lines_if_pam_faillock_so_not_present {
-	local _option="$1" _value="$2" _pamFile="$3"
-	sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent $_option=$_value" "$_pamFile"
-	sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail $_option=$_value" "$_pamFile"
-	sed -i --follow-symlinks "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" "$_pamFile"
+function insert_preauth {
+	local pam_file="$1"
+	local fail_interval="$2"
+	# is auth required pam_faillock.so preauth present?
+	if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$" "$pam_file" ; then
+		# is the fail_interval option set?
+		if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$" "$pam_file" ; then
+			# just change the value of fail_interval option to a correct value
+			sed -i --follow-symlinks "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\(fail_interval *= *\).*/\1\2$fail_interval/" "$pam_file"
+		# fail_interval option is not set.
+		else
+			# append a fail_interval option
+			sed -i --follow-symlinks "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ fail_interval=$fail_interval/" "$_pamFile"
+		fi
+	# auth required pam_faillock.so preauth is not present, insert the whole line
+	else
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent fail_interval=$fail_interval" "$pam_file"
+	fi
 }
 
+function insert_authfail {
+	local pam_file="$1"
+	local fail_interval="$2"
+	# is auth default pam_faillock.so authfail present?
+	if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*$" "$pam_file" ; then
+		# is the fail_interval option set?
+		if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$" "$pam_file" ; then
+			# just change the value of fail_interval option to a correct value
+			sed -i --follow-symlinks "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\(fail_interval *= *\).*/\1\2$fail_interval/" "$pam_file"
+		# fail_interval option is not set.
+		else
+			# append a fail_interval option
+			sed -i --follow-symlinks "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ fail_interval=$fail_interval/" "$_pamFile"
+		fi
+	# auth default pam_faillock.so authfail is not present, insert the whole line
+	else
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail fail_interval=$fail_interval" "$pam_file"
+	fi
+}
 
-for pamFile in "${AUTH_FILES[@]}"
+function insert_account {
+	local pam_file="$1"
+	if ! grep -qE "^\s*account\s+required\s+pam_faillock\.so.*$" "$pam_file" ; then
+		sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so" "$pam_file"
+	fi
+}
+
+function set_faillock_in_pam_file {
+	local pam_file="$1"
+	local fail_interval="$2"
+	insert_preauth "$pam_file" "$fail_interval"
+	insert_authfail "$pam_file" "$fail_interval"
+	insert_account "$pam_file"
+}
+
+for pam_file in "${AUTH_FILES[@]}"
 do
-	# 'true &&' has to be there due to build system limitation
-	true && set_faillock_option_to_value_in_pam_file "$pamFile" fail_interval "$var_accounts_passwords_pam_faillock_fail_interval" insert_lines_if_pam_faillock_so_not_present
+	set_faillock_in_pam_file "$pam_file" "$var_accounts_passwords_pam_faillock_fail_interval"
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
@@ -13,6 +13,8 @@
       <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_authfail_fail_interval_system-auth" />
       <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_password-auth" />
       <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" />
+      <criterion comment="account requires pam_faillock.so in /etc/pam.d/password-auth" test_ref="test_accounts_passwords_pam_faillock_account_requires_password-auth" />
+      <criterion comment="account requires pam_faillock.so in /etc/pam.d/system-auth" test_ref="test_accounts_passwords_pam_faillock_account_requires_system-auth" />
     </criteria>
   </definition>
 
@@ -36,6 +38,14 @@
     <ind:state state_ref="state_accounts_passwords_pam_faillock_fail_interval_password-auth" />
   </ind:textfilecontent54_test>
 
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check if pam_faillock.so is required in account section in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_account_requires_password-auth" version="2">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_account_requires_password-auth"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check if pam_faillock.so is required in account section in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_account_requires_system-auth" version="2">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_account_requires_system-auth"/>
+  </ind:textfilecontent54_test>
+
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_fail_interval_system-auth" version="2">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$</ind:pattern>
@@ -57,6 +67,18 @@
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" version="2">
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_account_requires_password-auth" version="2">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*account\s+required\s+pam_faillock\.so.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_account_requires_system-auth" version="2">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*account\s+required\s+pam_faillock\.so.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Lock out account after failed login attempts</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -4,8 +4,28 @@ prodtype: rhel6,rhel7,fedora
 
 title: 'Set Interval For Counting Failed Password Attempts'
 
-description: "Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive \nconfigures the system to lock out an accounts after a number of incorrect login\nattempts within a specified time period. Modify the content of both \n<tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt> as follows:\n<br /><br />\n<ul>\n<li>Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:\n<pre>auth required pam_faillock.so preauth silent deny=<sub idref=\"var_accounts_passwords_pam_faillock_deny\" /> unlock_time=<sub idref=\"var_accounts_passwords_pam_faillock_unlock_time\" /> fail_interval=<sub idref=\"var_accounts_passwords_pam_faillock_fail_interval\" /></pre></li>\n<li>Add the following line immediately <tt>after</tt> the <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:\n<pre>auth [default=die] pam_faillock.so authfail deny=<sub idref=\"var_accounts_passwords_pam_faillock_deny\" /> unlock_time=<sub idref=\"\
-    var_accounts_passwords_pam_faillock_unlock_time\" /> fail_interval=<sub idref=\"var_accounts_passwords_pam_faillock_fail_interval\" /></pre></li>\n<li>Add the following line immediately <tt>before</tt> the <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:\n<pre>account required pam_faillock.so</pre></li>\n</ul>"
+description: |-
+    Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive
+    configures the system to lock out an account after a number of incorrect
+    login attempts within a specified time period. Modify the content of both
+    <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt>
+    as follows:
+    <br /><br />
+    <ul>
+    <li>Add the following line immediately <tt>before</tt> the
+        <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
+    <pre>auth required pam_faillock.so preauth silent deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></pre>
+    </li>
+    <li>Add the following line immediately <tt>after</tt> the
+        <tt>pam_unix.so</tt> statement in the <tt>AUTH</tt> section:
+    <pre>auth [default=die] pam_faillock.so authfail deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /> unlock_time=<sub idref="var_accounts_passwords_pam_faillock_unlock_time" /> fail_interval=<sub idref="var_accounts_passwords_pam_faillock_fail_interval" />
+    </pre>
+    </li>
+    <li>Add the following line immediately <tt>before</tt> the
+        <tt>pam_unix.so</tt> statement in the <tt>ACCOUNT</tt> section:
+    <pre>account required pam_faillock.so</pre>
+    </li>
+    </ul>
 
 rationale: |-
     By limiting the number of failed logon attempts the risk of unauthorized system
@@ -31,4 +51,10 @@ references:
 
 ocil_clause: 'fail_interval is less than the required value'
 
-ocil: "To ensure the failed password attempt policy is configured correctly, run the following command:\n<pre>$ grep pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>\nFor each file, the output should show <tt>fail_interval=&lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is \n<tt><sub idref=\"var_accounts_passwords_pam_faillock_fail_interval\" /></tt>  or greater. \nIf the <tt>fail_interval</tt> parameter is not set, the default setting of 900 seconds is acceptable."
+ocil: |-
+    To ensure the failed password attempt policy is configured correctly,
+    run the following command:
+    <pre>$ grep pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>
+    For each file, the output should show <tt>fail_interval=&lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is <tt><sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></tt> or greater.
+    If the <tt>fail_interval</tt> parameter is not set, the default setting
+    of 900 seconds is acceptable.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/bash/shared.sh
@@ -2,23 +2,12 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_passwords_pam_faillock_unlock_time
 
-# Invoke the function without args, so its body is substituded right here.
-set_faillock_option_to_value_in_pam_file
+include_set_faillock_option
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
 
-
-function insert_lines_if_pam_faillock_so_not_present {
-	local _option="$1" _value="$2" _pamFile="$3"
-	sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent $_option=$_value" "$_pamFile"
-	sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail $_option=$_value" "$_pamFile"
-	sed -i --follow-symlinks "/^account.*required.*pam_unix.so/i account     required      pam_faillock.so" "$_pamFile"
-}
-
-
-for pamFile in "${AUTH_FILES[@]}"
+for pam_file in "${AUTH_FILES[@]}"
 do
-	# 'true &&' has to be there due to build system limitation
-	true && set_faillock_option_to_value_in_pam_file "$pamFile" unlock_time "$var_accounts_passwords_pam_faillock_unlock_time" insert_lines_if_pam_faillock_so_not_present
+	set_faillock_option "$pam_file" "unlock_time" "$var_accounts_passwords_pam_faillock_unlock_time"
 done

--- a/shared/bash_remediation_functions/include_set_faillock_option.sh
+++ b/shared/bash_remediation_functions/include_set_faillock_option.sh
@@ -1,0 +1,61 @@
+function include_set_faillock_option {
+	:
+}
+
+function insert_preauth {
+	local pam_file="$1"
+	local option="$2"
+	local value="$3"
+	# is auth required pam_faillock.so preauth present?
+	if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$" "$pam_file" ; then
+		# is the option set?
+		if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$option=([0-9]*).*$" "$pam_file" ; then
+			# just change the value of option to a correct value
+			sed -i --follow-symlinks "s/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\($option *= *\).*/\1\2$value/" "$pam_file"
+		# the option is not set.
+		else
+			# append the option
+			sed -i --follow-symlinks "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ $option=$value/" "$_pamFile"
+		fi
+	# auth required pam_faillock.so preauth is not present, insert the whole line
+	else
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent $option=$value" "$pam_file"
+	fi
+}
+
+function insert_authfail {
+	local pam_file="$1"
+	local option="$2"
+	local value="$3"
+	# is auth default pam_faillock.so authfail present?
+	if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*$" "$pam_file" ; then
+		# is the option set?
+		if grep -qE "^\s*auth\s+(\[default=die\])\s+pam_faillock\.so\s+authfail.*$option=([0-9]*).*$" "$pam_file" ; then
+			# just change the value of option to a correct value
+			sed -i --follow-symlinks "s/\(^auth.*[default=die].*pam_faillock.so.*authfail.*\)\($option *= *\).*/\1\2$value/" "$pam_file"
+		# the option is not set.
+		else
+			# append the option
+			sed -i --follow-symlinks "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ $option=$value/" "$_pamFile"
+		fi
+	# auth default pam_faillock.so authfail is not present, insert the whole line
+	else
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail $option=$value" "$pam_file"
+	fi
+}
+
+function insert_account {
+	local pam_file="$1"
+	if ! grep -qE "^\s*account\s+required\s+pam_faillock\.so.*$" "$pam_file" ; then
+		sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so" "$pam_file"
+	fi
+}
+
+function set_faillock_option {
+	local pam_file="$1"
+	local option="$2"
+	local value="$3"
+	insert_preauth "$pam_file" "$option" "$value"
+	insert_authfail "$pam_file" "$option" "$value"
+	insert_account "$pam_file"
+}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/account_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/account_missing.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=1
+authfail_set=1
+account_set=0
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="900"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/account_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/account_missing.fail.sh
@@ -11,4 +11,5 @@ auth_files[0]="/etc/pam.d/system-auth"
 auth_files[1]="/etc/pam.d/password-auth"
 interval="900"
 
+set_default_configuration
 insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_correct.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_correct.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=1
+authfail_set=1
+account_set=1
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="900"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_correct.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_correct.pass.sh
@@ -11,4 +11,5 @@ auth_files[0]="/etc/pam.d/system-auth"
 auth_files[1]="/etc/pam.d/password-auth"
 interval="900"
 
+set_default_configuration
 insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_missing.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=0
+authfail_set=0
+account_set=0
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="900"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/all_missing.fail.sh
@@ -11,4 +11,5 @@ auth_files[0]="/etc/pam.d/system-auth"
 auth_files[1]="/etc/pam.d/password-auth"
 interval="900"
 
+set_default_configuration
 insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/authfail_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/authfail_missing.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=1
+authfail_set=0
+account_set=1
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="900"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/authfail_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/authfail_missing.fail.sh
@@ -11,4 +11,5 @@ auth_files[0]="/etc/pam.d/system-auth"
 auth_files[1]="/etc/pam.d/password-auth"
 interval="900"
 
+set_default_configuration
 insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_password_auth_correct.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_password_auth_correct.fail.sh
@@ -5,6 +5,7 @@
 . shared.sh
 
 interval="900"
+set_default_configuration
 
 preauth_set=1
 authfail_set=1

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_password_auth_correct.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_password_auth_correct.fail.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+interval="900"
+
+preauth_set=1
+authfail_set=1
+account_set=1
+auth_file="/etc/pam.d/password-auth"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval $auth_file
+
+preauth_set=0
+authfail_set=0
+account_set=0
+auth_file="/etc/pam.d/system-auth"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval $auth_file

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_system_auth_correct.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_system_auth_correct.fail.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+interval="900"
+
+preauth_set=1
+authfail_set=1
+account_set=1
+auth_file="/etc/pam.d/system-auth"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval $auth_file
+
+preauth_set=0
+authfail_set=0
+account_set=0
+auth_file="/etc/pam.d/password-auth"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval $auth_file

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_system_auth_correct.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/only_system_auth_correct.fail.sh
@@ -5,6 +5,7 @@
 . shared.sh
 
 interval="900"
+set_default_configuration
 
 preauth_set=1
 authfail_set=1

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/password-auth
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/password-auth
@@ -1,0 +1,23 @@
+#%PAM-1.0
+# This file is auto-generated.
+# User changes will be destroyed the next time authconfig is run.
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        required      pam_deny.so
+
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/preauth_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/preauth_missing.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=0
+authfail_set=1
+account_set=1
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="900"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/preauth_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/preauth_missing.fail.sh
@@ -11,4 +11,5 @@ auth_files[0]="/etc/pam.d/system-auth"
 auth_files[1]="/etc/pam.d/password-auth"
 interval="900"
 
+set_default_configuration
 insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/shared.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/shared.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -x
+
+function insert_preauth {
+	local pam_file="$1"
+	local fail_interval="$2"
+	if ! grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$" "$pam_file" ; then
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent fail_interval=$fail_interval" "$pam_file"
+	fi
+}
+
+function remove_preauth {
+	local pam_file="$1"
+	if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$" "$pam_file" ; then
+		sed -E -i --follow-symlinks "/^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$/d" "$pam_file"
+	fi
+}
+
+function insert_authfail {
+	local pam_file="$1"
+	local fail_interval="$2"
+	if ! grep -qE "^\s*auth\s+((sufficient)|(\[default=die\]))\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$" "$pam_file" ; then
+		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail fail_interval=$fail_interval" "$pam_file"
+	fi
+}
+
+function remove_authfail {
+	local pam_file="$1"
+	if grep -qE "^\s*auth\s+((sufficient)|(\[default=die\]))\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$" "$pam_file" ; then
+		sed -E -i --follow-symlinks "/^\s*auth\s+((sufficient)|(\[default=die\]))\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$/d" "$pam_file"
+	fi
+}
+
+function insert_account {
+	local pam_file="$1"
+	if ! grep -qE "^\s*account\s+required\s+pam_faillock\.so.*$" "$pam_file" ; then
+		sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so" "$pam_file"
+	fi
+}
+
+function remove_account {
+	local pam_file="$1"
+	if grep -qE "^\s*account\s+required\s+pam_faillock\.so.*$" "$pam_file" ; then
+		sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_faillock.so/d" "$pam_file"
+	fi
+}
+
+function insert_or_remove_settings {
+	local preauth_set="$1"
+	local authfail_set="$2"
+	local account_set="$3"
+	local interval="$4"
+	shift 4
+	if [ $# -le 0 ] ; then
+		echo "No files"
+		exit
+	fi
+	for file in "$@" ; do
+		if [ $preauth_set -eq 1 ] ; then
+			insert_preauth $file $interval
+		else
+			remove_preauth $file
+		fi
+		if [ $authfail_set -eq 1 ] ; then
+			insert_authfail $file $interval
+		else
+			remove_authfail $file
+		fi
+		if [ $account_set -eq 1 ] ; then
+			insert_account $file
+		else
+			remove_account $file
+		fi
+	done
+}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/shared.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/shared.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 function insert_preauth {
 	local pam_file="$1"
 	local fail_interval="$2"

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/shared.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/shared.sh
@@ -5,45 +5,18 @@ set -x
 function insert_preauth {
 	local pam_file="$1"
 	local fail_interval="$2"
-	if ! grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$" "$pam_file" ; then
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent fail_interval=$fail_interval" "$pam_file"
-	fi
-}
-
-function remove_preauth {
-	local pam_file="$1"
-	if grep -qE "^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$" "$pam_file" ; then
-		sed -E -i --follow-symlinks "/^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*fail_interval=([0-9]*).*$/d" "$pam_file"
-	fi
+	sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent fail_interval=$fail_interval" "$pam_file"
 }
 
 function insert_authfail {
 	local pam_file="$1"
 	local fail_interval="$2"
-	if ! grep -qE "^\s*auth\s+((sufficient)|(\[default=die\]))\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$" "$pam_file" ; then
-		sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail fail_interval=$fail_interval" "$pam_file"
-	fi
-}
-
-function remove_authfail {
-	local pam_file="$1"
-	if grep -qE "^\s*auth\s+((sufficient)|(\[default=die\]))\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$" "$pam_file" ; then
-		sed -E -i --follow-symlinks "/^\s*auth\s+((sufficient)|(\[default=die\]))\s+pam_faillock\.so\s+authfail.*fail_interval=([0-9]*).*$/d" "$pam_file"
-	fi
+	sed -i --follow-symlinks "/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail fail_interval=$fail_interval" "$pam_file"
 }
 
 function insert_account {
 	local pam_file="$1"
-	if ! grep -qE "^\s*account\s+required\s+pam_faillock\.so.*$" "$pam_file" ; then
-		sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so" "$pam_file"
-	fi
-}
-
-function remove_account {
-	local pam_file="$1"
-	if grep -qE "^\s*account\s+required\s+pam_faillock\.so.*$" "$pam_file" ; then
-		sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_faillock.so/d" "$pam_file"
-	fi
+	sed -E -i --follow-symlinks "/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so" "$pam_file"
 }
 
 function insert_or_remove_settings {
@@ -59,18 +32,17 @@ function insert_or_remove_settings {
 	for file in "$@" ; do
 		if [ $preauth_set -eq 1 ] ; then
 			insert_preauth $file $interval
-		else
-			remove_preauth $file
 		fi
 		if [ $authfail_set -eq 1 ] ; then
 			insert_authfail $file $interval
-		else
-			remove_authfail $file
 		fi
 		if [ $account_set -eq 1 ] ; then
 			insert_account $file
-		else
-			remove_account $file
 		fi
 	done
+}
+
+function set_default_configuration {
+	cp password-auth /etc/pam.d/
+	cp system-auth /etc/pam.d/
 }

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/supercompliant_fail_interval.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/supercompliant_fail_interval.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=1
+authfail_set=1
+account_set=1
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="1000"
+
+set_default_configuration
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/system-auth
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/system-auth
@@ -1,0 +1,24 @@
+#%PAM-1.0
+# This file is auto-generated.
+# User changes will be destroyed the next time authconfig is run.
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        sufficient    pam_fprintd.so
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        required      pam_deny.so
+
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/wrong_fail_interval.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/wrong_fail_interval.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=1
+authfail_set=1
+account_set=1
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="200"
+
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/wrong_fail_interval.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/wrong_fail_interval.fail.sh
@@ -11,4 +11,5 @@ auth_files[0]="/etc/pam.d/system-auth"
 auth_files[1]="/etc/pam.d/password-auth"
 interval="200"
 
+set_default_configuration
 insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}


### PR DESCRIPTION
#### Description:
This PR:
* Adds more criteria to the OVAL definition to align the OVAL definition with the description in XCCDF rule
* Fixes formatting of XCCDF rule description and OCIL description
* Adds multi_platform_fedora to both OVAL and Bash remediation
* Adds basic test scenarios for this rule
* Fixes bugs found in Bash remediation by the new tests

#### Rationale:
This rule is a part of Fedora OSPP profile.
