### PR TITLE
Fix `utils/rule_dir_json.py`

### DIFF
--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -13,6 +13,7 @@ from .constants import oval_namespace as ovalns
 from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs
 from .xml import ElementTree as ET
 from .xml import oval_generated_header
+from .yaml import process_file
 from .id_translate import IDTranslator
 
 SHARED_OVAL = re.sub(r'ssg/.*', 'shared', __file__) + '/checks/oval/'
@@ -97,7 +98,7 @@ def applicable_platforms(oval_file):
 
     platforms = []
     header = oval_generated_header("applicable_platforms", "5.11", "0.0.1")
-    body = read_ovaldefgroup_file(oval_file)
+    body = process_file(oval_file, {})
     oval_tree = ET.fromstring(header + body + footer)
 
     element_path = "./{%s}def-group/{%s}definition/{%s}metadata/{%s}affected/{%s}platform"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,11 @@ add_test(
 )
 
 add_test(
+    NAME "test-rule-dir-json"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/rule_dir_json.py"
+)
+
+add_test(
     NAME "validate-parse-affected"
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_parse_affected.py" "${CMAKE_SOURCE_DIR}"
 )

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -17,13 +17,14 @@ import ssg.yaml
 
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BUILD_OUTPUT = os.path.join(SSG_ROOT, "build", "rule_dirs.json")
 
 
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-r", "--root", type=str, action="store", default=SSG_ROOT,
                    help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
-    parser.add_argument("-o", "--output", type=str, action="store", default="build/rule_dirs.json",
+    parser.add_argument("-o", "--output", type=str, action="store", default=BUILD_OUTPUT,
                    help="File to write json output to (defaults to build/rule_dirs.json)")
 
     return parser.parse_args()


### PR DESCRIPTION
This fixes the parsing of OVALs by `rule_dir_json` & friends; in particular, we now parse JINJA macros before loading the contents of the OVAL.

This also adds it to the cmake tests so it hopefully won't get broken in the future... :)
