### PR TITLE
Select missing audit privileged commands rules for OSPP42

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -147,7 +147,9 @@ selections:
     - audit_rules_dac_modification_lchown
     - audit_rules_unsuccessful_file_modification_lchown
     - audit_rules_privileged_commands_at
+    - audit_rules_privileged_commands_crontab
     - audit_rules_privileged_commands_mount
+    - audit_rules_privileged_commands_umount
     - audit_rules_privileged_commands_passwd
     - audit_rules_privileged_commands_unix_chkpwd
     - audit_rules_privileged_commands_userhelper

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,fedora
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - crontab'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,fedora
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - umount'
 

--- a/rhel7/profiles/ospp42.profile
+++ b/rhel7/profiles/ospp42.profile
@@ -141,7 +141,9 @@ selections:
     - audit_rules_dac_modification_lchown
     - audit_rules_unsuccessful_file_modification_lchown
     - audit_rules_privileged_commands_at
+    - audit_rules_privileged_commands_crontab
     - audit_rules_privileged_commands_mount
+    - audit_rules_privileged_commands_umount
     - audit_rules_privileged_commands_passwd
     - audit_rules_privileged_commands_unix_chkpwd
     - audit_rules_privileged_commands_userhelper


### PR DESCRIPTION

#### Description:

Select audit rules privileged commands for binaries below:
- crontab
- umount

#### Rationale:

- OSPP4.2 would like you to have execution of these binaries
