### PR TITLE
Fix regular expression in sssd_memcache_timeout

### DIFF
--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
@@ -6,7 +6,7 @@
 populate var_sssd_memcache_timeout
 
 SSSD_CONF="/etc/sssd/sssd.conf"
-MEMCACHE_TIMEOUT_REGEX="[[:space:]]*\[nss]([^(\n)]*(\n)+)+?[[:space:]]*memcache_timeout"
+MEMCACHE_TIMEOUT_REGEX="[[:space:]]*\[nss]([^\n\[]*\n+)+?[[:space:]]*memcache_timeout"
 NSS_REGEX="[[:space:]]*\[nss]"
 
 # Try find [nss] and memcache_timeout in sssd.conf, if it exists, set to

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_memcache_timeout" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\[nss](?:[^\n]*\n+)+?memcache_timeout[\s]+=[\s]+(\d+)$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[nss](?:[^\n\[]*\n+)+?[\s]*memcache_timeout[\s]*=[\s]*(\d+)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+TIMEOUT="86400"
+
+dnf -y install sssd
+systemctl enable sssd
+mkdir -p /etc/sssd
+touch $SSSD_CONF
+echo -e "[nss]\nsomething = wrong\n[pam]\nmemcache_timeout = $TIMEOUT" >> $SSSD_CONF


### PR DESCRIPTION
#### Description:

It turned out that the original regex used in OVAL check
was not correct as it would match also options from subsequent sections
after the [nss] section. Also adds test to the SSG TS.

#### Rationale:
See https://github.com/ComplianceAsCode/content/pull/3311 for more details.
