### PR TITLE
Fix product naming in OCP content

### DIFF
--- a/ocp3/cpe/ocp3-cpe-dictionary.xml
+++ b/ocp3/cpe/ocp3-cpe-dictionary.xml
@@ -3,12 +3,12 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
       <cpe-item name="cpe:/a:redhat:openshift_container_platform:3.10">
-            <title xml:lang="en-us">Red Hat Enterprise OpenShift Container Platform 3</title>
+            <title xml:lang="en-us">Red Hat OpenShift Container Platform 3</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_app_is_ocp3</check>
       </cpe-item>
       <cpe-item name="cpe:/a:redhat:openshift_container_platform:3.11">
-            <title xml:lang="en-us">Red Hat Enterprise OpenShift Container Platform 3</title>
+            <title xml:lang="en-us">Red Hat OpenShift Container Platform 3</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_app_is_ocp3</check>
       </cpe-item>

--- a/ocp3/overlays/c2s_support.xml
+++ b/ocp3/overlays/c2s_support.xml
@@ -1,6 +1,6 @@
 <Group id="c2s_support" hidden="true">
 <title>Documentation to Support C2S/CIS  Mapping</title>
-<description>These groups exist to document how the Red Hat Enterprise Linux
+<description>These groups exist to document how the Red Hat OpenShift Platform
 product meets (or does not meet) requirements listed in C2S/CIS, for
 those cases where Groups or Rules elsewhere in scap-security-guide do
 not clearly relate.
@@ -28,9 +28,9 @@ is not performed within the Operating System.</description>
 <Rule id="c2s_met_inherently">
 <title>Product Meets this Requirement</title>
 <rationale>
-Red Hat Enterprise Linux meets this requirement through design and implementation.
+Red Hat OpenShift Platform meets this requirement through design and implementation.
 </rationale>
-<ocil>RHEL7 supports this requirement and cannot be configured to be out of
+<ocil>Red Hat OpenShift Container Platform supports this requirement and cannot be configured to be out of
 compliance. This is a permanent not a finding.
 </ocil>
 <description>

--- a/ocp3/overlays/nist800171_support.xml
+++ b/ocp3/overlays/nist800171_support.xml
@@ -1,6 +1,6 @@
 <Group id="cui_support" hidden="true">
 <title>Documentation to Support NIST 800-171 Mapping</title>
-<description>These groups exist to document how the Red Hat Enterprise Linux
+<description>These groups exist to document how the Red Hat OpenShift Container Platform
 product meets (or does not meet) requirements listed in NIST 800-171, for
 those cases where Groups or Rules elsewhere in scap-security-guide do
 not clearly relate.
@@ -27,9 +27,9 @@ is not performed within the scope of Operating System configuration.</descriptio
 <Rule id="cui_met_inherently">
 <title>Product Meets this Requirement</title>
 <rationale>
-Red Hat Enterprise Linux meets this requirement through design and implementation.
+Red Hat OpenShift Container Platform meets this requirement through design and implementation.
 </rationale>
-<ocil>RHEL6 supports this requirement and cannot be configured to be out of
+<ocil>Red Hat OpenShift Container Platform supports this requirement and cannot be configured to be out of
 compliance. This is a permanent not a finding.
 </ocil>
 <description>

--- a/ocp3/overlays/nist_support.xml
+++ b/ocp3/overlays/nist_support.xml
@@ -1,6 +1,6 @@
 <Group id="nist_support" hidden="true">
 <title>Documentation to Support NIST 800-53 Mapping</title>
-<description>These groups exist to document how the Red Hat Enterprise Linux
+<description>These groups exist to document how the Red Hat OpenShift Container Platform
 product meets (or does not meet) requirements listed in NIST 800-53, for
 those cases where Groups or Rules elsewhere in scap-security-guide do
 not clearly relate.
@@ -27,9 +27,9 @@ is not performed within the Operating System.</description>
 <Rule id="nist_met_inherently">
 <title>Product Meets this Requirement</title>
 <rationale>
-Red Hat Enterprise Linux meets this requirement through design and implementation.
+Red Hat OpenShift Container Platform meets this requirement through design and implementation.
 </rationale>
-<ocil>RHEL6 supports this requirement and cannot be configured to be out of
+<ocil>Red Hat OpenShift Container Platform supports this requirement and cannot be configured to be out of
 compliance. This is a permanent not a finding.
 </ocil>
 <description>

--- a/ocp3/product.yml
+++ b/ocp3/product.yml
@@ -1,5 +1,5 @@
 product: ocp3
-full_name: Red Hat Enterprise OpenShift Container Platform 3
+full_name: Red Hat OpenShift Container Platform 3
 type: platform
 
 benchmark_root: "../applications"

--- a/ocp3/transforms/constants.xslt
+++ b/ocp3/transforms/constants.xslt
@@ -2,7 +2,7 @@
 
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
-<xsl:variable name="product_long_name">Red Hat Enterprise OpenShift Container Platform 3</xsl:variable>
+<xsl:variable name="product_long_name">Red Hat OpenShift Container Platform 3</xsl:variable>
 <xsl:variable name="product_short_name">OCP 3</xsl:variable>
 <xsl:variable name="product_stig_id_name">OCP_3_STIG</xsl:variable>
 <xsl:variable name="product_guide_id_name">OCP-3</xsl:variable>


### PR DESCRIPTION
- Remove RHEL and Enterprise wording from OCP content
