### PR TITLE
Fix auditd_audispd_syslog_plugin_activated on Fedora and RHEL8

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
@@ -2,6 +2,10 @@
 . /usr/share/scap-security-guide/remediation_functions
 var_syslog_active="yes"
 
+{{% if product in ["rhel8", "fedora"] %}}
+AUDISP_SYSLOGCONFIG=/etc/audit/plugins.d/syslog.conf
+{{% else %}}
 AUDISP_SYSLOGCONFIG=/etc/audisp/plugins.d/syslog.conf
+{{% endif %}}
 
 replace_or_append $AUDISP_SYSLOGCONFIG '^active' "$var_syslog_active" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/oval/shared.xml
@@ -5,7 +5,11 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
+{{% if product in ["rhel8", "fedora"] %}}
+      <description>active setting in /etc/audit/plugins.d/syslog.conf is set to 'yes'</description>
+{{% else %}}
       <description>active setting in /etc/audisp/plugins.d/syslog.conf is set to 'yes'</description>
+{{% endif %}}
     </metadata>
 
     <criteria>
@@ -19,7 +23,11 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_auditd_audispd_syslog_plugin_activated" version="1">
+{{% if product in ["rhel8", "fedora"] %}}
+    <ind:filepath>/etc/audit/plugins.d/syslog.conf</ind:filepath>
+{{% else %}}
     <ind:filepath>/etc/audisp/plugins.d/syslog.conf</ind:filepath>
+{{% endif %}}
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*active[ ]+=[ ]+yes[ ]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/rule.yml
@@ -5,8 +5,14 @@ title: 'Configure auditd to use audispd''s syslog plugin'
 description: |-
     To configure the <tt>auditd</tt> service to use the
     <tt>syslog</tt> plug-in of the <tt>audispd</tt> audit event multiplexor, set
-    the <tt>active</tt> line in <tt>/etc/audisp/plugins.d/syslog.conf</tt> to
-    <tt>yes</tt>. Restart the <tt>auditd</tt> service:
+    the <tt>active</tt> line in <tt>
+{{%- if product in ["rhel8", "fedora"] -%}}
+    /etc/audit/plugins.d/syslog.conf
+{{%- else -%}}
+    /etc/audisp/plugins.d/syslog.conf
+{{%- endif -%}}
+    </tt> to <tt>yes</tt>.
+    Restart the <tt>auditd</tt> service:
     <pre>$ sudo service auditd restart</pre>
 
 rationale: |-
@@ -32,11 +38,15 @@ references:
     ospp@rhel7: FAU_GEN.1.1.c
     pcidss: Req-10.5.3
 
-ocil_clause: 'it is not'
+ocil_clause: 'it is not activated'
 
 ocil: |-
     To verify the audispd's syslog plugin is active, run the following command:
+{{% if product in ["rhel8", "fedora"] %}}
+    <pre>$ sudo grep active /etc/audit/plugins.d/syslog.conf</pre>
+{{% else %}}
     <pre>$ sudo grep active /etc/audisp/plugins.d/syslog.conf</pre>
+{{% endif %}}
     If the plugin is active, the output will show <tt>yes</tt>.
 
 platform: machine

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 7
 # profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
 # remediation = bash
 

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 7
 # profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
 # remediation = bash
 

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_not_activated.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 7
 # profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
 # remediation = bash
 

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audit_syslog_plugin_activated.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audit_syslog_plugin_activated.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = bash
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/plugins.d/syslog.conf "active" "yes"

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audit_syslog_plugin_activated_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audit_syslog_plugin_activated_not_there.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = bash
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+delete_parameter /etc/audit/plugins.d/syslog.conf "active"

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audit_syslog_plugin_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audit_syslog_plugin_not_activated.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = bash
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/plugins.d/syslog.conf "active" "no"


### PR DESCRIPTION
#### Description:
In Audit 3.0 which is present in Fedora >= 29 and RHEL8, the
`syslog.conf` moved to `/etc/audit/plugins.d/`.

#### Rationale:
This rule is a part of RHEL8 OSPP profile.
