### PR TITLE
Enable OCP3 builds and add C2S rules

### DIFF
--- a/applications/benchmark.yml
+++ b/applications/benchmark.yml
@@ -1,0 +1,53 @@
+---
+documentation_complete: true
+
+title: Guide to the Secure Configuration of {{{ full_name }}}
+
+status: draft
+
+description: |
+    This guide presents a catalog of security-relevant
+    configuration settings for {{{ full_name }}}. It is a rendering of
+    content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
+    in order to support security automation.  The SCAP content is
+    is available in the <tt>scap-security-guide</tt> package which is developed at
+    {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
+    <br/><br/>
+    Providing system administrators with such guidance informs them how to securely
+    configure systems under their control in a variety of network roles. Policy
+    makers and baseline creators can use this catalog of settings, with its
+    associated references to higher-level security control catalogs, in order to
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
+    sensible in many operational scenarios. However, the XCCDF format enables
+    granular selection and adjustment of settings, and their association with OVAL
+    and OCIL content provides an automated checking capability. Transformations of
+    this document, and its associated automated checking content, are capable of
+    providing baselines that meet a diverse set of policy objectives. Some example
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
+    can be used as baselines, are available with this guide. They can be
+    processed, in an automated fashion, with tools that support the Security
+    Content Automation Protocol (SCAP). The DISA STIG, which provides required
+    settings for US Department of Defense systems, is one example of a baseline
+    created from this guidance.
+
+notice:
+    id: terms_of_use
+    description: |
+        Do not attempt to implement any of the settings in
+        this guide without first testing them in a non-operational environment. The
+        creators of this guidance assume no responsibility whatsoever for its use by
+        other parties, and makes no guarantees, expressed or implied, about its
+        quality, reliability, or any other characteristic.
+
+front-matter: |
+    The SCAP Security Guide Project<br/>
+    {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}
+
+rear-matter: |
+    Red Hat and Red Hat Enterprise Linux are either registered
+    trademarks or trademarks of Red Hat, Inc. in the United States and other
+    countries. All other names are registered trademarks or trademarks of their
+    respective companies.
+
+version: 0.9

--- a/applications/benchmark.yml
+++ b/applications/benchmark.yml
@@ -41,7 +41,7 @@ notice:
         quality, reliability, or any other characteristic.
 
 front-matter: |
-    The SCAP Security Guide Project<br/>
+    The ComplianceAsCode Project<br/>
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}
 
 rear-matter: |

--- a/applications/benchmark.yml
+++ b/applications/benchmark.yml
@@ -27,9 +27,9 @@ description: |
     XCCDF <em>Profiles</em>, which are selections of items that form checklists and
     can be used as baselines, are available with this guide. They can be
     processed, in an automated fashion, with tools that support the Security
-    Content Automation Protocol (SCAP). The DISA STIG, which provides required
-    settings for US Department of Defense systems, is one example of a baseline
-    created from this guidance.
+    Content Automation Protocol (SCAP). The NIST National Checklist Program (NCP),
+    which provides required settings for the United States Government, is one example
+    of a baseline created from this guidance.
 
 notice:
     id: terms_of_use

--- a/applications/intro/general-principles/group.yml
+++ b/applications/intro/general-principles/group.yml
@@ -1,0 +1,8 @@
+documentation_complete: true
+
+title: 'General Principles'
+
+description: |-
+    The following general principles motivate much of the advice in this
+    guide and should also influence any configuration decisions that are
+    not explicitly covered.

--- a/applications/intro/general-principles/principle-encrypt-transmitted-data/group.yml
+++ b/applications/intro/general-principles/principle-encrypt-transmitted-data/group.yml
@@ -1,0 +1,13 @@
+documentation_complete: true
+
+title: 'Encrypt Transmitted Data Whenever Possible'
+
+description: |-
+    Data transmitted over a network, whether wired or wireless, is susceptible
+    to passive monitoring. Whenever practical solutions for encrypting
+    such data exist, they should be applied. Even if data is expected to
+    be transmitted only over a local network, it should still be encrypted.
+    Encrypting authentication data, such as passwords, is particularly
+    important. Networks of {{{ full_name }}} machines can and should be configured
+    so that no unencrypted authentication data is ever transmitted between
+    machines.

--- a/applications/intro/general-principles/principle-least-privilege/group.yml
+++ b/applications/intro/general-principles/principle-least-privilege/group.yml
@@ -1,0 +1,10 @@
+documentation_complete: true
+
+title: 'Least Privilege'
+
+description: |-
+    Grant the least privilege necessary for user accounts and software to perform tasks.
+    For example, <tt>sudo</tt> can be implemented to limit authorization to super user
+    accounts on the system only to designated personnel. Another example is to limit
+    logins on server systems to only those administrators who need to log into them in
+    order to perform administration tasks.

--- a/applications/intro/general-principles/principle-separate-servers/group.yml
+++ b/applications/intro/general-principles/principle-separate-servers/group.yml
@@ -1,0 +1,9 @@
+documentation_complete: true
+
+title: 'Run Different Network Services on Separate Systems'
+
+description: |-
+    Whenever possible, a server should be dedicated to serving exactly one
+    network service. This limits the number of other services that can
+    be compromised in the event that an attacker is able to successfully
+    exploit a software flaw in one network service.

--- a/applications/intro/general-principles/principle-use-security-tools/group.yml
+++ b/applications/intro/general-principles/principle-use-security-tools/group.yml
@@ -1,0 +1,9 @@
+documentation_complete: true
+
+title: 'Configure Security Tools to Improve System Robustness'
+
+description: |-
+    Several tools exist which can be effectively used to improve a system's
+    resistance to and detection of unknown attacks. These tools can improve
+    robustness against attack at the cost of relatively little configuration
+    effort.

--- a/applications/intro/group.yml
+++ b/applications/intro/group.yml
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: Introduction
+
+description: |-
+    The purpose of this guidance is to provide security configuration
+    recommendations and baselines for {{{ full_name }}}.
+    The guide is intended for system and/or application administrators. Readers are assumed to
+    possess basic system administration skills for the application's operating systems, as well
+    as some familiarity with the product's documentation and administration
+    conventions. Some instructions within this guide are complex.
+    All directions should be followed completely and with understanding of
+    their effects in order to avoid serious adverse effects on the system
+    and its security.

--- a/applications/intro/how-to-use/group.yml
+++ b/applications/intro/how-to-use/group.yml
@@ -1,0 +1,5 @@
+documentation_complete: true
+
+title: 'How to Use This Guide'
+
+description: 'Readers should heed the following points when using the guide.'

--- a/applications/intro/how-to-use/intro-formatting-conventions/group.yml
+++ b/applications/intro/how-to-use/intro-formatting-conventions/group.yml
@@ -1,0 +1,9 @@
+documentation_complete: true
+
+title: 'Formatting Conventions'
+
+description: |-
+    Commands intended for shell execution, as well as configuration file text,
+    are featured in a <tt>monospace font</tt>. <i>Italics</i> are used
+    to indicate instances where the system administrator must substitute
+    the appropriate information into a command or configuration file.

--- a/applications/intro/how-to-use/intro-read-sections-completely/group.yml
+++ b/applications/intro/how-to-use/intro-read-sections-completely/group.yml
@@ -1,0 +1,9 @@
+documentation_complete: true
+
+title: 'Read Sections Completely and in Order'
+
+description: |-
+    Each section may build on information and recommendations discussed in
+    prior sections. Each section should be read and understood completely;
+    instructions should never be blindly applied. Relevant discussion may
+    occur after instructions for an action.

--- a/applications/intro/how-to-use/intro-reboot-required/group.yml
+++ b/applications/intro/how-to-use/intro-reboot-required/group.yml
@@ -1,0 +1,10 @@
+documentation_complete: true
+
+title: 'Reboot Required'
+
+description: |-
+    A system or service reboot is implicitly required after some actions in order to
+    complete the reconfiguration of the system. In many cases, the changes
+    will not take effect until a reboot is performed. In order to ensure
+    that changes are applied properly and to test functionality, always
+    reboot the system after applying a set of recommendations from this guide.

--- a/applications/intro/how-to-use/intro-root-shell-assumed/group.yml
+++ b/applications/intro/how-to-use/intro-root-shell-assumed/group.yml
@@ -1,0 +1,13 @@
+documentation_complete: true
+
+title: 'Root Shell Environment Assumed'
+
+description: |-
+    Most of the actions listed in this document are written with the
+    assumption that they will be executed by the root user running the
+    <tt>/bin/bash</tt> shell. Commands preceded with a hash mark (#)
+    assume that the administrator will execute the commands as root, i.e.
+    apply the command via <tt>sudo</tt> whenever possible, or use
+    <tt>su</tt> to gain root privileges if <tt>sudo</tt> cannot be
+    used. Commands which can be executed as a non-root user are are preceded
+    by a dollar sign ($) prompt.

--- a/applications/intro/how-to-use/intro-test-non-production/group.yml
+++ b/applications/intro/how-to-use/intro-test-non-production/group.yml
@@ -1,0 +1,8 @@
+documentation_complete: true
+
+title: 'Test in Non-Production Environment'
+
+description: |-
+    This guidance should always be tested in a non-production environment
+    before deployment. This test environment should simulate the setup in
+    which the system will be deployed as closely as possible.

--- a/applications/openshift/group.yml
+++ b/applications/openshift/group.yml
@@ -1,0 +1,5 @@
+documentation_complete: true
+
+title: 'OpenShift Settings'
+
+description: 'Contains rules that check correct OpenShift settings.'

--- a/applications/openshift/ocp-permissions/group.yml
+++ b/applications/openshift/ocp-permissions/group.yml
@@ -1,0 +1,8 @@
+documentation_complete: true
+
+title: 'Permissions'
+
+description: |-
+    Traditional security relies heavily on file and
+    directory permissions to prevent unauthorized users from reading or
+    modifying files to which they should not have access.

--- a/applications/openshift/ocp-permissions/ocp-files/directory_permissions_etc_origin/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/directory_permissions_etc_origin/rule.yml
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'The OpenShift Configuration Directory Must Have Mode 0700'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/origin/", perms="0700") }}}
+
+rationale: 'If users can modify the OpenShift configurations, the OpenShift cluster can become inoperable or compromised'
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/origin/", perms="-rwx------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/origin/", perms="-rwx------") }}}

--- a/applications/openshift/ocp-permissions/ocp-files/directory_permissions_var_lib_etcd/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/directory_permissions_var_lib_etcd/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'The OpenShift etcd Data Directory Must Have Mode 0700'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/lib/etcd", perms="0700") }}}
+
+rationale: |-
+    The <tt>/var/lib/etcd</tt> directory contains highly-avaliable distributed key/value data storage
+    across an OpenShift cluster. Allowing access to users to this directory could compromise OpenShift
+    data and the cluster.
+
+severity: medium
+
+references:
+    cis: 1.4.11
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd", perms="-rwx------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/lib/etcd", perms="-rwx------") }}}

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_kubeconfig/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns The OpenShift Node Kubeconfig File'
+
+description: '{{{ describe_file_group_owner(file="/etc/origin/node/node.kubeconfig", perms="0600") }}}
+rationale: |-
+    The <tt>/etc/origin/node/node.kubeconfig</tt> file contains information about the configuration of the
+    OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.2
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/origin/node/node.kubeconfig", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/origin/node/node.kubeconfig", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_node_config/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_node_config/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns The OpenShift Node Configuration File'
+
+description: '{{{ describe_file_group_owner(file="/etc/origin/node/node-config.yaml", group="root") }}}'
+
+rationale: |-
+    The <tt>/etc/origin/node/node-config.yaml</tt> file contains information about the configuration of the
+    OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.2
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/origin/node/node-config.yaml", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/origin/node/node-config.yaml", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_client_crt/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_client_crt/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns OpenShift Node Certificate File'
+
+description: '{{{ describe_file_group_owner(file="/etc/origin/node/client-ca.crt", group="root") }}}'
+
+rationale: |-
+    The <tt>/etc/origin/node/client-ca.crt</tt> file contains the certificate authority
+    certificate for an OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.8
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/origin/node/client-ca.crt", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/origin/node/client-ca.crt", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_service/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_service/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns The OpenShift Node Service File'
+
+description: '{{{ describe_file_group_owner(file="/etc/systemd/system/atomic-openshift-node.service", group="root") }}}'
+
+rationale: |-
+    The <tt>/etc/systemd/system/atomic-openshift-node.service</tt> file contains information about the configuration of the
+    OpenShift node service that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.4
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/systemd/system/atomic-openshift-node.service", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/systemd/system/atomic-openshift-node.service", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_node_config/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_node_config/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns The OpenShift Node Configuration File'
+
+description: '{{{ describe_file_owner(file="/etc/origin/node/node-config.yaml", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/origin/node/node-config.yaml</tt> file contains information about the configuration of the
+    OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.2
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/origin/node/node-config.yaml", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/origin/node/node-config.yaml", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_node_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_node_kubeconfig/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns The OpenShift Node Kubeconfig File'
+
+description: '{{{ describe_file_owner(file="/etc/origin/node/node.kubeconfig", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/origin/node/node.kubeconfig</tt> file contains information about the configuration of the
+    OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.2
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/origin/node/node.kubeconfig", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/origin/node/node.kubeconfig", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_client_crt/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_client_crt/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns OpenShift Node Certificate File'
+
+description: '{{{ describe_file_owner(file="/etc/origin/node/client-ca.crt", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/origin/node/client-ca.crt</tt> file contains the certificate authority
+    certificate for an OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.8
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/origin/node/client-ca.crt", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/origin/node/client-ca.crt", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_service/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_service/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns The OpenShift Node Service File'
+
+description: '{{{ describe_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/systemd/system/atomic-openshift-node.service</tt> file contains information about the configuration of the
+    OpenShift node service that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.4
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_config/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_config/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Verify Permissions on the OpenShift Node Configuration File'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/origin/node/node-config.yaml", perms="0600") }}}
+
+rationale: |-
+    If the <tt>/etc/origin/node/node-config.yaml</tt> file is writable by a group-owner or the
+    world the risk of its compromise is increased. The file contains the configuration of
+    an OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.1
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/origin/node/node-config.yaml", perms="-rw-------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/origin/node/node-config.yaml", perms="-rw-------") }}}

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_kubeconfig/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Verify Permissions on the OpenShift Node Kubeconfig File'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/origin/node/node.kubeconfig", perms="0600") }}}
+
+rationale: |-
+    If the <tt>/etc/origin/node/node.kubeconfig</tt> file is writable by a group-owner or the
+    world the risk of its compromise is increased. The file contains the configuration of
+    an OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.1
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/origin/node/node.kubeconfig", perms="-rw-------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/origin/node/node.kubeconfig", perms="-rw-------") }}}

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_client_crt/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_client_crt/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Verify Permissions on OpenShift Node Certificate File'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/origin/node/client-ca.crt", perms="0644") }}}
+
+rationale: |-
+    If the <tt>/etc/origin/node/client-ca.crt</tt> file is writable by a group-owner or the
+    world the risk of its compromise is increased. The file contains the certificate authority
+    certificate for an OpenShift node that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/origin/node/client-ca.crt", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/origin/node/client-ca.crt", perms="-rw-r--r--") }}}

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_service/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_service/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Verify Permissions on the OpenShift Node Service File'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/systemd/system/atomic-openshift-node.service", perms="0644") }}}
+
+rationale: |-
+    If the <tt>/etc/systemd/system/atomic-openshift-node.service</tt> file is writable by a group-owner or the
+    world the risk of its compromise is increased. The file contains the service configuration of the
+    OpenShift node service that is configured on the system. Protection of this file is
+    critical for OpenShift security.
+
+severity: medium
+
+references:
+    cis: 2.2.3
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/systemd/system/atomic-openshift-node.service", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/systemd/system/atomic-openshift-node.service", perms="-rw-r--r--") }}}

--- a/applications/openshift/ocp-permissions/ocp-files/group.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/group.yml
@@ -1,0 +1,13 @@
+documentation_complete: true
+
+title: |-
+    Verify Permissions on Important Files and
+    Directories
+
+description: |-
+    Permissions for many files on a system must be set
+    restrictively to ensure sensitive information is properly protected.
+    This section discusses important
+    permission restrictions which can be verified
+    to ensure that no harmful discrepancies have
+    arisen.

--- a/ocp3/product.yml
+++ b/ocp3/product.yml
@@ -2,7 +2,7 @@ product: ocp3
 full_name: Red Hat Enterprise OpenShift Container Platform 3
 type: platform
 
-benchmark_root: "../linux_os/guide"
+benchmark_root: "../applications"
 
 profiles_root: "./profiles"
 

--- a/ocp3/profiles/C2S-master.profile
+++ b/ocp3/profiles/C2S-master.profile
@@ -17,4 +17,34 @@ description: |-
 
 extends: C2S-node
 
-selections: []
+selections:
+    - file_groupowner_master_admin_conf
+    - file_groupowner_master_api_server
+    - file_groupowner_master_cni_conf
+    - file_groupowner_master_conf
+    - file_groupowner_master_controller_manager
+    - file_groupowner_master_etcd
+    - file_groupowner_master_openshift_conf
+    - file_groupowner_master_scheduler
+    - file_owner_master_admin_conf
+    - file_owner_master_api_server
+    - file_owner_master_cni_conf
+    - file_owner_master_conf
+    - file_owner_master_controller_manager
+    - file_owner_master_etcd
+    - file_owner_master_openshift_conf
+    - file_owner_master_scheduler
+    - file_permissions_master_admin_conf
+    - file_permissions_master_api_server
+    - file_permissions_master_cni_conf
+    - file_permissions_master_conf
+    - file_permissions_master_controller_manager
+    - file_permissions_master_etcd
+    - file_permissions_master_openshift_conf
+    - file_permissions_master_scheduler
+    - directory_permissions_etc_origin
+    - directory_permissions_var_lib_etcd
+    - file_groupowner_etc_origin
+    - file_owner_etc_origin
+    - file_groupowner_var_lib_etcd
+    - file_owner_var_lib_etcd

--- a/ocp3/profiles/C2S-node.profile
+++ b/ocp3/profiles/C2S-node.profile
@@ -15,4 +15,13 @@ description: |-
     ensure a system is in compliance or consistency with the CIS
     baseline.
 
-selections: []
+selections:
+    - file_permissions_node_config
+    - file_owner_node_config
+    - file_groupowner_node_config
+    - file_permissions_openshift_node_client_crt
+    - file_owner_openshift_node_client_crt
+    - file_groupowner_openshift_node_client_crt
+    - file_permissions_openshift_node_service
+    - file_owner_openshift_node_service
+    - file_groupowner_openshift_node_service

--- a/ocp3/profiles/opencis-ocp-master.profile
+++ b/ocp3/profiles/opencis-ocp-master.profile
@@ -1,21 +1,18 @@
 documentation_complete: true
 
-title: 'C2S for Master Node'
+title: 'Open Computing Information Security Profile for OpenShift Master Node'
 
 description: |-
-    This profile demonstrates compliance against the
-    U.S. Government Commercial Cloud Services (C2S) baseline.
-
     This baseline was inspired by the Center for Internet Security
     (CIS) Kubernetes Benchmark, v1.2.0 - 01-31-2017.
 
-    For the SCAP Security Guide project to remain in compliance with
+    For the ComplianceAsCode project to remain in compliance with
     CIS' terms and conditions, specifically Restrictions(8), note
-    there is no representation or claim that the C2S profile will
+    there is no representation or claim that the OpenCIS profile will
     ensure a system is in compliance or consistency with the CIS
     baseline.
 
-extends: C2S-node
+extends: opencis-ocp-node
 
 selections:
     - file_groupowner_master_admin_conf

--- a/ocp3/profiles/opencis-ocp-node.profile
+++ b/ocp3/profiles/opencis-ocp-node.profile
@@ -1,17 +1,14 @@
 documentation_complete: true
 
-title: 'C2S for Node'
+title: 'Open Computing Information Security Profile for OpenShift Node'
 
 description: |-
-    This profile demonstrates compliance against the
-    U.S. Government Commercial Cloud Services (C2S) baseline.
-
     This baseline was inspired by the Center for Internet Security
     (CIS) Kubernetes Benchmark, v1.2.0 - 01-31-2017.
 
-    For the SCAP Security Guide project to remain in compliance with
+    For the ComplianceAsCode project to remain in compliance with
     CIS' terms and conditions, specifically Restrictions(8), note
-    there is no representation or claim that the C2S profile will
+    there is no representation or claim that the OpenCIS profile will
     ensure a system is in compliance or consistency with the CIS
     baseline.
 

--- a/ocp3/templates/csv/file_dir_permissions.csv
+++ b/ocp3/templates/csv/file_dir_permissions.csv
@@ -1,0 +1,5 @@
+/etc/origin/node,node-config.yaml,0,0,0600,node_config
+/etc/systemd/system,atomic-openshift-node.service,0,0,0644,openshift_node_service
+/etc/origin/node,client-ca.crt,0,0,0600,openshift_node_client_crt
+/var/lib,etcd,0,0,,var_lib_etcd
+/etc,origin,0,0,,etc_origin


### PR DESCRIPTION
This starts to add OCP rules and content. Also uses a top-level `applications` directory for applications that could/can be installed for multiple different OSes.