### PR TITLE
Improve robustness of ensure_gpgcheck_never_disabled Bash fix

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/bash/shared.sh
@@ -1,2 +1,2 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
-sed -i 's/gpgcheck=.*/gpgcheck=1/g' /etc/yum.repos.d/*
+sed -i 's/gpgcheck\s*=.*/gpgcheck=1/g' /etc/yum.repos.d/*


### PR DESCRIPTION
#### Description:

- Allow Bash fix to match spaces between "gpgcheck" and "="

#### Rationale:

- The `repo` file can be configure with spaces between key and value.
