### PR TITLE
Fix auditd_audispd_encrypt_sent_records on Fedora and RHEL8

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
@@ -1,8 +1,14 @@
 # platform = multi_platform_all
 . /usr/share/scap-security-guide/remediation_functions
 
-var_enable_krb5="yes"
-
+{{% if product in ["rhel8", "fedora"] %}}
+AUDISP_REMOTE_CONFIG="/etc/audit/audisp-remote.conf"
+option="^transport"
+value="KRB5"
+{{% else %}}
 AUDISP_REMOTE_CONFIG="/etc/audisp/audisp-remote.conf"
+option="^enable_krb5"
+value="yes"
+{{% endif %}}
 
-replace_or_append $AUDISP_REMOTE_CONFIG '^enable_krb5' "$var_enable_krb5" "@CCENUM@"
+replace_or_append $AUDISP_REMOTE_CONFIG "$option" "$value" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
@@ -5,24 +5,36 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
+{{% if product in ["rhel8", "fedora"] %}}
+      <description>transport setting in /etc/audit/audisp-remote.conf is set to 'KRB5'</description>
+{{% else %}}
       <description>enable_krb5 setting in /etc/audisp/audisp-remote.conf is set to 'yes'</description>
+{{% endif %}}
     </metadata>
 
     <criteria>
-      <criterion comment="enable_krb5 setting in audisp-remote.conf" test_ref="test_auditd_audispd_encrypt_sent_records" />
+      <criterion comment="setting in audisp-remote.conf" test_ref="test_auditd_audispd_encrypt_sent_records" />
     </criteria>
 
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="enable_krb5 setting in audisp-remote.conf" id="test_auditd_audispd_encrypt_sent_records" version="1">
+  <ind:textfilecontent54_test check="all" comment="setting in audisp-remote.conf" id="test_auditd_audispd_encrypt_sent_records" version="1">
     <ind:object object_ref="object_auditd_audispd_encrypt_sent_records" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_auditd_audispd_encrypt_sent_records" version="1">
+{{% if product in ["rhel8", "fedora"] %}}
+    <ind:filepath>/etc/audit/audisp-remote.conf</ind:filepath>
+{{% else %}}
     <ind:filepath>/etc/audisp/audisp-remote.conf</ind:filepath>
+{{% endif %}}
     <!-- Allow only space (exactly) as delimiter -->
     <!-- Require at least one space before and after the equal sign -->
+{{% if product in ["rhel8", "fedora"] %}}
+    <ind:pattern operation="pattern match">^[ ]*transport[ ]+=[ ]+KRB5[ ]*$</ind:pattern>
+{{% else %}}
     <ind:pattern operation="pattern match">^[ ]*enable_krb5[ ]+=[ ]+yes[ ]*$</ind:pattern>
+{{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
@@ -7,9 +7,15 @@ title: 'Encrypt Audit Records Sent With audispd Plugin'
 description: |-
     Configure the operating system to encrypt the transfer of off-loaded audit
     records onto a different system or media from the system being audited.
+{{% if product in ["rhel8", "fedora"] %}}
+    Uncomment the <tt>transport</tt> option in <pre>/etc/audit/audisp-remote.conf</pre>,
+    and set it with the following line:
+    <pre>transport = KRB5</pre>
+{{% else %}}
     Uncomment the <tt>enable_krb5</tt> option in <pre>/etc/audisp/audisp-remote.conf</pre>,
     and set it with the following line:
     <pre>enable_krb5 = yes</pre>
+{{% endif %}}
 
 rationale: |-
     Information stored in one location is vulnerable to accidental or incidental deletion
@@ -31,8 +37,14 @@ ocil_clause: 'audispd is not encrypting audit records when sent over the network
 ocil: |-
     To verify the audispd plugin encrypts audit records off-loaded onto a different
     system or media from the system being audited, run the following command:
+{{% if product in ["rhel8", "fedora"] %}}
+    <pre>$ sudo grep -i transport /etc/audit/audisp-remote.conf</pre>
+    The output should return the following:
+    <pre>transport = KRB5</pre>
+{{% else %}}
     <pre>$ sudo grep -i enable_krb5 /etc/audisp/audisp-remote.conf</pre>
     The output should return the following:
     <pre>enable_krb5 = yes</pre>
+{{% endif %}}
 
 platform: machine

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
@@ -8,9 +8,8 @@ description: |-
     Configure the operating system to encrypt the transfer of off-loaded audit
     records onto a different system or media from the system being audited.
 {{% if product in ["rhel8", "fedora"] %}}
-    Uncomment the <tt>transport</tt> option in <pre>/etc/audit/audisp-remote.conf</pre>,
-    and set it with the following line:
-    <pre>transport = KRB5</pre>
+    Set the <tt>transport</tt> option in <pre>/etc/audit/audisp-remote.conf</pre>
+    to <tt>KRB5</tt>.
 {{% else %}}
     Uncomment the <tt>enable_krb5</tt> option in <pre>/etc/audisp/audisp-remote.conf</pre>,
     and set it with the following line:

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa, xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa, xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa, xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_bogus_value.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_bogus_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/audisp-remote.conf "transport" "BOGUS"

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_correct_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/audisp-remote.conf "transport" "KRB5"

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+delete_parameter /etc/audit/audisp-remote.conf "transport"

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_wrong_value.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/transport_wrong_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/audisp-remote.conf "transport" "TCP"


### PR DESCRIPTION
#### Description:
In Audit 3.0 which is present in Fedora >= 29 and RHEL8, the
`audisp-remote.conf` moved to `/etc/audit` and the `enable_krb5`
option has been superseded by `transport` option.
See `man 5 audisp-remote.conf`.

#### Rationale:
This rule is a part of RHEL8 OSPP profile.
