### PR TITLE
Add OL7 account rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 6, Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_unix_remember
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The passwords to remember should be set correctly.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -1,10 +1,25 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Limit Password Reuse'
 
-description: "Do not allow users to reuse recent passwords. This can be\naccomplished by using the <tt>remember</tt> option for the <tt>pam_unix</tt>\nor <tt>pam_pwhistory</tt> PAM modules. \n<br /><br />\nIn the file <tt>/etc/pam.d/system-auth</tt>, append <tt>remember=<sub idref=\"var_password_pam_unix_remember\" /></tt>\nto the line which refers to the <tt>pam_unix.so</tt> or <tt>pam_pwhistory.so</tt>module, as shown below:\n<ul>\n<li>for the <tt>pam_unix.so</tt> case:\n<pre>password sufficient pam_unix.so <i>...existing_options...</i> remember=<sub idref=\"var_password_pam_unix_remember\" /></pre>\n</li>\n<li>for the <tt>pam_pwhistory.so</tt> case:\n<pre>password requisite pam_pwhistory.so <i>...existing_options...</i> remember=<sub idref=\"var_password_pam_unix_remember\" /></pre>\n</li>\n</ul>\nThe DoD STIG requirement is 5 passwords."
+description: |-
+    Do not allow users to reuse recent passwords. This can be
+    accomplished by using the <tt>remember</tt> option for the <tt>pam_unix</tt>
+    or <tt>pam_pwhistory</tt> PAM modules.
+    <br /><br />
+    In the file <tt>/etc/pam.d/system-auth</tt>, append <tt>remember=<sub idref="var_password_pam_unix_remember" /></tt>
+    to the line which refers to the <tt>pam_unix.so</tt> or <tt>pam_pwhistory.so</tt>module, as shown below:
+    <ul>
+    <li>for the <tt>pam_unix.so</tt> case:
+    <pre>password sufficient pam_unix.so <i>...existing_options...</i> remember=<sub idref="var_password_pam_unix_remember" /></pre>
+    </li>
+    <li>for the <tt>pam_pwhistory.so</tt> case:
+    <pre>password requisite pam_pwhistory.so <i>...existing_options...</i> remember=<sub idref="var_password_pam_unix_remember" /></pre>
+    </li>
+    </ul>
+    The DoD STIG requirement is 5 passwords.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_passwords_pam_faillock_deny
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Set Deny For Failed Password Attempts'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_passwords_pam_faillock_unlock_time
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Set Lockout Time For Failed Password Attempts'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -1,12 +1,27 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Strength Minimum Digit Characters'
 
-description: "The pam_pwquality module's <tt>dcredit</tt> parameter controls requirements for\nusage of digits in a password. When set to a negative number, any password will be required to\ncontain that many digits. When set to a positive number, pam_pwquality will grant +1 additional\nlength credit for each digit. Modify the <tt>dcredit</tt> setting in \n<tt>/etc/security/pwquality.conf</tt> to require the use of a digit in passwords."
+description: |-
+    The pam_pwquality module's <tt>dcredit</tt> parameter controls requirements for
+    usage of digits in a password. When set to a negative number, any password will be required to
+    contain that many digits. When set to a positive number, pam_pwquality will grant +1 additional
+    length credit for each digit. Modify the <tt>dcredit</tt> setting in
+    <tt>/etc/security/pwquality.conf</tt> to require the use of a digit in passwords.
 
-rationale: "Use of a complex password helps to increase the time and resources required\nto compromise the password. Password complexity, or strength, is a measure of\nthe effectiveness of a password in resisting attempts at guessing and brute-force\nattacks. \n<br /><br />\nPassword complexity is one factor of several that determines how long it takes\nto crack a password. The more complex the password, the greater the number of \npossble combinations that need to be tested before the password is compromised.\nRequiring digits makes password guessing attacks more difficult by ensuring a larger\nsearch space."
+rationale: |-
+    Use of a complex password helps to increase the time and resources required
+    to compromise the password. Password complexity, or strength, is a measure of
+    the effectiveness of a password in resisting attempts at guessing and brute-force
+    attacks.
+    <br /><br />
+    Password complexity is one factor of several that determines how long it takes
+    to crack a password. The more complex the password, the greater the number of
+    possible combinations that need to be tested before the password is compromised.
+    Requiring digits makes password guessing attacks more difficult by ensuring a larger
+    search space.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
@@ -1,12 +1,31 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Strength Minimum Different Characters'
 
-description: "The pam_pwquality module's <tt>difok</tt> parameter sets the number of characters\nin a password that must not be present in and old password during a password change. \n<br /><br />\nModify the <tt>difok</tt> setting in <tt>/etc/security/pwquality.conf</tt>\nto equal <sub idref=\"var_password_pam_difok\" /> to require differing characters \nwhen changing passwords."
+description: |-
+    The pam_pwquality module's <tt>difok</tt> parameter sets the number of characters
+    in a password that must not be present in and old password during a password change.
+    <br /><br />
+    Modify the <tt>difok</tt> setting in <tt>/etc/security/pwquality.conf</tt>
+    to equal <sub idref="var_password_pam_difok" /> to require differing characters
+    when changing passwords.
 
-rationale: "Use of a complex password helps to increase the time and resources \nrequired to compromise the password. Password complexity, or strength, \nis a measure of the effectiveness of a password in resisting attempts \nat guessing and brute–force attacks.\n<br /><br />\nPassword complexity is one factor of several that determines how long \nit takes to crack a password. The more complex the password, the \ngreater the number of possible combinations that need to be tested \nbefore the password is compromised.\n<br /><br />\nRequiring a minimum number of different characters during password changes ensures that\nnewly changed passwords should not resemble previously compromised ones.\nNote that passwords which are changed on compromised systems will still be compromised, however."
+rationale: |-
+    Use of a complex password helps to increase the time and resources
+    required to compromise the password. Password complexity, or strength,
+    is a measure of the effectiveness of a password in resisting attempts
+    at guessing and brute–force attacks.
+    <br /><br />
+    Password complexity is one factor of several that determines how long
+    it takes to crack a password. The more complex the password, the
+    greater the number of possible combinations that need to be tested
+    before the password is compromised.
+    <br /><br />
+    Requiring a minimum number of different characters during password changes ensures that
+    newly changed passwords should not resemble previously compromised ones.
+    Note that passwords which are changed on compromised systems will still be compromised, however.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -1,12 +1,27 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Strength Minimum Lowercase Characters'
 
-description: "The pam_pwquality module's <tt>lcredit</tt> parameter controls requirements for\nusage of lowercase letters in a password. When set to a negative number, any password will be required to\ncontain that many lowercase characters. When set to a positive number, pam_pwquality will grant +1 additional\nlength credit for each lowercase character. Modify the <tt>lcredit</tt> setting in \n<tt>/etc/security/pwquality.conf</tt> to require the use of a lowercase character in passwords."
+description: |-
+    The pam_pwquality module's <tt>lcredit</tt> parameter controls requirements for
+    usage of lowercase letters in a password. When set to a negative number, any password will be required to
+    contain that many lowercase characters. When set to a positive number, pam_pwquality will grant +1 additional
+    length credit for each lowercase character. Modify the <tt>lcredit</tt> setting in
+    <tt>/etc/security/pwquality.conf</tt> to require the use of a lowercase character in passwords.
 
-rationale: "Use of a complex password helps to increase the time and resources required\nto compromise the password. Password complexity, or strength, is a measure of\nthe effectiveness of a password in resisting attempts at guessing and brute-force\nattacks. \n<br /><br />\nPassword complexity is one factor of several that determines how long it takes\nto crack a password. The more complex the password, the greater the number of \npossble combinations that need to be tested before the password is compromised.\nRequiring a minimum number of lowercase characters makes password guessing attacks\nmore difficult by ensuring a larger search space."
+rationale: |-
+    Use of a complex password helps to increase the time and resources required
+    to compromise the password. Password complexity, or strength, is a measure of
+    the effectiveness of a password in resisting attempts at guessing and brute-force
+    attacks.
+    <br /><br />
+    Password complexity is one factor of several that determines how long it takes
+    to crack a password. The more complex the password, the greater the number of
+    possble combinations that need to be tested before the password is compromised.
+    Requiring a minimum number of lowercase characters makes password guessing attacks
+    more difficult by ensuring a larger search space.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password to Maximum of Consecutive Repeating Characters from Same Character Class'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
@@ -1,12 +1,26 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Maximum Consecutive Repeating Characters'
 
-description: "The pam_pwquality module's <tt>maxrepeat</tt> parameter controls requirements for\nconsecutive repeating characters. When set to a positive number, it will reject passwords\nwhich contain more than that number of consecutive characters. Modify the <tt>maxrepeat</tt> setting\nin <tt>/etc/security/pwquality.conf</tt> to equal <sub idref=\"var_password_pam_maxrepeat\" /> to prevent a \nrun of (<sub idref=\"var_password_pam_maxrepeat\" /> + 1) or more identical characters."
+description: |-
+    The pam_pwquality module's <tt>maxrepeat</tt> parameter controls requirements for
+    consecutive repeating characters. When set to a positive number, it will reject passwords
+    which contain more than that number of consecutive characters. Modify the <tt>maxrepeat</tt> setting
+    in <tt>/etc/security/pwquality.conf</tt> to equal <sub idref="var_password_pam_maxrepeat" /> to prevent a
+    run of (<sub idref="var_password_pam_maxrepeat" /> + 1) or more identical characters.
 
-rationale: "Use of a complex password helps to increase the time and resources required to compromise the password. \nPassword complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at \nguessing and brute-force attacks.\n<br /><br />\nPassword complexity is one factor of several that determines how long it takes to crack a password. The more\ncomplex the password, the greater the number of possible combinations that need to be tested before the\npassword is compromised.\n<br /><br />\nPasswords with excessive repeating characters may be more vulnerable to password-guessing attacks."
+rationale: |-
+    Use of a complex password helps to increase the time and resources required to compromise the password.
+    Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at
+    guessing and brute-force attacks.
+    <br /><br />
+    Password complexity is one factor of several that determines how long it takes to crack a password. The more
+    complex the password, the greater the number of possible combinations that need to be tested before the
+    password is compromised.
+    <br /><br />
+    Passwords with excessive repeating characters may be more vulnerable to password-guessing attacks.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
@@ -1,12 +1,38 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Strength Minimum Different Categories'
 
-description: "The pam_pwquality module's <tt>minclass</tt> parameter controls\nrequirements for usage of different character classes, or types, of character\nthat must exist in a password before it is considered valid. For example,\nsetting this value to three (3) requires that any password must have characters\nfrom at least three different categories in order to be approved. The default\nvalue is zero (0), meaning there are no required classes. There are four\ncategories available:\n<pre>\n* Upper-case characters\n* Lower-case characters\n* Digits\n* Special characters (for example, punctuation)\n</pre>\nModify the <tt>minclass</tt> setting in <tt>/etc/security/pwquality.conf</tt> entry to require <sub idref=\"var_password_pam_minclass\" /> \ndiffering categories of characters when changing passwords."
+description: |-
+    The pam_pwquality module's <tt>minclass</tt> parameter controls
+    requirements for usage of different character classes, or types, of character
+    that must exist in a password before it is considered valid. For example,
+    setting this value to three (3) requires that any password must have characters
+    from at least three different categories in order to be approved. The default
+    value is zero (0), meaning there are no required classes. There are four
+    categories available:
+    <pre>
+    * Upper-case characters
+    * Lower-case characters
+    * Digits
+    * Special characters (for example, punctuation)
+    </pre>
+    Modify the <tt>minclass</tt> setting in <tt>/etc/security/pwquality.conf</tt> entry
+    to require <sub idref="var_password_pam_minclass" />
+    differing categories of characters when changing passwords.
 
-rationale: "Use of a complex password helps to increase the time and resources required to compromise the password.\nPassword complexity, or strength, is a measure of the effectiveness of a password in resisting attempts \nat guessing and brute-force attacks.\n<br /><br />\nPassword complexity is one factor of several that determines how long it takes to crack a password. The\nmore complex the password, the greater the number of possible combinations that need to be tested before\nthe password is compromised.\n<br /><br />\nRequiring a minimum number of character categories makes password guessing attacks more difficult \nby ensuring a larger search space."
+rationale: |-
+    Use of a complex password helps to increase the time and resources required to compromise the password.
+    Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts
+    at guessing and brute-force attacks.
+    <br /><br />
+    Password complexity is one factor of several that determines how long it takes to crack a password. The
+    more complex the password, the greater the number of possible combinations that need to be tested before
+    the password is compromised.
+    <br /><br />
+    Requiring a minimum number of character categories makes password guessing attacks more difficult
+    by ensuring a larger search space.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Minimum Length'
 
@@ -9,7 +9,16 @@ description: |-
     minimum characters required in a password. Add <tt>minlen=<sub idref="var_password_pam_minlen" /></tt>
     after pam_pwquality to set minimum password length requirements.
 
-rationale: "The shorter the password, the lower the number of possible combinations\nthat need to be tested before the password is compromised.\n<br />\nPassword complexity, or strength, is a measure of the effectiveness of a \npassword in resisting attempts at guessing and brute-force attacks. \nPassword length is one factor of several that helps to determine strength\nand how long it takes to crack a password. Use of more characters in a password\nhelps to exponentially increase the time and/or resources required to \ncompromose the password."
+rationale: |-
+    The shorter the password, the lower the number of possible combinations
+    that need to be tested before the password is compromised.
+    <br />
+    Password complexity, or strength, is a measure of the effectiveness of a
+    password in resisting attempts at guessing and brute-force attacks.
+    Password length is one factor of several that helps to determine strength
+    and how long it takes to crack a password. Use of more characters in a password
+    helps to exponentially increase the time and/or resources required to
+    compromose the password.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -1,12 +1,29 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Strength Minimum Special Characters'
 
-description: "The pam_pwquality module's <tt>ocredit=</tt> parameter controls requirements for\nusage of special (or \"other\") characters in a password. When set to a negative number, any password will be\nrequired to contain that many special characters. When set to a positive number, pam_pwquality will grant +1 \nadditional length credit for each special character. Modify the <tt>ocredit</tt> setting in \n<tt>/etc/security/pwquality.conf</tt> to equal <sub idref=\"var_password_pam_ocredit\" /> to require use of a special character in passwords."
+description: |-
+    The pam_pwquality module's <tt>ocredit=</tt> parameter controls requirements for
+    usage of special (or "other") characters in a password. When set to a negative number,
+    any password will be required to contain that many special characters. 
+    When set to a positive number, pam_pwquality will grant +1
+    additional length credit for each special character. Modify the <tt>ocredit</tt> setting
+    in <tt>/etc/security/pwquality.conf</tt> to equal <sub idref="var_password_pam_ocredit" />
+    to require use of a special character in passwords.
 
-rationale: "Use of a complex password helps to increase the time and resources required\nto compromise the password. Password complexity, or strength, is a measure of\nthe effectiveness of a password in resisting attempts at guessing and brute-force\nattacks. \n<br /><br />\nPassword complexity is one factor of several that determines how long it takes\nto crack a password. The more complex the password, the greater the number of \npossble combinations that need to be tested before the password is compromised.\nRequiring a minimum number of special characters makes password guessing attacks\nmore difficult by ensuring a larger search space."
+rationale: |-
+    Use of a complex password helps to increase the time and resources required
+    to compromise the password. Password complexity, or strength, is a measure of
+    the effectiveness of a password in resisting attempts at guessing and brute-force
+    attacks.
+    <br /><br />
+    Password complexity is one factor of several that determines how long it takes
+    to crack a password. The more complex the password, the greater the number of
+    possble combinations that need to be tested before the password is compromised.
+    Requiring a minimum number of special characters makes password guessing attacks
+    more difficult by ensuring a larger search space.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_retry
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_rhel-osp</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The password retry should meet minimum requirements</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Retry Prompts Permitted Per-Session'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set Password Strength Minimum Uppercase Characters'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_account_disable_post_pw_expiration
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The accounts should be configured to expire automatically following password expiration.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Set Account Expiration Following Inactivity'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/bash/rhel7.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/bash/rhel7.sh
@@ -1,9 +1,0 @@
-# platform = Red Hat Enterprise Linux 7
-. /usr/share/scap-security-guide/remediation_functions
-populate var_accounts_maximum_age_login_defs
-
-grep -q ^PASS_MAX_DAYS /etc/login.defs && \
-  sed -i "s/PASS_MAX_DAYS.*/PASS_MAX_DAYS     $var_accounts_maximum_age_login_defs/g" /etc/login.defs
-if ! [ $? -eq 0 ]; then
-    echo "PASS_MAX_DAYS      $var_accounts_maximum_age_login_defs" >> /etc/login.defs
-fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 6
+# platform = multi_platform_rhel, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_maximum_age_login_defs
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
@@ -2,9 +2,25 @@ documentation_complete: true
 
 title: 'Set Password Maximum Age'
 
-description: "To specify password maximum age for new accounts,\nedit the file <tt>/etc/login.defs</tt>\nand add or correct the following line:\n<pre>PASS_MAX_DAYS <sub idref=\"var_accounts_maximum_age_login_defs\" /></pre>\nA value of 180 days is sufficient for many environments. \nThe DoD requirement is 60.\nThe profile requirement is <tt><sub idref=\"var_accounts_maximum_age_login_defs\" /></tt>."
+description: |-
+    To specify password maximum age for new accounts,
+    edit the file <tt>/etc/login.defs</tt>
+    and add or correct the following line:
+    <pre>PASS_MAX_DAYS <sub idref="var_accounts_maximum_age_login_defs" /></pre>
+    A value of 180 days is sufficient for many environments.
+    The DoD requirement is 60.
+    The profile requirement is <tt><sub idref="var_accounts_maximum_age_login_defs" /></tt>.
 
-rationale: "Any password, no matter how complex, can eventually be cracked. Therefore, passwords\nneed to be changed periodically. If the operating system does not limit the lifetime\nof passwords and force users to change their passwords, there is the risk that the\noperating system passwords could be compromised. \n<br /><br />\nSetting the password maximum age ensures users are required to\nperiodically change their passwords. Requiring shorter password lifetimes\nincreases the risk of users writing down the password in a convenient\nlocation subject to physical compromise."
+rationale: |-
+    Any password, no matter how complex, can eventually be cracked. Therefore, passwords
+    need to be changed periodically. If the operating system does not limit the lifetime
+    of passwords and force users to change their passwords, there is the risk that the
+    operating system passwords could be compromised.
+    <br /><br />
+    Setting the password maximum age ensures users are required to
+    periodically change their passwords. Requiring shorter password lifetimes
+    increases the risk of users writing down the password in a convenient
+    location subject to physical compromise.
 
 severity: medium
 

--- a/ol7/templates/csv/accounts_password.csv
+++ b/ol7/templates/csv/accounts_password.csv
@@ -1,0 +1,14 @@
+# format:
+# <password_variable>,<operation>
+# - password_variable is the password parameter to evaluate
+# - operation is the comparison operation to perform in OVAL check
+
+dcredit,less than or equal
+difok,greater than or equal
+lcredit,less than or equal
+maxclassrepeat,less than or equal
+maxrepeat,less than or equal
+minclass,greater than or equal
+minlen,greater than or equal
+ocredit,less than or equal
+ucredit,less than or equal

--- a/shared/checks/oval/accounts_password_pam_pwquality.xml
+++ b/shared/checks/oval/accounts_password_pam_pwquality.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Check that pam_pwquality.so exists in system-auth</description>
     </metadata>

--- a/shared/templates/template_ANSIBLE_accounts_password
+++ b/shared/templates/template_ANSIBLE_accounts_password
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/shared/templates/template_BASH_accounts_password
+++ b/shared/templates/template_BASH_accounts_password
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/shared/templates/template_OVAL_accounts_password
+++ b/shared/templates/template_OVAL_accounts_password
@@ -4,6 +4,7 @@
       <title>Set Password {{{ VARIABLE }}} Requirements</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
       <description>The password {{{ VARIABLE }}} should meet minimum requirements</description>


### PR DESCRIPTION
#### Description:

Added ol7 support to account rules including set of generated from template.

Despite proposed a lot of changes, in general it is mostly text formatting and adding ol7 to the list of supported platforms.

Checked rules content, verified evaluation and fixes to work on Oracle Linux 7.
