### PR TITLE
Add Fedora 29 and 30 CPEs

### DIFF
--- a/fedora/cpe/fedora-cpe-dictionary.xml
+++ b/fedora/cpe/fedora-cpe-dictionary.xml
@@ -2,6 +2,16 @@
 <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
+      <cpe-item name="cpe:/o:fedoraproject:fedora:30">
+            <title xml:lang="en-us">Fedora 30</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_fedora</check>
+      </cpe-item>
+      <cpe-item name="cpe:/o:fedoraproject:fedora:29">
+            <title xml:lang="en-us">Fedora 29</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_fedora</check>
+      </cpe-item>
       <cpe-item name="cpe:/o:fedoraproject:fedora:28">
             <title xml:lang="en-us">Fedora 28</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/fedora/product.yml
+++ b/fedora/product.yml
@@ -11,6 +11,8 @@ pkg_manager: "dnf"
 init_system: "systemd"
 
 cpes:
+  - "cpe:/o:fedoraproject:fedora:30"
+  - "cpe:/o:fedoraproject:fedora:29"
   - "cpe:/o:fedoraproject:fedora:28"
   - "cpe:/o:fedoraproject:fedora:27"
   - "cpe:/o:fedoraproject:fedora:26"


### PR DESCRIPTION
#### Description:
Add Fedora 29 and 30 CPEs

#### Rationale:

Fedora 29 is coming soon and Fedora 30 is the current Rawhide.
