### PR TITLE
Update ol7 parts of linux_os guide

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/group.yml
+++ b/linux_os/guide/services/ldap/openldap_client/group.yml
@@ -11,12 +11,13 @@ description: |-
     much control over configuration as manual editing of configuration files. The
     authconfig tools do not allow you to specify locations of SSL certificate
     files, which is useful when trying to use SSL cleanly across several protocols.
+    Installation and configuration of OpenLDAP on {{{ full_name }}} is available at
     {{% if product == "rhel7" %}}
-    Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at
-    {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html") }}}.
+        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html") }}}.
     {{% elif product == "rhel6" %}}
-    Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 6 is available at
-    {{{ weblink(link="https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-Directory_Servers.html") }}}.
+        {{{ weblink(link="https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-Directory_Servers.html") }}}.
+    {{% elif product == "ol7" %}}
+        {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-s9-auth.html") }}}.
     {{% endif %}}
 
 warnings:

--- a/linux_os/guide/services/mail/group.yml
+++ b/linux_os/guide/services/mail/group.yml
@@ -18,7 +18,7 @@ description: |-
     the local system to a central site MTA (or directly delivered to a local account),
     but the system still cannot receive mail directly over a network.
     <br /><br />
-    The <tt>alternatives</tt> program in Red Hat Enterprise Linux permits selection of other mail server software
+    The <tt>alternatives</tt> program in {{{ full_name }}} permits selection of other mail server software
     (such as Sendmail), but Postfix is the default and is preferred.
     Postfix was coded with security in mind and can also be more effectively contained by
     SELinux as its modular design has resulted in separate processes performing specific actions.

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -6,10 +6,14 @@ title: 'Specify Additional Remote NTP Servers'
 
 description: |-
     Depending on specific functional requirements of a concrete
-    production environment, the Red Hat Enterprise Linux 7 Server system can be
+    production environment, the {{{ full_name }}} system can be
     configured to utilize the services of the <tt>chronyd</tt> NTP daemon (the
     default), or services of the <tt>ntpd</tt> NTP daemon. Refer to
-    {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+    {{% if product == "ol7" %}}
+        {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-nettime.html") }}}
+    {{% else %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+    {{% endif %}}
     for more detailed comparison of the features of both of the choices, and for
     further guidance how to choose between the two NTP daemons.
     <br />

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -6,10 +6,14 @@ title: 'Specify a Remote NTP Server'
 
 description: |-
     Depending on specific functional requirements of a concrete
-    production environment, the Red Hat Enterprise Linux 7 Server system can be
+    production environment, the {{{ full_name }}} system can be
     configured to utilize the services of the <tt>chronyd</tt> NTP daemon (the
     default), or services of the <tt>ntpd</tt> NTP daemon. Refer to
-    {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+    {{% if product == "ol7" %}}
+         {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-nettime.html") }}}
+    {{% else %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+    {{% endif %}}
     for more detailed comparison of the features of both of the choices, and for
     further guidance how to choose between the two NTP daemons.
     <br />

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -48,7 +48,13 @@ description: |-
     to use broadcast or multicast IP, or to perform authentication of packets with
     the <tt>Autokey</tt> protocol, should consider using <tt>ntpd</tt>.
     <br /><br />
-    Refer to {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}} for more detailed comparison of features of <tt>chronyd</tt>
+    Refer to
+    {{% if product == "ol7" %}}
+        {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-nettime.html") }}}
+    {{% else %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+    {{% endif %}}
+    for more detailed comparison of features of <tt>chronyd</tt>
     and <tt>ntpd</tt> daemon features respectively, and for further guidance how to
     choose between the two NTP daemons.
     <br /><br />

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
@@ -10,8 +10,7 @@ rationale: |-
     The <tt>telnet</tt> protocol is insecure and unencrypted. The use
     of an unencrypted transmission medium could allow an unauthorized user
     to steal credentials. The <tt>ssh</tt> package provides an
-    encrypted session and stronger security and is included in Red Hat
-    Enterprise Linux.
+    encrypted session and stronger security and is included in {{{ full_name }}}.
 
 severity: low
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -10,8 +10,47 @@ description: |-
     demonstrates use of FIPS-approved ciphers:
     <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
+{{% elif product == "ol7" %}}
+description: |-
+    Limit the ciphers to those algorithms which are FIPS-approved.
+    Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
+    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use of
+    FIPS 140-2 validated ciphers:
+    <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>
+    <br /><br />
+    The following ciphers are FIPS 140-2 certified on {{{ full_name }}}:
+    <br />- aes128-ctr
+    <br />- aes192-ctr
+    <br />- aes256-ctr
+    <br />- aes128-cbc
+    <br />- aes192-cbc
+    <br />- aes256-cbc
+    <br />- 3des-cbc
+    <br />- rijndael-cbc@lysator.liu.se
+    <br /><br />
+    Any combination of the above ciphers will pass this check. 
+    Official FIPS 140-2 paperwork for {{{ full_name }}} can be found at
+    {{{ weblink(link="https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3028.pdf") }}}
 {{% else %}}
-description: "Limit the ciphers to those algorithms which are FIPS-approved.\nCounter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.\nThe following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use of \nFIPS 140-2 validated ciphers:\n<pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>\n<br /><br />\nThe following ciphers are FIPS 140-2 certified on RHEL 7:\n<br />- aes128-ctr\n<br />- aes192-ctr\n<br />- aes256-ctr\n<br />- aes128-cbc\n<br />- aes192-cbc\n<br />- aes256-cbc\n<br />- 3des-cbc\n<br />- rijndael-cbc@lysator.liu.se\n<br /><br />\nAny combination of the above ciphers will pass this check. Official FIPS 140-2 paperwork for \nRHEL7 can be found at http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf."
+description: |-
+    Limit the ciphers to those algorithms which are FIPS-approved.
+    Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
+    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use of 
+    FIPS 140-2 validated ciphers:
+    <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>
+    <br /><br />
+    The following ciphers are FIPS 140-2 certified on RHEL 7:
+    <br />- aes128-ctr
+    <br />- aes192-ctr
+    <br />- aes256-ctr
+    <br />- aes128-cbc
+    <br />- aes192-cbc
+    <br />- aes256-cbc
+    <br />- 3des-cbc
+    <br />- rijndael-cbc@lysator.liu.se
+    <br /><br />
+    Any combination of the above ciphers will pass this check. Official FIPS 140-2 paperwork for
+    RHEL7 can be found at {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
 {{% endif %}}
 
 rationale: |-
@@ -23,7 +62,7 @@ rationale: |-
     <br />
     FIPS 140-2 is the current standard for validating that mechanisms used to access cryptographic modules
     utilize authentication that meets industry and government requirements. For government systems, this allows
-    Security Levels 1, 2, 3, or 4 for use on Red Hat Enterprise Linux.
+    Security Levels 1, 2, 3, or 4 for use on {{{ full_name }}}.
 
 severity: medium
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -10,7 +10,7 @@ description: |-
     demonstrates use of FIPS-approved ciphers:
     <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
-{{% elif product == "ol7" %}}
+{{% elif product in ["ol7","rhel7"] %}}
 description: |-
     Limit the ciphers to those algorithms which are FIPS-approved.
     Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
@@ -30,27 +30,11 @@ description: |-
     <br /><br />
     Any combination of the above ciphers will pass this check. 
     Official FIPS 140-2 paperwork for {{{ full_name }}} can be found at
+    {{% if product == "ol7" %}}
     {{{ weblink(link="https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3028.pdf") }}}
-{{% else %}}
-description: |-
-    Limit the ciphers to those algorithms which are FIPS-approved.
-    Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
-    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use of 
-    FIPS 140-2 validated ciphers:
-    <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>
-    <br /><br />
-    The following ciphers are FIPS 140-2 certified on RHEL 7:
-    <br />- aes128-ctr
-    <br />- aes192-ctr
-    <br />- aes256-ctr
-    <br />- aes128-cbc
-    <br />- aes192-cbc
-    <br />- aes256-cbc
-    <br />- 3des-cbc
-    <br />- rijndael-cbc@lysator.liu.se
-    <br /><br />
-    Any combination of the above ciphers will pass this check. Official FIPS 140-2 paperwork for
-    RHEL7 can be found at {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
+    {{% else %}}
+    {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
+    {{% endif %}}
 {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -2,7 +2,6 @@ documentation_complete: true
 
 title: 'Use Only FIPS 140-2 Validated Ciphers'
 
-{{% if product == "rhel6" %}}
 description: |-
     Limit the ciphers to those algorithms which are FIPS-approved.
     Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
@@ -10,13 +9,7 @@ description: |-
     demonstrates use of FIPS-approved ciphers:
     <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
-{{% elif product in ["ol7","rhel7"] %}}
-description: |-
-    Limit the ciphers to those algorithms which are FIPS-approved.
-    Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
-    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use of
-    FIPS 140-2 validated ciphers:
-    <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>
+{{% if product in ["rhel7","ol7"] %}}
     <br /><br />
     The following ciphers are FIPS 140-2 certified on {{{ full_name }}}:
     <br />- aes128-ctr

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -2,20 +2,13 @@ documentation_complete: true
 
 title: 'Use Only FIPS 140-2 Validated MACs'
 
-{{% if product == "rhel6" %}}
 description: |-
     Limit the MACs to those hash algorithms which are FIPS-approved.
     The following line in <tt>/etc/ssh/sshd_config</tt>
     demonstrates use of FIPS-approved MACs:
     <pre>MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported MACs.
-{{% elif product in ["rhel7","ol7"] %}}
-description: |-
-    Limit the MACs to those hash algorithms which are FIPS-approved.
-    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use
-    of FIPS-approved MACs:
-    <br /><br />
-    <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
+{{% if product in ["rhel7","ol7"] %}}
     <br /><br />
     Only the following message authentication codes are FIPS 140-2 certified on {{{ full_name }}}:
     <br />- hmac-sha1
@@ -26,7 +19,7 @@ description: |-
     <br />- hmac-sha2-512-etm@openssh.com
     <br /><br />
     Any combination of the above MACs will pass this check. Official FIPS 140-2 paperwork for
-    {{{ full_name }}} can be found at 
+    {{{ full_name }}} can be found at
     {{% if product == "ol7" %}}
     {{{ weblink(link="https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3028.pdf") }}}
     {{% else %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -9,8 +9,43 @@ description: |-
     demonstrates use of FIPS-approved MACs:
     <pre>MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported MACs.
+{{% elif product == "ol7" %}}
+description: |-
+    Limit the MACs to those hash algorithms which are FIPS-approved.
+    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use
+    of FIPS-approved MACs:
+    <br /><br />
+    <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
+    <br /><br />
+    Only the following message authentication codes are FIPS 140-2 certified on {{{ full_name }}}:
+    <br />- hmac-sha1
+    <br />- hmac-sha2-256
+    <br />- hmac-sha2-512
+    <br />- hmac-sha1-etm@openssh.com
+    <br />- hmac-sha2-256-etm@openssh.com
+    <br />- hmac-sha2-512-etm@openssh.com
+    <br /><br />
+    Any combination of the above MACs will pass this check. Official FIPS 140-2 paperwork for
+    {{{ full_name }}} can be found at 
+    {{{ weblink(link="https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3028.pdf") }}}
 {{% else %}}
-description: "Limit the MACs to those hash algorithms which are FIPS-approved.\nThe following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use \nof FIPS-approved MACs:\n<br /><br />\n<pre>MACs hmac-sha2-512,hmac-sha2-256</pre>\n<br /><br />\nOnly the following message authentication codes are FIPS 140-2 certified on RHEL 7:\n<br />- hmac-sha1\n<br />- hmac-sha2-256\n<br />- hmac-sha2-512\n<br />- hmac-sha1-etm@openssh.com\n<br />- hmac-sha2-256-etm@openssh.com\n<br />- hmac-sha2-512-etm@openssh.com\n<br /><br />\nAny combination of the above MACs will pass this check. Official FIPS 140-2 paperwork for\nRHEL7 can be found at http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf."
+description: |-
+    Limit the MACs to those hash algorithms which are FIPS-approved.
+    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use
+    of FIPS-approved MACs:
+    <br /><br />
+    <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
+    <br /><br />
+    Only the following message authentication codes are FIPS 140-2 certified on RHEL 7:
+    <br />- hmac-sha1
+    <br />- hmac-sha2-256
+    <br />- hmac-sha2-512
+    <br />- hmac-sha1-etm@openssh.com
+    <br />- hmac-sha2-256-etm@openssh.com
+    <br />- hmac-sha2-512-etm@openssh.com
+    <br /><br />
+    Any combination of the above MACs will pass this check. Official FIPS 140-2 paperwork for
+    RHEL7 can be found at {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
 {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -9,7 +9,7 @@ description: |-
     demonstrates use of FIPS-approved MACs:
     <pre>MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported MACs.
-{{% elif product == "ol7" %}}
+{{% elif product in ["rhel7","ol7"] %}}
 description: |-
     Limit the MACs to those hash algorithms which are FIPS-approved.
     The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use
@@ -27,25 +27,11 @@ description: |-
     <br /><br />
     Any combination of the above MACs will pass this check. Official FIPS 140-2 paperwork for
     {{{ full_name }}} can be found at 
+    {{% if product == "ol7" %}}
     {{{ weblink(link="https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp3028.pdf") }}}
-{{% else %}}
-description: |-
-    Limit the MACs to those hash algorithms which are FIPS-approved.
-    The following line in <tt>/etc/ssh/sshd_config</tt> demonstrates use
-    of FIPS-approved MACs:
-    <br /><br />
-    <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
-    <br /><br />
-    Only the following message authentication codes are FIPS 140-2 certified on RHEL 7:
-    <br />- hmac-sha1
-    <br />- hmac-sha2-256
-    <br />- hmac-sha2-512
-    <br />- hmac-sha1-etm@openssh.com
-    <br />- hmac-sha2-256-etm@openssh.com
-    <br />- hmac-sha2-512-etm@openssh.com
-    <br /><br />
-    Any combination of the above MACs will pass this check. Official FIPS 140-2 paperwork for
-    RHEL7 can be found at {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
+    {{% else %}}
+    {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
+    {{% endif %}}
 {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/services/sssd/group.yml
+++ b/linux_os/guide/services/sssd/group.yml
@@ -16,6 +16,8 @@ description: |-
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/SSSD.html") }}}
     {{%- elif product == "rhel6" -%}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/SSSD-Introduction.html") }}}
+    {{%- elif product == "ol7" -%}}
+        {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-sssd-auth.html") }}}
     {{%- endif %}}
 
 platform: machine

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/rule.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8
 title: 'Configure SSSD LDAP Backend to Use TLS For All Transactions'
 
 description: |-
-    This check verifies that RHEL7 implements cryptography
+    This check verifies that {{{ full_name }}} implements cryptography
     to protect the integrity of remote LDAP authentication sessions.
     <br /><br />
     To determine if LDAP is being used for authentication, use the following

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
@@ -5,5 +5,9 @@ title: 'Hardware Tokens for Authentication'
 description: |-
     The use of hardware tokens such as smart cards for system login
     provides stronger, two-factor authentication than using a username and password.
+    {{% if product == "ol7" %}}
+    In {{{ full_name }}} servers, hardware token login
+    {{% else %}}
     In Red Hat Enterprise Linux servers and workstations, hardware token login
+    {{% endif %}}
     is not enabled by default and must be enabled in the system settings.

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -13,12 +13,17 @@ description: |-
     <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards") }}}</b></li>
     {{% elif product == "rhel8" %}}
     <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards") }}}</b></li>
+    {{% elif product == "ol7" %}}
+    <li><b>{{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-s4-auth.html") }}}</b></li>
     {{% endif %}}
     </ul>
+    
+    {{% if product != "ol7" %}}
     For guidance on enabling SSH to authenticate against a Common Access Card (CAC), consult documentation at:
     <ul>
     <li><b>{{{ weblink(link="https://access.redhat.com/solutions/82273") }}}</b></li>
     </ul>
+    {{% endif %}}
 
 rationale: |-
     Smart card login provides two-factor authentication stronger than

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
@@ -9,7 +9,7 @@ description: |-
     not exist at all, the root user can login through any communication device on the
     system, whether via the console or via a raw network interface. This is dangerous
     as user can login to the system as root via Telnet, which sends the password in
-    plain text over the network. By default, Red Hat Enteprise Linux's
+    plain text over the network. By default, {{{ full_name }}}'s
     <tt>/etc/securetty</tt> file only allows the root user to login at the console
     physically attached to the system. To prevent root from logging in, remove the
     contents of this file. To prevent direct root logins, remove the contents of this

--- a/linux_os/guide/system/bootloader-grub2/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_password/rule.yml
@@ -35,11 +35,14 @@ rationale: |-
     Password protection on the boot loader configuration ensures
     users with physical access cannot trivially alter
     important bootloader settings. These include which kernel to use,
-    and whether to enter single-user mode. For more information on how to configure
-    the grub2 superuser account and password, please refer to
+    and whether to enter single-user mode.
+    {{% if product == "rhel7" %}}
+    For more information on how to configure the grub2 superuser account and password, 
+    please refer to
     <ul>
     <li>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Protecting_GRUB_2_with_a_Password.html") }}}</li>.
     </ul>
+    {{% endif %}}
 
 severity: high
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/rule.yml
@@ -35,11 +35,14 @@ rationale: |-
     Password protection on the boot loader configuration ensures
     users with physical access cannot trivially alter
     important bootloader settings. These include which kernel to use,
-    and whether to enter single-user mode. For more information on how to configure
-    the grub2 superuser account and password, please refer to
+    and whether to enter single-user mode.
+    {{% if product == "rhel7" %}}
+    For more information on how to configure the grub2 superuser account and password, 
+    please refer to
     <ul>
     <li>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Protecting_GRUB_2_with_a_Password.html") }}}</li>.
     </ul>
+    {{% endif %}}
 
 severity: medium
 

--- a/linux_os/guide/system/permissions/group.yml
+++ b/linux_os/guide/system/permissions/group.yml
@@ -15,8 +15,8 @@ description: |-
     name of each local partition substituted for <i>PART</i> in turn.
     <br /><br />
     The following command prints a list of all xfs partitions on the local
-    system, which is the default filesystem for Red Hat Enterprise Linux
-    7 installations:
+    system, which is the default filesystem for {{{ full_name }}} 
+    installations:
     <pre>$ mount -t xfs | awk '{print $3}'</pre>
     For any systems that use a different
     local filesystem type, modify this command as appropriate.

--- a/linux_os/guide/system/selinux/group.yml
+++ b/linux_os/guide/system/selinux/group.yml
@@ -10,7 +10,7 @@ description: |-
     <br /><br />
     The default SELinux policy, as configured on {{{ full_name }}}, has been
     sufficiently developed and debugged that it should be usable on
-    almost any Red Hat system with minimal configuration and a small
+    almost any system with minimal configuration and a small
     amount of system administrator training. This policy prevents
     system services - including most of the common network-visible
     services such as mail servers, FTP servers, and DNS servers - from
@@ -20,10 +20,12 @@ description: |-
     so forth.
     <br /><br />
     This guide recommends that SELinux be enabled using the
-    default (targeted) policy on every Red Hat system, unless that
+    default (targeted) policy on every {{{ full_name }}} system, unless that
     system has unusual requirements which make a stronger policy
     appropriate.
     {{% if product == "rhel7" %}}
     <br /><br />
     For more information on SELinux, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide") }}}</b>.
+    {{% elif product == "ol7" %}}
+    For more information on SELinux, see <b>{{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-s1-syssec.html") }}}</b>.
     {{% endif %}}

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel6,rhel7,rhel8
 title: 'Encrypt Partitions'
 
 description: |-
-    Red Hat Enterprise Linux 7 natively supports partition encryption through the
+    {{{ full_name }}} natively supports partition encryption through the
     Linux Unified Key Setup-on-disk-format (LUKS) technology. The easiest way to
     encrypt a partition is during installation time.
     <br /><br />
@@ -28,8 +28,12 @@ description: |-
     with a minimum <tt>512</tt> bit key size which should be compatible with FIPS enabled.
     <br /><br />
     Detailed information on encrypting partitions using LUKS or LUKS ciphers can be found on
-    the Red Hat Documentation web site:<br />
-    {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html") }}}.
+    the {{{ full_name }}} Documentation web site:<br />
+    {{% if product == "ol7" %}}
+        {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54670/html/ol7-encrypt-sec.html") }}}.
+    {{% else %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html") }}}.
+    {{% endif %}}
 
 rationale: |-
     The risk of a system's physical compromise, particularly mobile systems such as

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
@@ -12,6 +12,10 @@ description: |-
     For more information about enforcing preferences in the GNOME environment using the GConf
     configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
     the man page <tt>gconftool-2(1)</tt>.
+    {{% elif product == "ol7" %}}
+    For more information about enforcing preferences in the GNOME3 environment using the DConf
+    configuration system, see <b>{{{ weblink(link="http://wiki.gnome.org/dconf") }}}</b> and
+    the man page <tt>dconf(1)</tt>.
     {{% else %}}
     For more information about enforcing preferences in the GNOME3 environment using the DConf
     configuration system, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/index.html") }}}/></b> and the man page <tt>dconf(1)</tt>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
@@ -2,8 +2,8 @@ documentation_complete: true
 
 title: 'Configure GNOME Screen Locking'
 
-{{% if product == "rhel6" %}}
 description: |-
+{{% if product == "rhel6" %}}
     In the default GNOME desktop, the screen can be locked
     by choosing <b>Lock Screen</b> from the <b>System</b> menu.
     <br /><br />
@@ -32,7 +32,6 @@ description: |-
     configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
     the man page <tt>gconftool-2(1)</tt>.
 {{% else %}}
-description: |-
     In the default GNOME3 desktop, the screen can be locked
     by selecting the user name in the far right corner of the main panel and
     selecting <b>Lock</b>.

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
@@ -31,26 +31,6 @@ description: |-
     enforcing preferences in the GNOME environment using the GConf
     configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
     the man page <tt>gconftool-2(1)</tt>.
-{{% elif product == "ol7" %}}
-description: |-
-    In the default GNOME3 desktop, the screen can be locked
-    by selecting the user name in the far right corner of the main panel and
-    selecting <b>Lock</b>.
-    <br /><br />
-    The following sections detail commands to enforce idle activation of the screensaver,
-    screen locking, a blank-screen screensaver, and an idle activation time.
-    <br /><br />
-    Because users should be trained to lock the screen when they
-    step away from the computer, the automatic locking feature is only
-    meant as a backup.
-    <br /><br />
-    The root account can be screen-locked; however, the root account should
-    <i>never</i> be used to log into an X Windows environment and should only
-    be used to for direct login via console in emergency circumstances.
-    <br /><br />
-    For more information about enforcing preferences in the GNOME3 environment using the DConf
-    configuration system, see <b>{{{ weblink(link="http://wiki.gnome.org/dconf") }}}</b> and
-    the man page <tt>dconf(1)</tt>.
 {{% else %}}
 description: |-
     In the default GNOME3 desktop, the screen can be locked
@@ -70,6 +50,9 @@ description: |-
     <br /><br />
     For more information about enforcing preferences in the GNOME3 environment using the DConf
     configuration system, see <b>{{{ weblink(link="http://wiki.gnome.org/dconf") }}}</b> and
-    the man page <tt>dconf(1)</tt>. For Red Hat specific information on configuring DConf
+    the man page <tt>dconf(1)</tt>.
+    {{% if product == "rhel7" %}}
+    For Red Hat specific information on configuring DConf
     settings, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/part-Configuration_and_Administration.html") }}}</b>
+    {{% endif %}}
 {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
@@ -31,6 +31,26 @@ description: |-
     enforcing preferences in the GNOME environment using the GConf
     configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
     the man page <tt>gconftool-2(1)</tt>.
+{{% elif product == "ol7" %}}
+description: |-
+    In the default GNOME3 desktop, the screen can be locked
+    by selecting the user name in the far right corner of the main panel and
+    selecting <b>Lock</b>.
+    <br /><br />
+    The following sections detail commands to enforce idle activation of the screensaver,
+    screen locking, a blank-screen screensaver, and an idle activation time.
+    <br /><br />
+    Because users should be trained to lock the screen when they
+    step away from the computer, the automatic locking feature is only
+    meant as a backup.
+    <br /><br />
+    The root account can be screen-locked; however, the root account should
+    <i>never</i> be used to log into an X Windows environment and should only
+    be used to for direct login via console in emergency circumstances.
+    <br /><br />
+    For more information about enforcing preferences in the GNOME3 environment using the DConf
+    configuration system, see <b>{{{ weblink(link="http://wiki.gnome.org/dconf") }}}</b> and
+    the man page <tt>dconf(1)</tt>.
 {{% else %}}
 description: |-
     In the default GNOME3 desktop, the screen can be locked

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_certified/rule.yml
@@ -1,14 +1,21 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,ol7
 
 title: 'The Installed Operating System Is Vendor Supported and Certified'
 
 description: |-
     The installed operating system must be maintained and certified by a vendor.
+    {{% if product == "ol7" %}}
+    Oracle Linux is supported by Oracle Corporation. As the Oracle
+    Linux vendor, Oracle Corporation is responsible for providing security patches as well
+    as meeting and maintaining goverment certifications and standards.
+    {{% else %}}
     Red Hat Enterprise Linux is supported by Red Hat, Inc. As the Red Hat Enterprise
     Linux vendor, Red Hat, Inc. is responsible for providing security patches as well
     as meeting and maintaining goverment certifications and standards.
+    {{% endif %}}
+
 
 rationale: |-
     An operating system is considered "supported" if the vendor continues to provide

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/group.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/group.yml
@@ -4,6 +4,10 @@ title: 'Endpoint Protection Software'
 
 description: |-
     Endpoint protection security software that is not provided or supported
+    {{% if product == "ol7" %}}
+    by Oracle Corporation can be installed to provide complementary or duplicative
+    {{% else %}}
     by Red Hat can be installed to provide complementary or duplicative
+    {{% endif %}}
     security capabilities to those provided by the base platform.  Add-on
     software may not be appropriate for some specialized systems.

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel6,rhel7,rhel8,fedora
 title: 'Install Intrusion Detection Software'
 
 description: |-
-    The base Red Hat platform already includes a sophisticated auditing system that
+    The base {{{ full_name }}} platform already includes a sophisticated auditing system that
     can detect intruder activity, as well as SELinux, which provides host-based
     intrusion prevention capabilities by confining privileged programs and user
     sessions which may become compromised.

--- a/linux_os/guide/system/software/integrity/fips/group.yml
+++ b/linux_os/guide/system/software/integrity/fips/group.yml
@@ -11,6 +11,6 @@ description: |-
     <br /><br />
     FIPS 140-2 is the current standard for validating that mechanisms used to access cryptographic modules
     utilize authentication that meets industry and government requirements. For government systems, this allows
-    Security Levels 1, 2, 3, or 4 for use on Red Hat Enterprise Linux.
+    Security Levels 1, 2, 3, or 4 for use on {{{ full_name }}}.
     <br /><br />
     See <b>{{{ weblink(link="http://csrc.nist.gov/publications/PubsFIPS.html") }}}</b> for more information.

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -54,8 +54,12 @@ warnings:
         The system needs to be rebooted for these changes to take effect.
     - regulatory: |-
         The ability to enable FIPS does not denote FIPS compliancy or certification.
-        Red Hat, Inc. and Red Hat Enterprise Linux are respectively FIPS certified and compliant. Community
-        projects such as CentOS, Scientific Linux, Fedora, etc. do not necessarily meet FIPS certification and compliancy.
+        {{% if product == "ol7" %}}
+        {{{ full_name }}} is FIPS certified and compliant.
+        {{% else %}}
+        Red Hat, Inc. and Red Hat Enterprise Linux are respectively FIPS certified and compliant. 
+        {{% endif %}}
+        Community projects such as CentOS, Scientific Linux, Fedora, etc. do not necessarily meet FIPS certification and compliancy.
         Therefore, non-certified vendors and/or projects do not meet this requirement even if technically feasible.
         <br /><br />
         See <b>{{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/1401vend.htm") }}}</b>


### PR DESCRIPTION
#### Description:

- OL7 guide changes
- specific platform names usage replaced with {{{ full_name }}} macro in shared places to make content platform agnostic

Checked OL7 generated content, briefly checked RHEL7 and RHEL6 related guide changes not broken.