### PR TITLE
Create /dev/shm entry in /etc/fstab if needed

### DIFF
--- a/fedora/templates/csv/mount_options.csv
+++ b/fedora/templates/csv/mount_options.csv
@@ -6,9 +6,12 @@
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
 #  add the 'create_fstab_entry_if_needed' literal string as the third argument.
-/dev/shm,nodev #except-for:anaconda
-/dev/shm,noexec #except-for:anaconda
-/dev/shm,nosuid #except-for:anaconda
+
+# /dev/shm is created by systemd and is not available at install time
+# /dev/shm may not be in /etc/fstab, add entry if needed
+/dev/shm,nodev,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,noexec,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,nosuid,create_fstab_entry_if_needed #except-for:anaconda
 /tmp,nodev
 /tmp,noexec
 /tmp,nosuid

--- a/rhel7/templates/csv/mount_options.csv
+++ b/rhel7/templates/csv/mount_options.csv
@@ -8,9 +8,10 @@
 #  add the 'create_fstab_entry_if_needed' literal string as the third argument.
 
 # /dev/shm is created by systemd and is not available at install time
-/dev/shm,nodev #except-for:anaconda
-/dev/shm,noexec #except-for:anaconda
-/dev/shm,nosuid #except-for:anaconda
+# /dev/shm may not be in /etc/fstab, add entry if needed
+/dev/shm,nodev,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,noexec,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,nosuid,create_fstab_entry_if_needed #except-for:anaconda
 /home,nosuid
 /home,nodev
 /tmp,nodev


### PR DESCRIPTION
#### Description:

- Generate remediation with capability to add  `/etc/fstab` entry if needed.

#### Rationale:

- `/dev/shm` may not be in `/etc/fstab`, add entry if needed.
- One of the mount options rules `noexec`, `nosuid`, `nodev` for `/dev/shm` always failed, while the other two succeeded.
