### PR TITLE
Improve parameters for ensure_fedora_gpgkey_installed

### DIFF
--- a/fedora/product.yml
+++ b/fedora/product.yml
@@ -12,11 +12,11 @@ init_system: "systemd"
 
 # The fingerprints below are retrieved from https://getfedora.org/keys/
 latest_version: 29
-latest_release_fingerprint: "5A03 B4DD 8254 ECA0 2FDA  1637 A20A A56B 4294 76B4"
+latest_release_fingerprint: "5A03B4DD8254ECA02FDA1637A20AA56B429476B4"
 latest_pkg_release: 5a886537
 latest_pkg_version: 429476b4
 
 previous_version: 28
-previous_release_fingerprint: "128C F232 A937 1991 C8A6  5695 E08E 7E62 9DB6 2FB1"
+previous_release_fingerprint: "128CF232A9371991C8A65695E08E7E629DB62FB1"
 previous_pkg_release: 59920156
 previous_pkg_version: 9db62fb1

--- a/fedora/product.yml
+++ b/fedora/product.yml
@@ -13,10 +13,10 @@ init_system: "systemd"
 # The fingerprints below are retrieved from https://getfedora.org/keys/
 latest_version: 29
 latest_release_fingerprint: "5A03B4DD8254ECA02FDA1637A20AA56B429476B4"
-latest_pkg_release: 5a886537
-latest_pkg_version: 429476b4
+latest_pkg_release: "5a886537"
+latest_pkg_version: "429476b4"
 
 previous_version: 28
 previous_release_fingerprint: "128CF232A9371991C8A65695E08E7E629DB62FB1"
-previous_pkg_release: 59920156
-previous_pkg_version: 9db62fb1
+previous_pkg_release: "59920156"
+previous_pkg_version: "9db62fb1"

--- a/fedora/product.yml
+++ b/fedora/product.yml
@@ -11,7 +11,12 @@ pkg_manager: "dnf"
 init_system: "systemd"
 
 # The fingerprints below are retrieved from https://getfedora.org/keys/
-latest_version: 28
-latest_release_fingerprint: "128C F232 A937 1991 C8A6  5695 E08E 7E62 9DB6 2FB1"
-previous_version: 27
-previous_release_fingerprint: "860E 19B0 AFA8 00A1 7518  81A6 F55E 7430 F528 2EE4"
+latest_version: 29
+latest_release_fingerprint: "5A03 B4DD 8254 ECA0 2FDA  1637 A20A A56B 4294 76B4"
+latest_pkg_release: 5a886537
+latest_pkg_version: 429476b4
+
+previous_version: 28
+previous_release_fingerprint: "128C F232 A937 1991 C8A6  5695 E08E 7E62 9DB6 2FB1"
+previous_pkg_release: 59920156
+previous_pkg_version: 9db62fb1

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -25,10 +25,12 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
+  # Backup IFS value
+  IFS_BKP=$IFS
   IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '"^fpr' | cut -d ":" -f 10))
   GPG_RESULT=$?
   # Reset IFS back to default
-  unset IFS
+  IFS=$IFS_BKP
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -25,7 +25,7 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
-  IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint "${REDHAT_RELEASE_KEY}" | grep 'Key fingerprint ='))
+  IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '"^fpr' | cut -d ":" -f 10))
   GPG_RESULT=$?
   # Reset IFS back to default
   unset IFS

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -32,7 +32,7 @@ then
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then
-    tr -s ' ' <<< "${GPG_OUT}" | grep -vE "${FEDORA_RELEASE_FINGERPRINT}" || {
+    echo "${GPG_OUT}" | grep -vE "${FEDORA_RELEASE_FINGERPRINT}" || {
       # If file doesn't contains any keys with unknown fingerprint, import it
       rpm --import "${REDHAT_RELEASE_KEY}"
     }

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
@@ -1,3 +1,23 @@
+{{% macro fedora_gpgkey_criterion(fedora_version, pkg_release, pkg_version) %}}
+   <criterion comment="Fedora {{{ fedora_version }}} package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"
+        test_ref="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
+{{% endmacro %}}
+
+{{% macro fedora_gpgkey_check(fedora_version, pkg_release, pkg_version) %}}
+  <!-- Test for Fedora {{{ fedora_version }}} release key -->
+  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
+  id="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
+  comment="Fedora {{{ pkg_version }}} release key package is installed">
+    <linux:object object_ref="object_package_gpg-pubkey" />
+    <linux:state state_ref="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
+  </linux:rpminfo_test>
+
+  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
+    <linux:release>{{{ pkg_release }}}</linux:release>
+    <linux:version>{{{ pkg_version }}}</linux:version>
+  </linux:rpminfo_state>
+{{% endmacro %}}
+
 <def-group>
   <definition class="compliance" id="ensure_fedora_gpgkey_installed" version="2">
     <metadata>
@@ -10,10 +30,8 @@
     <criteria comment="Fedora Vendor keys" operator="AND">
       <extend_definition comment="Fedora installed" definition_ref="installed_OS_is_fedora" />
       <criteria comment="Supported Fedora key is installed" operator="OR">
-        <criterion comment="Fedora {{{ latest_version }}} package gpg-pubkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}} is installed"
-        test_ref="test_package_gpgkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}_installed" />
-        <criterion comment="Fedora {{{ previous_version }}} package gpg-pubkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}} is installed"
-        test_ref="test_package_gpgkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}_installed" />
+          {{{ fedora_gpgkey_criterion(latest_version, latest_pkg_release, latest_pkg_version) }}}
+          {{{ fedora_gpgkey_criterion(previous_version, previous_pkg_release, previous_pkg_version) }}}
       </criteria>
     </criteria>
   </definition>
@@ -24,30 +42,7 @@
   </linux:rpminfo_object>
 
   <!-- Perform the particular tests themselves -->
-  <!-- Test for Fedora {{{ latest_version }}} release key -->
-  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}_installed" version="1"
-  comment="Fedora {{{ latest_pkg_version }}} release key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}" />
-  </linux:rpminfo_test>
-
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}" version="1">
-    <linux:release>{{{ latest_pkg_release }}}</linux:release>
-    <linux:version>{{{ latest_pkg_version }}}</linux:version>
-  </linux:rpminfo_state>
-
-  <!-- Test for Fedora {{{ previous_version }}} release key -->
-  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}_installed" version="1"
-  comment="Fedora {{{ previous_pkg_version }}} release key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}" />
-  </linux:rpminfo_test>
-
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}" version="1">
-    <linux:release>{{{ previous_pkg_release }}}</linux:release>
-    <linux:version>{{{ previous_pkg_version }}}</linux:version>
-  </linux:rpminfo_state>
+  {{{ fedora_gpgkey_check(latest_version, latest_pkg_release, latest_pkg_version) }}}
+  {{{ fedora_gpgkey_check(previous_version, previous_pkg_release, previous_pkg_version) }}}
 
 </def-group>

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
@@ -10,8 +10,10 @@
     <criteria comment="Fedora Vendor keys" operator="AND">
       <extend_definition comment="Fedora installed" definition_ref="installed_OS_is_fedora" />
       <criteria comment="Supported Fedora key is installed" operator="OR">
-        <criterion comment="Fedora 28 package gpg-pubkey-9db62fb1-59920156 is installed"
-        test_ref="test_package_gpgkey-9db62fb1-59920156_installed" />
+        <criterion comment="Fedora {{{ latest_version }}} package gpg-pubkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}} is installed"
+        test_ref="test_package_gpgkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}_installed" />
+        <criterion comment="Fedora {{{ previous_version }}} package gpg-pubkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}} is installed"
+        test_ref="test_package_gpgkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}_installed" />
       </criteria>
     </criteria>
   </definition>
@@ -22,17 +24,30 @@
   </linux:rpminfo_object>
 
   <!-- Perform the particular tests themselves -->
-  <!-- Test for Fedora 28 release key -->
+  <!-- Test for Fedora {{{ latest_version }}} release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-9db62fb1-59920156_installed" version="1"
-  comment="Fedora 28 release key package is installed">
+  id="test_package_gpgkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}_installed" version="1"
+  comment="Fedora {{{ latest_pkg_version }}} release key package is installed">
     <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-9db62fb1-59920156" />
+    <linux:state state_ref="state_package_gpg-pubkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-9db62fb1-59920156" version="1">
-    <linux:release>59920156</linux:release>
-    <linux:version>9db62fb1</linux:version>
+  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ latest_pkg_version }}}-{{{ latest_pkg_release }}}" version="1">
+    <linux:release>{{{ latest_pkg_release }}}</linux:release>
+    <linux:version>{{{ latest_pkg_version }}}</linux:version>
+  </linux:rpminfo_state>
+
+  <!-- Test for Fedora {{{ previous_version }}} release key -->
+  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
+  id="test_package_gpgkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}_installed" version="1"
+  comment="Fedora {{{ previous_pkg_version }}} release key package is installed">
+    <linux:object object_ref="object_package_gpg-pubkey" />
+    <linux:state state_ref="state_package_gpg-pubkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}" />
+  </linux:rpminfo_test>
+
+  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ previous_pkg_version }}}-{{{ previous_pkg_release }}}" version="1">
+    <linux:release>{{{ previous_pkg_release }}}</linux:release>
+    <linux:version>{{{ previous_pkg_version }}}</linux:version>
   </linux:rpminfo_state>
 
 </def-group>

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -23,7 +23,7 @@ then
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then
-    tr -s ' ' <<< "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_2_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}" || {
+    echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_2_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}" || {
       # If $REDHAT_RELEASE_KEY file doesn't contain any keys with unknown fingerprint, import it
       rpm --import "${REDHAT_RELEASE_KEY}"
     }

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -12,6 +12,8 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
+  # Backup IFS value
+  IFS_BKP=$IFS
 {{% if product == "rhel8" %}}
   IFS=$'\n' GPG_OUT=($(gpg --show-key --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10))
 {{% else %}}
@@ -19,7 +21,7 @@ then
 {{% endif %}}
   GPG_RESULT=$?
   # Reset IFS back to default
-  unset IFS
+  IFS=$IFS_BKP
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then


### PR DESCRIPTION

#### Description:

- The Rule, OVAL and Bash fix will source the parameters for the gpg-pubkey from `fedora/product.yml`.
- Add back the checks for the two keys of the supported releases.

#### Rationale:

- Parametrized`gpg-pubkey` values in OVAL check will make it easy to move forward when next releases come.
