### PR TITLE
Check if Libreswan is configured to use crypto-policies

### DIFF
--- a/fedora/profiles/standard.profile
+++ b/fedora/profiles/standard.profile
@@ -88,3 +88,4 @@ selections:
     - sshd_set_idle_timeout
     - sshd_set_keepalive
     - configure_ssh_crypto_policy
+    - configure_libreswan_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_fedora
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "@RULE_TITLE@"
+  lineinfile:
+    path: /etc/ipsec.conf
+    line: "include /etc/crypto-policies/back-ends/libreswan.config"
+    create: yes
+  tags:
+    @ANSIBLE_TAGS@

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/bash/shared.sh
@@ -1,0 +1,11 @@
+# platform =  multi_platform_fedora
+
+function remediate_libreswan_crypto_policy() {
+    CONFIG_FILE="/etc/ipsec.conf"
+    if ! grep -qP "^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:|(?:#.*))$" "$CONFIG_FILE" ; then
+        echo 'include /etc/crypto-policies/back-ends/libreswan.config' >> "$CONFIG_FILE"
+    fi
+    return 0
+}
+
+remediate_libreswan_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="configure_libreswan_crypto_policy" version="1">
+    <metadata>
+      <title>Configure Libreswan to use System Crypto Policy.</title>
+      <affected family="unix">
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>Libreswan should be configured to use the system-wide crypto policy setting.</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_configure_libreswan_crypto_policy"
+        comment="Check that the libreswan configuration includes the crypto policy config file" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_configure_libreswan_crypto_policy"
+    comment="Check that the libreswan configuration includes the crypto policy config file"
+    check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_configure_libreswan_crypto_policy" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_configure_libreswan_crypto_policy"
+  version="1">
+    <ind:filepath>/etc/ipsec.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:|(?:#.*))$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Configure Libreswan to use System Crypto Policy'
+
+description: |-
+    Crypto Policies provide a centralized control over crypto algorithms usage of many packages.
+    Libreswan is supported by system crypto policy, but the Libreswan configuration may be
+    set up to ignore it.
+
+    To check that Crypto Policies settings are configured correctly, ensure that the <tt>/etc/ipsec.conf</tt>
+    includes the appropriate configuration file.
+    In <tt>/etc/ipsec.conf</tt>, make sure that the following line
+    is not commented out or superseded by later includes:
+    <tt>include /etc/crypto-policies/back-ends/libreswan.config</tt>
+
+rationale: |-
+    Overriding the system crypto policy makes the behavior of the Libreswan
+    service violate expectations, and makes system configuration more
+    fragmented.
+
+severity: unknown
+
+ocil_clause: |-
+    <tt>/etc/ipsec.conf</tt> does not contain <tt>include /etc/crypto-policies/back-ends/libreswan.config</tt>
+
+ocil: |-
+    To verify that Libreswan uses the system crypto policy, run the following command:
+    <pre>$ grep include /etc/ipsec.conf</pre>
+    The output should return something similar to:
+    <pre>include /etc/crypto-policies/back-ends/libreswan.config</pre>

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/ipsec.conf
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/ipsec.conf
@@ -1,0 +1,28 @@
+# /etc/ipsec.conf - Libreswan IPsec configuration file
+#
+# see 'man ipsec.conf' and 'man pluto' for more information
+#
+# For example configurations and documentation, see https://libreswan.org/wiki/
+
+config setup
+	# Normally, pluto logs via syslog.
+	#logfile=/var/log/pluto.log
+	#
+	# Do not enable debug options to debug configuration issues!
+	#
+	# plutodebug="control parsing"
+	# plutodebug="all crypt"
+	plutodebug=none
+	#
+	# NAT-TRAVERSAL support
+	# exclude networks used on server side by adding %v4:!a.b.c.0/24
+	# It seems that T-Mobile in the US and Rogers/Fido in Canada are
+	# using 25/8 as "private" address space on their wireless networks.
+	# This range has never been announced via BGP (at least up to 2015)
+	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v4:100.64.0.0/10,%v6:fd00::/8,%v6:fe80::/10
+
+# if it exists, include system wide crypto-policy defaults
+include /etc/crypto-policies/back-ends/libreswan.config
+
+# It is best to add your IPsec connections as separate files in /etc/ipsec.d/
+include /etc/ipsec.d/*.conf

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_commented.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_commented.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+cp ipsec.conf /etc
+config_file="/etc/ipsec.conf"
+crypto="/etc/crypto-policies/back-ends/libreswan.config"
+if grep -qP "^\s*include\s+$crypto" "$config_file" ; then
+    sed -i "s%\s*include\s\+$crypto%#include $crypto%" "$config_file"
+else
+    echo "#include /etc/crypto-policies/back-ends/libreswan.config" >> "$config_file"
+fi

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+cp ipsec.conf /etc
+config_file="/etc/ipsec.conf"
+if ! grep -P '^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:|(?:#.*))$' "$config_file" ; then
+    echo "include /etc/crypto-policies/back-ends/libreswan.config" >> "$config_file"
+fi

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_not_there.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_not_there.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+cp ipsec.conf /etc
+config_file="/etc/ipsec.conf"
+crypto="/etc/crypto-policies/back-ends/libreswan.config"
+if grep -qP "^\s*include\s+$crypto" "$config_file" ; then
+    sed -i "\%\s*include\s\+$crypto%d" "$config_file"
+fi

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/wrong_value.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+cp ipsec.conf /etc
+config_file="/etc/ipsec.conf"
+crypto="/etc/crypto-policies/back-ends/libreswan.config"
+bad_crypto="/etc/crypto-ends/libreswan.config"
+if grep -qP "^\s*include\s+$crypto" "$config_file" ; then
+    sed -i "s%\s*include\s\+$crypto%include $bad_crypto%" "$config_file"
+else
+    echo "include $bad_crypto" >> "$config_file"
+fi


### PR DESCRIPTION
#### Description:
Adds a rule that check if libreswan configuration adheres to system-wide crypto policy.Also adds tests for SSG Test Suite for this rule.

#### Rationale:
Libreswan shouldn't be configured to opt out from system-wide crypto policies.
