### PR TITLE
Fix for issue 3344

### DIFF
--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
@@ -17,7 +17,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_tftpd_uses_secure_mode" version="1">
     <ind:filepath>/etc/xinetd.d/tftp</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*server_args[\s]+=[\s]+\-s[\s]+.+$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*server_args[\s]+=.*[\s]+\-s[\s]+.+$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
Rather than only matching this line, exactly,
`server_args = -s /var/lib/tftpboot`
allow for additional arguments in the front like I found in a Red Hat Satellite server
`server_args = -v -s /var/lib/tftpboot -m /etc/tftpd.map`

#### Description:
This change is caused by how Tenable has coded Nessus to scan for this.
They are looking for an exact string rather than specific arguments in a configuration line.

#### Rationale:
Change the regex to allow for arguments between the equal sign and the "-s"

- Fixes # 3344
