### PR TITLE
Fix file_permissions generation

### DIFF
--- a/fedora/templates/csv/file_dir_permissions.csv
+++ b/fedora/templates/csv/file_dir_permissions.csv
@@ -2,10 +2,10 @@
 /etc,gshadow,0,0,0000
 /etc,passwd,0,0,0644
 /etc,group,0,0,0644
-/etc,cron.allow,,,0644,cron_allow
-/etc/httpd/conf.d,*,,,0640,httpd_server_conf_d_files
-/etc/httpd/conf,*,,,0640,httpd_server_conf_files
-/etc/ssh,*.pub,,,0644,sshd_pub_key
-/etc/ssh,*_key,,,0640,sshd_private_key
-/etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
+/etc,cron.allow,0,0,0644,cron_allow
+/etc/httpd/conf.d,^.*$,,,0640,httpd_server_conf_d_files
+/etc/httpd/conf,^.*$,,,0640,httpd_server_conf_files
+/etc/ssh,^.*.pub$,,,0644,sshd_pub_key
+/etc/ssh,^.*_key$,,,0640,sshd_private_key
+/etc/httpd/conf.modules.d,^.*$,,,0640,https_server_modules_files
 /boot/grub2,grub.cfg,0,0,0600,grub2_cfg

--- a/ocp3/templates/csv/file_dir_permissions.csv
+++ b/ocp3/templates/csv/file_dir_permissions.csv
@@ -1,5 +1,5 @@
-/etc/cni/net.d/,*,0,0,0644,master_cni_conf
-/etc/origin/,,0,0,0700,etc_origin
+/etc/cni/net.d,^.*$,0,0,0644,master_cni_conf
+/etc/origin,,0,0,0700,etc_origin
 /etc/origin/master,admin.kubeconfig,0,0,0600,master_admin_conf
 /etc/origin/master,master-config.yaml,0,0,0600,master_openshift_conf
 /etc/origin/master,openshift-master.kubeconfig,0,0,0600,master_openshift_kubeconfig
@@ -11,4 +11,4 @@
 /etc/origin/node/pods,controller.yaml,0,0,0600,master_controller_manager
 /etc/origin/node/pods,etcd.yaml,0,0,0600,master_etcd
 /etc/systemd/system,atomic-openshift-node.service,0,0,0644,openshift_node_service
-/var/lib/etcd/,,0,0,0700,var_lib_etcd
+/var/lib/etcd,,0,0,0700,var_lib_etcd

--- a/rhel6/templates/csv/file_dir_permissions.csv
+++ b/rhel6/templates/csv/file_dir_permissions.csv
@@ -3,9 +3,9 @@
 /etc,passwd,0,0,0644
 /etc,group,0,0,0644
 /etc,cron.allow,0,0,0644,cron_allow
-/etc/httpd/conf.d,*,,,0640,httpd_server_conf_d_files
-/etc/httpd/conf,*,,,0640,httpd_server_conf_files
-/etc/ssh,*.pub,,,0644,sshd_pub_key
-/etc/ssh,*_key,,,0600,sshd_private_key
-/etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
+/etc/httpd/conf.d,^.*$,,,0640,httpd_server_conf_d_files
+/etc/httpd/conf,^.*$,,,0640,httpd_server_conf_files
+/etc/ssh,^.*.pub$,,,0644,sshd_pub_key
+/etc/ssh,^.*_key$,,,0640,sshd_private_key
+/etc/httpd/conf.modules.d,^.*$,,,0640,https_server_modules_files
 /boot/grub,grub.conf,0,0,0600,grub_conf

--- a/rhel7/templates/csv/file_dir_permissions.csv
+++ b/rhel7/templates/csv/file_dir_permissions.csv
@@ -3,10 +3,10 @@
 /etc,passwd,0,0,0644
 /etc,group,0,0,0644
 /etc,cron.allow,0,0,0644,cron_allow
-/etc/httpd/conf.d,*,,,0640,httpd_server_conf_d_files
-/etc/httpd/conf,*,,,0640,httpd_server_conf_files
-/etc/ssh,*.pub,,,0644,sshd_pub_key
-/etc/ssh,*_key,,,0640,sshd_private_key
-/etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
+/etc/httpd/conf.d,^.*$,,,0640,httpd_server_conf_d_files
+/etc/httpd/conf,^.*$,,,0640,httpd_server_conf_files
+/etc/ssh,^.*.pub$,,,0644,sshd_pub_key
+/etc/ssh,^.*_key$,,,0640,sshd_private_key
+/etc/httpd/conf.modules.d,^.*$,,,0640,https_server_modules_files
 /boot/grub2,grub.cfg,0,0,0600,grub2_cfg
 /boot/efi/EFI/redhat,grub.cfg,0,0,0700,efi_grub2_cfg

--- a/shared/templates/create_permissions.py
+++ b/shared/templates/create_permissions.py
@@ -96,45 +96,57 @@ class PermissionGenerator(FilesGenerator):
                     "./bash/file_permissions{0}.sh", path_id
                 )
 
-        elif target == "ansible" and not re.match(r'\^.*\$', file_name, 0):
-            if mode:
+        elif target == "ansible":
+            if not re.match(r'\^.*\$', file_name, 0):
+                if mode:
+                    self.file_from_template(
+                        "./template_ANSIBLE_file_permissions",
+                        {
+                            "FILEPATH":      full_path,
+                            "FILEMODE":      mode,
+                        },
+                        "./ansible/file_permissions{0}.yml", path_id
+                    )
+                if uid:
+                    self.file_from_template(
+                        "./template_ANSIBLE_file_owner",
+                        {
+                            "FILEPATH":      full_path,
+                            "FILEUID":       uid,
+                        },
+                        "./ansible/file_owner{0}.yml", path_id
+                    )
+                if gid:
+                    self.file_from_template(
+                        "./template_ANSIBLE_file_groupowner",
+                        {
+                            "FILEPATH":      full_path,
+                            "FILEGID":       gid,
+                        },
+                        "./ansible/file_groupowner{0}.yml", path_id
+                    )
+
                 self.file_from_template(
-                    "./template_ANSIBLE_file_permissions",
+                    "./template_ANSIBLE_permissions",
                     {
                         "FILEPATH":      full_path,
+                        "FILEMODE":      mode,
+                        "FILEUID":       uid,
+                        "FILEGID":       gid,
+                    },
+                    "./ansible/permissions{0}.yml", path_id
+                )
+            else:
+                self.file_from_template(
+                    "./template_ANSIBLE_file_regex_permissions",
+                    {
+                        "FILEPATH":      dir_path,
+                        "FILENAME":      file_name,
                         "FILEMODE":      mode,
                     },
                     "./ansible/file_permissions{0}.yml", path_id
                 )
-            if uid:
-                self.file_from_template(
-                    "./template_ANSIBLE_file_owner",
-                    {
-                        "FILEPATH":      full_path,
-                        "FILEUID":       uid,
-                    },
-                    "./ansible/file_owner{0}.yml", path_id
-                )
-            if gid:
-                self.file_from_template(
-                    "./template_ANSIBLE_file_groupowner",
-                    {
-                        "FILEPATH":      full_path,
-                        "FILEGID":       gid,
-                    },
-                    "./ansible/file_groupowner{0}.yml", path_id
-                )
 
-            self.file_from_template(
-                "./template_ANSIBLE_permissions",
-                {
-                    "FILEPATH":      full_path,
-                    "FILEMODE":      mode,
-                    "FILEUID":       uid,
-                    "FILEGID":       gid,
-                },
-                "./ansible/permissions{0}.yml", path_id
-            )
 
         elif target == "oval":
             # support pattern matching, requiring that the filename starts with '^'

--- a/shared/templates/template_ANSIBLE_file_regex_permissions
+++ b/shared/templates/template_ANSIBLE_file_regex_permissions
@@ -1,0 +1,23 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+- name: Find {{{ FILEPATH }}} file(s)
+  find:
+    paths: "{{{ FILEPATH }}}"
+    patterns: "{{{ FILENAME }}}"
+  register: files_found
+  tags:
+    @ANSIBLE_TAGS@
+
+- name: Set permissions for {{{ FILEPATH }}} file(s)
+  file:
+    path: "{{ item.path }}"
+    mode: {{{ FILEMODE }}}
+  with_items:
+    - "{{ files_found.files }}"
+  tags:
+    @ANSIBLE_TAGS@
+  @ANSIBLE_ENSURE_PLATFORM@
+

--- a/sle12/templates/csv/file_dir_permissions.csv
+++ b/sle12/templates/csv/file_dir_permissions.csv
@@ -2,10 +2,10 @@
 /etc,gshadow,0,0,0000
 /etc,passwd,0,0,0644
 /etc,group,0,0,0644
-/etc,cron.allow,,,0644,cron_allow
-/etc/httpd/conf.d,*,,,0640,httpd_server_conf_d_files
-/etc/httpd/conf,*,,,0640,httpd_server_conf_files
-/etc/ssh,*.pub,,,0644,sshd_pub_key
-/etc/ssh,*_key,,,0600,sshd_private_key
-/etc/httpd/conf.modules.d,*,,,0640,https_server_modules_files
+/etc,cron.allow,0,0,0644,cron_allow
+/etc/httpd/conf.d,^.*$,,,0640,httpd_server_conf_d_files
+/etc/httpd/conf,^.*$,,,0640,httpd_server_conf_files
+/etc/ssh,^.*.pub$,,,0644,sshd_pub_key
+/etc/ssh,^.*_key$,,,0640,sshd_private_key
+/etc/httpd/conf.modules.d,^.*$,,,0640,https_server_modules_files
 /boot/grub,grub.conf,0,0,0600,grub_conf


### PR DESCRIPTION
- Add ANSIBLE template for handling file permissions with regex
- Fix regex in corresponding file_dir_permissions.csv files. Regex was incorrectly entered.
- Fixes #3601
- Fixes #3525