### PR TITLE
Replace a specific OS version with a generic name

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/group.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/group.yml
@@ -61,8 +61,8 @@ description: |-
     </pre>
     To view the network zones currently active, enter the following command as root:
     <pre># firewall-cmd --get-service</pre>
-    The following listing displays the result of this command on common Red Hat
-    Enterprise Linux 7 Server system:
+    The following listing displays the result of this command
+    on common {{{ full_name }}} system:
     <pre>
     # firewall-cmd --get-service
     amanda-client bacula bacula-client dhcp dhcpv6 dhcpv6-client dns ftp


### PR DESCRIPTION
#### Description:
This change will substitute the product name into the group description.


#### Rationale:
This group is a part of Fedora OSPP profile.
