### PR TITLE
Container-only rules

### DIFF
--- a/linux_os/guide/services/base/service_irqbalance_enabled/rule.yml
+++ b/linux_os/guide/services/base/service_irqbalance_enabled/rule.yml
@@ -24,3 +24,5 @@ references:
     nist: CM-7
 
 ocil: '{{{ ocil_service_disabled(service="irqbalance") }}}'
+
+platform: machine

--- a/linux_os/guide/services/cron_and_at/group.yml
+++ b/linux_os/guide/services/cron_and_at/group.yml
@@ -8,3 +8,5 @@ description: |-
     all systems to perform necessary maintenance tasks, while at may or
     may not be required on a given system. Both daemons should be
     configured defensively.
+
+platform: machine

--- a/linux_os/guide/services/docker/docker_storage_configured/rule.yml
+++ b/linux_os/guide/services/docker/docker_storage_configured/rule.yml
@@ -20,3 +20,5 @@ severity: low
 
 identifiers:
     cce@rhel7: 80441-9
+
+platform: machine

--- a/linux_os/guide/services/docker/service_docker_enabled/rule.yml
+++ b/linux_os/guide/services/docker/service_docker_enabled/rule.yml
@@ -20,3 +20,5 @@ identifiers:
     cce@rhel7: 80440-1
 
 ocil: '{{{ ocil_service_enabled(service="docker") }}}'
+
+platform: machine

--- a/linux_os/guide/services/mail/group.yml
+++ b/linux_os/guide/services/mail/group.yml
@@ -23,3 +23,5 @@ description: |-
     Postfix was coded with security in mind and can also be more effectively contained by
     SELinux as its modular design has resulted in separate processes performing specific actions.
     More information is available on its website, {{{ weblink(link="http://www.postfix.org") }}}.
+
+platform: machine

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -55,3 +55,5 @@ description: |-
     The upstream manual pages at {{{ weblink(link="http://chrony.tuxfamily.org/manual.html") }}} for
     <tt>chronyd</tt> and {{{ weblink(link="http://www.ntp.org") }}} for <tt>ntpd</tt> provide additional
     information on the capabilities and configuration of each of the NTP daemons.
+
+platform: machine

--- a/linux_os/guide/services/ssh/group.yml
+++ b/linux_os/guide/services/ssh/group.yml
@@ -12,3 +12,5 @@ description: |-
     {{{ weblink(link="http://www.openssh.org") }}}.
     Its server program is called <tt>sshd</tt> and provided by the RPM package
     <tt>openssh-server</tt>.
+
+platform: machine

--- a/linux_os/guide/services/sssd/group.yml
+++ b/linux_os/guide/services/sssd/group.yml
@@ -17,3 +17,5 @@ description: |-
     {{%- elif product == "rhel6" -%}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/SSSD-Introduction.html") }}}
     {{%- endif %}}
+
+platform: machine

--- a/linux_os/guide/services/sssd/sssd-ldap/group.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/group.yml
@@ -13,3 +13,5 @@ description: |-
     <br /><br />
     SSSD can support many backends including LDAP. The <tt>sssd-ldap</tt> backend
     allows SSSD to fetch identity information from an LDAP server.
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
@@ -82,3 +82,5 @@ warnings:
         key sequence if running in <tt>runlevel 6</tt> (e.g. in GNOME, KDE, etc.)! The
         <tt>Ctrl-Alt-Del</tt> key sequence will only be disabled if running in
         the non-graphical <tt>runlevel 3</tt>.
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     <tt>systemd.confirm_spawn=(1|yes|true|on)</tt> in the kernel boot arguments.
     Presence of a <tt>systemd.confirm_spawn=(1|yes|true|on)</tt> indicates
     that interactive boot is enabled at boot time.
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -71,3 +71,5 @@ ocil: |-
         <pre>ExecStart=-/sbin/sulogin</pre>
     {{%- endif %}}
 {{% endif %}}
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_screen_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_screen_installed/rule.yml
@@ -41,3 +41,5 @@ references:
 ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="screen") }}}'
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     To verify the operating system has the packages required for multifactor
     authentication installed, run the following command:
     <pre>$ sudo yum list installed esc pam_pkcs11 authconfig-gtk</pre>
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -41,3 +41,5 @@ references:
 ocil_clause: 'non-exempt accounts are not using CAC authentication'
 
 ocil: "Interview the SA to determine if all accounts not exempted by policy are\nusing CAC authentication.\nFor DoD systems, the following systems and accounts are exempt from using\nsmart card (CAC) authentication:\n<ul>\n<li>SIPRNET systems</li> \n<li>Standalone systems</li>\n<li>Application accounts</li>\n<li>Temporary employee accounts, such as students or interns, who cannot easily receive a CAC or PIV</li>\n<li>Operational tactical locations that are not collocated with RAPIDS workstations to issue CAC or ALT</li>\n<li>Test systems, such as those with an Interim Approval to Test (IATT) and use a separate VPN, firewall, or security measure preventing access to network and system components from outside the protection boundary documented in the IATT.</li>\n</ul>"
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
@@ -42,3 +42,5 @@ ocil: |-
     <pre>cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;</pre>
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
@@ -31,3 +31,5 @@ references:
     ospp@rhel7: FIA_AFL.1
 
 ocil: '{{{ ocil_service_disabled(service="debug-shell") }}}'
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
@@ -55,3 +55,5 @@ warnings:
         number of ways while still achieving the desired effect.  Here the system calls
         have been placed independent of other system calls.  Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect.  Here the system calls
         have been placed independent of other system calls.  Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -59,3 +59,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -59,3 +59,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -58,3 +58,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -53,3 +53,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/group.yml
@@ -19,3 +19,5 @@ description: |-
     <pre>-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=4294967295 -F key=perm_mod
         -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=4294967295 -F key=perm_mod
         -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid&gt;=1000 -F auid!=4294967295 -F key=perm_mod</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -47,3 +47,5 @@ ocil: |-
     <pre>$ sudo grep "path=/usr/bin/chcon" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
     <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -F key=privileged-priv_change</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -46,3 +46,5 @@ ocil: |-
     <pre>$ sudo grep "path=/usr/sbin/restorecon" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
     <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -F key=privileged-priv_change</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -47,3 +47,5 @@ ocil: |-
     <pre>$ sudo grep "path=/usr/sbin/semanage" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
     <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -F key=privileged-priv_change</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -47,3 +47,5 @@ ocil: |-
     <pre>$ sudo grep "path=/usr/sbin/setsebool" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
     <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -F key=privileged-priv_change</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
@@ -59,3 +59,5 @@ warnings:
         <li><tt>audit_rules_file_deletion_events_unlink</tt></li>
         <li><tt>audit_rules_file_deletion_events_unlinkat</tt></li>
         </ul>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -40,3 +40,5 @@ references:
     stigid@rhel7: "030880"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="rename") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -40,3 +40,5 @@ references:
     stigid@rhel7: "030890"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="renameat") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -40,3 +40,5 @@ references:
     stigid@rhel7: "030900"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="rmdir") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -40,3 +40,5 @@ references:
     stigid@rhel7: "030910"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="unlink") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -40,3 +40,5 @@ references:
     stigid@rhel7: "030920"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="unlinkat") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -62,3 +62,5 @@ warnings:
         <li><tt>audit_rules_kernel_module_loading_rmmod</tt></li>
         <li><tt>audit_rules_kernel_module_loading_modprobe</tt></li>
         </ul>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -38,3 +38,5 @@ references:
     stigid@rhel7: "030830"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="delete_module") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -36,3 +36,5 @@ references:
     stigid@rhel7: "030821"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="finit_module") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -37,3 +37,5 @@ references:
     stigid@rhel7: "030820"
 
 {{{ complete_ocil_entry_audit_syscall(syscall="init_module") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_insmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_insmod/rule.yml
@@ -41,3 +41,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/usr/sbin/insmod\|-w /usr/sbin/insmod"</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_modprobe/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_modprobe/rule.yml
@@ -41,3 +41,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/usr/sbin/modprobe\|-w /usr/sbin/modprobe"</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_rmmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_rmmod/rule.yml
@@ -41,3 +41,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/usr/sbin/rmmod\|-w /usr/sbin/rmmod"</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
@@ -49,3 +49,5 @@ warnings:
         <li><tt>audit_rules_login_events_faillock</tt></li>
         <li><tt>audit_rules_login_events_lastlog</tt></li>
         </ul>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -43,3 +43,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/var/run/faillock\|-w /var/run/faillock"</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
@@ -43,3 +43,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/var/log/lastlog\|-w /var/log/lastlog"</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
@@ -44,3 +44,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/var/log/tallylog\|-w /var/log/tallylog"</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -77,3 +77,5 @@ warnings:
         <li><tt>audit_rules_privileged_commands_umount</tt></li>
         <li><tt>audit_rules_privileged_commands_passwd</tt></li>
         </ul>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep chage /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep chsh /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep crontab /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep gpasswd /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep newgrp /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep pam_timestamp_check /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep passwd /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep postdrop /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep postqueue /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -46,3 +46,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep pt_chown /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep ssh-keysign /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep su /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep sudo /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep sudoedit /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep umount /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep unix_chkpwd /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep userhelper /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     It should return a relevant line in the audit rules.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
@@ -35,3 +35,5 @@ references:
     hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.310(a)(2)(iv),164.312(d),164.310(d)(2)(iii),164.312(b),164.312(e)
     nist: AC-6,AU-1(b),AU-2(a),AU-2(c),AU-2(d),IR-5
     pcidss: Req-10.5.2
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     If the system is configured to watch for changes to its SELinux
     configuration, a line should be returned (including
     <tt>perm=wa</tt> indicating permissions that are watched).
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
@@ -48,3 +48,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for all media exportation events, run the following command:
     <pre>$ sudo auditctl -l | grep syscall | grep mount</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
@@ -53,3 +53,5 @@ ocil: |-
     <pre>auditctl -l | egrep '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/sysconfig/network)'</pre>
     If the system is configured to watch for network configuration changes, a line should be returned for
     each file specified (and <tt>perm=wa</tt> should be indicated for each).
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/rule.yml
@@ -39,3 +39,5 @@ references:
     nist: AC-17(7),AU-1(b),AU-2(a),AU-2(c),AU-2(d),AU-12(a),AU-12(c),IR-5
     ospp@rhel7: FAU_GEN.1.1.c
     pcidss: Req-10.2.3
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
@@ -45,3 +45,5 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/etc/sudoers\|watch=/etc/sudoers.d\|-w /etc/sudoers\|-w /etc/sudoers.d"</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/rule.yml
@@ -46,3 +46,5 @@ ocil: |-
     <pre>$ sudo grep "\-f 2" /etc/audit/audit.rules</pre>
     The output should contain:
     <pre>-f 2</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/rule.yml
@@ -68,3 +68,5 @@ warnings:
         <li><tt>audit_rules_usergroup_modification_gshadow</tt></li>
         <li><tt>audit_rules_usergroup_modification_passwd</tt></li>
         </ul>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
@@ -52,3 +52,5 @@ ocil: |-
     <br /><br />
     If the system is configured to watch for account changes, lines should be returned for
     each file specified (and with <tt>perm=wa</tt> for each).
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
@@ -52,3 +52,5 @@ ocil: |-
     <br /><br />
     If the system is configured to watch for account changes, lines should be returned for
     each file specified (and with <tt>perm=wa</tt> for each).
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
@@ -52,3 +52,5 @@ ocil: |-
     <br /><br />
     If the system is configured to watch for account changes, lines should be returned for
     each file specified (and with <tt>perm=wa</tt> for each).
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
@@ -52,3 +52,5 @@ ocil: |-
     <br /><br />
     If the system is configured to watch for account changes, lines should be returned for
     each file specified (and with <tt>perm=wa</tt> for each).
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
@@ -52,3 +52,5 @@ ocil: |-
     <br /><br />
     If the system is configured to watch for account changes, lines should be returned for
     each file specified (and with <tt>perm=wa</tt> for each).
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
@@ -49,3 +49,5 @@ references:
 ocil_clause: 'the system is not configured to audit time changes'
 
 {{{ complete_ocil_entry_audit_syscall(syscall="adjtimex") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/rule.yml
@@ -49,3 +49,5 @@ references:
 ocil_clause: 'the system is not configured to audit time changes'
 
 {{{ complete_ocil_entry_audit_syscall(syscall="clock_settime") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
@@ -49,3 +49,5 @@ references:
 ocil_clause: 'the system is not configured to audit time changes'
 
 {{{ complete_ocil_entry_audit_syscall(syscall="settimeofday") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
@@ -55,3 +55,5 @@ ocil: |-
     If the system is not configured to audit time changes, this is a finding.
     If the system is 64-bit only, this is not applicable<br />
     {{{ complete_ocil_entry_audit_syscall(syscall="stime") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     command:
     <pre>$ sudo auditctl -l | grep "watch=/etc/localtime"</pre>
     If the system is configured to audit this activity, it will return a line.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -63,3 +63,5 @@ warnings:
         <li><tt>audit_rules_unsuccessful_file_modification_ftruncate</tt></li>
         <li><tt>audit_rules_unsuccessful_file_modification_creat</tt></li>
         </ul>
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -54,3 +54,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -54,3 +54,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -54,3 +54,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -54,3 +54,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -54,3 +54,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -54,3 +54,5 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/rule.yml
@@ -31,3 +31,5 @@ references:
 ocil: |-
     {{{ describe_file_owner(file="/var/log/audit", owner="root") }}}
     {{{ describe_file_owner(file="/var/log/audit/*", owner="root") }}}
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
@@ -35,3 +35,5 @@ ocil: |-
     Run the following command to check the mode of the system audit logs:
     <pre>$ sudo ls -l /var/log/audit</pre>
     Audit logs must be mode 0640 or less permissive.
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     The output should return something similar to where <i>REMOTE_SYSTEM</i>
     is an IP address or hostname:
     <pre>remote_server = <i>REMOTE_SYSTEM</i></pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
     <pre>disk_full_action = single</pre>
     Acceptable values also include <tt>syslog</tt> and
     <tt>halt</tt>.
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
@@ -34,3 +34,5 @@ ocil: |-
     <pre>$ sudo grep -i enable_krb5 /etc/audisp/audisp-remote.conf</pre>
     The output should return the following:
     <pre>enable_krb5 = yes</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
     <pre>network_failure_action = single</pre>
     Acceptable values also include <tt>syslog</tt> and
     <tt>halt</tt>.
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     To verify the audispd's syslog plugin is active, run the following command:
     <pre>$ sudo grep active /etc/audisp/plugins.d/syslog.conf</pre>
     If the plugin is active, the output will show <tt>yes</tt>.
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/rule.yml
@@ -41,3 +41,5 @@ ocil: |-
     determine if the system is configured to send email to an
     account when it needs to notify an administrator:
     <pre>action_mail_acct = root</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
@@ -46,3 +46,5 @@ ocil: |-
     determine if the system is configured to either suspend, switch to single user mode,
     or halt when disk space has run low:
     <pre>admin_space_left_action single</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     <pre>flush = DATA</pre>
     Acceptable values are <tt>DATA</tt>, and <tt>SYNC</tt>. The setting is
     case-insensitive.
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     determine how much data the system will retain in each audit log file:
     <tt>$ sudo grep max_log_file /etc/audit/auditd.conf</tt>
     <pre>max_log_file = 6</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
@@ -49,3 +49,5 @@ ocil: |-
     maximum size:
     <tt>$ sudo grep max_log_file_action /etc/audit/auditd.conf</tt>
     <pre>max_log_file_action <tt>rotate</tt></pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     determine how many logs the system is configured to retain after rotation:
     <tt>$ sudo grep num_logs /etc/audit/auditd.conf</tt>
     <pre>num_logs = 5</pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
@@ -39,3 +39,5 @@ ocil: |-
     Inspect <tt>/etc/audit/auditd.conf</tt> and locate the following line to
     determine if the system is configured correctly:
     <pre>space_left <i>SIZE_in_MB</i></pre>
+
+platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/rule.yml
@@ -55,3 +55,5 @@ ocil: |-
     <tt>$ sudo grep space_left_action /etc/audit/auditd.conf</tt>
     <pre>space_left_action</pre>
     Acceptable values are <tt>email</tt>, <tt>suspend</tt>, <tt>single</tt>, and <tt>halt</tt>.
+
+platform: machine

--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -61,3 +61,5 @@ warnings:
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
 {{% endif %}}
         </ul>
+
+platform: machine

--- a/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
@@ -39,3 +39,5 @@ references:
     stigid@rhel7: "030000"
 
 ocil: '{{{ ocil_service_enabled(service="auditd") }}}'
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
@@ -27,3 +27,5 @@ ocil: |-
     <pre>$ sudo ls -lL /boot/efi/EFI/redhat/grub.cfg</pre>
     If properly configured, the output should indicate the following
     permissions: <tt>-rwx------</tt>
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/rule.yml
@@ -31,3 +31,5 @@ ocil: |-
     <pre>$ sudo ls -lL /boot/grub2/grub.cfg</pre>
     If properly configured, the output should indicate the following
     permissions: <tt>-rw-------</tt>
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/group.yml
@@ -14,3 +14,5 @@ description: |-
     parameters and endangering security, protect the boot loader configuration
     with a password and ensure its configuration file's permissions
     are set properly.
+
+platform: machine

--- a/linux_os/guide/system/logging/group.yml
+++ b/linux_os/guide/system/logging/group.yml
@@ -19,3 +19,5 @@ description: |-
     This section discusses how to configure rsyslog for
     best effect, and how to use tools provided with the system to maintain and
     monitor logs.
+
+platform: machine

--- a/linux_os/guide/system/network/network-firewalld/group.yml
+++ b/linux_os/guide/system/network/network-firewalld/group.yml
@@ -20,3 +20,5 @@ description: |-
     immediately implemented. There is no need to save or apply the changes. No
     unintended disruption of existing network connections occurs as no part of
     the firewall has to be reloaded.
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -20,3 +20,5 @@ references:
     nist: CM-7
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_ra", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -21,3 +21,5 @@ references:
     nist: CM-7
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
@@ -29,3 +29,5 @@ references:
     stigid@rhel7: "040830"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_source_route", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -24,3 +24,5 @@ references:
 ocil: |-
     {{{ ocil_sysctl_option_value(sysctl="net.ipv6.conf.all.forwarding", value="0") }}}
     The ability to forward packets is only appropriate for routers.
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -21,3 +21,5 @@ references:
     nist: CM-7
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_ra", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -24,3 +24,5 @@ references:
     nist: CM-7
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
@@ -27,3 +27,5 @@ references:
     nist: AC-4
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_source_route", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
@@ -30,3 +30,5 @@ references:
 ocil_clause: 'the ipv6 support is disabled on network interfaces'
 
 ocil: "If the system uses IPv6, this is not applicable.\n<br /><br />\nIf the system is configured to prevent the usage of the\n<tt>ipv6</tt> on network interfaces, it will contain a line\nof the form:\n<pre>net.ipv6.conf.all.disable_ipv6 = 1</pre>\nSuch lines may be inside any file in the <tt>/etc/sysctl.d</tt> directory. \nThis permits insertion of the IPv6 kernel module (which other parts of \nthe system expect to be present), but otherwise keeps all network interfaces\nfrom using IPv6.\nRun the following command to search for such\nlines in all files in <tt>/etc/sysctl.d</tt>:\n<pre xml:space=\"preserve\">$ grep -r ipv6 /etc/sysctl.d</pre>"
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
@@ -26,3 +26,5 @@ references:
     stigid@rhel7: "040641"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.accept_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
@@ -26,3 +26,5 @@ references:
     stigid@rhel7: "040610"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.accept_source_route", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
@@ -28,3 +28,5 @@ references:
     nist: AC-17(7),CM-7,SC-5(3)
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.log_martians", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -28,3 +28,5 @@ references:
     nist: AC-4,SC-5,SC-7
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.rp_filter", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
@@ -26,3 +26,5 @@ references:
     nist: AC-4,CM-7,SC-5
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.secure_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
@@ -26,3 +26,5 @@ references:
     stigid@rhel7: "040640"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.accept_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
@@ -26,3 +26,5 @@ references:
     stigid@rhel7: "040620"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.accept_source_route", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
@@ -24,3 +24,5 @@ references:
     nist: AC-17(7),CM-7,SC-5(3)
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.log_martians", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
@@ -27,3 +27,5 @@ references:
     nist: AC-4,SC-5,SC-7
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.rp_filter", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
@@ -26,3 +26,5 @@ references:
     nist: AC-4,CM-7,SC-5,SC-7
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.secure_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
@@ -32,3 +32,5 @@ references:
     stigid@rhel7: "040630"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.icmp_echo_ignore_broadcasts", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
@@ -24,3 +24,5 @@ references:
     nist: CM-7,SC-5
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.icmp_ignore_bogus_error_responses", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
@@ -32,3 +32,5 @@ references:
     srg: SRG-OS-000480-GPOS-00227
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.tcp_syncookies", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
@@ -32,3 +32,5 @@ references:
     stigid@rhel7: "040660"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.send_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
@@ -32,3 +32,5 @@ references:
     stigid@rhel7: "040650"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.send_redirects", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -31,3 +31,5 @@ references:
 ocil: |-
     {{{ ocil_sysctl_option_value(sysctl="net.ipv4.ip_forward", value="0") }}}
     The ability to forward packets is only appropriate for routers.
+
+platform: machine

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     stigid: "020101"
 
 {{{ complete_ocil_entry_module_disable(module="dccp") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
@@ -31,3 +31,5 @@ references:
     nist: CM-7
 
 {{{ complete_ocil_entry_module_disable(module="sctp") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/rule.yml
@@ -31,3 +31,5 @@ references:
     nist: AC-17(8),AC-18(a),AC-18(d),AC-18(3),CM-7
 
 {{{ complete_ocil_entry_module_disable(module="bluetooth") }}}
+
+platform: machine

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_in_bios/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_in_bios/rule.yml
@@ -24,3 +24,5 @@ identifiers:
 references:
     disa: "85"
     nist: AC-17(8),AC-18(a),AC-18(d),AC-18(3),CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/bios_assign_password/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/bios_assign_password/rule.yml
@@ -22,3 +22,5 @@ severity: unknown
 identifiers:
     cce@rhel6: 27131-2
     cce@rhel7: 27194-0
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/bios_disable_usb_boot/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/bios_disable_usb_boot/rule.yml
@@ -22,3 +22,5 @@ identifiers:
 references:
     disa: "1250"
     nist: AC-19(a),AC-19(d),AC-19(e)
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -22,3 +22,5 @@ references:
     cis: 1.1.1.1
     cui: 3.4.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
@@ -22,3 +22,5 @@ references:
     cis: 1.1.1.2
     cui: 3.4.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
@@ -22,3 +22,5 @@ references:
     cis: 1.1.1.4
     cui: 3.4.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
@@ -22,3 +22,5 @@ references:
     cis: 1.1.1.5
     cui: 3.4.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
@@ -22,3 +22,5 @@ references:
     cis: 1.1.1.3
     cui: 3.4.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
@@ -22,3 +22,5 @@ references:
     cis: 1.1.1.6
     cui: 3.4.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -22,3 +22,5 @@ references:
     cis: 1.1.1.7
     cui: 3.4.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
@@ -34,3 +34,5 @@ references:
     stigid@rhel7: "020100"
 
 {{{ complete_ocil_entry_module_disable(module="usb-storage") }}}
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -17,3 +17,5 @@ identifiers:
 references:
     cis: 1.1.15
     nist: CM-7,MP-2
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -24,3 +24,5 @@ identifiers:
 references:
     cis: 1.1.17
     nist: CM-7,MP-2
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -21,3 +21,5 @@ identifiers:
 references:
     cis: 1.1.16
     nist: CM-7,MP-2
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
@@ -20,3 +20,5 @@ severity: unknown
 
 references:
     cis: 1.1.14
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -23,3 +23,5 @@ references:
     cis: 1.1.3
     nist: CM-7,MP-2
     stigid@rhel7: "021000"
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
@@ -22,3 +22,5 @@ identifiers:
 references:
     cis: 1.1.11
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
@@ -27,3 +27,5 @@ identifiers:
 references:
     cis: 1.1.18
     nist: AC-19(a),AC-19(d),AC-19(e),CM-7,MP-2
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
@@ -30,3 +30,5 @@ ocil: |-
     <pre>$ grep -v noexec /etc/fstab</pre>
     The resulting output will show partitions which do not have the <tt>noexec</tt> flag. Verify all partitions
     in the output are not removable media.
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
@@ -29,3 +29,5 @@ references:
     nist: AC-6,AC-19(a),AC-19(d),AC-19(e),CM-7,MP-2
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "021010"
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -19,3 +19,5 @@ identifiers:
 references:
     cis: 1.1.3
     nist: CM-7,MP-2
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -26,3 +26,5 @@ references:
     disa@rhel6: '381'
     cis: 1.1.5
     nist: CM-7,MP-2
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -23,3 +23,5 @@ identifiers:
 references:
     cis: 1.1.4
     nist: CM-7,MP-2
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
@@ -20,3 +20,5 @@ identifiers:
 references:
     cis: 1.1.6
     nist: CM-7
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -14,3 +14,5 @@ severity: unknown
 
 references:
     cis: 1.1.8
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -18,3 +18,5 @@ severity: unknown
 
 references:
     cis: 1.1.10
+
+platform: machine

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -18,3 +18,5 @@ severity: unknown
 
 references:
     cis: 1.1.9
+
+platform: machine

--- a/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
@@ -23,3 +23,5 @@ references:
     nist: SI-11
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="fs.suid_dumpable", value="0") }}}
+
+platform: machine

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     <pre>$ sysctl kernel.exec-shield</pre>
     The output should be:
     {{{ describe_sysctl_option_value(sysctl="kernel.exec-shield", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
@@ -24,3 +24,5 @@ references:
     stigid: "040201"
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.randomize_va_space", value="2") }}}
+
+platform: machine

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -23,3 +23,5 @@ identifiers:
 references:
     cui: 3.1.7
     nist: CM-6(b)
+
+platform: machine

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
@@ -39,3 +39,5 @@ warnings:
         The kernel-PAE package should not be
         installed on older systems that do not support the XD or NX bit, as
         8this may prevent them from booting.8
+
+platform: machine

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -21,3 +21,5 @@ references:
     nist: SI-11
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.dmesg_restrict", value="1") }}}
+
+platform: machine

--- a/linux_os/guide/system/selinux/docker_selinux_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/docker_selinux_enabled/rule.yml
@@ -23,3 +23,5 @@ severity: high
 
 identifiers:
     cce@rhel7: 80442-7
+
+platform: machine

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
@@ -35,3 +35,5 @@ warnings:
         Automatic remediation of this control is not available. Remediation
         can be achieved by amending SELinux policy or stopping the unconfined
         daemons as outlined above.
+
+platform: machine

--- a/linux_os/guide/system/selinux/selinux_policytype/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_policytype/rule.yml
@@ -48,3 +48,5 @@ ocil_clause: 'it does not'
 ocil: |-
     Check the file <tt>/etc/selinux/config</tt> and ensure the following line appears:
     <pre>SELINUXTYPE=<sub idref="var_selinux_policy_name" /></pre>
+
+platform: machine

--- a/linux_os/guide/system/selinux/selinux_state/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_state/rule.yml
@@ -39,3 +39,5 @@ ocil_clause: 'SELINUX is not set to enforcing'
 ocil: |-
     Check the file <tt>/etc/selinux/config</tt> and ensure the following line appears:
     <pre>SELINUX=<sub idref="var_selinux_state" /></pre>
+
+platform: machine

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -67,3 +67,5 @@ ocil: |-
     " TYPE="crypto_LUKS"</pre>
     <br /><br />
     Pseudo-file systems, such as /proc, /sys, and tmpfs, are not required to use disk encryption and are not a finding.
+
+platform: machine

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
@@ -32,3 +32,5 @@ references:
     stigid@rhel7: "021310"
 
 {{{ complete_ocil_entry_separate_partition(part="/home") }}}
+
+platform: machine

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
@@ -31,3 +31,5 @@ references:
     stigid@rhel7: "021340"
 
 {{{ complete_ocil_entry_separate_partition(part="/tmp") }}}
+
+platform: machine

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
@@ -33,3 +33,5 @@ references:
     stigid@rhel7: "021320"
 
 {{{ complete_ocil_entry_separate_partition(part="/var") }}}
+
+platform: machine

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
@@ -27,3 +27,5 @@ references:
     nist: AU-9,SC-32
 
 {{{ complete_ocil_entry_separate_partition(part="/var/log") }}}
+
+platform: machine

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -35,3 +35,5 @@ references:
     stigid@rhel7: "021330"
 
 {{{ complete_ocil_entry_separate_partition(part="/var/log/audit") }}}
+
+platform: machine

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -20,3 +20,5 @@ references:
     cis: 1.1.7
 
 {{{ complete_ocil_entry_separate_partition(part="/var/tmp") }}}
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     system-db:local
     system-db:site
     system-db:distro</pre>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
@@ -31,3 +31,5 @@ ocil: |-
     To ensure that users cannot enable disable and restart on the login screen, run the following:
     <pre>$ grep disable-restart-buttons /etc/dconf/db/gdm.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/disable-restart-buttons</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
@@ -28,3 +28,5 @@ ocil: |-
     To ensure that users cannot enable displaying the user list, run the following:
     <pre>$ grep disable-user-list /etc/dconf/db/gdm.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/disable-user-list</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
@@ -44,3 +44,5 @@ ocil: |-
     To ensure that users cannot disable smart card authentication on the login screen, run the following:
     <pre>$ grep enable-smartcard-authentication /etc/dconf/db/gdm.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/enable-smartcard-authentication</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     number of failures on the login screen, run the following:
     <pre>$ grep allowed-failures /etc/dconf/db/gdm.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/allowed-failures</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     The output should show the following:
     <pre>[daemon]
     AutomaticLoginEnable=false</pre>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     The output should show the following:
     <pre>[daemon]
     TimedLoginEnable=false</pre>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
@@ -53,3 +53,5 @@ ocil: |-
     If properly configured, the output for <tt>automount</tt> should be <tt>/org/gnome/desktop/media-handling/automount</tt>
     If properly configured, the output for <tt>automount-open</tt> should be <tt>/org/gnome/desktop/media-handling/auto-open</tt>
     If properly configured, the output for <tt>autorun-never</tt> should be <tt>/org/gnome/desktop/media-handling/autorun-never</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     To ensure that users cannot how long until the the screensaver locks, run the following:
     <pre>$ grep disable-all /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/thumbnailers/disable-all</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
     <pre>$ grep wifi-create /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/nm-applet/disable-wifi-create</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
@@ -42,3 +42,5 @@ ocil: |-
     <pre>$ grep wireless-networks-available /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/nm-applet/suppress-wireless-networks-available</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
@@ -41,3 +41,5 @@ ocil: |-
     <pre>$ grep authentication-methods /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/Vino/authentication-methods</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
@@ -44,3 +44,5 @@ ocil: |-
     <pre>$ grep require-encryption /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/Vino/require-encryption</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
@@ -53,3 +53,5 @@ ocil: |-
     To ensure that users cannot disable the screensaver idle inactivity setting, run the following:
     <pre>$ grep idle-activation-enabled /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/idle-activation-enabled</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -50,3 +50,5 @@ ocil: |-
     To ensure that users cannot change the screensaver inactivity timeout setting, run the following:
     <pre>$ grep idle-delay /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/session/idle-delay</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     To ensure that users cannot change how long until the the screensaver locks, run the following:
     <pre>$ grep lock-delay /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output for <tt>lock-delay</tt> should be <tt>/org/gnome/desktop/screensaver/lock-delay</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     To ensure that users cannot change how long until the the screensaver locks, run the following:
     <pre>$ grep lock-enabled /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output for <tt>lock-enabled</tt> should be <tt>/org/gnome/desktop/screensaver/lock-enabled</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
@@ -44,3 +44,5 @@ ocil: |-
     To ensure that users cannot set the screensaver background, run the following:
     <pre>$ grep picture-uri /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/picture-uri</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
     To ensure that users cannot enable user name on the lock screen, run the following:
     <pre>$ grep show-full-name-in-top-bar /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/show-full-name-in-top-bar</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
@@ -39,3 +39,5 @@ ocil: |-
     <pre>$ grep 'lock-delay' /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should return:
     <tt>/org/gnome/desktop/screensaver/lock-delay</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
@@ -39,3 +39,5 @@ ocil: |-
     <pre>$ grep 'idle-delay' /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should return:
     <tt>/org/gnome/desktop/session/idle-delay</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
@@ -34,3 +34,5 @@ ocil: |-
     <pre>$ grep logout /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/settings-daemon/plugins/media-keys/logout</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
@@ -27,3 +27,5 @@ ocil: |-
     <pre>$ grep location /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/system/location/enabled</tt> and <tt>/org/gnome/clocks/geolocation</tt>.
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/rule.yml
@@ -39,3 +39,5 @@ ocil: |-
     <pre>$ grep power /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/settings-daemon/plugins/power/active</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     <pre>$ grep user-administration /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be
     <tt>/org/gnome/desktop/lockdown/user-administration-disabled</tt>
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     To check on the age of uvscan virus definition files, run the following command:
     <pre>$ sudo cd /opt/NAI/LinuxShield/engine/dat
     $ sudo ls -la avvscan.dat avvnames.dat avvclean.dat</pre>
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -43,3 +43,5 @@ warnings:
         detection tools, such as the McAfee Host-based Security System, are available
         to integrate with existing infrastructure. When these supplemental tools
         interfere with proper functioning of SELinux, SELinux takes precedence.
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
@@ -36,3 +36,5 @@ warnings:
     - general: |-
         Due to McAfee HIPS being 3rd party software, automated
         remediation is not available for this configuration check.
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/rule.yml
@@ -27,3 +27,5 @@ ocil: |-
     To check on the age of McAfee virus definition files, run the following command:
     <pre>$ sudo cd /opt/NAI/LinuxShield/engine/dat
     $ sudo ls -la avvscan.dat avvnames.dat avvclean.dat</pre>
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/service_nails_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/service_nails_enabled/rule.yml
@@ -24,3 +24,5 @@ references:
     srg: SRG-OS-000480-GPOS-00227
 
 ocil: '{{{ ocil_service_enabled(service="nails") }}}'
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -60,3 +60,5 @@ warnings:
         <br /><br />
         See <b>{{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/1401vend.htm") }}}</b>
         for a list of FIPS certified vendors.
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -56,3 +56,5 @@ ocil: |-
     <pre>05 4 * * * root /usr/sbin/aide --check</pre>
 
     NOTE: The usage of special cron times, such as @daily or @weekly, is acceptable.
+
+platform: machine

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -436,7 +436,10 @@ class Group(object):
 
         if self.platform:
             platform_el = ET.SubElement(group, "platform")
-            platform_cpe = XCCDF_PLATFORM_TO_CPE[self.platform]
+            try:
+                platform_cpe = XCCDF_PLATFORM_TO_CPE[self.platform]
+            except KeyError:
+                raise ValueError("Unsupported platform '%s' in rule '%s'." % (self.platform, self.id_))
             platform_el.set("idref", platform_cpe)
 
         for _value in self.values.values():
@@ -622,7 +625,10 @@ class Rule(object):
 
         if self.platform:
             platform_el = ET.SubElement(rule, "platform")
-            platform_cpe = XCCDF_PLATFORM_TO_CPE[self.platform]
+            try:
+                platform_cpe = XCCDF_PLATFORM_TO_CPE[self.platform]
+            except KeyError:
+                raise ValueError("Unsupported platform '%s' in rule '%s'." % (self.platform, self.id_))
             platform_el.set("idref", platform_cpe)
 
         return rule

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -464,11 +464,15 @@ class Group(object):
     def add_group(self, group):
         if group is None:
             return
+        if self.platform and not group.platform:
+            group.platform = self.platform
         self.groups[group.id_] = group
 
     def add_rule(self, rule):
         if rule is None:
             return
+        if self.platform and not rule.platform:
+            rule.platform = self.platform
         self.rules[rule.id_] = rule
 
     def __str__(self):
@@ -717,6 +721,8 @@ def add_from_directory(action, parent_group, guide_directory, profiles_dir,
                                     profiles_dir, env_yaml, bash_remediation_fns)
 
     if group is not None:
+        if parent_group:
+            parent_group.add_group(group)
         for value_yaml in values:
             if action == "list-inputs":
                 print(value_yaml)
@@ -736,9 +742,7 @@ def add_from_directory(action, parent_group, guide_directory, profiles_dir,
                 rule = Rule.from_yaml(rule_yaml, env_yaml)
                 group.add_rule(rule)
 
-        if parent_group:
-            parent_group.add_group(group)
-        else:
+        if not parent_group:
             # We are on the top level!
             # Lets dump the XCCDF group or benchmark to a file
             if action == "build":

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -6,6 +6,7 @@ import os.path
 import datetime
 import sys
 
+from .constants import XCCDF_PLATFORM_TO_CPE
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 
 from .checks import is_cce_valid
@@ -395,6 +396,7 @@ class Group(object):
         self.values = {}
         self.groups = {}
         self.rules = {}
+        self.platform = None
 
     @staticmethod
     def from_yaml(yaml_file, env_yaml=None):
@@ -410,6 +412,7 @@ class Group(object):
         group.description = required_key(yaml_contents, "description")
         del yaml_contents["description"]
         group.warnings = yaml_contents.pop("warnings", [])
+        group.platform = yaml_contents.pop("platform", None)
 
         for warning_list in group.warnings:
             if len(warning_list) != 1:
@@ -430,6 +433,11 @@ class Group(object):
         title.text = self.title
         add_sub_element(group, 'description', self.description)
         add_warning_elements(group, self.warnings)
+
+        if self.platform:
+            platform_el = ET.SubElement(group, "platform")
+            platform_cpe = XCCDF_PLATFORM_TO_CPE[self.platform]
+            platform_el.set("idref", platform_cpe)
 
         for _value in self.values.values():
             group.append(_value.to_xml_element())
@@ -480,6 +488,7 @@ class Rule(object):
         self.ocil = None
         self.external_oval = None
         self.warnings = []
+        self.platform = None
 
     @staticmethod
     def from_yaml(yaml_file, env_yaml=None):
@@ -507,6 +516,7 @@ class Rule(object):
         rule.ocil = yaml_contents.pop("ocil", None)
         rule.external_oval = yaml_contents.pop("oval_external_content", None)
         rule.warnings = yaml_contents.pop("warnings", [])
+        rule.platform = yaml_contents.pop("platform", None)
 
         for warning_list in rule.warnings:
             if len(warning_list) != 1:
@@ -609,6 +619,11 @@ class Rule(object):
                 ocil.set("clause", self.ocil_clause)
 
         add_warning_elements(rule, self.warnings)
+
+        if self.platform:
+            platform_el = ET.SubElement(rule, "platform")
+            platform_cpe = XCCDF_PLATFORM_TO_CPE[self.platform]
+            platform_el.set("idref", platform_cpe)
 
         return rule
 

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -203,5 +203,10 @@ OCILREFATTR_TO_TAG = {
     "question_ref": "question",
 }
 
+XCCDF_PLATFORM_TO_CPE = {
+    "machine": "cpe:/a:machine",
+    "container": "cpe:/a:container"
+}
+
 # Application constants
 DEFAULT_UID_MIN = 1000

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,3 +43,8 @@ add_test(
     NAME "stable-profile-ids"
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/stable_profile_ids.py" "${CMAKE_BINARY_DIR}"
 )
+
+add_test(
+    NAME "machine-only-rules"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_machine_only_rules.py" --source_dir "${CMAKE_SOURCE_DIR}" --build_dir "${CMAKE_BINARY_DIR}"
+)

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -50,9 +50,12 @@ def check_ds(ds_path, what, input_elems):
         elem_short_id = elem_id.replace(replacement, "")
         if elem_short_id not in input_elems:
             continue
-        machine_platform = elem.findall(
-            "{%s}platform[@idref='%s']" %
-            (ssg.constants.XCCDF12_NS, machine_cpe))
+        platforms = elem.findall("{%s}platform" % ssg.constants.XCCDF12_NS)
+        machine_platform = False
+        for p in platforms:
+            idref = p.get("idref")
+            if idref == machine_cpe:
+                machine_platform = True
         if not machine_platform:
             sys.stderr.write("%s %s in %s is missing <platform> element" %
                              (what, elem_short_id, ds_path))

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -7,9 +7,6 @@ import sys
 import ssg.constants
 import ssg.yaml
 
-ns = {
-    "xccdf": "http://checklists.nist.gov/xccdf/1.2"
-}
 machine_cpe = "cpe:/a:machine"
 
 
@@ -43,18 +40,19 @@ def check_ds(ds_path, what, input_elems):
     root = tree.getroot()
     if what == "groups":
         replacement = "xccdf_org.ssgproject.content_group_"
-        xpath_query = ".//xccdf:Group"
+        xpath_query = ".//{%s}Group" % ssg.constants.XCCDF12_NS
     if what == "rules":
         replacement = "xccdf_org.ssgproject.content_rule_"
-        xpath_query = ".//xccdf:Rule"
-    benchmark = root.find(".//xccdf:Benchmark", ns)
-    for elem in benchmark.findall(xpath_query, ns):
+        xpath_query = ".//{%s}Rule" % ssg.constants.XCCDF12_NS
+    benchmark = root.find(".//{%s}Benchmark" % ssg.constants.XCCDF12_NS)
+    for elem in benchmark.findall(xpath_query):
         elem_id = elem.get("id")
         elem_short_id = elem_id.replace(replacement, "")
         if elem_short_id not in input_elems:
             continue
         machine_platform = elem.findall(
-            "xccdf:platform[@idref='" + machine_cpe + "']", ns)
+            "{%s}platform[@idref='%s']" %
+            (ssg.constants.XCCDF12_NS, machine_cpe))
         if not machine_platform:
             sys.stderr.write("%s %s in %s is missing <platform> element" %
                              (what, elem_short_id, ds_path))

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -36,9 +36,9 @@ def check_product(build_dir, product, guide_dir):
 def check_ds(ds_path, what, input_elems):
     try:
         tree = ET.parse(ds_path)
-    except FileNotFoundError as e:
-        print("The product datastream '%s' hasn't been build,"
-              "skipping the test." % (ds_path), file=sys.stderr)
+    except IOError as e:
+        sys.stderr.write("The product datastream '%s' hasn't been build, "
+              "skipping the test." % (ds_path))
         return True
     root = tree.getroot()
     if what == "groups":
@@ -56,8 +56,8 @@ def check_ds(ds_path, what, input_elems):
         machine_platform = elem.findall(
             "xccdf:platform[@idref='" + machine_cpe + "']", ns)
         if not machine_platform:
-            print("%s %s in %s is missing <platform> element" %
-                  (what, elem_short_id, ds_path), file=sys.stderr)
+            sys.stderr.write("%s %s in %s is missing <platform> element" %
+                  (what, elem_short_id, ds_path))
             return False
     return True
 

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+import os
+import argparse
+import xml.etree.ElementTree as ET
+import sys
+import ssg.constants
+import ssg.yaml
+
+ns = {
+    "xccdf": "http://checklists.nist.gov/xccdf/1.2"
+}
+machine_cpe = "cpe:/a:machine"
+
+
+def main():
+    args = parse_command_line_args()
+    for product in ssg.constants.product_directories:
+        product_dir = os.path.join(args.source_dir, product)
+        product_yaml_path = os.path.join(product_dir, "product.yml")
+        product_yaml = ssg.yaml.open_raw(product_yaml_path)
+        guide_dir = os.path.abspath(
+            os.path.join(product_dir, product_yaml['benchmark_root']))
+        if not check_product(args.build_dir, product, guide_dir):
+            sys.exit(1)
+
+
+def check_product(build_dir, product, guide_dir):
+    input_groups, input_rules = scan_rules_groups(guide_dir, False)
+    ds_path = os.path.join(build_dir, "ssg-" + product + "-ds.xml")
+    if not check_ds(ds_path, "groups", input_groups):
+        return False
+    return True
+
+
+def check_ds(ds_path, what, input_elems):
+    try:
+        tree = ET.parse(ds_path)
+    except FileNotFoundError as e:
+        print("The product datastream '%s' hasn't been build,"
+              "skipping the test." % (ds_path), file=sys.stderr)
+        return True
+    root = tree.getroot()
+    if what == "groups":
+        replacement = "xccdf_org.ssgproject.content_group_"
+        xpath_query = ".//xccdf:Group"
+    if what == "rules":
+        replacement = "xccdf_org.ssgproject.content_rule_"
+        xpath_query = ".//xccdf:Rule"
+    benchmark = root.find(".//xccdf:Benchmark", ns)
+    for elem in benchmark.findall(xpath_query, ns):
+        elem_id = elem.get("id")
+        elem_short_id = elem_id.replace(replacement, "")
+        if elem_short_id not in input_elems:
+            continue
+        machine_platform = elem.findall(
+            "xccdf:platform[@idref='" + machine_cpe + "']", ns)
+        if not machine_platform:
+            print("%s %s in %s is missing <platform> element" %
+                  (what, elem_short_id, ds_path), file=sys.stderr)
+            return False
+    return True
+
+
+def parse_command_line_args():
+    parser = argparse.ArgumentParser(
+        description="Tests if 'machine' CPEs are "
+                    "propagated to the built datastream")
+    parser.add_argument("--source_dir", required=True,
+                        help="Content source directory path")
+    parser.add_argument("--build_dir", required=True,
+                        help="Build directory containing built datastreams")
+    args = parser.parse_args()
+    return args
+
+
+def check_if_machine_only(dirpath, name, is_machine_only_group):
+    if name in os.listdir(dirpath):
+        if is_machine_only_group:
+            return True
+        yml_path = os.path.join(dirpath, name)
+        with open(yml_path, "r") as yml_file:
+            yml_file_contents = yml_file.read()
+            if "platform: machine" in yml_file_contents:
+                return True
+    return False
+
+
+def scan_rules_groups(dirpath, parent_machine_only):
+    groups = set()
+    rules = set()
+    name = os.path.basename(dirpath)
+    is_machine_only = False
+    if check_if_machine_only(dirpath, "group.yml", parent_machine_only):
+        groups.add(name)
+        is_machine_only = True
+    if check_if_machine_only(dirpath, "rule.yml", parent_machine_only):
+        rules.add(name)
+    for dir_item in os.listdir(dirpath):
+        subdir_path = os.path.join(dirpath, dir_item)
+        if os.path.isdir(subdir_path):
+            subdir_groups, subdir_rules = scan_rules_groups(
+                subdir_path, is_machine_only)
+            groups |= subdir_groups
+            rules |= subdir_rules
+    return groups, rules
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -38,7 +38,7 @@ def check_ds(ds_path, what, input_elems):
         tree = ET.parse(ds_path)
     except IOError as e:
         sys.stderr.write("The product datastream '%s' hasn't been build, "
-              "skipping the test." % (ds_path))
+                         "skipping the test." % (ds_path))
         return True
     root = tree.getroot()
     if what == "groups":
@@ -57,7 +57,7 @@ def check_ds(ds_path, what, input_elems):
             "xccdf:platform[@idref='" + machine_cpe + "']", ns)
         if not machine_platform:
             sys.stderr.write("%s %s in %s is missing <platform> element" %
-                  (what, elem_short_id, ds_path))
+                             (what, elem_short_id, ds_path))
             return False
     return True
 


### PR DESCRIPTION
#### Description:
Fixes  regression #3569 .

Adds a new field into rule and group YAML and a support for this new field into our scripts. It allows us to mark rules as bare-metal machine only or container only by adding "platform: machine" or "platform: container" to rule.yml or group.yml. This will be populated into XCCDF as platform element. The platform element is a child element of Rule or Group element. For convenience the CPE in idref attribute value is defined as a constant (under ssg/constants.py).

Then, we mark rules as machine only - we mark those rules that were marked as machine-only before we converted to the new YAML format.


#### Rationale
Certain rules doesn't make sense in containers, they shouldn't be evaluated if the scanned target is a container, they should be evaluated only if scan target is bare-metal or VM.

This problem is supposed to be solved by marking those rules by special CPEs, eg. cpe:/a:machine
or cpe:/a:container. See eg. #2337 where we added <platform idref="cpe:/a:machine" /> to multiple rules or groups.

However, -then- after we added the CPEs we converted the rules and groups to new YAML format. Unfortunately, the CPEs were not converted. That means all the rules are now applicable to containers.