### PR TITLE
Fix the machine/container filter for Ansible remediations.

### DIFF
--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -125,7 +125,7 @@
         <xsl:when test="$rule/xccdf:platform">
           <xsl:choose>
             <xsl:when test="$platform_cpe = 'machine'">
-              <xsl:value-of select="concat('when:  # Bare-metal/VM task, not applicable for containers', $newline, '    - ansible_virtualization_role != &quot;guest&quot;', $newline, '    - ansible_virtualization_type != &quot;docker&quot;')"/>
+              <xsl:value-of select="concat('when:  # Bare-metal/VM task, not applicable for containers', $newline, '    - (ansible_virtualization_role != &quot;guest&quot; or ansible_virtualization_type != &quot;docker&quot;)')"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:value-of select="concat('# Error ensuring that the platform is applicable - unknown platform CPE spec encountered: &quot;', $platform_cpe, '&quot;')"/>
@@ -147,7 +147,7 @@
         <xsl:when test="$rule/xccdf:platform">
           <xsl:choose>
             <xsl:when test="$platform_cpe = 'machine'">
-              <xsl:value-of select="'(ansible_virtualization_role != &quot;guest&quot; and ansible_virtualization_type != &quot;docker&quot;)'"/>
+              <xsl:value-of select="'(ansible_virtualization_role != &quot;guest&quot; or ansible_virtualization_type != &quot;docker&quot;)'"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:value-of select="concat(' # Error ensuring that the platform is applicable - unknown platform CPE spec encountered: &quot;', $platform_cpe, '&quot;')"/>


### PR DESCRIPTION
The previous behaviour could result in rule being skipped if the target was a guest (even a VM one) OR it had something to do with docker.
Now, it is skipped iff both of those statements are true.