### PR TITLE
Added Crypto Policy rule for OpenSSL.

### DIFF
--- a/fedora/profiles/standard.profile
+++ b/fedora/profiles/standard.profile
@@ -89,3 +89,4 @@ selections:
     - sshd_set_keepalive
     - configure_ssh_crypto_policy
     - configure_libreswan_crypto_policy
+    - configure_openssl_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
@@ -1,0 +1,24 @@
+# platform =  multi_platform_fedora
+
+OPENSSL_CRYPTO_POLICY_SECTION='[ crypto_policy ]'
+OPENSSL_CRYPTO_POLICY_SECTION_REGEX='\[\s*crypto_policy\s*\]'
+OPENSSL_CRYPTO_POLICY_INCLUSION='.include /etc/crypto-policies/back-ends/openssl.config'
+OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*/etc/crypto-policies/back-ends/openssl.config$'
+
+function remediate_openssl_crypto_policy() {
+	CONFIG_FILE="/etc/pki/tls/openssl.cnf"
+	if test -f "$CONFIG_FILE"; then
+		if ! grep -q "^\\s*$OPENSSL_CRYPTO_POLICY_SECTION_REGEX" "$CONFIG_FILE"; then
+			printf '\n%s\n\n%s' "$OPENSSL_CRYPTO_POLICY_SECTION" "$OPENSSL_CRYPTO_POLICY_INCLUSION" >> "$CONFIG_FILE"
+			return 0
+		elif ! grep -q "^\\s*$OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX" "$CONFIG_FILE"; then
+			sed -i "s|$OPENSSL_CRYPTO_POLICY_SECTION_REGEX|&\\n\\n$OPENSSL_CRYPTO_POLICY_INCLUSION\\n|" "$CONFIG_FILE"
+			return 0
+		fi
+	else
+		echo "Aborting remediation as '$CONFIG_FILE' was not even found." >&2
+		return 1
+	fi
+}
+
+remediate_openssl_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="configure_openssl_crypto_policy" version="1">
+    <metadata>
+      <title>Configure OpenSSL to use System Crypto Policy</title>
+      <affected family="unix">
+        <platform>multi_platform_fedora</platform>
+      </affected>
+      <description>OpenSSL should be configured to use the system-wide crypto policy setting.</description>
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_configure_openssl_crypto_policy"
+      comment="Check that the configuration mandates usage of system-wide crypto policies." />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_configure_openssl_crypto_policy"
+  comment="Check that the configuration mandates usage of system-wide crypto policies."
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_configure_openssl_crypto_policy" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_configure_openssl_crypto_policy"
+  version="1">
+    <ind:filepath>/etc/pki/tls/openssl.cnf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*\[\s*crypto_policy\s*\]\s*\n*\s*\.include\s*/etc/crypto-policies/back-ends/openssl.config\s*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>
+

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Configure OpenSSL library to use System Crypto Policy'
+
+description: |-
+    Crypto Policies provide a centralized control over crypto algorithms usage of many packages.
+    OpenSSL is supported by crypto policy, but the OpenSSL configuration may be
+    set up to ignore it.
+    To check that Crypto Policies settings are configured correctly, you have to examine the OpenSSL config file
+    available under <tt>/etc/pki/tls/openssl.cnf</tt>.
+    This file has the <tt>ini</tt> format, and it enables crypto policy support
+    if there is a <tt>[ crypto_policy ]</tt> section that contains the <tt>.include /etc/crypto-policies/back-ends/openssl.config</tt> directive.
+
+rationale: |-
+    Overriding the system crypto policy makes the behavior of the Java runtime violates expectations,
+    and makes system configuration more fragmented.
+
+severity: unknown
+
+ocil_clause: |-
+    the OpenSSL config file doesn't contain the whole section,
+    or that the section doesn't have the <pre>.include /etc/crypto-policies/back-ends/openssl.config</pre> directive
+
+ocil: |-
+    To verify that OpenSSL uses the system crypro policy, check out that the OpenSSL config file
+    <pre>/etc/pki/tls/openssl.cnf</pre> contains the <pre>[ crypto_policy ]</pre> section with the
+    <pre>.include /etc/crypto-policies/back-ends/openssl.config</pre> directive:
+    <pre>grep -A 3 '\[\s*crypto_policy\s*\]\s*$' /etc/pki/tls/openssl.cnf | grep '^\s*\.include \s*/etc/crypto-policies/back-ends/openssl.config\s*$' </pre>.
+

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -27,5 +27,5 @@ ocil: |-
     To verify that OpenSSL uses the system crypro policy, check out that the OpenSSL config file
     <pre>/etc/pki/tls/openssl.cnf</pre> contains the <pre>[ crypto_policy ]</pre> section with the
     <pre>.include /etc/crypto-policies/back-ends/openssl.config</pre> directive:
-    <pre>grep -A 3 '\[\s*crypto_policy\s*\]\s*$' /etc/pki/tls/openssl.cnf | grep '^\s*\.include \s*/etc/crypto-policies/back-ends/openssl.config\s*$' </pre>.
+    <pre>grep '\.include\s* /etc/crypto-policies/back-ends/openssl.config$' /etc/pki/tls/openssl.cnf</pre>.
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/common.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/common.sh
@@ -1,0 +1,377 @@
+CONFIG_FILE="/etc/pki/tls/openssl.cnf"
+
+# $1: Pass content to the crypto policy location
+function create_config_file_with {
+	mkdir -p $(dirname "$CONFIG_FILE")
+cat << EOF > "$CONFIG_FILE"
+#
+# OpenSSL example configuration file.
+# This is mostly being used for generation of certificate requests.
+#
+
+# Note that you can include other files from the main configuration
+# file using the .include directive.
+#.include filename
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME			= .
+#RANDFILE		= $ENV::HOME/.rnd
+
+# Extra OBJECT IDENTIFIER info:
+#oid_file		= $ENV::HOME/.oid
+oid_section		= new_oids
+
+# To use this configuration file with the "-extfile" option of the
+# "openssl x509" utility, name here the section containing the
+# X.509v3 extensions to use:
+# extensions		= 
+# (Alternatively, use a configuration file that has only
+# X.509v3 extensions in its main [= default] section.)
+
+# Load default TLS policy configuration
+
+openssl_conf = default_modules
+
+[ default_modules ]
+
+ssl_conf = ssl_module
+
+[ ssl_module ]
+
+system_default = crypto_policy
+
+$1
+
+[ new_oids ]
+
+# We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+# Add a simple OID like this:
+# testoid1=1.2.3.4
+# Or use config file substitution like this:
+# testoid2=${testoid1}.5.6
+
+# Policies used by the TSA examples.
+tsa_policy1 = 1.2.3.4.1
+tsa_policy2 = 1.2.3.4.5.6
+tsa_policy3 = 1.2.3.4.5.7
+
+####################################################################
+[ ca ]
+default_ca	= CA_default		# The default ca section
+
+####################################################################
+[ CA_default ]
+
+dir		= /etc/pki/CA		# Where everything is kept
+certs		= $dir/certs		# Where the issued certs are kept
+crl_dir		= $dir/crl		# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+#unique_subject	= no			# Set to 'no' to allow creation of
+					# several certs with same subject.
+new_certs_dir	= $dir/newcerts		# default place for new certs.
+
+certificate	= $dir/cacert.pem 	# The CA certificate
+serial		= $dir/serial 		# The current serial number
+crlnumber	= $dir/crlnumber	# the current crl number
+					# must be commented out to leave a V1 CRL
+crl		= $dir/crl.pem 		# The current CRL
+private_key	= $dir/private/cakey.pem# The private key
+RANDFILE	= $dir/private/.rand	# private random number file
+
+x509_extensions	= usr_cert		# The extensions to add to the cert
+
+# Comment out the following two lines for the "traditional"
+# (and highly broken) format.
+name_opt 	= ca_default		# Subject Name options
+cert_opt 	= ca_default		# Certificate field options
+
+# Extension copying option: use with caution.
+# copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+# crl_extensions	= crl_ext
+
+default_days	= 365			# how long to certify for
+default_crl_days= 30			# how long before next CRL
+default_md	= sha256		# use SHA-256 by default
+preserve	= no			# keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy		= policy_match
+
+# For the CA policy
+[ policy_match ]
+countryName		= match
+stateOrProvinceName	= match
+organizationName	= match
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+# For the 'anything' policy
+# At this point in time, you must list all acceptable 'object'
+# types.
+[ policy_anything ]
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+
+####################################################################
+[ req ]
+default_bits		= 2048
+default_md		= sha256
+default_keyfile 	= privkey.pem
+distinguished_name	= req_distinguished_name
+attributes		= req_attributes
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+
+# This sets a mask for permitted string types. There are several options. 
+# default: PrintableString, T61String, BMPString.
+# pkix	 : PrintableString, BMPString (PKIX recommendation before 2004)
+# utf8only: only UTF8Strings (PKIX recommendation after 2004).
+# nombstr : PrintableString, T61String (no BMPStrings or UTF8Strings).
+# MASK:XXXX a literal mask value.
+# WARNING: ancient versions of Netscape crash on BMPStrings or UTF8Strings.
+string_mask = utf8only
+
+# req_extensions = v3_req # The extensions to add to a certificate request
+
+[ req_distinguished_name ]
+countryName			= Country Name (2 letter code)
+countryName_default		= XX
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+#stateOrProvinceName_default	= Default Province
+
+localityName			= Locality Name (eg, city)
+localityName_default		= Default City
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= Default Company Ltd
+
+# we can do this but it is not needed normally :-)
+#1.organizationName		= Second Organization Name (eg, company)
+#1.organizationName_default	= World Wide Web Pty Ltd
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+#organizationalUnitName_default	=
+
+commonName			= Common Name (eg, your name or your server\'s hostname)
+commonName_max			= 64
+
+emailAddress			= Email Address
+emailAddress_max		= 64
+
+# SET-ex3			= SET extension number 3
+
+[ req_attributes ]
+challengePassword		= A challenge password
+challengePassword_min		= 4
+challengePassword_max		= 20
+
+unstructuredName		= An optional company name
+
+[ usr_cert ]
+
+# These extensions are added when 'ca' signs a request.
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This is required for TSA certificates.
+# extendedKeyUsage = critical,timeStamping
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[ v3_ca ]
+
+
+# Extensions for a typical CA
+
+
+# PKIX recommendation.
+
+subjectKeyIdentifier=hash
+
+authorityKeyIdentifier=keyid:always,issuer
+
+basicConstraints = critical,CA:true
+
+# Key usage: this is typical for a CA certificate. However since it will
+# prevent it being used as an test self-signed certificate it is best
+# left out by default.
+# keyUsage = cRLSign, keyCertSign
+
+# Some might want this also
+# nsCertType = sslCA, emailCA
+
+# Include email address in subject alt name: another PKIX recommendation
+# subjectAltName=email:copy
+# Copy issuer details
+# issuerAltName=issuer:copy
+
+# DER hex encoding of an extension: beware experts only!
+# obj=DER:02:03
+# Where 'obj' is a standard or added object
+# You can even override a supported extension:
+# basicConstraints= critical, DER:30:03:01:01:FF
+
+[ crl_ext ]
+
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+
+[ proxy_cert_ext ]
+# These extensions should be added when creating a proxy certificate
+
+# This goes against PKIX guidelines but some CAs do it and some software
+# requires this to avoid interpreting an end user certificate as a CA.
+
+basicConstraints=CA:FALSE
+
+# Here are some examples of the usage of nsCertType. If it is omitted
+# the certificate can be used for anything *except* object signing.
+
+# This is OK for an SSL server.
+# nsCertType			= server
+
+# For an object signing certificate this would be used.
+# nsCertType = objsign
+
+# For normal client use this is typical
+# nsCertType = client, email
+
+# and for everything including object signing:
+# nsCertType = client, email, objsign
+
+# This is typical in keyUsage for a client certificate.
+# keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+# This will be displayed in Netscape's comment listbox.
+nsComment			= "OpenSSL Generated Certificate"
+
+# PKIX recommendations harmless if included in all certificates.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+# This stuff is for subjectAltName and issuerAltname.
+# Import the email address.
+# subjectAltName=email:copy
+# An alternative to produce certificates that aren't
+# deprecated according to PKIX.
+# subjectAltName=email:move
+
+# Copy subject details
+# issuerAltName=issuer:copy
+
+#nsCaRevocationUrl		= http://www.domain.dom/ca-crl.pem
+#nsBaseUrl
+#nsRevocationUrl
+#nsRenewalUrl
+#nsCaPolicyUrl
+#nsSslServerName
+
+# This really needs to be in place for it to be a proxy certificate.
+proxyCertInfo=critical,language:id-ppl-anyLanguage,pathlen:3,policy:foo
+
+####################################################################
+[ tsa ]
+
+default_tsa = tsa_config1	# the default TSA section
+
+[ tsa_config1 ]
+
+# These are used by the TSA reply generation only.
+dir		= /etc/pki/CA		# TSA root directory
+serial		= $dir/tsaserial	# The current serial number (mandatory)
+crypto_device	= builtin		# OpenSSL engine to use for signing
+signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
+					# (optional)
+certs		= $dir/cacert.pem	# Certificate chain to include in reply
+					# (optional)
+signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
+signer_digest  = sha256			# Signing digest to use. (Optional)
+default_policy	= tsa_policy1		# Policy if request did not specify it
+					# (optional)
+other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
+digests     = sha1, sha256, sha384, sha512  # Acceptable message digests (mandatory)
+accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
+clock_precision_digits  = 0	# number of digits after dot. (optional)
+ordering		= yes	# Is ordering defined for timestamps?
+				# (optional, default: no)
+tsa_name		= yes	# Must the TSA name be included in the reply?
+				# (optional, default: no)
+ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
+				# (optional, default: no)
+ess_cert_id_alg		= sha1	# algorithm to compute certificate
+				# identifier (optional, default: sha1)
+
+EOF
+}

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/nothing.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/nothing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+. common.sh
+
+create_config_file_with ""

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/ok.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/ok.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+. common.sh
+
+create_config_file_with "[ crypto_policy ]
+
+.include /etc/crypto-policies/back-ends/openssl.config
+"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/section_not_include.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/section_not_include.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+. common.sh
+
+create_config_file_with "[ crypto_policy ]"


### PR DESCRIPTION
The rule ensures that the library adheres to the system-wide crypto policy by default.

Remarks:

* The rule is part of the Fedora standard profile.
* The SSG tests pass, I recommend using the Docker backend.
* There is no Ansible fix for the rule, as the OpenSSL config file is something between an ini file and normal config file. The fix is probably doable, but it is far from being trivial.