### PR TITLE
Move verbose argument closer to last submodule

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -286,7 +286,6 @@ class GenericRunner(object):
         self.command_options.extend([
             '--benchmark-id', self.benchmark_id,
             '--profile', self.profile,
-            '--verbose', 'DEVEL',
             '--progress', '--oval-results',
         ])
         self.command_operands.append(self.datastream)
@@ -340,7 +339,10 @@ class GenericRunner(object):
         raise NotImplementedError()
 
     def initial(self):
-        self.command_options += ['--results', self.results_path]
+        self.command_options += [
+                '--verbose', 'DEVEL',
+                '--results', self.results_path
+        ]
         result = self.make_oscap_call()
         return result
 


### PR DESCRIPTION

#### Description:

- Put `--verbose` option right after last submodule command. 

#### Rationale:

- Verbose option in OpenSCAP 1.3.0 changed place and is now common to all
modules.
- This change is also backwards compatible with OpenSCAP 1.2.x series.
