### PR TITLE
Fix auditd_audispd_configure_remote_server on Fedora and RHEL8

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
@@ -2,6 +2,10 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_audispd_remote_server
 
+{{% if product in ["rhel8", "fedora"] %}}
+AUDITCONFIG=/etc/audit/audisp-remote.conf
+{{% else %}}
 AUDITCONFIG=/etc/audisp/audisp-remote.conf
+{{% endif %}}
 
 replace_or_append $AUDITCONFIG '^remote_server' "$var_audispd_remote_server" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
@@ -5,10 +5,14 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
+{{% if product in ["rhel8", "fedora"] %}}
+      <description>remote_server setting in /etc/audit/audisp-remote.conf is set to a certain IP address or hostname</description>
+{{% else %}}
       <description>remote_server setting in /etc/audisp/audisp-remote.conf is set to a certain IP address or hostname</description>
+{{% endif %}}
     </metadata>
     <criteria>
-        <criterion comment="remote_server setting in /etc/audisp/audisp-remote.conf" test_ref="test_auditd_audispd_configure_remote_server" />
+        <criterion comment="remote_server setting in audisp-remote.conf" test_ref="test_auditd_audispd_configure_remote_server" />
     </criteria>
   </definition>
 
@@ -18,7 +22,11 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_auditd_audispd_configure_remote_server" version="1">
+{{% if product in ["rhel8", "fedora"] %}}
+    <ind:filepath>/etc/audit/audisp-remote.conf</ind:filepath>
+{{% else %}}
     <ind:filepath>/etc/audisp/audisp-remote.conf</ind:filepath>
+{{% endif %}}
     <!-- Allow only space (exactly) as delimiter -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*remote_server[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
@@ -7,7 +7,13 @@ title: 'Configure audispd Plugin To Send Logs To Remote Server'
 description: |-
     Configure the audispd plugin to off-load audit records onto a different
     system or media from the system being audited.
-    Set the <tt>remote_server</tt> option in <pre>/etc/audisp/audisp-remote.conf</pre>
+    Set the <tt>remote_server</tt> option in <pre>
+{{%- if product in ["rhel8", "fedora"] -%}}
+    /etc/audit/audisp-remote.conf
+{{%- else -%}}
+    /etc/audisp/audisp-remote.conf
+{{%- endif -%}}
+    </pre>
     with an IP address or hostname of the system that the audispd plugin should
     send audit records to. For example replacing <i>REMOTE_SYSTEM</i> with an IP
     address or hostname:
@@ -33,7 +39,11 @@ ocil_clause: 'audispd is not sending logs to a remote system'
 ocil: |-
     To verify the audispd plugin off-loads audit records onto a different system or
     media from the system being audited, run the following command:
+{{% if product in ["rhel8", "fedora"] %}}
+    <pre>$ sudo grep -i remote_server /etc/audit/audisp-remote.conf</pre>
+{{% else %}}
     <pre>$ sudo grep -i remote_server /etc/audisp/audisp-remote.conf</pre>
+{{% endif %}}
     The output should return something similar to where <i>REMOTE_SYSTEM</i>
     is an IP address or hostname:
     <pre>remote_server = <i>REMOTE_SYSTEM</i></pre>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
@@ -2,7 +2,12 @@ documentation_complete: true
 
 title: 'Remote server for audispd to send audit records'
 
-description: 'The setting for remote_server in /etc/audisp/audisp-remote.conf'
+description: |-
+{{% if product in ["rhel8", "fedora"] %}}
+    The setting for remote_server in /etc/audit/audisp-remote.conf
+{{% else %}}
+    The setting for remote_server in /etc/audisp/audisp-remote.conf
+{{% endif %}}
 
 type: string
 

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audisp_remote_server_hostname.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audisp_remote_server_hostname.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp42
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audisp_remote_server_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audisp_remote_server_not_there.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp42
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audit_remote_server_hostname.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audit_remote_server_hostname.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/audisp-remote.conf "remote_server" "myhost.mydomain.com"

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audit_remote_server_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_configure_remote_server/audit_remote_server_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8, multi_platform_fedora
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+. ../../auditd_utils.sh
+prepare_auditd_test_enviroment
+delete_parameter /etc/audit/audisp-remote.conf "remote_server"


### PR DESCRIPTION


#### Description:
In Audit 3.0 which is present in Fedora >= 29 and RHEL8, the
`audisp-remote.conf` has been moved to `/etc/audit/`.


#### Rationale:
This rule is a part of RHEL8 OSPP profile.