### PR TITLE
Add partition rules support for ol7

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
@@ -20,4 +20,4 @@ severity: unknown
 references:
     anssi: NT28(R12)
 
-{{{ complete_ocil_entry_separate_partition(part="/home") }}}
+{{{ complete_ocil_entry_separate_partition(part="/srv") }}}

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,ol7
 
 title: 'Ensure /var/tmp Located On Separate Partition'
 

--- a/ol7/profiles/standard.profile
+++ b/ol7/profiles/standard.profile
@@ -76,3 +76,5 @@ selections:
     - service_oddjobd_disabled
     - service_rdisc_disabled
     - service_rsyslog_enabled
+    - partition_for_var_log
+    - partition_for_var_log_audit

--- a/ol7/templates/csv/mounts.csv
+++ b/ol7/templates/csv/mounts.csv
@@ -1,0 +1,9 @@
+# format:
+# <mount_point> - this means <mount_point> on separate partition
+/home
+/srv
+/tmp
+/var
+/var/log
+/var/log/audit
+/var/tmp


### PR DESCRIPTION
#### Description:

Added OL7 partition rules.
In addition fixed /srv rule OCIL reference, used one for /home

Testing successful on Oracle Linux 7