### PR TITLE
Fix ANSIBLE0012 in tasks for security mount option in remote filesystems

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
@@ -17,6 +17,6 @@
   shell: awk '$2=="{{ item }}"{$4=$4",sec=krb5:krb5i:krb5p"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
   with_items:
     - "{{ points_register.stdout_lines }}"
+  when: (points_register.stdout | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
   tags:
     @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
@@ -8,6 +8,7 @@
   shell: grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "sec=krb5:krb5i:krb5p" | awk '{print $2}'
   register: points_register
   check_mode: no
+  changed_when: False
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
+++ b/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
@@ -8,6 +8,7 @@
   shell: grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "{{{ MOUNTOPTION }}}" | awk '{print $2}'
   register: points_register
   check_mode: no
+  changed_when: False
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@


### PR DESCRIPTION
#### Description:

- Tasks that gather information never make changes to the system.
Lets make them return result as not changed.
- Add when condition to kerberos mount options task.
The Ansbile task should only be run when points_register is not empty.

- Fixes Ansible lint errors 
```
Task: Get nfs and nfs4 mount points, that don't have nosuid
- [EANSIBLE0012] Commands should not change things if nothing needs doing
```