### PR TITLE
depricate fedora 27

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
@@ -12,8 +12,6 @@
       <criteria comment="Supported Fedora key is installed" operator="OR">
         <criterion comment="Fedora 28 package gpg-pubkey-9db62fb1-59920156 is installed"
         test_ref="test_package_gpgkey-9db62fb1-59920156_installed" />
-        <criterion comment="Fedora 27 package gpg-pubkey-f5282ee4-58ac92a3 is installed"
-        test_ref="test_package_gpgkey-f5282ee4-58ac92a3_installed" />
       </criteria>
     </criteria>
   </definition>
@@ -35,19 +33,6 @@
   <linux:rpminfo_state id="state_package_gpg-pubkey-9db62fb1-59920156" version="1">
     <linux:release>59920156</linux:release>
     <linux:version>9db62fb1</linux:version>
-  </linux:rpminfo_state>
-
-  <!-- Test for Fedora 27 release key -->
-  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-f5282ee4-58ac92a3_installed" version="1"
-  comment="Fedora 27 release key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpgkey-f5282ee4-58ac92a3" />
-  </linux:rpminfo_test>
-
-  <linux:rpminfo_state id="state_package_gpgkey-f5282ee4-58ac92a3" version="1">
-    <linux:release>58ac92a3</linux:release>
-    <linux:version>f5282ee4</linux:version>
   </linux:rpminfo_state>
 
 </def-group>

--- a/shared/checks/oval/installed_OS_is_fedora.xml
+++ b/shared/checks/oval/installed_OS_is_fedora.xml
@@ -5,9 +5,6 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/o:fedoraproject:fedora:25" source="CPE" />
-      <reference ref_id="cpe:/o:fedoraproject:fedora:26" source="CPE" />
-      <reference ref_id="cpe:/o:fedoraproject:fedora:27" source="CPE" />
       <reference ref_id="cpe:/o:fedoraproject:fedora:28" source="CPE" />
       <description>The operating system installed on the system is Fedora</description>
     </metadata>


### PR DESCRIPTION
copy/paste from Fedora devel list:

-------------
As of the 30th of November 2018, Fedora 27 has reached its end of life
for updates and support. No further updates, including security
updates, will be available for Fedora 27. Fedora 28 will continue to receive
updates until 4 weeks after the release of Fedora 30.
The maintenance schedule of Fedora releases is documented on the
Fedora Project wiki [0]. The Fedora Project wiki also contains
instructions [1] on how to upgrade from a previous release of Fedora
to a version receiving updates.


[0]https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle#Maintenance_Schedule
[1]https://fedoraproject.org/wiki/Upgrading?rd=DistributionUpgrades
