### PR TITLE
Added more stabilized profile IDs

### DIFF
--- a/tests/stable_profile_ids.py
+++ b/tests/stable_profile_ids.py
@@ -18,8 +18,11 @@ from collections import defaultdict
 # xccdf_org.ssgproject.content_profile_ospp42 becomes ospp42
 
 STABLE_PROFILE_IDS = {
-    "RHEL-6": ["pci-dss"],
-    "RHEL-7": ["ospp", "ospp42", "pci-dss"],
+    "FEDORA": ["standard"],
+    "RHEL-6": ["C2S", "CS2", "CSCF-RHEL6-MLS", "fisma-medium-rhel6-server",
+               "pci-dss", "rht-ccp", "stig-rhel6-disa", "usgcb-rhel6-server"],
+    "RHEL-7": ["C2S", "cjis", "hipaa", "nist-800-171-cui", "rht-ccp",
+               "ospp", "ospp42", "pci-dss", "stig-rhel7-disa"],
 }
 
 BENCHMARK_ID_PREFIX = "xccdf_org.ssgproject.content_benchmark_"


### PR DESCRIPTION
#### Description:

- Add more profile IDs that should not be changed anymore

#### Rationale:

- Changing profiles you use can be pain, if it's hardcoded into automation. This way, we will ensure we don't break this backwards compatibility by accident.
