### PR TITLE
OL7 more pci dss rules

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
@@ -1,11 +1,11 @@
-# platform = Red Hat Enterprise Linux 7,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_multiple_time_servers
 
 # Invoke the function without args, so its body is substituded right here.
-rhel7_ensure_there_are_servers_in_ntp_compatible_config_file
+ensure_there_are_servers_in_ntp_compatible_config_file
 
 config_file="/etc/ntp.conf"
 /usr/sbin/pidof ntpd || config_file="/etc/chrony.conf"
 
-[ "$(grep -c '^server' "$config_file")" -gt 1 ] || rhel7_ensure_there_are_servers_in_ntp_compatible_config_file "$config_file" "$var_multiple_time_servers"
+[ "$(grep -c '^server' "$config_file")" -gt 1 ] || ensure_there_are_servers_in_ntp_compatible_config_file "$config_file" "$var_multiple_time_servers"

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Multiple remote chronyd or ntpd NTP Servers for time synchronization should be specified (and dependencies are met)</description>
     </metadata>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Specify Additional Remote NTP Servers'
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/bash/shared.sh
@@ -1,11 +1,11 @@
-# platform = Red Hat Enterprise Linux 7,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7,multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_multiple_time_servers
 
 # Invoke the function without args, so its body is substituded right here.
-rhel7_ensure_there_are_servers_in_ntp_compatible_config_file
+ensure_there_are_servers_in_ntp_compatible_config_file
 
 config_file="/etc/ntp.conf"
 /usr/sbin/pidof ntpd || config_file="/etc/chrony.conf"
 
-grep -q ^server "$config_file" || rhel7_ensure_there_are_servers_in_ntp_compatible_config_file "$config_file" "$var_multiple_time_servers"
+grep -q ^server "$config_file" || ensure_there_are_servers_in_ntp_compatible_config_file "$config_file" "$var_multiple_time_servers"

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>A remote chronyd or ntpd NTP Server for time synchronization should be specified (and dependencies are met)</description>
     </metadata>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Specify a Remote NTP Server'
 

--- a/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Multiple ntpd NTP Servers for time synchronization should be specified.</description>
     </metadata>

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>A remote ntpd NTP Server for time synchronization should be
       specified (and dependencies are met)</description>

--- a/linux_os/guide/services/ntp/var_multiple_time_servers.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_servers.var
@@ -11,3 +11,4 @@ interactive: false
 options:
     fedora: "0.fedora.pool.ntp.org,1.fedora.pool.ntp.org,2.fedora.pool.ntp.org,3.fedora.pool.ntp.org"
     rhel: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
+    ol: "0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate sshd_idle_timeout_value
 

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel, multi_platform_fedora, multi_platform_ol
 
 {{%- if product == "rhel6" -%}}
 sed -i --follow-symlinks '/pam_limits.so/a session\t    required\t  pam_lastlog.so showfailed' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Configure the system to notify users of last login/access using pam_lastlog.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/anaconda/shared.anaconda
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/anaconda/shared.anaconda
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel, multi_platform_ol
 
 package --add=pam_pkcs11 --add=esc

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7, multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 # Install required packages
@@ -39,7 +39,7 @@ pam_pkcs11.so nodebug"
 SMARTCARD_AUTH_CONF="/etc/pam.d/smartcard-auth"
 # Define 'pam_pkcs11.so' auth section to be appended past $PAM_ENV_SO into $SMARTCARD_AUTH_CONF
 SMARTCARD_AUTH_SECTION="\
-auth        [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only"
+auth        [success=done ignore=ignore default=die] pam_pkcs11.so nodebug wait_for_card"
 # Define expected 'pam_permit.so' row in $SMARTCARD_AUTH_CONF
 PAM_PERMIT_SO="account.*required.*pam_permit.so"
 # Define 'pam_pkcs11.so' password section

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Enable Smart Card logins</description>
     </metadata>
@@ -116,7 +117,7 @@
 {{% if product == "rhel6" %}}
       <literal_component>pam_pkcs11.so[\s]wait_for_card[\s]card_only\n</literal_component>
 {{% else %}}
-      <literal_component>pam_pkcs11.so[\s]nodebug[\s]wait_for_card\n</literal_component>
+      <literal_component>pam_pkcs11.so[\s]nodebug[\s]wait_for_card\n.*</literal_component>
 {{% endif %}}
       <literal_component>\npassword[\s]+required[\s]+pam_pkcs11.so\n</literal_component>
     </concat>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,fedora
+prodtype: rhel6,rhel7,fedora,ol7
 
 title: 'Enable Smart Card Login'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>All GIDs referenced in /etc/passwd must be defined in /etc/group.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -55,9 +55,7 @@ warnings:
         <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
         <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-{{% if product == "rhel7" %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% elif product == "ol7" %}}
+{{% if product in ["rhel7", "ol7"] %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
 {{% else %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>

--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: rhel7,fedora,ol7
 
 title: 'Enable Auditing for Processes Which Start Prior to the Audit Daemon'
 
@@ -56,6 +56,8 @@ warnings:
         <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
 {{% if product == "rhel7" %}}
+        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
+{{% elif product == "ol7" %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
 {{% else %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/rule.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/rule.yml
@@ -2,7 +2,13 @@ documentation_complete: true
 
 title: 'Ensure Logrotate Runs Periodically'
 
-description: "The <tt>logrotate</tt> utility allows for the automatic rotation of \nlog files.  The frequency of rotation is specified in <tt>/etc/logrotate.conf</tt>, \nwhich triggers a cron task.  To configure logrotate to run daily, add or correct \nthe following line in <tt>/etc/logrotate.conf</tt>:\n<pre># rotate log files <i>frequency</i>\ndaily</pre>"
+description: |-
+    The <tt>logrotate</tt> utility allows for the automatic rotation of
+    log files.  The frequency of rotation is specified in <tt>/etc/logrotate.conf</tt>,
+    which triggers a cron task.  To configure logrotate to run daily, add or correct
+    the following line in <tt>/etc/logrotate.conf</tt>:
+    <pre># rotate log files <i>frequency</i>
+    daily</pre>
 
 rationale: |-
     Log files that are not properly rotated run the risk of growing so large
@@ -24,4 +30,8 @@ references:
 
 ocil_clause: 'logrotate is not configured to run daily'
 
-ocil: "To determine the status and frequency of logrotate, run the following command:\n<pre>$ sudo grep logrotate /var/log/cron*</pre>\nIf logrotate is configured properly, output should include references to \n<tt>/etc/cron.daily</tt>."
+ocil: |-
+    To determine the status and frequency of logrotate, run the following command:
+    <pre>$ sudo grep logrotate /var/log/cron*</pre>
+    If logrotate is configured properly, output should include references to
+    <tt>/etc/cron.daily</tt>.

--- a/linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_rhel-osp</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The prelinking feature can interfere with the operation of
       checksum integrity tools (e.g. AIDE), mitigates the protection provided

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -73,3 +73,14 @@ selections:
     - audit_rules_session_events
     - audit_rules_unsuccessful_file_modification
     - audit_rules_privileged_commands
+    - ensure_logrotate_activated
+    - sshd_idle_timeout_value=15_minutes
+    - sshd_set_idle_timeout
+    - disable_prelink
+    - display_login_attempts
+    - gid_passwd_group_same
+    - grub2_audit_argument
+    - smartcard_auth
+    - var_multiple_time_servers=ol
+    - chronyd_or_ntpd_specify_multiple_servers
+    - chronyd_or_ntpd_specify_remote_server

--- a/ol7/templates/csv/packages_installed.csv
+++ b/ol7/templates/csv/packages_installed.csv
@@ -2,9 +2,12 @@ aide
 audit
 chrony
 dconf
+esc
 glibc,0:2.17-55.0.4.el7_0.3
 libreswan
 ntp
 openssh-server
+pam_pkcs11
+pcsc-lite
 rsyslog
 uuidd

--- a/ol7/templates/csv/packages_removed.csv
+++ b/ol7/templates/csv/packages_removed.csv
@@ -6,6 +6,7 @@ net-snmp
 ntpdate
 oddjob
 openssh-server
+prelink
 rsh
 rsh-server
 ypbind

--- a/ol7/templates/csv/services_enabled.csv
+++ b/ol7/templates/csv/services_enabled.csv
@@ -1,4 +1,5 @@
 auditd,audit,
 chronyd,chrony,
 ntpd,ntp,
+pcscd,pcsc-lite,
 rsyslog,rsyslog,

--- a/shared/bash_remediation_functions/ensure_there_are_servers_in_ntp_compatible_config_file.sh
+++ b/shared/bash_remediation_functions/ensure_there_are_servers_in_ntp_compatible_config_file.sh
@@ -1,7 +1,7 @@
 # Function ensures that the ntp/chrony config file contains valid server entries
 # $1: Path to the config file
 # $2: Comma-separated list of servers
-function rhel7_ensure_there_are_servers_in_ntp_compatible_config_file {
+function ensure_there_are_servers_in_ntp_compatible_config_file {
 	# If invoked with no arguments, exit. This is an intentional behavior.
 	[ $# -gt 1 ] || return 0
 	[ $# = 2 ] || die "$0 requires zero or exactly two arguments"

--- a/shared/checks/oval/bootloader_disable_recovery_set_to_true.xml
+++ b/shared/checks/oval/bootloader_disable_recovery_set_to_true.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>GRUB_DISABLE_RECOVERY set to 'true' in
       /etc/default/grub</description>

--- a/shared/checks/oval/chronyd_specify_multiple_servers.xml
+++ b/shared/checks/oval/chronyd_specify_multiple_servers.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Multiple chronyd NTP Servers for time synchronization should be specified.</description>
     </metadata>

--- a/shared/checks/oval/chronyd_specify_remote_server.xml
+++ b/shared/checks/oval/chronyd_specify_remote_server.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>A remote NTP Server for time synchronization should be
       specified (and dependencies are met)</description>

--- a/shared/templates/template_BASH_grub2_bootloader_argument
+++ b/shared/templates/template_BASH_grub2_bootloader_argument
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7, multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7, multi_platform_fedora, multi_platform_ol
 
 # Correct the form of default kernel command line in GRUB
 if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then

--- a/shared/templates/template_OVAL_grub2_bootloader_argument
+++ b/shared/templates/template_OVAL_grub2_bootloader_argument
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Look for argument {{{ ARG_NAME_VALUE }}} in the kernel line in /etc/default/grub.</description>
     </metadata>


### PR DESCRIPTION
#### Description:

Enabled more ol7 pci-dss profile rules

- Enabled rules
    - ensure_logrotate_activated
    - sshd_set_idle_timeout
    - disable_prelink
    - display_login_attempts
    - gid_passwd_group_same
    - grub2_audit_argument
    - smartcard_auth
    - chronyd_or_ntpd_specify_multiple_servers
    - chronyd_or_ntpd_specify_remote_server
- renamed rhel7_ensure_there_are_servers_in_ntp_compatible_config_file to something more generic
- var_multiple_time_servers.var extended with ol7 specific servers
- smartcard_auth rhel7 bash fix merged to shared, fixed SMARTCARD_AUTH_SECTION to match OVAL expectation (hope last one is correct)
- in smartcard_auth OVAL fixed regex issue introduced in  1687648 commit

Verified rules and remediation to work on Oracle Linux 7
Checked merged content to present in rhel7 xccdf.
