### PR TITLE
Finish rule sshd_disable_rhosts on Fedora

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Disable .rhosts Files</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>Emulation of the rsh command through the ssh server should
       be disabled (and dependencies are met)</description>

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/comment.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/comment.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^IgnoreRhosts" /etc/ssh/sshd_config; then
+	sed -i "s/^IgnoreRhosts.*/# IgnoreRhosts no/" /etc/ssh/sshd_config
+else
+	echo "# IgnoreRhosts no" >> /etc/ssh/sshd_config
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/correct_value.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^IgnoreRhosts" /etc/ssh/sshd_config; then
+	sed -i "s/^IgnoreRhosts.*/IgnoreRhosts yes/" /etc/ssh/sshd_config
+else
+	echo "IgnoreRhosts yes" >> /etc/ssh/sshd_config
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/line_not_there.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/line_not_there.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+sed -i "/^IgnoreRhosts.*/d" /etc/ssh/sshd_config

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/wrong_value.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_disable_rhosts/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^IgnoreRhosts" /etc/ssh/sshd_config; then
+	sed -i "s/^IgnoreRhosts.*/IgnoreRhosts no/" /etc/ssh/sshd_config
+else
+	echo "IgnoreRhosts no" >> /etc/ssh/sshd_config
+fi


### PR DESCRIPTION
#### Description:
Add multi_platform_fedora to OVAL
Add basic test scenarios

#### Rationale:
This rule is a part of Fedora OSPP profile.