### PR TITLE
Ol7 dconf gnome screensaver

### DIFF
--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The DConf User profile should have the local DB configured.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
@@ -1,10 +1,22 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Configure GNOME3 DConf User Profile'
 
-description: "By default, DConf provides a standard user profile. This profile contains a list\nof DConf configuration databases. The user profile and database always take the\nhighest priority. As such the DConf User profile should always exist and be\nconfigured correctly. \n<br /><br />\nTo make sure that the user profile is configured correctly, the <tt>/etc/dconf/profile/user</tt> should be set as follows:\n<pre>user-db:user\nsystem-db:local\nsystem-db:site\nsystem-db:distro\n</pre>"
+description: |-
+    By default, DConf provides a standard user profile. This profile contains a list
+    of DConf configuration databases. The user profile and database always take the
+    highest priority. As such the DConf User profile should always exist and be
+    configured correctly.
+    <br /><br />
+    To make sure that the user profile is configured correctly, the <tt>/etc/dconf/profile/user</tt>
+    should be set as follows:
+    <pre>user-db:user
+    system-db:local
+    system-db:site
+    system-db:distro
+    </pre>
 
 rationale: |-
     Failure to have a functional DConf profile prevents GNOME3 configuration settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Idle activation of the screen saver should be enabled.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
@@ -1,10 +1,20 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Enable GNOME3 Screensaver Idle Activation'
 
-description: "To activate the screensaver in the GNOME3 desktop after a period of inactivity,\nadd or set <tt>idle-activation-enabled</tt> to <tt>true</tt> in \n<tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:\n<pre>[org/gnome/desktop/screensaver]\nidle_activation_enabled=true</pre>\nOnce the setting has been added, add a lock to\n<tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.\nFor example:\n<pre>/org/gnome/desktop/screensaver/idle-activation-enabled</pre>\nAfter the settings have been set, run <tt>dconf update</tt>."
+description: |-
+    To activate the screensaver in the GNOME3 desktop after a period of inactivity,
+    add or set <tt>idle-activation-enabled</tt> to <tt>true</tt> in
+    <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
+    <pre>[org/gnome/desktop/screensaver]
+    idle-activation-enabled=true</pre>
+    Once the setting has been added, add a lock to
+    <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.
+    For example:
+    <pre>/org/gnome/desktop/screensaver/idle-activation-enabled</pre>
+    After the settings have been set, run <tt>dconf update</tt>.
 
 rationale: |-
     A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Idle activation of the screen saver should not be changed by users.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure Users Cannot Change GNOME3 Screensaver Idle Activation'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate inactivity_timeout_value
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The allowed period of inactivity before the screensaver is activated.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set GNOME3 Screensaver Inactivity Timeout'
 
@@ -12,7 +12,7 @@ description: |-
     For example, to configure the system for a 15 minute delay, add the following to
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>:
     <pre>[org/gnome/desktop/session]
-    idle-delay='uint32 900'</pre>
+    idle-delay=uint32 900</pre>
     Once the setting has been added, add a lock to
     <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.
     For example:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_screensaver_lock_delay
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Idle activation of the screen lock should be enabled immediately or
       after a delay.</description>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -1,10 +1,21 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Set GNOME3 Screensaver Lock Delay After Activation Period'
 
-description: "To activate the locking delay of the screensaver in the GNOME3 desktop when \nthe screensaver is activated, add or set <tt>lock-delay</tt> to <tt>uint32 <sub idref=\"var_screensaver_lock_delay\" /></tt> in\n<tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:\n<pre>[org/gnome/desktop/screensaver]\nlock-delay=uint32 <sub idref=\"var_screensaver_lock_delay\" />\n</pre>\nOnce the setting has been added, add a lock to\n<tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.\nFor example:\n<pre>/org/gnome/desktop/screensaver/lock-delay</pre>\nAfter the settings have been set, run <tt>dconf update</tt>."
+description: |-
+    To activate the locking delay of the screensaver in the GNOME3 desktop when
+    the screensaver is activated, add or set <tt>lock-delay</tt> to <tt>uint32 <sub idref="var_screensaver_lock_delay" /></tt> in
+    <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
+    <pre>[org/gnome/desktop/screensaver]
+    lock-delay=uint32 <sub idref="var_screensaver_lock_delay" />
+    </pre>
+    Once the setting has been added, add a lock to
+    <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.
+    For example:
+    <pre>/org/gnome/desktop/screensaver/lock-delay</pre>
+    After the settings have been set, run <tt>dconf update</tt>.
 
 rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Idle activation of the screen lock should be enabled.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Enable GNOME3 Screensaver Lock After Idle Period'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Idle activation of the screen lock should not be changed by users.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure Users Cannot Change GNOME3 Screensaver Lock After Idle Period'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The GNOME3 screensaver should be blank.</description>
     </metadata>
@@ -30,7 +31,7 @@
     <!-- GSettings expects proper datatype specifier when setting 'picture-uri' per:
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require 'string' datatype to be specified in 'picture-uri' configuration too -->
-    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?picture-uri=[\s]\'\'$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?picture-uri=(string[\s])?\'\'$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Implement Blank Screensaver'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>GNOME3 screen splash shield should not display full name of logged in user.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Disable Full User Name on Splash Shield'
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Ensure that users cannot change GNOME3 screensaver idle and lock settings.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Ensure Users Cannot Change GNOME3 Screensaver Settings'
 

--- a/ol7/templates/csv/packages_installed.csv
+++ b/ol7/templates/csv/packages_installed.csv
@@ -1,6 +1,7 @@
 aide
 audit
 chrony
+dconf
 glibc,0:2.17-55.0.4.el7_0.3
 libreswan
 ntp


### PR DESCRIPTION
#### Description:

Added ol7 support to dconf_gnome_screensaver rules including dependencies.
In addition:
- Updated text formatting to use multi line
- Updated 'idle-delay' value in dconf_gnome_screensaver_idle_delay description
- Updated 'idle-activation-enabled' key in dconf_gnome_screensaver_idle_activation_enabled description
- To be in sync with the dconf_gnome_screensaver_mode_blank bash fix updated pattern in OVAL to match values using type.

Checked gnome options to be applicable on OL7
Verified evaluation and fixes to work on OL7.