### PR TITLE
Enable OVAL for rule grub2_enable_fips_mode on Fedora

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/anaconda/shared.anaconda
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/anaconda/shared.anaconda
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 
 package --add=dracut-fips

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
 
 # include remediation functions library
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
@@ -4,11 +4,12 @@
       <title>Enable FIPS Mode in GRUB2</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>Look for argument fips=1 in the kernel line in /etc/default/grub.</description>
     </metadata>
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is RHEL7" definition_ref="installed_OS_is_rhel7" />
+      <extend_definition comment="Installed OS is certified" definition_ref="installed_OS_is_certified" />
       <extend_definition comment="prelink disabled" definition_ref="disable_prelink" />
       <extend_definition comment="package dracut-fips installed" definition_ref="package_dracut-fips_installed" />
       <criteria operator="OR">

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -55,7 +55,7 @@ warnings:
     - regulatory: |-
         The ability to enable FIPS does not denote FIPS compliancy or certification.
         Red Hat, Inc. and Red Hat Enterprise Linux are respectively FIPS certified and compliant. Community
-        projects such as CentOS, Scientific Linux, etc. do not necessarily meet FIPS certification and compliancy.
+        projects such as CentOS, Scientific Linux, Fedora, etc. do not necessarily meet FIPS certification and compliancy.
         Therefore, non-certified vendors and/or projects do not meet this requirement even if technically feasible.
         <br /><br />
         See <b>{{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/1401vend.htm") }}}</b>

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/anaconda/shared.anaconda
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/anaconda/shared.anaconda
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_fedora
 
 package --add=dracut-fips

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_fedora
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_fedora
 
 # include remediation functions library
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
@@ -9,6 +9,7 @@
       <title>Package dracut-fips Installed</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>The RPM package dracut-fips should be installed.</description>
     </metadata>

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
+prodtype: rhel6,rhel7,fedora
 
 title: 'Install the dracut-fips Package'
 


### PR DESCRIPTION
#### Description:
I change the condition that the installed OS must be RHEL 7
to a check that installed OS is certified, because there
can be multiple operating systems that are FIPS certified,
not only RHEL 7. However, the rule will always fail on
Fedora.  I also add Fedora to the disclaimer.  I had to to
add `dracut-fips` to the list of installed packages,
otherwise the OVAL definition package_dracut-fips_installed
that extends this OVAL definition would be missing and that
would lead to the fact that the whole OVAL definition will
be stripped by our build system.

#### Rationale:
This rule is a part of Fedora OSPP profile.
