### PR TITLE
Add checks for removals of abrt and sendmail to OSPP

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -190,3 +190,4 @@ selections:
     - audit_rules_etc_group_openat
     - audit_rules_etc_group_open_by_handle_at
     - package_abrt_removed
+    - package_sendmail_removed

--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -189,3 +189,4 @@ selections:
     - audit_rules_etc_group_open
     - audit_rules_etc_group_openat
     - audit_rules_etc_group_open_by_handle_at
+    - package_abrt_removed

--- a/fedora/templates/csv/packages_removed.csv
+++ b/fedora/templates/csv/packages_removed.csv
@@ -5,5 +5,6 @@ openssh-server
 prelink
 setroubleshoot
 xorg-x11-server-common
+sendmail
 sssd
 systemd

--- a/fedora/templates/csv/packages_removed.csv
+++ b/fedora/templates/csv/packages_removed.csv
@@ -1,3 +1,4 @@
+abrt
 mcstrans
 net-snmp
 openssh-server

--- a/linux_os/guide/services/base/group.yml
+++ b/linux_os/guide/services/base/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6, rhel7, fedora
+prodtype: rhel6,rhel7,fedora
 
 title: 'Base Services'
 

--- a/linux_os/guide/services/base/group.yml
+++ b/linux_os/guide/services/base/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6, rhel7
+prodtype: rhel6, rhel7, fedora
 
 title: 'Base Services'
 

--- a/linux_os/guide/services/base/package_abrt_removed/rule.yml
+++ b/linux_os/guide/services/base/package_abrt_removed/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+prodtype: rhel6,rhel7,fedora
+
+title: 'Uninstall Automatic Bug Reporting Tool (abrt)'
+
+description: |-
+    The Automatic Bug Reporting Tool (<tt>abrt</tt>) collects
+    and reports crash data when an application crash is detected. Using a variety
+    of plugins, abrt can email crash reports to system administrators, log crash
+    reports to files, or forward crash reports to a centralized issue tracking
+    system such as RHTSupport.
+    {{{ describe_package_remove(package="abrt") }}}
+
+rationale: |-
+    Mishandling crash data could expose sensitive information about
+    vulnerabilities in software executing on the system, as well as sensitive
+    information from within a process's address space or registers.
+
+severity: unknown
+
+{{{ complete_ocil_entry_package(package="abrt") }}}

--- a/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
+++ b/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
+prodtype: rhel6,rhel7,fedora
 
 title: 'Uninstall Sendmail Package'
 

--- a/rhel7/profiles/ospp42.profile
+++ b/rhel7/profiles/ospp42.profile
@@ -185,3 +185,4 @@ selections:
     - audit_rules_etc_group_openat
     - audit_rules_etc_group_open_by_handle_at
     - package_abrt_removed
+    - package_sendmail_removed

--- a/rhel7/profiles/ospp42.profile
+++ b/rhel7/profiles/ospp42.profile
@@ -184,3 +184,4 @@ selections:
     - audit_rules_etc_group_open
     - audit_rules_etc_group_openat
     - audit_rules_etc_group_open_by_handle_at
+    - package_abrt_removed


### PR DESCRIPTION
#### Description:

Adds rules that check that packages abrt and sendmail are removed to Fedora OSPP and RHEL7 OSPP 4.2 profiles.

#### Rationale:
These rules should be part of OSPP.
