### PR TITLE
Fix OVAL error when encryption policy file doesn't exist

### DIFF
--- a/applications/openshift/api-server/api_server_experimental_encryption_provider_cipher/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_experimental_encryption_provider_cipher/oval/shared.xml
@@ -8,9 +8,18 @@
       <description>The etcd datastore should be configured with the aescbc cipher.</description>
     </metadata>
     <criteria operator="AND">
+      <criterion comment="encryption policy files exists" test_ref="test_encryption_policy_file_exists" />
       <criterion comment="aescbc cipher is configured" test_ref="test_api_server_experimental_encryption_provider_cipher" />
     </criteria>
   </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="encryption policy files exists" id="test_encryption_policy_file_exists" version="1">
+    <unix:object object_ref="object_encryption_policy_file_exists" />
+  </unix:file_test>
+  <unix:file_object comment="/etc/shadow" id="object_encryption_policy_file_exists" version="1">
+    <unix:path>/etc/origin/master</unix:path>
+    <unix:filename>encryption-config.yaml</unix:filename>
+  </unix:file_object>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="aescbc cipher is configured" id="test_api_server_experimental_encryption_provider_cipher" version="1">
     <ind:object object_ref="object_api_server_experimental_encryption_provider_cipher" />


### PR DESCRIPTION
OVAL was erroring when file didn't exist
