### PR TITLE
Update ensure_redhat_gpgkey_installed for RHEL8

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -15,7 +15,12 @@
 # It should fail if it doesn't find any fingerprints in file - maybe file was not parsed well.
 
 - name: Read signatures in GPG key
-  shell: gpg --with-fingerprint '/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release' | grep 'Key fingerprint =' | tr -s ' ' | sed 's;.*= ;;g'
+  # According to /usr/share/doc/gnupg2/DETAILS fingerprints are in "fpr" record in field 10
+  {{% if product == "rhel8" -%}}
+  shell: gpg --show-key --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
+  {{%- else -%}}
+  shell: gpg --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
+  {{%- endif %}}
   changed_when: False
   register: gpg_fingerprints
   check_mode: no
@@ -25,7 +30,7 @@
 
 - name: Set Fact - Valid fingerprints
   set_fact:
-     gpg_valid_fingerprints: ("567E 347A D004 4ADE 55BA 8A5F 199E 2F91 FD43 1D51" "43A6 E49C 4A38 F4BE 9ABF 2A53 4568 9C88 2FA6 58E0")
+     gpg_valid_fingerprints: ("567E347AD0044ADE55BA8A5F199E2F91FD431D51" "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0")
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -12,6 +12,7 @@
         <criteria comment="Red Hat Installed" operator="OR">
           <extend_definition comment="RHEL6 installed" definition_ref="installed_OS_is_rhel6" />
           <extend_definition comment="RHEL7 installed" definition_ref="installed_OS_is_rhel7" />
+          <extend_definition comment="RHEL8 installed" definition_ref="installed_OS_is_rhel8" />
           <extend_definition comment="SL6 installed" definition_ref="installed_OS_is_sl6" />
           <extend_definition comment="SL7 installed" definition_ref="installed_OS_is_sl7" />
         </criteria>


### PR DESCRIPTION
#### Description:
Fedora rule ensure_fedora_gpgkey_installed shouldn't be applicable to RHEL8.
Option gpg --with-fingeprint no longer works in RHEL8.
The key fingerprint can be obtained by gpg --show-key instead.
To parse the results using --with-colons is recommended.
We have to change the filters to parse the key fingerprints
and therefore it is more convenient for us the have the hard-coded
fingerprints without spaces.
There was a bug in bash remediation GPG_OUT is defined as an array
but then it was handled as a variable, which means only the first
item in the array was checked.

#### Rationale:
This rule is a part of RHEL8 OSPP profile.
