### PR TITLE
Add prodtype to OCP to prevent polluting non-ocp builds

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable the AlwaysAdmit Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the AlwaysPullImages Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_DenyEscalatingExec/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_DenyEscalatingExec/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the DenyEscalatingExec Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_EventRateLimit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_EventRateLimit/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the EventRateLimit Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the NamespaceLifecyle Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the NodeRestriction Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_PodSecurityPolicy/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_PodSecurityPolicy/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the PodSecurityPolicy Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the SecurityContextDeny Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the ServiceAccount Admission Control Plugin'
 
 description: |-

--- a/applications/openshift/api-server/api_server_advanced_auditing/rule.yml
+++ b/applications/openshift/api-server/api_server_advanced_auditing/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable Advanced Auditing for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable Anonymous Authentication to the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_audit_log_maxage/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxage/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Audit Log Maxage'
 
 description: |-

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Maximum Retained Audit Logs'
 
 description: |-

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure Maximum Audit Log Size'
 
 description: |-

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Audit Log Path'
 
 description: |-

--- a/applications/openshift/api-server/api_server_authorization_mode/rule.yml
+++ b/applications/openshift/api-server/api_server_authorization_mode/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable use of AlwaysAllow for the API Server Authorization Mode'
 
 description: |-

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable basic-auth-file for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Client Certificate Authority for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the etcd Certificate Authority for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the etcd Certificate for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the etcd Certificate Key for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_experimental_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_experimental_encryption_provider_cipher/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Encryption Provider Cipher'
 
 description: |-

--- a/applications/openshift/api-server/api_server_experimental_encryption_provider_config/rule.yml
+++ b/applications/openshift/api-server/api_server_experimental_encryption_provider_config/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Encryption Provider'
 
 description: |-

--- a/applications/openshift/api-server/api_server_insecure_allow_any_token/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_allow_any_token/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable Insecure Tokens'
 
 description: |-

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable Use of the Insecure Bind Address'
 
 description: |-

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable Insecure Port Access'
 
 description: |-

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the kubelet Certificate Authority for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the kubelet Certificate File for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the kubelet Certificate Key for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_kubelet_https/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_https/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable kubelet HTTPS connections to the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_profiling/rule.yml
+++ b/applications/openshift/api-server/api_server_profiling/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable Profiling on the API server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the API Server Request Timeout'
 
 description: |-

--- a/applications/openshift/api-server/api_server_secure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_secure_port/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable the Secure Port for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_service_account_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_key/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Service Account Public Key for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable service-account-lookup on the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Certificate for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Use Strong Cryptographic Ciphers on the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure the Certificate Key for the API Server'
 
 description: |-

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable Token-based Authentication'
 
 description: |-

--- a/applications/openshift/api-server/group.yml
+++ b/applications/openshift/api-server/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'OpenShift API Server'
 
 description: |-

--- a/applications/openshift/controller/controller_bind_address/rule.yml
+++ b/applications/openshift/controller/controller_bind_address/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure Controller bind-address argument is set'
 
 description: |-

--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure that the RotateKubeletServerCertificate argument is set'
 
 description: |-

--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable terminated-pod-gc-threshold for the Controller Manager'
 
 description: |-

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure that the --use-service-account-credentials argument is set'
 
 description: |-

--- a/applications/openshift/controller/group.yml
+++ b/applications/openshift/controller/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'OpenShift Controller Settings'
 
 description: 'This section contains recommendations for the kube-controller-manager configuration'

--- a/applications/openshift/etcd/etcd_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable etcd Self-Signed Certificates'
 
 description: |-

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure That The etcd Client Certificate Is Correctly Set'
 
 description: |-

--- a/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable The Client Certificate Authentication'
 
 description: |-

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure That The etcd Key File Is Correctly Set'
 
 description: |-

--- a/applications/openshift/etcd/etcd_max_wals/rule.yml
+++ b/applications/openshift/etcd/etcd_max_wals/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable etcd Auto Log Rotation'
 
 description: |-

--- a/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable etcd Peer Self-Signed Certificates'
 
 description: |-

--- a/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure That The etcd Peer Client Certificate Is Correctly Set'
 
 description: |-

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Enable The Peer Client Certificate Authentication'
 
 description: |-

--- a/applications/openshift/etcd/etcd_peer_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure That The etcd Peer Key File Is Correctly Set'
 
 description: |-

--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure A Unique CA Certificate for etcd'
 
 description: |-

--- a/applications/openshift/etcd/etcd_wal_dir/rule.yml
+++ b/applications/openshift/etcd/etcd_wal_dir/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Configure etcd Log Storage'
 
 description: |-

--- a/applications/openshift/etcd/group.yml
+++ b/applications/openshift/etcd/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'OpenShift etcd Settings'
 
 description: 'Contains rules that check correct OpenShift etcd settings.'

--- a/applications/openshift/group.yml
+++ b/applications/openshift/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'OpenShift Settings'
 
 description: 'Contains rules that check correct OpenShift settings.'

--- a/applications/openshift/kubelet/group.yml
+++ b/applications/openshift/kubelet/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Kubernetes Kubelet Settings'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Configure the Client CA Certificate'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Do Not Limit Event Creation'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure That The kubelet Client Certificate Is Correctly Set'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Ensure That The kubelet Server Key Is Correctly Set'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_disable_anon_access/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_anon_access/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Disable Anonymous Access'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_disable_cadvisor_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_cadvisor_port/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Disable cAdvisor Port'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Disable Hostname Override'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Disable the Read-Only Port'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_authorization/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_authorization/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Ensure AlwaysAllow Is Not Set'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Enable Client Certificate Rotation'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Allow Automatic Firewall Configuration'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_kernel_defaults/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Prevent Kernel Settings Modification'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Enable Server Certificate Rotation'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Do Not Disable Streaming Timeouts'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_privileged_containers/rule.yml
+++ b/applications/openshift/kubelet/kubelet_privileged_containers/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'kubelet - Disable Privileged Containers'
 
 description: |-

--- a/applications/openshift/ocp-permissions/group.yml
+++ b/applications/openshift/ocp-permissions/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Permissions'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_etc_origin/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_etc_origin/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Configuration Directory'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_admin_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_admin_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Admin Kubeconfig File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/master/admin.kubeconfig", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_api_server/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_api_server/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift API Specification File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/node/pods/apiserver.yaml", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_cni_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_cni_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
 
 description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_controller_manager/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_controller_manager/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Controller Manager Specification File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/node/pods/controller.yaml", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_etcd/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_etcd/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift etcd Specification File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/node/pods/etcd.yaml", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_openshift_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_openshift_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Master Configuration File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/master/master-config.yaml", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_openshift_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_openshift_kubeconfig/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Master Kubeconfig File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/master/openshift-master.kubeconfig", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_scheduler_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_scheduler_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Scheduler Configuration File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/master/scheduler.json", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_node_config/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_node_config/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Node Configuration File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/node/node-config.yaml", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_node_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_node_kubeconfig/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Node Kubeconfig File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/node/node.kubeconfig", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_client_crt/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_client_crt/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns OpenShift Node Certificate File'
 
 description: '{{{ describe_file_group_owner(file="/etc/origin/node/client-ca.crt", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_service/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_openshift_node_service/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift Node Service File'
 
 description: '{{{ describe_file_group_owner(file="/etc/systemd/system/atomic-openshift-node.service", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_var_lib_etcd/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_var_lib_etcd/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Group Who Owns The OpenShift etcd Data Directory'
 
 description: '{{{ describe_file_group_owner(file="/var/lib/etcd", group="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_etc_origin/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_etc_origin/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Configuration Directory'
 
 description: '{{{ describe_file_owner(file="/etc/origin/", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_admin_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_admin_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Admin Kubeconfig File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/master/admin.kubeconfig", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_api_server/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_api_server/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift API Specification File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/node/pods/apiserver.yaml", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_cni_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_cni_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Container Network Interface Files'
 
 description: '{{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_controller_manager/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_controller_manager/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Controller Manager Specification File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/node/pods/controller.yaml", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_etcd/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_etcd/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift etcd Specification File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/node/pods/etcd.yaml", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_openshift_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_openshift_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Master Configuration File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/master/master-config.yaml", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_openshift_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_openshift_kubeconfig/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Master Kubeconfig File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/master/openshift-master.kubeconfig", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_scheduler_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_scheduler_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Scheduler Configuration File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/master/scheduler.json", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_node_config/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_node_config/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Node Configuration File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/node/node-config.yaml", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_node_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_node_kubeconfig/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Node Kubeconfig File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/node/node.kubeconfig", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_client_crt/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_client_crt/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns OpenShift Node Certificate File'
 
 description: '{{{ describe_file_owner(file="/etc/origin/node/client-ca.crt", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_service/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_openshift_node_service/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift Node Service File'
 
 description: '{{{ describe_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_var_lib_etcd/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_var_lib_etcd/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify User Who Owns The OpenShift etcd Data Directory'
 
 description: '{{{ describe_file_owner(file="/var/lib/etcd", owner="root") }}}'

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_etc_origin/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_etc_origin/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'The OpenShift Configuration Directory Must Have Mode 0700'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_admin_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_admin_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Admin Kubeconfig File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_api_server/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_api_server/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift API Specification File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_cni_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_cni_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_controller_manager/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_controller_manager/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Controller Manager Specification File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_etcd/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_etcd/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift etcd Specification File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openshift_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openshift_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Master Configuration File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openshift_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openshift_kubeconfig/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Master Kubeconfig File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_scheduler_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_scheduler_conf/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Scheduler Configuration File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_config/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_config/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Node Configuration File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_kubeconfig/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_node_kubeconfig/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Node Kubeconfig File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_client_crt/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_client_crt/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on OpenShift Node Certificate File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_service/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_openshift_node_service/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Verify Permissions on the OpenShift Node Service File'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_var_lib_etcd/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_var_lib_etcd/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'The OpenShift etcd Data Directory Must Have Mode 0700'
 
 description: |-

--- a/applications/openshift/ocp-permissions/ocp-files/group.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: |-
     Verify Permissions on Important Files and
     Directories

--- a/applications/openshift/scheduler/group.yml
+++ b/applications/openshift/scheduler/group.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'OpenShift - Kubernetes - Scheduler Settings'
 
 description: 'Contains evaluations for kube-scheduler configuration settings.'

--- a/applications/openshift/scheduler/scheduler_profiling_argument/rule.yml
+++ b/applications/openshift/scheduler/scheduler_profiling_argument/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ocp3
+
 title: 'Disable Scheduler Profiling'
 
 description: |-

--- a/applications/openstack/cinder/group.yml
+++ b/applications/openstack/cinder/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: osp13
+prodtype: rhosp13
 
 title: 'Cinder STIG Checklist'
 

--- a/applications/openstack/horizon/group.yml
+++ b/applications/openstack/horizon/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: osp13
+prodtype: rhosp13
 
 title: 'Horizon STIG Checklist'
 

--- a/applications/openstack/keystone/group.yml
+++ b/applications/openstack/keystone/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: osp13
+prodtype: rhosp13
 
 title: 'Keystone STIG Checklist'
 

--- a/applications/openstack/neutron/group.yml
+++ b/applications/openstack/neutron/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: osp13
+prodtype: rhosp13
 
 title: 'Neutron STIG Checklist'
 

--- a/applications/openstack/nova/group.yml
+++ b/applications/openstack/nova/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: osp13
+prodtype: rhosp13
 
 title: 'Nova STIG Checklist'
 

--- a/ocp3/transforms/constants.xslt
+++ b/ocp3/transforms/constants.xslt
@@ -6,7 +6,7 @@
 <xsl:variable name="product_short_name">OCP 3</xsl:variable>
 <xsl:variable name="product_stig_id_name">OCP_3_STIG</xsl:variable>
 <xsl:variable name="product_guide_id_name">OCP-3</xsl:variable>
-<xsl:variable name="prod_type">OCP3</xsl:variable>
+<xsl:variable name="prod_type">ocp3</xsl:variable>
 
 
 <!-- Define URI of official CIS Kubernetes Benchmark -->

--- a/rhosp13/transforms/constants.xslt
+++ b/rhosp13/transforms/constants.xslt
@@ -5,7 +5,7 @@
 <xsl:variable name="product_long_name">Red Hat OpenStack Platform 13</xsl:variable>
 <xsl:variable name="product_short_name">RHOSP 13</xsl:variable>
 <xsl:variable name="product_stig_id_name">RHOSP_13_STIG</xsl:variable>
-<xsl:variable name="prod_type">osp13</xsl:variable>
+<xsl:variable name="prod_type">rhosp13</xsl:variable>
 
 <xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="product_guide_id_name">RHEL-13-OSP</xsl:variable>


### PR DESCRIPTION
Prevents OpenShift content from being added to non-OpenShift builds.
