### PR TITLE
Ignore warnings on tasks using rpm shell command

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -19,6 +19,8 @@
 
 - name: "Read files with incorrect hash"
   shell: "rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/' | awk '{print $NF}'"
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect hash using rpm module
   register: files_with_incorrect_hash
   changed_when: False
   when: (package_manager_reinstall_cmd is defined) and @ANSIBLE_PLATFORM_CONDITION@
@@ -28,6 +30,8 @@
 
 - name: "Reinstall packages of files with incorrect hash"
   shell: "{{package_manager_reinstall_cmd}} $(rpm -qf '{{item}}')"
+  args:
+    warn: False # Ignore ANSIBLE0006, this task is flexible with regards to package manager
   with_items: "{{ files_with_incorrect_hash.stdout_lines }}"
   when: (package_manager_reinstall_cmd is defined and (files_with_incorrect_hash.stdout_lines | length > 0)) and @ANSIBLE_PLATFORM_CONDITION@
   tags:

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -5,6 +5,8 @@
 # disruption = medium
 - name: "Read list of files with incorrect ownership"
   shell: "rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)==\"U\" || substr($0,7,1)==\"G\") print $NF }'"
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect ownership using rpm module
   register: files_with_incorrect_ownership
   failed_when: False
   changed_when: False
@@ -15,6 +17,8 @@
     
 - name: Create list of uniq packages
   shell: "rpm -qf {{ files_with_incorrect_ownership.stdout_lines }}|sort |uniq"
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't fetch packages with files with incorrect ownership using rpm module
   register: uniq_list_of_packages
   when: (files_with_incorrect_ownership.stdout_lines | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
   tags:
@@ -22,6 +26,8 @@
 
 - name: "Correct file ownership with RPM"
   shell: "rpm --quiet --setugids '{{item}}'"
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't correct ownership using rpm module
   with_items: "{{ uniq_list_of_packages.stdout_lines }}"
   when: (files_with_incorrect_ownership.stdout_lines | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
   tags:

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -5,6 +5,8 @@
 # disruption = medium
 - name: "Read list of files with incorrect permissions"
   shell: "rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)==\"M\") print $NF }'"
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect permissions using rpm module
   register: files_with_incorrect_permissions
   failed_when: False
   changed_when: False
@@ -15,6 +17,8 @@
 
 - name: "Correct file permissions with RPM"
   shell: "rpm --quiet --setperms $(rpm -qf '{{item}}')"
+  args:
+    warn: False # Ignore ANSIBLE0006, we can't correct permissions using rpm module
   with_items: "{{ files_with_incorrect_permissions.stdout_lines }}"
   when: (files_with_incorrect_permissions.stdout_lines | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
   tags:


### PR DESCRIPTION

#### Description:

- Do not warn about ANSIBLE0006 on these shell `rpm` tasks 

#### Rationale:

- The tasks cannot be executed by rpm module

- `ansible-lint` will ignore messages like the following:
```Task: Read list of files with incorrect ownership
- [EANSIBLE0006] rpm used in place of yum or rpm_key module

Task: Create list of uniq packages
- [EANSIBLE0006] rpm used in place of yum or rpm_key module

Task: Correct file ownership with RPM
- [EANSIBLE0006] rpm used in place of yum or rpm_key module
- [EANSIBLE0013] Use shell only when shell functionality is required
```