### PR TITLE
Fix an underscore

### DIFF
--- a/shared/bash_remediation_functions/include_set_faillock_option.sh
+++ b/shared/bash_remediation_functions/include_set_faillock_option.sh
@@ -15,7 +15,7 @@ function insert_preauth {
 		# the option is not set.
 		else
 			# append the option
-			sed -i --follow-symlinks "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ $option=$value/" "$_pamFile"
+			sed -i --follow-symlinks "/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ $option=$value/" "$pam_file"
 		fi
 	# auth required pam_faillock.so preauth is not present, insert the whole line
 	else
@@ -36,7 +36,7 @@ function insert_authfail {
 		# the option is not set.
 		else
 			# append the option
-			sed -i --follow-symlinks "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ $option=$value/" "$_pamFile"
+			sed -i --follow-symlinks "/^auth.*[default=die].*pam_faillock.so.*authfail.*/ s/$/ $option=$value/" "$pam_file"
 		fi
 	# auth default pam_faillock.so authfail is not present, insert the whole line
 	else

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/fail_interval_missing.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_interval/fail_interval_missing.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. shared.sh
+
+preauth_set=1
+authfail_set=1
+account_set=1
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+interval="900"
+
+set_default_configuration
+insert_or_remove_settings $preauth_set $authfail_set $account_set $interval ${auth_files[*]}
+sed -i "s/fail_interval=$interval//" ${auth_files[*]}


### PR DESCRIPTION
#### Description:
The correct name of the variable is pam_file.

#### Rationale:
Referencing non-existing variable is a bug.