### PR TITLE
Add Crypto Policy for Kerberos

### DIFF
--- a/fedora/profiles/standard.profile
+++ b/fedora/profiles/standard.profile
@@ -90,3 +90,4 @@ selections:
     - configure_ssh_crypto_policy
     - configure_libreswan_crypto_policy
     - configure_openssl_crypto_policy
+    - configure_kerberos_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/fedora.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/fedora.yml
@@ -1,6 +1,6 @@
 # platform = multi_platform_fedora
-# reboot = false
-# strategy = restrict
+# reboot = true
+# strategy = configure
 # complexity = low
 # disruption = low
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/fedora.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/fedora.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_fedora
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "@RULE_TITLE@"
+  file:
+    src: /etc/crypto-policies/back-ends/krb5.config
+    path: /etc/krb5.conf.d/crypto-policies
+    state: link
+  tags:
+    @ANSIBLE_TAGS@

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/bash/fedora.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/bash/fedora.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_fedora
+
+rm -f /etc/krb5.conf.d/crypto-policies
+ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/bash/fedora.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/bash/fedora.sh
@@ -1,4 +1,8 @@
 # platform = multi_platform_fedora
+# reboot = true
+# strategy = configure
+# complexity = low
+# disruption = low
 
 rm -f /etc/krb5.conf.d/crypto-policies
 ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
@@ -1,0 +1,42 @@
+{{%- if target_oval_version == [5, 11] -%}}
+{{# there is no good alternative for symlink_test for OVAL 5.10 #}}
+<def-group>
+  <definition class="compliance" id="configure_kerberos_crypto_policy" version="1">
+    <metadata>
+      <title>Configure kerberos to use System Crypto Policy</title>
+      <affected family="unix">
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Kerberos should be configured to use the system-wide crypto policy setting.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="kerberos crypto-policy softlink exists" test_ref="test_configure_kerberos_crypto_policy" />
+    </criteria>
+  </definition>
+
+  <external_variable comment="defined crypto policy" datatype="string" id="var_system_crypto_policy" version="1" />
+
+  <!-- As the oval symlink_test goes all the way through to the canonical path,
+  and the canonical path is the actual selected policy configuration,
+  we need to know the targeted crypto policy to check if kerberos crypto policy is linked correctly -->
+  <local_variable id="var_kerberos_policy_regex" datatype="string" comment="regex variable for canonical path to targeted kerberos policy" version="1">
+    <concat>
+      <literal_component>^/usr/share/crypto-policies/</literal_component>
+      <variable_component var_ref="var_system_crypto_policy"/>
+      <literal_component>/krb5.txt$</literal_component>
+    </concat>
+  </local_variable>
+
+  <unix:symlink_test check="all" check_existence="all_exist" comment="kerberos crypto-policy softlink exists" id="test_configure_kerberos_crypto_policy" version="1">
+    <unix:object object_ref="object_configure_kerberos_crypto_policy" />
+    <unix:state state_ref="state_configure_kerberos_crypto_policy" />
+  </unix:symlink_test>
+  <unix:symlink_object comment="kerberos crypto-policy softlink exists" id="object_configure_kerberos_crypto_policy" version="1">
+    <unix:filepath>/etc/krb5.conf.d/crypto-policies</unix:filepath>
+  </unix:symlink_object>
+  <unix:symlink_state comment="kerberos crypto-policy is linked to crypto-policy kerberos config" id="state_configure_kerberos_crypto_policy" version="1">
+    <unix:filepath>/etc/krb5.conf.d/crypto-policies</unix:filepath>
+    <unix:canonical_path operation="pattern match" var_ref="var_kerberos_policy_regex"/>
+  </unix:symlink_state>
+</def-group>
+{{%- endif -%}}

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Configure Kerberos to use System Crypto Policy'
+
+description: |-
+    Crypto Policies provide a centralized control over crypto algorithms usage of many packages.
+    Kerberos is supported by crypto policy, but it's configuration may be
+    set up to ignore it.
+    To check that Crypto Policies settings for Kerberos are configured correctly, examine that there is a symlink at
+    /etc/krb5.conf.d/crypto-policies targeting /etc/cypto-policies/back-ends/krb5.config.
+    If the symlink exists, kerberos is configured to use the system-wide crypto policy settings.
+
+rationale: |-
+    Overriding the system crypto policy makes the behavior of Kerberos violate expectations,
+    and makes system configuration more fragmented.
+
+severity: unknown
+
+ocil_clause: 'the symlink does not exist or points to a different target'
+
+ocil: |-
+    Check that the symlink exists and target the correct kerberos crypto policy, with the following command:<br/>
+    <pre>file /etc/krb5.conf.d/crypto-policies</pre>
+    <br/>
+    If command ouput shows the following line, kerberos is configured to use the system-wide crypto policy.
+    <br/>
+    <pre>/etc/krb5.conf.d/crypto-policies: symbolic link to /etc/crypto-policies/back-ends/krb5.config</pre>
+

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
@@ -21,10 +21,8 @@ severity: unknown
 ocil_clause: 'the symlink does not exist or points to a different target'
 
 ocil: |-
-    Check that the symlink exists and target the correct kerberos crypto policy, with the following command:<br/>
+    Check that the symlink exists and target the correct kerberos crypto policy, with the following command:
     <pre>file /etc/krb5.conf.d/crypto-policies</pre>
-    <br/>
     If command ouput shows the following line, kerberos is configured to use the system-wide crypto policy.
-    <br/>
     <pre>/etc/krb5.conf.d/crypto-policies: symbolic link to /etc/crypto-policies/back-ends/krb5.config</pre>
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_correct_policy.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_correct_policy.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+rm -f /etc/krb5.conf.d/crypto-policies
+ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_missing_policy.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_missing_policy.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+rm -f /etc/krb5.conf.d/crypto-policies

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_wrong_policy.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_wrong_policy.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+rm -f /etc/krb5.conf.d/crypto-policies
+ln -s /etc/crypto-policies/back-ends/openssh.config /etc/krb5.conf.d/crypto-policies


### PR DESCRIPTION
#### Description:

- The rule ensures that kerberos adheres to the system-wide crypto policy.

#### Rationale:

- Kerberos could be configured to opt-out of the system-wide crypto policies.
