### PR TITLE
Fix ansible-lint mount option errors

### DIFF
--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -7,6 +7,7 @@
   shell: mount | grep ' {{{ MOUNTPOINT }}} ' |cut -d ' ' -f 1
   register: device_name
   check_mode: no
+  changed_when: False
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -5,6 +5,8 @@
 # disruption = high
 - name: get back device associated to mountpoint
   shell: mount | grep ' {{{ MOUNTPOINT }}} ' |cut -d ' ' -f 1
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't fetch device name with mount module
   register: device_name
   check_mode: no
   changed_when: False
@@ -15,11 +17,15 @@
 - block:
   - name: get back device previous mount option
     shell: mount | grep ' {{{ MOUNTPOINT }}} ' | sed -re 's:.*\((.*)\):\1:'
+    args:
+      warn: False # Ignore ANSIBLE0006, we can't fetch current mount options with mount module
     register: device_cur_mountoption
     check_mode: no
 
   - name: get back device fstype
     shell: mount | grep ' {{{ MOUNTPOINT }}} ' | cut -d ' ' -f 5
+    args:
+      warn: False # Ignore ANSIBLE0006, we can't fetch fstype with mount module
     register: device_fstype
     check_mode: no
 

--- a/shared/templates/template_ANSIBLE_mount_option_var
+++ b/shared/templates/template_ANSIBLE_mount_option_var
@@ -7,6 +7,8 @@
 
 - name: get back device associated to mountpoint
   shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' |cut -d ' ' -f 1
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't fetch device name with mount module
   register: device_name
   check_mode: no
   changed_when: False
@@ -17,11 +19,15 @@
 - block:
   - name: get back device previous mount option
     shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | sed -re 's:.*\((.*)\):\1:'
+    args:
+      warn: False # Ignore ANSIBLE0006, we can't fetch mount options with mount module
     register: device_cur_mountoption
     check_mode: no
 
   - name: get back device fstype
     shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | cut -d ' ' -f 5
+    args:
+      warn: False # Ignore ANSIBLE0006, we can't fetch fstype with mount module
     register: device_fstype
     check_mode: no
 

--- a/shared/templates/template_ANSIBLE_mount_option_var
+++ b/shared/templates/template_ANSIBLE_mount_option_var
@@ -9,6 +9,7 @@
   shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' |cut -d ' ' -f 1
   register: device_name
   check_mode: no
+  changed_when: False
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@


### PR DESCRIPTION
#### Description:

- Tasks that gather information never make changes to the system.
Lets make them return result as not changed.
- Skip ANSIBLE0006 warnings in tasks that use shell module and mount command to fetch data about mount points.

#### Rationale:

- Ansible mount module cannot be used to fetch data.

- Fixes following ansible-lint messages:
```
Task: get back device associated to mountpoint
- [EANSIBLE0006] mount used in place of mount module
- [EANSIBLE0012] Commands should not change things if nothing needs doing
```