### PR TITLE
Deliver a standard set of non-certification profiles to derivatives

### DIFF
--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -79,7 +79,6 @@ def main():
 
     tree = ssg.xml.ElementTree.ElementTree()
     tree.parse(options.input_content)
-
     root = tree.getroot()
 
     benchmarks = []
@@ -96,6 +95,7 @@ def main():
         raise RuntimeError("No Benchmark found!")
 
     for namespace, benchmark in benchmarks:
+        ssg.build_derivatives.profile_handling(benchmark, namespace)
         if not ssg.build_derivatives.add_cpes(benchmark, namespace, mapping):
             raise RuntimeError(
                 "Could not add derivative OS CPEs to Benchmark '%s'."

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import re
 from .xml import ElementTree
+from .constants import standard_profiles, OSCAP_VENDOR
 
 
 def add_cpes(elem, namespace, mapping):
@@ -105,6 +106,18 @@ def remove_idents(tree_root, namespace, prod="RHEL"):
             if fix.text is not None:
                 fix.text = re.sub(r"[\s]+- CCE-.*", "", fix.text)
                 fix.text = re.sub(r"CCE-[0-9]*-[0-9]*", "", fix.text)
+
+
+def profile_handling(tree_root, namespace):
+    ns_profiles = []
+    for i in standard_profiles:
+        ns_profiles.append("xccdf_%s.content_profile_%s" % (OSCAP_VENDOR, i))
+    all_profiles = standard_profiles + ns_profiles
+    for profile in tree_root.findall(".//{%s}Profile" % (namespace)):
+        if profile.get("id") not in all_profiles:
+            print(profile.get("id"))
+            tree_root.remove(profile)
+
 
 def replace_platform(tree_root, namespace, product):
     for oval in tree_root.findall(".//{%s}oval_definitions" % (namespace)):

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -46,6 +46,7 @@ XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
 min_ansible_version = "2.3"
 ansible_version_requirement_pre_task_name = \
     "Verify Ansible meets SCAP-Security-Guide version requirements."
+standard_profiles = ['standard', 'pci-dss', 'desktop', 'server']
 
 oval_header = (
     """


### PR DESCRIPTION
- Downstream does a sed on the content that creates numerous content bugs.
  This removes legal statements pertaining to FIPS certifications and creates invalid
  certification statements around derivatives.
