### PR TITLE
Added ansible-lint and yamllint checks of ansible playbooks into CTest

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -33,10 +33,17 @@ source code:
 yum install git
 ```
 
-(optional) Install the ShellCheck package to perform fix script static analysis:
+(optional) Install the `ShellCheck` package to perform fix script static analysis:
 
 ```bash
 yum install ShellCheck
+```
+
+(optional) Install `yamllint` and `ansible-lint` packages to perform Ansible
+playbooks checks. These checks are not enabled by default in CTest, to enable
+them add `-DANSIBLE_CHECKS=ON` option to `cmake`.
+```bash
+yum install yamllint ansible-lint
 ```
 
 (optional) Install the `ninja` build system if you want to use it instead of

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,8 @@ find_program(SHELLCHECK_EXECUTABLE NAMES shellcheck)
 find_program(LINKCHECKER_EXECUTABLE NAMES linkchecker)
 find_program(GREP_EXECUTABLE NAMES grep)
 find_program(ANSIBLE_PLAYBOOK_EXECUTABLE NAMES ansible-playbook)
+find_program(ANSIBLE_LINT_EXECUTABLE NAMES ansible-lint)
+find_program(YAMLLINT_EXECUTABLE NAMES yamllint)
 
 configure_file("${CMAKE_SOURCE_DIR}/build_config.yml.in" "${CMAKE_BINARY_DIR}/build_config.yml" @ONLY)
 
@@ -183,6 +185,8 @@ message(STATUS "linkchecker (optional): ${LINKCHECKER_EXECUTABLE}")
 message(STATUS "grep (optional): ${GREP_EXECUTABLE}")
 message(STATUS "python pytest module (optional): ${PY_PYTEST}")
 message(STATUS "ansible-playbook module (optional): ${ANSIBLE_PLAYBOOK_EXECUTABLE}")
+message(STATUS "ansible-lint module (optional): ${ANSIBLE_LINT_EXECUTABLE}")
+message(STATUS "yamllint module (optional): ${YAMLLINT_EXECUTABLE}")
 message(STATUS " ")
 
 message(STATUS "Build options:")
@@ -224,6 +228,10 @@ message(STATUS "Oracle Linux 7: ${SSG_PRODUCT_OL7}")
 
 message(STATUS " ")
 
+# Remove this option when we would like to run ansible-lint and yamllint against our playbooks by default.
+# Right now these checks are not performed and need to be enabled by adding -DANSIBLE_CHECKS=ON to cmake
+# before running ctest.
+option(ANSIBLE_CHECKS "Set to ON to enable ansible-lint and yamllint checks" OFF)
 enable_testing()
 
 include(SSGCommon)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -266,8 +266,22 @@ macro(ssg_build_remediations PRODUCT)
     if (ANSIBLE_PLAYBOOK_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
         add_test(
             NAME "ansible-role-syntax-check-${PRODUCT}"
-            COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_syntax_check.sh" "${ANSIBLE_PLAYBOOK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/roles" "${PRODUCT}"
+            COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_PLAYBOOK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/roles" "${PRODUCT}"
         )
+    endif()
+    if (ANSIBLE_CHECKS)
+        if (ANSIBLE_LINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
+            add_test(
+                NAME "ansible-role-ansible-lint-check-${PRODUCT}"
+                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/roles" "${PRODUCT}"
+            )
+        endif()
+        if (YAMLLINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
+            add_test(
+                NAME "ansible-role-yamllint-check-${PRODUCT}"
+                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/roles" "${PRODUCT}" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
+            )
+        endif()
     endif()
 endmacro()
 

--- a/tests/ansible_playbook_check.sh
+++ b/tests/ansible_playbook_check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+pushd "$2" > /dev/null
+
+if [[ $1 =~ ansible-playbook ]]; then
+	$1 --syntax-check ssg-$3-role-*.yml
+	ret=$?
+elif [[ $1 =~ ansible-lint ]]; then
+	$1 -p ssg-$3-role-*.yml
+	ret=$?
+elif [[ $1 =~ yamllint ]]; then
+	$1 -c $4 ssg-$3-role-*.yml
+	ret=$?
+else
+	echo "Error: '$1' is not expected executable" 1>&2
+	ret=1
+fi
+
+popd > /dev/null
+exit $ret

--- a/tests/ansible_playbook_syntax_check.sh
+++ b/tests/ansible_playbook_syntax_check.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-pushd "$2" > /dev/null
-$1 --syntax-check ssg-$3-role-*.yml
-ret=$?
-popd > /dev/null
-exit $ret

--- a/tests/yamllint_config.yml
+++ b/tests/yamllint_config.yml
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  line-length:
+    level: warning
+    max: 160
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  comments: disable
+  comments-indentation: disable
+  empty-lines:
+    level: warning
+  truthy: disable


### PR DESCRIPTION
#### Description:

CMake is extended with option ANSIBLE_CHECKS to also enable `ansible-lint`
and `yamllint` checks of generated playbooks (thse checks are not enabled
by default in CTest). To perform these checks:
```
$ cd build/
$ cmake -DANSIBLE_CHECKS=ON ../ && make
$ ctest -R ansible
```