### PR TITLE
Galaxy Upload script refactoring.

### DIFF
--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -43,6 +43,17 @@ yaml.add_representer(collections.OrderedDict, dict_representer)
 yaml.add_constructor(_mapping_tag, dict_constructor)
 # End arcaduf gist
 
+PROFILE_WHITELIST = set([
+    "C2S",
+    "hipaa",
+    "nist-800-171-cui",
+    "ospp",
+    "pci-dss",
+    "rht-ccp",
+    "stig-rhel7-disa",
+])
+
+
 ORGANIZATION_NAME = "RedHatOfficial"
 GIT_COMMIT_AUTHOR_NAME = "Red Hat Security Automation development team"
 GIT_COMMIT_AUTHOR_EMAIL = "scap-security-guide@lists.fedorahosted.org"
@@ -271,7 +282,8 @@ def parse_args():
         help="Name of the Github organization")
     parser.add_argument(
         "--profile", "-p", default=[], nargs="*", action="append",
-        help="What profiles to upload, if not specified, upload them all.")
+        metavar="PROFILE", choices=PROFILE_WHITELIST,
+        help="What profiles to upload, if not specified, upload all that are applicable.")
     return parser.parse_args()
 
 
@@ -290,15 +302,7 @@ def locally_clone_and_init_repositories(organization, repo_list):
 def main():
     args = parse_args()
 
-    role_whitelist = set([
-        "rhel7-role-C2S",
-        "rhel7-role-hipaa",
-        "rhel7-role-nist-800-171-cui",
-        "rhel7-role-ospp",
-        "rhel7-role-pci-dss",
-        "rhel7-role-rht-ccp",
-        "rhel7-role-stig-rhel7-disa"
-    ])
+    role_whitelist = {"rhel7-role-%s" % p for p in PROFILE_WHITELIST}
     if args.profile:
         selected_roles = {"rhel7-role-%s" % p for p in args.profile}
         role_whitelist.intersection_update(selected_roles)

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -38,6 +38,7 @@ def dict_representer(dumper, data):
 def dict_constructor(loader, node):
     return collections.OrderedDict(loader.construct_pairs(node))
 
+
 yaml.add_representer(collections.OrderedDict, dict_representer)
 yaml.add_constructor(_mapping_tag, dict_constructor)
 # End arcaduf gist
@@ -68,9 +69,9 @@ def create_empty_repositories(github_new_repos, github_org):
             has_downloads=False)
 
 
-def clone_and_init_repository(parent_dir, repo):
+def clone_and_init_repository(parent_dir, organization, repo):
     os.system(
-        "git clone git@github.com:%s/%s.git" % (ORGANIZATION_NAME, repo))
+        "git clone git@github.com:%s/%s.git" % (organization, repo))
     os.system("ansible-galaxy init " + repo + " --force")
     os.chdir(repo)
     try:
@@ -82,132 +83,178 @@ def clone_and_init_repository(parent_dir, repo):
         os.chdir("..")
 
 
-def update_repository(repository, local_file_path):
-    print("Processing %s..." % repository.name)
+class Repository(object):
+    def __init__(self, repo, local_filename):
+        self.repository = repo
+        self.local_filename = local_filename
 
-    with io.open(local_file_path, 'r', encoding="utf-8") as f:
-        filedata = f.read()
+        self.role_data = None
+        self.vars_data = []
+        self.tasks_data = []
+        self.pre_tasks_data = []
 
-    role_data = yaml.load(filedata)
-    vars_data = []
-    if "vars" in role_data[0]:
-        vars_data = role_data[0]["vars"]
+        self.tasks_local_content = None
 
-    tasks_data = []
-    if "tasks" in role_data[0]:
-        tasks_data = role_data[0]["tasks"]
+        self.description = None
+        self.title = None
 
-    # ansible language doesn't allow pre_tasks for roles, if the only pre task
-    # is the ansible version check we can ignore it because the minimal version
-    # is in role metadata
-    if "pre_tasks" in role_data[0]:
-        pre_tasks_data = role_data[0]["pre_tasks"]
-        if len(pre_tasks_data) == 1 and \
-                pre_tasks_data[0]["name"] == \
-                ssg.ansible.ansible_version_requirement_pre_task_name:
-            pass
-        else:
-            sys.stderr.write(
-                "%s contains pre_tasks other than the version check. "
-                "pre_tasks are not supported for ansible roles and "
-                "will be skipped!.\n")
+    def gather_data(self):
+        with io.open(self.local_filename, 'r', encoding="utf-8") as f:
+            filedata = f.read()
 
-    tasks_local_content = yaml.dump(tasks_data, width=120, indent=4,
-                                    default_flow_style=False)
+        self.role_data = yaml.load(filedata)
+        if "vars" in self.role_data[0]:
+            self.vars_data = self.role_data[0]["vars"]
 
-    # Add \n in between tasks to increase readability
-    tasks_local_content = tasks_local_content.replace('\n- ', '\n\n- ')
-    tasks_remote_content = repository.get_file_contents("/tasks/main.yml")
+        if "tasks" in self.role_data[0]:
+            self.tasks_data = self.role_data[0]["tasks"]
 
-    if tasks_local_content != tasks_remote_content.decoded_content:
-        repository.update_file(
-            "/tasks/main.yml",
-            "Updates tasks/main.yml",
-            tasks_local_content,
-            tasks_remote_content.sha,
-            author=InputGitAuthor(
-                GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
-        )
+        # ansible language doesn't allow pre_tasks for roles, if the only pre task
+        # is the ansible version check we can ignore it because the minimal version
+        # is in role metadata
+        if "pre_tasks" in self.role_data[0]:
+            pre_tasks_data = self.role_data[0]["pre_tasks"]
+            if len(pre_tasks_data) == 1 and \
+                    pre_tasks_data[0]["name"] == \
+                    ssg.ansible.ansible_version_requirement_pre_task_name:
+                pass
+            else:
+                sys.stderr.write(
+                    "%s contains pre_tasks other than the version check. "
+                    "pre_tasks are not supported for ansible roles and "
+                    "will be skipped!.\n")
 
-        print("Updating tasks/main.yml in %s" % repository.name)
+        self.tasks_local_content = yaml.dump(
+            self.tasks_data, width=120, indent=4, default_flow_style=False)
 
-    vars_local_content = yaml.dump(vars_data, width=120, indent=4,
-                                   default_flow_style=False)
-    vars_remote_content = repository.get_file_contents("/vars/main.yml")
+        description = self.get_description_from_filedata(filedata)
+        self.description = description
 
-    if vars_local_content != vars_remote_content.decoded_content:
-        repository.update_file(
-            "/vars/main.yml",
-            "Updates vars/main.yml",
-            vars_local_content,
-            vars_remote_content.sha,
-            author=InputGitAuthor(
-                GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
-        )
+    def _reformat_local_content(self):
+        # Add \n in between tasks to increase readability
+        self.tasks_local_content = self.tasks_local_content.replace('\n- ', '\n\n- ')
 
-        print("Updating vars/main.yml in %s" % repository.name)
+        self.description = self.description.replace('# ', '')
+        self.description = self.description.replace('#', '')
 
-    separator = "#" * 79
-    first_separator_pos = filedata.find(separator)
-    second_separator_pos = filedata.find(separator,
-                                         first_separator_pos + len(separator))
-    description = filedata[first_separator_pos + len(separator) + 3:
-                           second_separator_pos - 3]
-    description = description.replace('# ', '')
-    description = description.replace('#', '')
-    title = re.search('Profile Title:\s+(.+)$',
-                      description, re.MULTILINE).group(1)
-    description = description.replace('\n', '  \n')
+    def get_description_from_filedata(self, filedata):
+        separator = "#" * 79
+        offset_from_separator = 3
 
-    repository.edit(
-        repository.name,
-        description="%s - Ansible role generated from the SCAP Security Guide "
-        "project" % (title),
-        homepage="https://www.open-scap.org/",
-    )
+        first_separator_pos = filedata.find(
+            separator)
+        second_separator_pos = filedata.find(
+            separator, first_separator_pos + len(separator))
 
-    with io.open(README_TEMPLATE_PATH, 'r',  encoding="utf-8") as f:
-        readme_template = f.read()
+        description_start = first_separator_pos + len(separator) + offset_from_separator
+        description_stop = second_separator_pos - offset_from_separator
+        description = filedata[description_start:description_stop]
 
-    local_readme_content = readme_template.replace("@DESCRIPTION@",
-                                                   description)
-    local_readme_content = local_readme_content.replace("@TITLE@", title)
-    local_readme_content = local_readme_content.replace(
-        "@MIN_ANSIBLE_VERSION@", ssg.ansible.min_ansible_version)
-    local_readme_content = local_readme_content.replace("@ROLE_NAME@",
-                                                        repository.name)
+        return description
 
-    remote_readme_file = repository.get_file_contents("/README.md")
+    def _update_tasks_content_if_needed(self):
+        tasks_remote_content = self.repository.get_file_contents("/tasks/main.yml")
 
-    if local_readme_content != remote_readme_file.decoded_content:
-        print("Updating README.md in %s" % repository.name)
+        if self.tasks_local_content != tasks_remote_content.decoded_content:
+            self.repository.update_file(
+                "/tasks/main.yml",
+                "Updates tasks/main.yml",
+                self.tasks_local_content,
+                tasks_remote_content.sha,
+                author=InputGitAuthor(
+                    GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
+            )
+            print("Updating tasks/main.yml in %s" % self.repository.name)
 
-        repository.update_file(
-            "/README.md",
-            "Updates README.md",
-            local_readme_content,
-            remote_readme_file.sha,
-            author=InputGitAuthor(
-                GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
-        )
+    def _update_vars_content_if_needed(self):
+        vars_remote_content = self.repository.get_file_contents("/vars/main.yml")
+        vars_local_content = yaml.dump(self.vars_data, width=120, indent=4,
+                                       default_flow_style=False)
 
-    with open(META_TEMPLATE_PATH, 'r') as f:
-        meta_template = f.read()
+        if vars_local_content != vars_remote_content.decoded_content:
+            self.repository.update_file(
+                "/vars/main.yml",
+                "Updates vars/main.yml",
+                vars_local_content,
+                vars_remote_content.sha,
+                author=InputGitAuthor(
+                    GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
+            )
 
-    local_meta_content = meta_template.replace("@DESCRIPTION@", title)
-    local_meta_content = local_meta_content.replace(
-        "@MIN_ANSIBLE_VERSION@", ssg.ansible.min_ansible_version)
-    remote_meta_file = repository.get_file_contents("/meta/main.yml")
+            print("Updating vars/main.yml in %s" % self.repository.name)
 
-    if local_meta_content != remote_meta_file.decoded_content:
-        print("Updating meta/main.yml in %s" % repository.name)
-        repository.update_file(
-            "/meta/main.yml",
-            "Updates meta/main.yml",
-            local_meta_content,
-            remote_meta_file.sha,
-            author=InputGitAuthor(
-                GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
+    def _generate_readme_content(self):
+        with io.open(README_TEMPLATE_PATH, 'r',  encoding="utf-8") as f:
+            readme_template = f.read()
+
+        local_readme_content = readme_template.replace(
+            "@DESCRIPTION@", self.description)
+        local_readme_content = local_readme_content.replace(
+            "@TITLE@", self.title)
+        local_readme_content = local_readme_content.replace(
+            "@MIN_ANSIBLE_VERSION@", ssg.ansible.min_ansible_version)
+        local_readme_content = local_readme_content.replace(
+            "@ROLE_NAME@", self.repository.name)
+        return local_readme_content
+
+    def _update_readme_content_if_needed(self):
+        local_readme_content = self._generate_readme_content()
+        remote_readme_file = self.repository.get_file_contents("/README.md")
+
+        if local_readme_content != remote_readme_file.decoded_content.decode("utf-8"):
+            print("Updating README.md in %s" % self.repository.name)
+
+            self.repository.update_file(
+                "/README.md",
+                "Updates README.md",
+                local_readme_content,
+                remote_readme_file.sha,
+                author=InputGitAuthor(
+                    GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
+            )
+
+    def _update_meta_content_if_needed(self):
+        with open(META_TEMPLATE_PATH, 'r') as f:
+            meta_template = f.read()
+
+        local_meta_content = meta_template.replace("@DESCRIPTION@", self.title)
+        local_meta_content = local_meta_content.replace(
+            "@MIN_ANSIBLE_VERSION@", ssg.ansible.min_ansible_version)
+        remote_meta_file = self.repository.get_file_contents("/meta/main.yml")
+
+        if local_meta_content != remote_meta_file.decoded_content:
+            print("Updating meta/main.yml in %s" % self.repository.name)
+            self.repository.update_file(
+                "/meta/main.yml",
+                "Updates meta/main.yml",
+                local_meta_content,
+                remote_meta_file.sha,
+                author=InputGitAuthor(
+                    GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
+            )
+
+    def update(self):
+        print("Processing %s..." % self.repository.name)
+
+        self.gather_data()
+        self._reformat_local_content()
+        self.title = re.search(
+            r'Profile Title:\s+(.+)$', self.description, re.MULTILINE).group(1)
+        # Why so?
+        self.description = self.description.replace('\n', '  \n')
+
+        self._update_tasks_content_if_needed()
+        self._update_vars_content_if_needed()
+        self._update_readme_content_if_needed()
+        self._update_meta_content_if_needed()
+
+        repo_description = (
+            "{title} - Ansible role generated from the SCAP Security Guide project"
+            .format(title=self.title))
+        self.repository.edit(
+            self.repository.name,
+            description=repo_description,
+            homepage="https://www.open-scap.org/",
         )
 
 
@@ -219,7 +266,25 @@ def parse_args():
         help="Path to directory containing the generated roles. Most "
         "likely this is going to be ./build/roles",
         dest="build_roles_dir")
+    parser.add_argument(
+        "--organization", "-o", default=ORGANIZATION_NAME,
+        help="Name of the Github organization")
+    parser.add_argument(
+        "--profile", "-p", default=[], nargs="*",
+        help="What profiles to build, if not specified, build all.")
     return parser.parse_args()
+
+
+def locally_clone_and_init_repositories(organization, repo_list):
+    temp_dir = mkdtemp()
+    current_dir = os.getcwd()
+    os.chdir(temp_dir)
+    try:
+        for repo in repo_list:
+            clone_and_init_repository(temp_dir, organization, repo)
+    finally:
+        os.chdir(current_dir)
+        shutil.rmtree(temp_dir)
 
 
 def main():
@@ -234,6 +299,9 @@ def main():
         "rhel7-role-rht-ccp",
         "rhel7-role-stig-rhel7-disa"
     ])
+    if args.profile:
+        selected_roles = {"rhel7-role-%s" % p for p in args.profile}
+        role_whitelist.intersection_update(selected_roles)
 
     # the first 4 cut chars are for "ssg-"
     # the last 4 cut chars are for ".yml"
@@ -249,33 +317,22 @@ def main():
     password = getpass.getpass("password (or empty for token): ")
 
     github = Github(username, password)
-    github_org = github.get_organization(ORGANIZATION_NAME)
+    github_org = github.get_organization(args.organization)
     github_repositories = [repo.name for repo in github_org.get_repos()]
 
     # Create empty repositories
     github_new_repos = sorted(list(set(roles) - set(github_repositories)))
     if github_new_repos:
         create_empty_repositories(github_new_repos, github_org)
-        github_repositories = [repo.name for repo in github_org.get_repos()]
 
-        # Locally clone and init repositories
-        temp_dir = mkdtemp()
-        current_dir = os.getcwd()
-        os.chdir(temp_dir)
-        try:
-            for repo in github_new_repos:
-                clone_and_init_repository(temp_dir, repo)
-        finally:
-            os.chdir(current_dir)
-            shutil.rmtree(temp_dir)
+        locally_clone_and_init_repositories(args.organization, github_repositories)
 
     # Update repositories
     for repo in sorted(github_org.get_repos(), key=lambda repo: repo.name):
         if repo.name in roles:
-            update_repository(
-                repo, os.path.join(args.build_roles_dir,
-                                   "ssg-" + repo.name + ".yml")
-            )
+            corresponding_filename = os.path.join(
+                args.build_roles_dir, "ssg-" + repo.name + ".yml")
+            Repository(repo, corresponding_filename).update()
         else:
             print("Repo %s should be deleted, please verify and do that "
                   "manually!" % repo.name)


### PR DESCRIPTION
This PR features refactoring of the script that is not supposed to alter it's behavior - if called in the same way as the pre-refactoring script, it should produce exactly the same output (except e.g. random ordering issues).

Notable changes:
* Split the large `update_repository` function into smaller methods of the newly-introduced `Repository` class.
* Backwards-compatible CLI changes: Allowed specification of alternative organization, allowed restriction of processed profiles.