### PR TITLE
controller_terminated_pod_gc_threshhold

### DIFF
--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/oval/shared.xml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/oval/shared.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="controller_terminated_pod_gc_threshhold" version="1">
+    <metadata>
+      <title>Ensure that terminated-pod-gc-threshold is enabled.</title>
+      <affected family="unix">
+        <platform>multi_platform_ocp</platform>
+      </affected>
+      <description>Ensure terminated-pod-gc-threshold is enabled.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="terminated-pod-gc-threshold is configured" test_ref="test_controller_terminated_pod_gc_threshhold" negate="true" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="terminated-pod-gc-threshold is configured" id="test_controller_terminated_pod_gc_threshhold" version="1">
+    <ind:object object_ref="object_controller_terminated_pod_gc_threshhold" />
+    <ind:state state_ref="state_controller_terminated_pod_gc_threshhold" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_controller_terminated_pod_gc_threshhold" version="1">
+    <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*kubernetesMasterConfig\:(?:[^\n]*\n+)+?[\s]*controllerArguments\:[\s]*[\n]+[\s]*terminated-pod-gc-threshold\:[\s]*[\n]+[\s]*-[\s]+(\S+).*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_controller_terminated_pod_gc_threshhold" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^'false'$</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/oval/shared.xml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/oval/shared.xml
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="controller_terminated_pod_gc_threshhold" version="1">
     <metadata>
-      <title>Ensure that terminated-pod-gc-threshold is enabled.</title>
+      <title>Enable terminated-pod-gc-threshold for the Controller Manager</title>
       <affected family="unix">
         <platform>multi_platform_ocp</platform>
       </affected>

--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Ensure terminated-pod-gc-threshold argument is enabled'
+title: 'Enable terminated-pod-gc-threshold for the Controller Manager'
 
 description: |-
     To ensure the garbage collector is activated upon pod termination,

--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
@@ -1,15 +1,17 @@
 documentation_complete: true
 
-title: 'Ensure that the --terminated-pod-gc-threshold argument is set'
+title: 'Ensure terminated-pod-gc-threshold argument is enabled'
 
 description: |-
-    To activate garbage collector on pod termination, edit the Controller
-    Manager pod specification file
-    <tt>/etc/kubernetes/manifests/kube-controller-manager.yaml</tt> on the
-    master node and set the <tt>--terminated-pod-gc-threshold</tt> to an
-    appropriate threshold. For example:
-
-    <pre>--terminated-pod-gc-threshold=10</pre>
+    To ensure the garbage collector is activated upon pod termination,
+    edit the Controller Manager pod specification file
+    <tt>/etc/origin/master/master-config.yaml</tt> on the
+    master node(s) and set the <tt>terminated-pod-gc-threshold</tt> to
+    <tt>true</tt>. For example:
+    <pre>kubernetesMasterConfig:
+      controllerArguments:
+        terminated-pod-gc-threshold:
+          - true</pre>
 
 rationale: |-
     Garbage collection is important to ensure sufficient resource availability
@@ -22,14 +24,18 @@ rationale: |-
 
 severity: low
 
-ocil_clause: '<tt>--terminated-pod-gc-threshold</tt> is not set as appropriate'
+ocil_clause: '<tt>terminated-pod-gc-threshold</tt> is not enabled'
 
 ocil: |-
     Run the following command on the master node(s):
-    <pre>$ ps -ef | grep kube-controller-manager</pre>
+    <pre>$ grep terminated-pod-gc-threshold /etc/origin/master/master-config.yaml</pre>
 
-    Verify that the <tt>--terminated-pod-gc-threshold</tt> argument is set
-    as appropriate.
+    Verify that the <tt>terminated-pod-gc-threshold</tt> argument is not set
+    to <tt>false</tt>.
+
+    If the configuration file does not explicitly set
+    <tt>terminated-pod-gc-threshold</tt>, and the grep command returns no
+    text, the default value of <tt>true</tt> is being used..
 
 identifiers:
     cce@ocp3: 80592-9

--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
@@ -35,7 +35,7 @@ ocil: |-
 
     If the configuration file does not explicitly set
     <tt>terminated-pod-gc-threshold</tt>, and the grep command returns no
-    text, the default value of <tt>true</tt> is being used..
+    text, the default value of <tt>true</tt> is being used.
 
 identifiers:
     cce@ocp3: 80592-9

--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
@@ -28,7 +28,7 @@ ocil_clause: '<tt>terminated-pod-gc-threshold</tt> is not enabled'
 
 ocil: |-
     Run the following command on the master node(s):
-    <pre>$ grep terminated-pod-gc-threshold /etc/origin/master/master-config.yaml</pre>
+    <pre>$ sudo grep terminated-pod-gc-threshold /etc/origin/master/master-config.yaml</pre>
 
     Verify that the <tt>terminated-pod-gc-threshold</tt> argument is not set
     to <tt>false</tt>.

--- a/ocp3/profiles/opencis-ocp-master.profile
+++ b/ocp3/profiles/opencis-ocp-master.profile
@@ -48,7 +48,6 @@ selections:
     - controller_root_ca
     - controller_rotate_kubelet_server_certs
     - controller_service_account_private_key
-    - controller_terminated_pod_gc_threshhold
     - controller_use_service_account
     - etcd_auto_tls
     - etcd_cert_file

--- a/ocp3/profiles/opencis-ocp-master.profile
+++ b/ocp3/profiles/opencis-ocp-master.profile
@@ -48,6 +48,7 @@ selections:
     - controller_root_ca
     - controller_rotate_kubelet_server_certs
     - controller_service_account_private_key
+    - controller_terminated_pod_gc_threshhold
     - controller_use_service_account
     - etcd_auto_tls
     - etcd_cert_file


### PR DESCRIPTION
The OpenShift Container Platform node performs two types of garbage collection: container garbage collection and image garbage collection. Container garbage collection is enabled by default and happens automatically in response to eviction thresholds being reached  However, the preferred approach of using a controller (e.g. DeploymentConfig, ReplicationSet) to manage Pods will not leave Pods in terminated states, which are created when using Jobs or standalone Pods.
OpenShift does not set the terminated-pod-gc-threshold value differently from the Kubernetes default of 12500.  Setting this value explicitly to can be achieved via kubernetesMasterConfig.controllerArguments in the master-config.yaml.
https://docs.openshift.com/container-platform/3.10/admin_guide/garbage_collection.html)

Given mitigations of this is being dropped.
