### PR TITLE
Fix file permissions for rule_file_permissions_sshd_private_key

### DIFF
--- a/fedora/templates/csv/file_dir_permissions.csv
+++ b/fedora/templates/csv/file_dir_permissions.csv
@@ -6,6 +6,6 @@
 /etc/httpd/conf.d,*,,,0640,httpd_server_conf_d_files
 /etc/httpd/conf,*,,,0640,httpd_server_conf_files
 /etc/ssh,*.pub,,,0644,sshd_pub_key
-/etc/ssh,*_key,,,0600,sshd_private_key
+/etc/ssh,*_key,,,0640,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
 /boot/grub2,grub.cfg,0,0,600,grub2_cfg

--- a/rhel7/templates/csv/file_dir_permissions.csv
+++ b/rhel7/templates/csv/file_dir_permissions.csv
@@ -6,7 +6,7 @@
 /etc/httpd/conf.d,*,,,0640,httpd_server_conf_d_files
 /etc/httpd/conf,*,,,0640,httpd_server_conf_files
 /etc/ssh,*.pub,,,0644,sshd_pub_key
-/etc/ssh,*_key,,,0600,sshd_private_key
+/etc/ssh,*_key,,,0640,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
 /boot/grub2,grub.cfg,0,0,600,grub2_cfg
 /boot/efi/EFI/redhat,grub.cfg,0,0,700,efi_grub2_cfg


### PR DESCRIPTION
#### Description:

RHEL, CentOS and Fedora ssh private key files should be `0640`. This is because `ssh_keys` group owns ssh private key files in `/etc/ssh` and also `ssh-keysign` binary:
```
$ ls -l /usr/libexec/openssh/ssh-keysign 
-r-xr-sr-x. 1 root ssh_keys 461672 Aug 25 14:31 /usr/libexec/openssh/ssh-keysign
$ ls -l /etc/ssh/ | grep rsa
-rw-r-----. 1 root ssh_keys   1675 Jun  5 19:30 ssh_host_rsa_key
-rw-r--r--. 1 root root        382 Jun  5 19:30 ssh_host_rsa_key.pub
```
Other products should still use `0600` for ssh private key files
