### PR TITLE
 Added support for default role variables

### DIFF
--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -167,15 +167,17 @@ class Role(object):
 
     def add_task_variables_to_default_variables_if_needed(self):
         default_vars_to_add = sorted(self.added_variables)
-        lines = ["---", "# defaults file for {role_name}\n".format(role_name=self.repository.name)]
+        lines = [
+            "---", "# defaults file for {role_name}\n".format(role_name=self.remote_repo.name),
+        ]
         lines += ["{var_name}: true".format(var_name=var_name) for var_name in default_vars_to_add]
         lines.append("")
 
         default_vars_local_content = "\n".join(lines)
 
-        default_vars_remote_content = self.repository.get_file_contents("/defaults/main.yml")
+        default_vars_remote_content = self.remote_repo.get_file_contents("/defaults/main.yml")
         if default_vars_local_content != default_vars_remote_content.decoded_content:
-            self.repository.update_file(
+            self.remote_repo.update_file(
                 "/defaults/main.yml",
                 "Updates defaults/main.yml",
                 default_vars_local_content,
@@ -183,7 +185,7 @@ class Role(object):
                 author=InputGitAuthor(
                     GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
             )
-            print("Updating defaults/main.yml in %s" % self.repository.name)
+            print("Updating defaults/main.yml in %s" % self.remote_repo.name)
 
     def _reformat_local_content(self):
         # Add \n in between tasks to increase readability
@@ -331,7 +333,7 @@ def parse_args():
         "--organization", "-o", default=ORGANIZATION_NAME,
         help="Name of the Github organization")
     parser.add_argument(
-        "--profile", "-p", default=[], nargs="*", action="append",
+        "--profile", "-p", default=[], action="append",
         metavar="PROFILE", choices=PROFILE_WHITELIST,
         help="What profiles to upload, if not specified, upload all that are applicable.")
     return parser.parse_args()
@@ -352,7 +354,8 @@ def locally_clone_and_init_repositories(organization, repo_list):
 def main():
     args = parse_args()
 
-    role_whitelist = {"rhel7-role-%s" % p for p in PROFILE_WHITELIST}
+    all_role_whitelist = {"rhel7-role-%s" % p for p in PROFILE_WHITELIST}
+    role_whitelist = set(all_role_whitelist)
     if args.profile:
         selected_roles = {"rhel7-role-%s" % p for p in args.profile}
         role_whitelist.intersection_update(selected_roles)
@@ -363,8 +366,8 @@ def main():
         [f[4:-4]
          for f in os.listdir(args.build_roles_dir) if f.endswith(".yml")]
     )
-    # print(available_roles)
-    roles = available_roles.intersection(role_whitelist)
+    selected_roles = available_roles.intersection(role_whitelist)
+    potential_roles = available_roles.intersection(all_role_whitelist)
 
     print("Input your GitHub credentials:")
     username = raw_input("username or token: ")
@@ -375,7 +378,7 @@ def main():
     github_repositories = [repo.name for repo in github_org.get_repos()]
 
     # Create empty repositories
-    github_new_repos = sorted(list(set(roles) - set(github_repositories)))
+    github_new_repos = sorted(list(set(selected_roles) - set(github_repositories)))
     if github_new_repos:
         create_empty_repositories(github_new_repos, github_org)
 
@@ -383,11 +386,11 @@ def main():
 
     # Update repositories
     for repo in sorted(github_org.get_repos(), key=lambda repo: repo.name):
-        if repo.name in roles:
+        if repo.name in selected_roles:
             corresponding_filename = os.path.join(
                 args.build_roles_dir, "ssg-" + repo.name + ".yml")
             Role(repo, corresponding_filename).update_repository()
-        else:
+        elif repo.name not in potential_roles:
             print("Repo %s should be deleted, please verify and do that "
                   "manually!" % repo.name)
 


### PR DESCRIPTION
The script now generates `when:` clauses to each task using newly introduced variables.
Those variables are extracted from existing tags. For every variable added, a corresponding entry in `defaults/main.yml` is created, where the variable is set to true, so the playbook behaves in the same way as before this change.

~For reference, this PR basically contains #3610.~