### PR TITLE
Replace grep with awk for rpm_verification tests as it more acurately…

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = high
 # disruption = medium
 - name: "Read list of files with incorrect ownership"
-  shell: rpm -Va --nofiledigest | grep "^.....\(U\|.G\)" | awk '{print $NF}'
+  shell: "rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)==\"U\" || substr($0,7,1)==\"G\") print $NF }'"
   register: files_with_incorrect_ownership
   failed_when: False
   changed_when: False

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/bash/shared.sh
@@ -9,7 +9,7 @@ SETPERMS_RPM_LIST=()
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep "^.*\(G\|U\)" | cut -d ' ' -f4-))
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'))
 
 # For each file path from that list:
 # * Determine the RPM package the file path is shipped by,

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
@@ -9,7 +9,7 @@ description: |-
     permissions of installed software packages, including many that are
     important to system security. After locating a file with incorrect
     permissions, which can be found with
-    <pre>rpm -Va | grep "^.....\(U\|.G\)"</pre>
+    <pre>rpm -Va | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'</pre>
     run the following command to determine which package owns it:
     <pre>$ rpm -qf <i>FILENAME</i></pre>
     Next, run the following command to reset its permissions to
@@ -45,7 +45,7 @@ ocil_clause: 'there is output'
 ocil: |-
     The following command will list which files on the system have ownership different from what
     is expected by the RPM database:
-    <pre>$ rpm -Va | grep "^.....\(U\|.G\)"</pre>
+    <pre>$ rpm -Va | rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'</pre>
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = high
 # disruption = medium
 - name: "Read list of files with incorrect permissions"
-  shell: "rpm -Va --nofiledigest | awk '/^.M/ {print $NF}'"
+  shell: "rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)==\"M\") print $NF }'"
   register: files_with_incorrect_permissions
   failed_when: False
   changed_when: False

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
@@ -9,7 +9,7 @@ declare -a SETPERMS_RPM_LIST
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | grep '^.M' | awk '{print $NF}'))
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }'))
 
 # For each file path from that list:
 # * Determine the RPM package the file path is shipped by,

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -11,7 +11,7 @@ description: |-
     Verify that the file permissions of system files
     and commands match vendor values. Check the file permissions
     with the following command:
-    <pre>$ sudo rpm -Va | grep '^.M'</pre>
+    <pre>$ sudo rpm -Va | awk '{ if (substr($0,2,1)=="M") print $NF }'</pre>
     Output indicates files that do not match vendor defaults.
     After locating a file with incorrect permissions,
     run the following command to determine which package owns it:
@@ -53,7 +53,7 @@ ocil_clause: 'there is output'
 ocil: |-
     The following command will list which files on the system have permissions different from what
     is expected by the RPM database:
-    <pre>$ rpm -Va | grep '^.M'</pre>
+    <pre>$ rpm -Va | awk '{ if (substr($0,2,1)=="M") print $NF }'</pre>
 
 warnings:
     - general: |-


### PR DESCRIPTION
… detects flags that are returned by rpm -Va.

#### Description:

Replaces grep with awk to better test flags that are returned by rpm -vA during rpm_verification

#### Rationale:

When testing rpm_verification, the search string that grep was using would only match if the flag was prefaced with a "." creating false returns if something else had changed with the file such as the size or if owner and group membership had both been modified since the file was installed by RPM.  These patches fix that in the check content as well as bash and Ansible by using awk to look at the single flag for permission modified, owner modification or a change to group membership.