### PR TITLE
Prefix file permissions to be octal numbers

### DIFF
--- a/fedora/templates/csv/file_dir_permissions.csv
+++ b/fedora/templates/csv/file_dir_permissions.csv
@@ -8,4 +8,4 @@
 /etc/ssh,*.pub,,,0644,sshd_pub_key
 /etc/ssh,*_key,,,0640,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
-/boot/grub2,grub.cfg,0,0,600,grub2_cfg
+/boot/grub2,grub.cfg,0,0,0600,grub2_cfg

--- a/ol7/templates/csv/file_dir_permissions.csv
+++ b/ol7/templates/csv/file_dir_permissions.csv
@@ -1,5 +1,5 @@
 /etc,shadow,0,0,0000
 /etc,group,0,0,0644
 /etc,passwd,0,0,0644
-/boot/grub2,grub.cfg,0,0,600,grub2_cfg
+/boot/grub2,grub.cfg,0,0,0600,grub2_cfg
 /boot/efi/EFI/redhat,grub.cfg,0,0,,efi_grub2_cfg

--- a/rhel6/templates/csv/file_dir_permissions.csv
+++ b/rhel6/templates/csv/file_dir_permissions.csv
@@ -8,4 +8,4 @@
 /etc/ssh,*.pub,,,0644,sshd_pub_key
 /etc/ssh,*_key,,,0600,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
-/boot/grub,grub.conf,0,0,600,grub_conf
+/boot/grub,grub.conf,0,0,0600,grub_conf

--- a/rhel7/templates/csv/file_dir_permissions.csv
+++ b/rhel7/templates/csv/file_dir_permissions.csv
@@ -8,5 +8,5 @@
 /etc/ssh,*.pub,,,0644,sshd_pub_key
 /etc/ssh,*_key,,,0640,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
-/boot/grub2,grub.cfg,0,0,600,grub2_cfg
-/boot/efi/EFI/redhat,grub.cfg,0,0,700,efi_grub2_cfg
+/boot/grub2,grub.cfg,0,0,0600,grub2_cfg
+/boot/efi/EFI/redhat,grub.cfg,0,0,0700,efi_grub2_cfg

--- a/sle12/templates/csv/file_dir_permissions.csv
+++ b/sle12/templates/csv/file_dir_permissions.csv
@@ -8,4 +8,4 @@
 /etc/ssh,*.pub,,,0644,sshd_pub_key
 /etc/ssh,*_key,,,0600,sshd_private_key
 /etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
-/boot/grub,grub.conf,0,0,600,grub_conf
+/boot/grub,grub.conf,0,0,0600,grub_conf


### PR DESCRIPTION

#### Description:

- `ansible-lint` would like mode parameter of file module to be seen as an octal number. 
I.e. starting with a leading `0`.

#### Rationale:

- I've tried to quote the value of `mode:` parameter as defined in the `file` module [manual](https://docs.ansible.com/ansible/2.7/modules/file_module.html), but `ansible-lint` still complained about it.

- Fix `ansible-lint` messages:
```
Task: Ensure permission 600 on /boot/grub/grub.conf
- [EANSIBLE0009] Octal file permissions must contain leading zero
```