### PR TITLE
New rule to configure screen lock in tmux

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/bash/shared.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+
+tmux_conf="/etc/tmux.conf"
+
+if grep -qP '^\s*set\s+-g\s+lock-command' "$tmux_conf" ; then
+    sed -i 's/^\s*set\s\+-g\s\+lock-command.*$/set -g lock-command vlock/' "$tmux_conf"
+else
+    echo "set -g lock-command vlock" >> "$tmux_conf"
+fi
+

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="configure_tmux_lock_command" version="1">
+    <metadata>
+      <title>Configure the tmux Lock Command</title>
+      <affected family="unix">
+        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+      </affected>
+      <description>Check if the vlock command is configured to be used as a locking mechanism in tmux.</description>
+    </metadata>
+    <criteria comment="Configure the tmux Lock Command" operator="AND">
+      <criterion comment="check lock-command is set to vlock in /etc/tmux.conf"
+        test_ref="test_configure_tmux_lock_command" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="check lock-command is set to vlock in /etc/tmux.conf"
+  id="test_configure_tmux_lock_command" version="1">
+    <ind:object object_ref="obj_configure_tmux_lock_command" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_configure_tmux_lock_command" version="1">
+    <ind:filepath>/etc/tmux.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-command\s+vlock\s*(?:|(?:#.*))?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+prodtype: rhel8,fedora
+
+title: 'Configure the tmux Lock Command'
+
+description: |-
+    To enable console screen locking in <tt>tmux</tt> terminal multiplexer,
+    the <tt>vlock</tt> command must be configured to be used as a locking
+    mechanism.
+    Add the following line to <tt>/etc/tmux.conf</tt>:
+    <pre>set -g lock-command vlock</pre>.
+    The console can now be locked with the following key combination:
+    <pre>ctrl+b :lock-session</pre>
+
+rationale: |-
+    The <tt>tmux</tt> package allows for a session lock to be implemented and configured.
+    However, the session lock is implemented by an external command. The <tt>tmux</tt>
+    default configuration does not contain an effective session lock.
+
+severity: medium
+
+ocil_clause: 'lock-command is not set'
+
+ocil: |-
+    To verify that vlock is configured as a locking mechanism in tmux, run the following command:
+    <pre>$ grep lock-command /etc/tmux.conf</pre>
+    The output should return the following:
+    <pre>set -g lock-command vlock</pre>
+
+platform: machine

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -33,6 +33,7 @@ selections:
     - var_password_pam_lcredit=1
     - accounts_password_pam_lcredit
     - package_tmux_installed
+    - configure_tmux_lock_command
     - sysctl_kernel_yama_ptrace_scope
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_kexec_load_disabled

--- a/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/file_empty.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/file_empty.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo > '/etc/tmux.conf'

--- a/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/line_commented.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/line_commented.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo '# set -g lock-command vlock' >> '/etc/tmux.conf'

--- a/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/line_is_there.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/line_is_there.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo 'set -g lock-command vlock' >> '/etc/tmux.conf'

--- a/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_console_screen_locking/rule_configure_tmux_lock_command/wrong_value.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo 'set -g lock-command locker' >> '/etc/tmux.conf'


### PR DESCRIPTION
#### Description:
On RHEL8, console screen locking can be implemented using tmux. However, tmux doesn't provide this feature implicitly. It needs to be configured to enable locking command. This commit adds a new rule, OVAL and Bash remediation that checks if tmux is configured to use screen lock. Also includes a few basic test scenarios for SSGTS.

#### Rationale:
To set up console screen locking it isn't sufficient to have tmux only installed, but it also needs to be configured properly.
