### PR TITLE
Add OCP Service Runtime configuration template

### DIFF
--- a/ocp3/templates/csv/ocp_service_runtime_config.csv
+++ b/ocp3/templates/csv/ocp_service_runtime_config.csv
@@ -1,0 +1,1 @@
+/usr/bin/hyperkube,--anonymous-auth,false

--- a/shared/templates/create_ocp_service_runtime_config.py
+++ b/shared/templates/create_ocp_service_runtime_config.py
@@ -1,0 +1,53 @@
+#
+# create_ocp_service_runtime_config.py
+#   automatically generate checks for ocp process runtime configurations
+
+import sys
+import re
+
+from template_common import FilesGenerator, UnknownTargetError
+
+
+class OCPServiceRuntimeConfigGenerator(FilesGenerator):
+    def generate(self, target, ocp_process_info):
+        process_cmd, process_cmd_option, process_cmd_val = ocp_process_info
+        # convert variable name to a format suitable for 'id' tags
+        ocp_proc_id = re.sub(r'[-._]', '_', process_cmd_option.strip("--="))
+        process_cmd_option = process_cmd_option.strip("=")
+        if target == "oval":
+            self.file_from_template(
+                "./template_OVAL_ocp_service_runtime_config",
+                {
+                    "OCPCMDOPTIONID": ocp_proc_id,
+                    "OCPPROCESS": process_cmd,
+                    "OCPCMDOPTION": process_cmd_option,
+                    "OCPCMDVAL": process_cmd_val
+                },
+                "./oval/ocp_service_runtime_config_{0}.xml", ocp_proc_id)
+
+#        elif target == "bash":
+#            self.file_from_template(
+#                "./template_BASH_ocp_service_runtime_config",
+#                {
+#                    "OCPPROCESS": process_cmd,
+#                    "OCPCMDOPTION": process_cmd_option,
+#                    "OCPCMDVAL": process_cmd_val
+#                    },
+#                "./bash/ocp_service_runtime_config_{0}.sh", ocp_proc_id)
+#
+#        elif target == "ansible":
+#            self.file_from_template(
+#                "./template_ANSIBLE_ocp_service_runtime_config",
+#                {
+#                    "OCPPROCESS": process_cmd,
+#                    "OCPCMDOPTION": process_cmd_option,
+#                    "OCPCMDVAL": process_cmd_val
+#                },
+#                "./ansible/ocp_service_runtime_config_{0}.yml", ocp_proc_id)
+
+        else:
+            raise UnknownTargetError(target)
+
+    def csv_format(self):
+        return("CSV should contains lines of the format: " +
+               "process_cmd,process_cmd_option,process_cmd_val")

--- a/shared/templates/template_OVAL_ocp_service_runtime_config
+++ b/shared/templates/template_OVAL_ocp_service_runtime_config
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="ocp_process_runtime_{{{ OCPCMDOPTIONID }}}" version="1">
+    <metadata>
+      <title>Check OpenShift Runtime Process Configuration of {{{ OCPPROCESS }}} - {{{ OCPCMDOPTIONID }}}</title>
+      <affected family="unix">
+        <platform>multi_platform_ocp</platform>
+      </affected>
+      <description>Verify the OpenShift process runtime configuration of the {{{ OCPCMDOPTIONID }}} option.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="ocp process runtime parameter {{{ OCPCMDOPTION }}} set to {{{ OCPCMDVAL }}}" test_ref="test_ocp_runtime_{{{ OCPCMDOPTIONID }}}" />
+    </criteria>
+  </definition>
+  <unix:process58_test check="all" comment="ocp process runtime parameter {{{ OCPCMDOPTION }}} set to {{{ OCPCMDVAL }}}" id="test_ocp_runtime_{{{ OCPCMDOPTIONID }}}" version="1">
+    <unix:object object_ref="object_ocp_runtime_{{{ OCPCMDOPTIONID }}}" />
+    <unix:state state_ref="state_ocp_runtime_{{{ OCPCMDOPTIONID }}}" />
+  </unix:process58_test>
+  <unix:process58_object id="object_ocp_runtime_{{{ OCPCMDOPTIONID }}}" version="1">
+    <unix:command_line operation="pattern match">^{{{ OCPPROCESS }}}.*$</unix:command_line>
+    <unix:pid datatype="int" operation="greater than">0</unix:pid>
+  </unix:process58_object>
+  <unix:process58_state id="state_ocp_runtime_{{{ OCPCMDOPTIONID }}}" version="1">
+    <unix:command_line operation="pattern match">^.*[\s]+{{{ OCPCMDOPTION }}}={{{ OCPCMDVAL }}}([\s]+.*$|$)</unix:command_line>
+  </unix:process58_state>
+</def-group>

--- a/ssg/build_templates.py
+++ b/ssg/build_templates.py
@@ -29,6 +29,7 @@ from create_audit_rules_usergroup_modification import AuditRulesUserGroupModific
 from create_audit_rules_execution import AuditRulesExecutionGenerator
 from create_audit_rules_path_syscall import AuditRulesPathSyscallGenerator
 from create_grub2_bootloader_argument import GRUB2BootloaderArgumentGenerator
+from create_ocp_service_runtime_config import OCPServiceRuntimeConfigGenerator
 
 
 class Builder(object):
@@ -76,6 +77,7 @@ class Builder(object):
             "audit_rules_execution.csv":        AuditRulesExecutionGenerator(),
             "audit_rules_path_syscall.csv":        AuditRulesPathSyscallGenerator(),
             "grub2_bootloader_argument.csv":        GRUB2BootloaderArgumentGenerator(),
+            "ocp_service_runtime_config.csv":        OCPServiceRuntimeConfigGenerator(),
         }
         self.langs = TEMPLATED_LANGUAGES
         utils_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
#### Description:

- Adds OVAL template for checking `ps -ef` ocp process configuration options. For example,

```
$ ps -ef | grep hyperkube | grep anonymous-auth

root     15243     1  5 Sep24 ?        1-00:38:17 /usr/bin/hyperkube kubelet --v=2 --address=0.0.0.0 --allow-privileged=true --anonymous-auth=true --authentication-token-webhook=true --authentication-token-webhook-cache-ttl=5m --authorization-mode=Webhook --authorization-webhook-cache-authorized-ttl=5m --authorization-webhook-cache-unauthorized-ttl=5m --bootstrap-kubeconfig=/etc/origin/node/bootstrap.kubeconfig --cadvisor-port=0 --cert-dir=/etc/origin/node/certificates --cgroup-driver=systemd --client-ca-file=/etc/origin/node/client-ca.crt --cluster-dns=10.10.93.6 --cluster-domain=cluster.local --container-runtime-endpoint=/var/run/dockershim.sock --containerized=false --enable-controller-attach-detach=true --experimental-dockershim-root-directory=/var/lib/dockershim --fail-swap-on=false --feature-gates=RotateKubeletClientCertificate=true,RotateKubeletServerCertificate=true --file-check-frequency=0s --healthz-bind-address= --healthz-port=0 --host-ipc-sources=api --host-ipc-sources=file --host-network-sources=api --host-network-sources=file --host-pid-sources=api --host-pid-sources=file --hostname-override= --http-check-frequency=0s --image-service-endpoint=/var/run/dockershim.sock --iptables-masquerade-bit=0 --kubeconfig=/etc/origin/node/node.kubeconfig --max-pods=250 --network-plugin=cni --node-ip= --node-labels=node-role.kubernetes.io/master=true --pod-infra-container-image=registry.access.redhat.com/openshift3/ose-pod:v3.10.34 --pod-manifest-path=/etc/origin/node/pods --port=10250 --read-only-port=0 --register-node=true --root-dir=/var/lib/origin/openshift.local.volumes --rotate-certificates=true --tls-cert-file= --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA --tls-cipher-suites=TLS_RSA_WITH_AES_128_GCM_SHA256 --tls-cipher-suites=TLS_RSA_WITH_AES_256_GCM_SHA384 --tls-cipher-suites=TLS_RSA_WITH_AES_128_CBC_SHA --tls-cipher-suites=TLS_RSA_WITH_AES_256_CBC_SHA --tls-min-version=VersionTLS12 --tls-private-key-file=
```

