### PR TITLE
Add a warning of missing remediation

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
@@ -38,3 +38,10 @@ ocil: |-
     Inspect the file <tt>/etc/firewalld/firewalld.conf</tt> to determine
     the default zone for the <tt>firewalld</tt>. It should be set to <tt>DefaultZone=drop</tt>:
     <pre>$ sudo grep DefaultZone /etc/firewalld/firewalld.conf</pre>
+
+warnings:
+    - general: |-
+        To prevent denying any access to the system, automatic remediation
+        of this control is not available. Remediation must be automated as
+        a component of machine provisioning, or followed manually as outlined
+        above.

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
@@ -31,3 +31,8 @@ ocil: |-
     To check for unlabeled device files, run the following command:
     <pre>$ sudo find /dev -context *:device_t:* \( -type c -o -type b \) -printf "%p %Z\n"</pre>
     It should produce no output in a well-configured system.
+
+warnings:
+    - general: |-
+        Automatic remediation of this control is not available. The remediation
+        can be achieved by amending SELinux policy.

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
@@ -29,3 +29,9 @@ references:
     cui: 3.1.2,3.1.5,3.7.2
     hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3),164.308(a)(4),164.310(b),164.310(c),164.312(a),164.312(e)
     nist: AC-6,AU-9,CM-7
+
+warnings:
+    - general: |-
+        Automatic remediation of this control is not available. Remediation
+        can be achieved by amending SELinux policy or stopping the unconfined
+        daemons as outlined above.


### PR DESCRIPTION
#### Description:
Add warnings that remediation is not available.
This will be visible in HTML report therefore it will help users to identify why those rules haven't been fixed automatically.

#### Rationale:
These rules are a part of Fedora OSPP profile.
