### PR TITLE
Improve SSG Test Suite. [WIP]

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,7 @@ ssh on the libvirt domain and have Ansible installed on the host machine.
 
 1. Install domain, using provided kickstart
 
-   To install the domain via graphical install, supply boot option:  
+   To install the domain via graphical install, supply boot option:
    `inst.ks=https://raw.githubusercontent.com/ComplianceAsCode/content/master/tests/kickstarts/rhel_centos_7.cfg`.
    And the installation will be guided by the kickstart.
 
@@ -214,10 +214,15 @@ The rule tests results are saved as `results.json` into the corresponding log di
 You can then analyze those results by running e.g.
 
 ```
-python analyze_results.py $(find . -name results.json)
+python analyze_results_rule.py $(find . -name results.json | grep rule)
 ```
 
 The tool will print some general statistics and it will give you more detailed information about
 scenarios that yielded different results.
 Sometimes, different results may have been caused by different test environments, whereas sometimes
 the security content is different, and those scans can be identified by respective scanning dates only.
+
+For examining profile-based results, use the `analyze_results_profile.py` script.
+
+If you supply only one result `.json` file to either of the utilities, they will print
+a human-readable summary of the test run.

--- a/tests/analyze_results_profile.py
+++ b/tests/analyze_results_profile.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import json
+import collections
+import argparse
+
+from ssg_test_suite import common
+
+
+set_dict = collections.defaultdict(set)
+
+
+def aggregate_results_by_scenarios(rule_results):
+    aggregated = collections.defaultdict(list)
+    for result in rule_results:
+        aggregated[result.run].append(result)
+    return aggregated
+
+
+def parse_args():
+    parser = argparse.ArgumentParser("Profile-based scan result analysis/comparison.")
+    parser.add_argument("json_results", nargs="+")
+    parser.add_argument("--stage")
+    return parser.parse_args()
+
+
+def summarize_results(results, aggregated_results):
+    rules_that_ended_by_success = 0
+    for r in results:
+        if r.success:
+            rules_that_ended_by_success += 1
+
+    msg = ("Analyzed {total_count} rules. Of those, "
+           "{success_count} were not a failiure of some kind.\n"
+           .format(total_count=len(results),
+                   success_count=rules_that_ended_by_success))
+    print(msg)
+
+    for stage, results in aggregated_results.items():
+        msg = "*** {stage} ***".format(stage=stage)
+        print(msg)
+
+        for status, rules in results.items():
+            msg = ("{status}: {count}\t"  # {rules}"
+                   .format(status=status, count=len(rules), rules=" ".join(rules)))
+            print(msg)
+        print()
+
+
+def summarize_differences(ar1, ar2, stage=None):
+    if stage:
+        stages = [stage]
+    else:
+        stages = ar1.keys()
+
+    for stage in stages:
+        results1 = ar1[stage]
+        results2 = ar2[stage]
+
+        status_by_rules2 = dict()
+        for status, rules2 in results2.items():
+            for r in rules2:
+                status_by_rules2[r] = status
+
+        msg = "*** stage {stage} ***".format(stage=stage)
+        print(msg)
+
+        for status, rules1 in results1.items():
+            rules2 = results2[status]
+
+            rules_of_different_status = rules1.difference(rules2)
+            new_status_by_rules = {r: status_by_rules2[r] for r in rules_of_different_status}
+
+            msg = ("{status}: {num_changed} changed the status:"
+                   .format(status=status, num_changed=len(new_status_by_rules)))
+            print(msg)
+
+            for r, new in new_status_by_rules.items():
+                msg = "\t- {rid} -> {new}".format(rid=r, new=new)
+                print(msg)
+        print()
+
+
+def aggregate_results_by_stage(rules):
+    aggregated_results = dict(
+        initial_scan=collections.defaultdict(set),
+        final_scan=collections.defaultdict(set))
+
+    for r in rules:
+        rule_stem = common.shorten_rule_id(r.run.rule_id)
+        for stage, status in r.passed_stages.items():
+            if stage in aggregated_results:
+                aggregated_results[stage][status].add(rule_stem)
+
+    return aggregated_results
+
+
+def analyze_results(json_results, stage):
+    results = [json.load(open(fname, "r")) for fname in json_results]
+    rules = [[common.ProfileResult(r) for r in r_list] for r_list in results]
+    ar = [aggregate_results_by_stage(r) for r in rules]
+
+    if len(ar) == 2:
+        summarize_differences(ar[0], ar[1], stage)
+    elif len(ar) == 1:
+        summarize_results(rules[0], ar[0])
+
+
+def main():
+    args = parse_args()
+    analyze_results(args.json_results, args.stage)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -3,13 +3,14 @@ import subprocess
 from collections import namedtuple
 import enum
 import functools
+import re
 
 
-Scenario_run = namedtuple(
-    "Scenario_run",
-    ("rule_id", "script"))
-Scenario_conditions = namedtuple(
-    "Scenario_conditions",
+Run_id = namedtuple(
+    "Run_id",
+    ("rule_id", "name"))
+Run_conditions = namedtuple(
+    "Run_conditions",
     ("backend", "scanning_mode", "remediated_by", "datastream"))
 
 
@@ -27,12 +28,9 @@ class Stage(enum.IntEnum):
     FINAL_SCAN = 4
 
 
-@functools.total_ordering
-class RuleResult(object):
+class ResultBase(object):
     STAGE_STRINGS = {
-        "preparation",
         "initial_scan",
-        "remediation",
         "final_scan",
     }
 
@@ -42,8 +40,8 @@ class RuleResult(object):
     Supports ordering by success - the most successful run orders first.
     """
     def __init__(self, result_dict=None):
-        self.scenario = Scenario_run("", "")
-        self.conditions = Scenario_conditions("", "", "", "")
+        self.run = Run_id("", "")
+        self.conditions = Run_conditions("", "", "", "")
         self.when = ""
         self.passed_stages = dict()
         self.passed_stages_count = 0
@@ -53,25 +51,18 @@ class RuleResult(object):
             self.load_from_dict(result_dict)
 
     def load_from_dict(self, data):
-        self.scenario = Scenario_run(data["rule_id"], data["scenario_script"])
-        self.conditions = Scenario_conditions(
-            data["backend"], data["scanning_mode"],
-            data["remediated_by"], data["datastream"])
+        self.run = Run_id(data["rule_id"], self.get_run_name(data))
+
+        self.conditions = Run_conditions(
+            backend=data["backend"], scanning_mode=data["scanning_mode"],
+            remediated_by=data["remediated_by"], datastream=data["datastream"])
         self.when = data["run_timestamp"]
 
-        self.passed_stages = {key: data[key] for key in self.STAGE_STRINGS if key in data}
-        self.passed_stages_count = sum(self.passed_stages.values())
-
-        self.success = data.get("final_scan", False)
-        if not self.success:
-            self.success = (
-                "remediation" not in data
-                and data.get("initial_scan", False))
+        self.analyze_success(data)
 
     def save_to_dict(self):
         data = dict()
-        data["rule_id"] = self.scenario.rule_id
-        data["scenario_script"] = self.scenario.script
+        data["rule_id"] = self.run.rule_id
 
         data["backend"] = self.conditions.backend
         data["scanning_mode"] = self.conditions.scanning_mode
@@ -106,6 +97,59 @@ class RuleResult(object):
         return self.passed_stages_count > other.passed_stages_count
 
 
+@functools.total_ordering
+class ProfileResult(ResultBase):
+    def get_run_name(self, data):
+        return data["profile"]
+
+    def analyze_success(self, data):
+        successes = ("pass", "fixed", "notselected")
+        self.passed_stages = {key: data[key] for key in self.STAGE_STRINGS if key in data}
+        self.passed_stages_count = sum(
+            [1 for val in self.passed_stages.values() if val in successes])
+
+        self.success = data.get("final_scan", False)
+        if not self.success:
+            self.success = (
+                "remediation" not in data
+                and data.get("initial_scan", False))
+
+        self.success = self.success in successes
+
+    def save_to_dict(self):
+        data = super(ProfileResult, self).save_to_dict()
+        data["profile"] = self.run.name
+        return data
+
+
+@functools.total_ordering
+class RuleResult(ResultBase):
+    STAGE_STRINGS = {
+        "preparation",
+        "initial_scan",
+        "remediation",
+        "final_scan",
+    }
+
+    def get_run_name(self, data):
+        return data["scenario_script"]
+
+    def analyze_success(self, data):
+        self.passed_stages = {key: data[key] for key in self.STAGE_STRINGS if key in data}
+        self.passed_stages_count = sum(self.passed_stages.values())
+
+        self.success = data.get("final_scan", False)
+        if not self.success:
+            self.success = (
+                "remediation" not in data
+                and data.get("initial_scan", False))
+
+    def save_to_dict(self):
+        data = super(RuleResult, self).save_to_dict()
+        data["scenario_script"] = self.run.name
+        return data
+
+
 def run_cmd_local(command, verbose_path, env=None):
     command_string = ' '.join(command)
     logging.debug('Running {}'.format(command_string))
@@ -132,3 +176,11 @@ def _run_cmd(command_list, verbose_path, env=None):
         returncode = e.returncode
         output = e.output
     return returncode, output.decode('utf-8')
+
+
+def shorten_rule_id(rule_id):
+    rule_stem = re.sub("xccdf_org.ssgproject.content_rule_(.+)", r"\1", rule_id)
+    assert len(rule_stem) < len(rule_id), (
+        "The rule ID '{rule_id}' has a strange form, as it doesn't have "
+        "the common rule prefix.".format(rule_id=rule_id))
+    return rule_stem

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -286,9 +286,9 @@ class GenericRunner(object):
         self.command_options.extend([
             '--benchmark-id', self.benchmark_id,
             '--profile', self.profile,
-            '--verbose', 'DEVEL',
             '--progress', '--oval-results',
         ])
+        #   '--verbose', 'DEVEL',  # Has been taken away, as it is incompatible between oscap 1.2 and 1.3
         self.command_operands.append(self.datastream)
 
     def run_stage(self, stage):
@@ -304,11 +304,11 @@ class GenericRunner(object):
         self.command_operands = []
 
         result = None
-        if stage == 'initial':
+        if stage == 'initial_scan':
             result = self.initial()
         elif stage == 'remediation':
             result = self.remediation()
-        elif stage == 'final':
+        elif stage == 'final_scan':
             result = self.final()
         else:
             raise RuntimeError('Unknown stage: {}.'.format(stage))

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -2,11 +2,15 @@
 from __future__ import print_function
 
 import logging
-
+import os
+import json
 
 import ssg_test_suite.oscap
 import ssg_test_suite.virt
+from ssg_test_suite import common
+from ssg_test_suite import xml_operations
 from ssg_test_suite.rule import get_viable_profiles
+from ssg_test_suite.log import LogHelper
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -23,15 +27,54 @@ class ProfileChecker(ssg_test_suite.oscap.Checker):
         self.run_test_for_all_profiles(profiles)
 
     def _run_test(self, profile, test_data):
+        self.results = {}
+
         logging.info("Evaluation of profile {0}.".format(profile))
         self.executed_tests += 1
 
         runner_cls = ssg_test_suite.oscap.REMEDIATION_PROFILE_RUNNERS[self.remediate_using]
         runner = runner_cls(
             self.test_env, profile, self.datastream, self.benchmark_id)
+        results_file = runner.results_path
 
-        for stage in ("initial", "remediation", "final"):
+        stage = "initial_scan"
+        result = runner.run_stage(stage)
+        results = xml_operations.get_rule_results_from_profile_result_file(runner.results_path)
+
+        self.define_current_results_with_stage(profile, stage, results)
+
+        for stage in ("remediation", "final_scan"):
             result = runner.run_stage(stage)
+
+        # Normally, the results are in the final stage, but oscap final scan may be skipped
+        # by the oscap remediation
+        stage_with_final_results = stage
+        # There may be no results for remediation (consider e.g. Ansible remediation),
+        # so for results, we go for the final scan.
+        results = xml_operations.get_rule_results_from_profile_result_file(runner.results_path)
+        self.update_current_results_with_stage(stage_with_final_results, results)
+
+        self.results = [r.save_to_dict() for r in self.results.values()]
+        with open(os.path.join(LogHelper.LOG_DIR, "results.json"), "w") as f:
+            json.dump(self.results, f)
+
+        return result
+
+    def define_current_results_with_stage(self, profile, stage, results):
+        for rid, value in results.items():
+            self.results[rid] = common.ProfileResult()
+            self.results[rid].scenario = common.Run_id(rid, profile)
+            self.results[rid].conditions = common.Run_conditions(
+                backend=self.test_env.name, scanning_mode=self.test_env.scanning_mode,
+                remediated_by=self.remediate_using, datastream=self.datastream)
+            self.results[rid].when = self.test_timestamp_str
+
+        self.update_current_results_with_stage(stage, results)
+
+    def update_current_results_with_stage(self, stage, results):
+        for rid, value in results.items():
+            rule_result = value
+            self.results[rid].record_stage_result(stage, rule_result)
 
 
 def perform_profile_check(options):

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -218,7 +218,7 @@ class RuleChecker(ssg_test_suite.oscap.Checker):
         return self._final_scan_went_ok(runner, rule_id)
 
     def _initial_scan_went_ok(self, runner, rule_id, context):
-        success = runner.run_stage_with_context("initial", context)
+        success = runner.run_stage_with_context("initial_scan", context)
         self._current_result.record_stage_result("initial_scan", success)
         if not success:
             msg = ("The initial scan failed for rule '{}'."
@@ -244,7 +244,7 @@ class RuleChecker(ssg_test_suite.oscap.Checker):
         return success
 
     def _final_scan_went_ok(self, runner, rule_id):
-        success = runner.run_stage_with_context('final', 'pass')
+        success = runner.run_stage_with_context('final_scan', 'pass')
         self._current_result.record_stage_result("final_scan", success)
         if not success:
             msg = ("The check after remediation failed for rule '{}'."
@@ -286,10 +286,11 @@ class RuleChecker(ssg_test_suite.oscap.Checker):
     def _check_and_record_rule_scenario(self, scenario, remote_rule_dir, rule_id):
         self._current_result = common.RuleResult()
 
-        self._current_result.conditions = common.Scenario_conditions(
-            self.test_env.name, self.test_env.scanning_mode,
-            self.remediate_using, self.datastream)
-        self._current_result.scenario = common.Scenario_run(rule_id, scenario.script)
+        self._current_result.conditions = common.Run_conditions(
+            backend=self.test_env.name, scanning_mode=self.test_env.scanning_mode,
+            remediated_by=self.remediate_using, datastream=self.datastream)
+        self._current_result.scenario = common.Run_id(
+            rule_id=rule_id, name=scenario.script)
         self._current_result.when = self.test_timestamp_str
 
         self._check_rule_scenario(scenario, remote_rule_dir, rule_id)

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -142,11 +142,3 @@ def determine_ip(domain):
                 if ipaddr['type'] == libvirt.VIR_IP_ADDR_TYPE_IPV4:
                     logging.debug('IP address is {0}'.format(ipaddr['addr']))
                     return ipaddr['addr']
-
-
-def start_domain(domain):
-    if not domain.isActive():
-        logging.debug("Starting domain '{0}'".format(domain.name()))
-        domain.create()
-        logging.debug('Waiting 30s for domain to start')
-        time.sleep(30)

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -13,6 +13,19 @@ NAMESPACES = {
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
+def get_rule_results_from_profile_result_file(profile_results):
+    all_results = {}
+
+    root = ET.parse(profile_results).getroot()
+    rule_results = root.findall("./xccdf:TestResult/xccdf:rule-result", NAMESPACES)
+    for r in rule_results:
+        rule_id = r.attrib["idref"]
+        result = r.getchildren()[0].text
+        all_results[rule_id] = result
+
+    return all_results
+
+
 def infer_benchmark_id_from_component_ref_id(datastream, ref_id):
     root = ET.parse(datastream).getroot()
     component_ref_node = root.find("*//ds:component-ref[@id='{0}']"

--- a/tests/unit/ssg_test_suite/test_analyze_results.py
+++ b/tests/unit/ssg_test_suite/test_analyze_results.py
@@ -4,7 +4,8 @@ import os
 import pytest
 
 from ssg_test_suite import common
-import analyze_results as analyze
+import analyze_results_rule as analyze_rule
+import analyze_results_rule as analyze_profile
 
 
 @pytest.fixture
@@ -32,14 +33,14 @@ def test_success(raw_results):
 
 
 def test_aggregation(results_list):
-    aggregated = analyze.aggregate_results_by_scenarios(results_list)
+    aggregated = analyze_rule.aggregate_results_by_scenarios(results_list)
     assert len(aggregated) == 3
 
 
 def test_differences(different_results):
     assert sorted(different_results)[0].success
 
-    difference = analyze.analyze_differences(different_results)
+    difference = analyze_rule.analyze_differences(different_results)
     assert difference.why_failed == "remediation"
 
 


### PR DESCRIPTION
The SSG Test Suite results analysis has been expanded.

- Profile test runs analysis has been introduced.
- Single test result analysis (summary) has been introduced both for rule and profile test runs.
- Offline libvirt-based scan has been enabled.

As a result, code needed to be refactored:
- Renamed `Scenario_run` to `Run_id`, as the data structure stores rule ID and `name` of the run (was: `script`).
- Renamed stage `initial` to `initial_scan` and `final` to `final_scan`, so they are more descriptive and consistent with the analysis code.
- Extracted the common functionality of a result class to a base class of `RuleResult` and `ProfileResult`.