### PR TITLE
Add SSSD rule to enable smart cards and add smart card rules to RHEL7 OSPP

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_rhel, multi_platform_fedora
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+- name: "Enable Smartcards in SSSD"
+  ini_file:
+    dest: /etc/sssd/sssd.conf
+    section: pam
+    option: pam_cert_auth 
+    value: true
+    create: yes
+  tags:
+    @ANSIBLE_TAGS@

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7,multi_platform_fedora
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7,multi_platform_fedora
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -1,0 +1,21 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_OPT="pam_cert_auth"
+SSSD_OPT_VAL=true
+PAM_REGEX="[[:space:]]*\[pam]"
+PAM_OPT_REGEX="${PAM_REGEX}([^\n\[]*\n+)+?[[:space:]]*${SSSD_OPT}"
+
+if grep -qzosP $PAM_OPT_REGEX $SSSD_CONF; then
+	sed -i "s/${SSSD_OPT}[^(\n)]*/${SSSD_OPT} = ${SSSD_OPT_VAL}/" $SSSD_CONF
+elif grep -qs $PAM_REGEX $SSSD_CONF; then
+	sed -i "/$PAM_REGEX/a ${SSSD_OPT} = ${SSSD_OPT_VAL}" $SSSD_CONF
+else
+	mkdir -p /etc/sssd
+	touch $SSSD_CONF
+	echo -e "[pam]\n${SSSD_OPT} = ${SSSD_OPT_VAL}" >> $SSSD_CONF
+fi

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
@@ -1,0 +1,32 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="sssd_enable_smartcards" version="1">
+    <metadata>
+      <title>Enable Smartcards in SSSD</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>SSSD should be configured to authenticate access to the system
+    using smart cards.</description>
+    </metadata>
+    <criteria operator="OR">
+      <criteria operator="OR">
+        <extend_definition comment="Check if sssd service is disabled" definition_ref="service_sssd_disabled" />
+        <extend_definition comment="Check if /etc/sssd/sssd.conf is configured for usage"
+        definition_ref="sssd_conf_exists" negate="true"/>
+      </criteria>
+      <criterion comment="Check pam_cert_auth in /etc/sssd/sssd.conf"
+      test_ref="test_sssd_enable_smartcards" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the value of pam_cert_auth setting in the /etc/sssd/sssd.conf file"
+  id="test_sssd_enable_smartcards" version="1">
+    <ind:object object_ref="obj_sssd_enable_smartcards" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_sssd_enable_smartcards" version="1">
+    <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*\[pam](?:[^\n\[]*\n+)+?[\s]*pam_cert_auth[\s]*=[\s]*true$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -1,0 +1,43 @@
+documentation_complete: true
+
+prodtype: rhel7,fedora
+
+title: 'Enable Smartcards in SSSD'
+
+description: |-
+    SSSD should be configured to authenticate access to the system
+    using smart cards. To enable smart cards in SSSD, set <tt>pam_cert_auth</tt>
+    to <tt>true</tt> under the <tt>[pam]</tt>
+    section in <tt>/etc/sssd/sssd.conf</tt>. For example:
+    <pre>[pam]
+    pam_cert_auth = true
+    </pre>
+
+rationale: |-
+    Using an authentication device, such as a CAC or token that is separate from
+    the information system, ensures that even if the information system is
+    compromised, that compromise will not affect credentials stored on the
+    authentication device.
+    <br /><br />
+    Multifactor solutions that require devices separate from
+    information systems gaining access include, for example, hardware tokens
+    providing time-based or challenge-response authenticators and smart cards such
+    as the U.S. Government Personal Identity Verification card and the DoD Common
+    Access Card.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 80570-5
+
+references:
+    disa: "1954"
+    srg: SRG-OS-000375-GPOS-00160
+
+ocil_clause: 'smart cards are not enabled in SSSD'
+
+ocil: |-
+    To verify that smart cards are enabled in SSSD, run the following command:
+    <pre>$ sudo grep pam_cert_auth /etc/sssd/sssd.conf</pre>
+    If configured properly, output should be
+    <pre>pam_cert_auth = true</pre>

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -381,7 +381,13 @@ selections:
     - set_password_hashing_algorithm_libuserconf
     - set_password_hashing_algorithm_logindefs
     - set_password_hashing_algorithm_systemauth
-    - smartcard_auth
+    - package_opensc_installed
+    - var_smartcard_drivers=cac
+    - configure_opensc_nss_db
+    - configure_opensc_card_drivers
+    - force_opensc_card_drivers
+    - service_pcscd_enabled
+    - sssd_enable_smartcards
     - sssd_memcache_timeout
     - sssd_offline_cred_expiration
     - sssd_ssh_known_hosts_timeout


### PR DESCRIPTION
This PR replaces existing smart card rules (mainly `smartcard_auth` since it is now deprecated) in the RHEL7 OSPP profile with the new OpenSC/SSSD integration.