### PR TITLE
Extend set of ol7 standard service rules

### DIFF
--- a/linux_os/guide/services/base/group.yml
+++ b/linux_os/guide/services/base/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Base Services'
 

--- a/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
+prodtype: rhel6,rhel7,ol7
 
 title: 'Disable Automatic Bug Reporting Tool (abrtd)'
 

--- a/linux_os/guide/services/base/service_ntpdate_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_ntpdate_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
+prodtype: rhel6,rhel7,ol7
 
 title: 'Disable ntpdate Service (ntpdate)'
 

--- a/linux_os/guide/services/base/service_oddjobd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_oddjobd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
+prodtype: rhel6,rhel7,ol7
 
 title: 'Disable Odd Job Daemon (oddjobd)'
 

--- a/linux_os/guide/services/base/service_rdisc_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rdisc_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7
+prodtype: rhel6,rhel7,ol7
 
 title: 'Disable Network Router Discovery Daemon (rdisc)'
 

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/rule.yml
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Disable At Service (atd)'
 

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7,multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 if ! `rpm -q --quiet chrony` && ! `rpm -q --quiet ntp-`; then

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>At least one of the chronyd or ntpd services should be enabled if possible.</description>
     </metadata>

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Enable the NTP Daemon'
 
@@ -12,7 +12,11 @@ description: |-
     Note: The <tt>ntpd</tt> daemon is not enabled by default. Though as mentioned
     in the previous sections in certain environments the <tt>ntpd</tt> daemon might
     be preferred to be used rather than the <tt>chronyd</tt> one. Refer to:
-    {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+    {{% if product == "ol7" %}}
+        {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-nettime.html") }}}
+    {{% else %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+    {{% endif %}}
     for guidance which NTP daemon to choose depending on the environment used.
 
 rationale: |-

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Disable the Automounter'
 

--- a/ol7/templates/csv/packages_installed.csv
+++ b/ol7/templates/csv/packages_installed.csv
@@ -1,7 +1,9 @@
 aide
 audit
-openssh-server
-uuidd
+chrony
 glibc,0:2.17-55.0.4.el7_0.3
 libreswan
+ntp
+openssh-server
 rsyslog
+uuidd

--- a/ol7/templates/csv/packages_removed.csv
+++ b/ol7/templates/csv/packages_removed.csv
@@ -1,4 +1,12 @@
+abrt
+at
+autofs
+iputils
 net-snmp
+ntpdate
+oddjob
 openssh-server
+rsh
+rsh-server
 ypbind
 ypserv

--- a/ol7/templates/csv/services_disabled.csv
+++ b/ol7/templates/csv/services_disabled.csv
@@ -1,4 +1,10 @@
 # service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+abrtd,abrt,
+atd,at,
+autofs,autofs,
+ntpdate,ntpdate,
+oddjobd,oddjob,
+rdisc,iputils,
 sshd,openssh-server,
-rlogin,,
+rlogin,rsh-server,
 rsh,,

--- a/ol7/templates/csv/services_enabled.csv
+++ b/ol7/templates/csv/services_enabled.csv
@@ -1,1 +1,4 @@
 auditd,audit,
+chronyd,chrony,
+ntpd,ntp,
+rsyslog,rsyslog,


### PR DESCRIPTION
#### Description:

Enabled service rules applicable to ol7 standard and pci-dss profiles.

Testing successful on Oracle Linux 7

PS:  It was a bit tricky to investigate why linux_os/guide/services/base rules not included in generated xccdf - resolved adding ol7 prodtype in corresponding group.yml. Probably it would make sense to add build warning if child item blocked by parent prodtype limitation.
