### PR TITLE
Enable and update kernel_module_loading remediation for RHEL6

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
@@ -13,9 +13,14 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-        PATTERN="-a always,exit -F arch=$ARCH -S init_module -S delete_module -S finit_module -S create_module \(-F key=\|-k \).*"
         GROUP="modules"
+{{% if product == "rhel6" %}}
+        PATTERN="-a always,exit -F arch=$ARCH -S init_module -S delete_module \(-F key=\|-k \).*"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -S delete_module -k modules"
+{{% else %}}
+        PATTERN="-a always,exit -F arch=$ARCH -S init_module -S delete_module -S finit_module -S create_module \(-F key=\|-k \).*"
         FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -S delete_module -S finit_module -S create_module -k modules"
+{{% endif %}}
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"


### PR DESCRIPTION
#### Description:
- Bash remediation for rule audit_rules_kernel_module_loading applies for RHEL6.
- Update remediation not to add audit rules for create_module and finit_module.

#### Rationale:

- Since https://github.com/ComplianceAsCode/content/pull/3137/commits/760be17f749c25df45095ed35b056fe5000d35b5 the remediation has been missing on RHEL6.
