### PR TITLE
update shared.sh

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
@@ -9,7 +9,7 @@ declare -a SETPERMS_RPM_LIST
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f4-))
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | awk '{print $NF}'))
 
 # For each file path from that list:
 # * Determine the RPM package the file path is shipped by,


### PR DESCRIPTION
Removed cut function and returned the last field with awk, this provides better listing since not all values returned will have the same fields. It also removes whitespace at the beginning of the values returned. see comparison below:


```
[root@soctxadm01:~]# rpm -Va --nofiledigest | grep '^.M' | cut -d ' ' -f4-
/etc/selinux/targeted/active/seusers
 /etc/selinux/targeted/active/users_extra
/var/lib/rpm/__db.001
/var/lib/rpm/__db.002
/var/lib/rpm/__db.003
 /opt/splunkforwarder/etc/auth
/var/lib/systemd/random-seed
 /etc/insights-client/.exp.sed
 /etc/insights-client/.fallback.json
 /etc/insights-client/.fallback.json.asc
 /etc/insights-client/cert-api.access.redhat.com.pem
/etc/insights-client/insights-client.conf
 /etc/insights-client/redhattools.pub.gpg
 /etc/insights-client/rpm.egg
 /etc/insights-client/rpm.egg.asc
/var/lock/iscsi
/var/lock/iscsi/lock
/run/lsm
/run/lsm/ipc
/var/log/dmesg
[root@soctxadm01:~]# rpm -Va --nofiledigest | grep '^.M' | awk '{print $NF}'
/etc/selinux/targeted/active/seusers
/etc/selinux/targeted/active/users_extra
/var/lib/rpm/__db.001
/var/lib/rpm/__db.002
/var/lib/rpm/__db.003
/opt/splunkforwarder/etc/auth
/var/lib/systemd/random-seed
/etc/insights-client/.exp.sed
/etc/insights-client/.fallback.json
/etc/insights-client/.fallback.json.asc
/etc/insights-client/cert-api.access.redhat.com.pem
/etc/insights-client/insights-client.conf
/etc/insights-client/redhattools.pub.gpg
/etc/insights-client/rpm.egg
/etc/insights-client/rpm.egg.asc
/var/lock/iscsi
/var/lock/iscsi/lock
/run/lsm
/run/lsm/ipc
/var/log/dmesg
```

#### Description:

Change rpm command to get list of files that permissions changed on.

#### Rationale:

The original method returns empty fields from values who have less fields.  

