### PR TITLE
Remove product name from Benchmark example

### DIFF
--- a/linux_os/guide/benchmark.yml
+++ b/linux_os/guide/benchmark.yml
@@ -27,9 +27,9 @@ description: |
     XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
-    Content Automation Protocol (SCAP). The DISA STIG for {{{ full_name }}},
-    which provides required settings for US Department of Defense systems, is
-    one example of a baseline created from this guidance.
+    Content Automation Protocol (SCAP). The DISA STIG, which provides required
+    settings for US Department of Defense systems, is one example of a baseline
+    created from this guidance.
 
 notice:
     id: terms_of_use


### PR DESCRIPTION
#### Description:

- Using `{{{ full_name }}}` in reference to the DISA STIG in the Benchmark description is confusing if the
  product does not actually have a STIG.