### PR TITLE
Add ocp-node checks to master

### DIFF
--- a/ocp3/profiles/opencis-ocp-master.profile
+++ b/ocp3/profiles/opencis-ocp-master.profile
@@ -12,6 +12,8 @@ description: |-
     ensure a system is in compliance or consistency with the CIS
     baseline.
 
+extends: opencis-ocp-node
+
 selections:
     - file_groupowner_etc_origin
     - file_groupowner_master_admin_conf


### PR DESCRIPTION
I accidentally removed this when I shouldn't have.
