### PR TITLE
Add ol7 audit_rules_privileged_commands template rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - at'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chage'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chsh'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - crontab'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - gpasswd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - mount'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newgrp'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pam_timestamp_check'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - passwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postdrop'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postqueue'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - ssh-keysign'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - su'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudo'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudoedit'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - umount'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix_chkpwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd> Collects Information on the Use of Privileged Commands - userhelper'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - usernetctl'
 

--- a/ol7/profiles/standard.profile
+++ b/ol7/profiles/standard.profile
@@ -23,3 +23,22 @@ selections:
     - accounts_password_all_shadowed
     - mount_option_dev_shm_nodev
     - mount_option_dev_shm_nosuid
+    - audit_rules_privileged_commands_at
+    - audit_rules_privileged_commands_chage
+    - audit_rules_privileged_commands_chsh
+    - audit_rules_privileged_commands_crontab
+    - audit_rules_privileged_commands_gpasswd
+    - audit_rules_privileged_commands_mount
+    - audit_rules_privileged_commands_newgrp
+    - audit_rules_privileged_commands_pam_timestamp_check
+    - audit_rules_privileged_commands_passwd
+    - audit_rules_privileged_commands_postdrop
+    - audit_rules_privileged_commands_postqueue
+    - audit_rules_privileged_commands_ssh_keysign
+    - audit_rules_privileged_commands_su
+    - audit_rules_privileged_commands_sudo
+    - audit_rules_privileged_commands_sudoedit
+    - audit_rules_privileged_commands_umount
+    - audit_rules_privileged_commands_unix_chkpwd
+    - audit_rules_privileged_commands_userhelper
+    - audit_rules_privileged_commands_usernetctl

--- a/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
+++ b/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/shared/templates/template_BASH_audit_rules_privileged_commands
+++ b/shared/templates/template_BASH_audit_rules_privileged_commands
@@ -1,9 +1,9 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-PATTERN="-a always,exit -F path={{{ PATH }}}\\s*.*"
+PATTERN="-a always,exit -F path={{{ PATH }}}\\s\\+.*"
 GROUP="privileged"
 FULL_RULE="-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Audit rules about the information on the use of {{{ NAME }}} is enabled.</description>
     </metadata>


### PR DESCRIPTION
#### Description:

- Added ol7 support to audit_rules_privileged_commands template rules.
- Fixed BASH template to make pattern less greedy: handled sudoedit, sudo and su case where only su rule is finally available - replaced "<PATH>\s*" with "<PATH>\s\\+"
- Extended ol7 'standard' profile to include enabled audit rules.

Testing successful on Oracle Linux 7

Upd: github description escaping issue - updated "\\+" as github editor doesn't show single "\\" when comment is published.