### PR TITLE
Add sysctl kernel parameter rules to Fedora OSPP

### DIFF
--- a/fedora/templates/csv/sysctl_values.csv
+++ b/fedora/templates/csv/sysctl_values.csv
@@ -1,4 +1,8 @@
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
+kernel.dmesg_restrict,1
+kernel.kexec_load_disabled,1
+kernel.kptr_restrict,1
 kernel.randomize_va_space,2
+kernel.yama.ptrace_scope,1
 net.ipv6.conf.all.disable_ipv6,1

--- a/shared/templates/template_BASH_sysctl
+++ b/shared/templates/template_BASH_sysctl
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_fedora
 # reboot = true
 # strategy = disable
 # complexity = low


### PR DESCRIPTION
#### Description:

Add OVAL and Bash remediation for rules sysctl_kernel_dmesg_restrict, sysctl_kernel_kexec_load_disabled, sysctl_kernel_kptr_restrict, sysctl_kernel_yama_ptrace_scope

#### Rationale:

These rules have been recently added to Fedora OSPP profile by PR #3361, but they're missing OVAL and Bash remediation.
