### PR TITLE
Added Crypto Policy rule for SSH

### DIFF
--- a/fedora/profiles/standard.profile
+++ b/fedora/profiles/standard.profile
@@ -87,3 +87,4 @@ selections:
     - sshd_idle_timeout_value=5_minutes
     - sshd_set_idle_timeout
     - sshd_set_keepalive
+    - configure_ssh_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_fedora
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+
+- name: "@RULE_TITLE@"
+  lineinfile:
+    dest: /etc/sysconfig/sshd
+    state: absent
+    regexp: ^\s*CRYPTO_POLICY.*$
+  tags:
+    @ANSIBLE_TAGS@

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/bash/shared.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_fedora
+
+SSH_CONF="/etc/sysconfig/sshd"
+
+sed -i "/^\s*CRYPTO_POLICY.*$/d" $SSH_CONF

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="configure_ssh_crypto_policy" version="1">
+    <metadata>
+      <title>Configure SSH to use System Crypto Policy.</title>
+      <affected family="unix">
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>SSH should be configured to use the system-wide crypto policy setting.</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_configure_ssh_crypto_policy"
+      comment="Check that the SSH configuration mandates usage of system-wide crypto policies." />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_configure_ssh_crypto_policy"
+  comment="Check that the SSH configuration mandates usage of system-wide crypto policies."
+  check="all" check_existence="none_exist" version="1">
+    <ind:object object_ref="object_configure_ssh_crypto_policy" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_configure_ssh_crypto_policy" version="1">
+    <ind:filepath>/etc/sysconfig/sshd</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*CRYPTO_POLICY\s*=.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Configure SSH to use System Crypto Policy'
+
+description: |-
+    Crypto Policies provide a centralized control over crypto algorithms usage of many packages.
+    SSH is supported by crypto policy, but the SSH configuration may be
+    set up to ignore it.
+    To check that Crypto Policies settings are configured correctly, ensure that
+    the <tt>CRYPTO_POLICY</tt> variable is either commented or not set at all
+    in the <tt>/etc/sysconfig/sshd</tt>.
+
+rationale: |-
+    Overriding the system crypto policy makes the behavior of the SSH service violate expectations,
+    and makes system configuration more fragmented.
+
+severity: unknown
+
+ocil_clause: 'the CRYPTO_POLICY variable is not set or is commented in the /etc/sysconfig/sshd'
+
+ocil: |-
+    Check that the <tt>CRYPTO_POLICY</tt> variable is not set or is commented in the
+    <tt>/etc/sysconfig/sshd</tt>.

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/absent.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/absent.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+SSH_CONF="/etc/sysconfig/sshd"
+
+sed -i "/^\s*CRYPTO_POLICY.*$/d" $SSH_CONF

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/comment.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/comment.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+SSH_CONF="/etc/sysconfig/sshd"
+
+sed -i "/^\s*CRYPTO_POLICY.*$/d" $SSH_CONF
+echo "# CRYPTO_POLICY=" >> $SSH_CONF

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/no_config_file.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/no_config_file.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+SSH_CONF="/etc/sysconfig/sshd"
+
+rm -f $SSH_CONF

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/overrides.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/overrides.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+SSH_CONF="/etc/sysconfig/sshd"
+
+sed -i "/^\s*CRYPTO_POLICY.*$/d" $SSH_CONF
+echo "CRYPTO_POLICY=" >> $SSH_CONF


### PR DESCRIPTION
#### Description:

- The rule `configure_ssh_crypto_policy` was added including OVAL check,
bash and ansible remediations.
- Also added a test for the rule (into SSG Test Suite).

#### Rationale:

- SSH could be configured to opt-out of the system-wide crypto policy, this rule should prevent that situation.