### PR TITLE
Add mount options /dev/shm to OSPP profiles

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -191,3 +191,6 @@ selections:
     - audit_rules_etc_group_open_by_handle_at
     - package_abrt_removed
     - package_sendmail_removed
+    - mount_option_dev_shm_nodev
+    - mount_option_dev_shm_noexec
+    - mount_option_dev_shm_nosuid

--- a/fedora/templates/csv/mount_options.csv
+++ b/fedora/templates/csv/mount_options.csv
@@ -6,9 +6,9 @@
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
 #  add the 'create_fstab_entry_if_needed' literal string as the third argument.
-/dev/shm,nodev
-/dev/shm,noexec
-/dev/shm,nosuid
+/dev/shm,nodev #except-for:anaconda
+/dev/shm,noexec #except-for:anaconda
+/dev/shm,nosuid #except-for:anaconda
 /tmp,nodev
 /tmp,noexec
 /tmp,nosuid

--- a/rhel7/profiles/ospp42.profile
+++ b/rhel7/profiles/ospp42.profile
@@ -186,3 +186,6 @@ selections:
     - audit_rules_etc_group_open_by_handle_at
     - package_abrt_removed
     - package_sendmail_removed
+    - mount_option_dev_shm_nodev
+    - mount_option_dev_shm_noexec
+    - mount_option_dev_shm_nosuid


### PR DESCRIPTION
#### Description:
This commit adds rules of /dev/shm mount options to Fedora OSPP
profile and RHEL 7 OSPP 4.2 profile.
The template for Fedora will not generate Anaconda remediations
because the same limitation is set in RHEL 7 rules.

#### Rationale:
These rules should be included in OSPP.
