### PR TITLE
Extend ol7 CPE dict with container and machine platforms

### DIFF
--- a/ol7/cpe/ol7-cpe-dictionary.xml
+++ b/ol7/cpe/ol7-cpe-dictionary.xml
@@ -7,5 +7,14 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_ol7_family</check>
       </cpe-item>
-
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
 </cpe-list>


### PR DESCRIPTION
#### Description:

Extend OL7 CPE dict with "container" and "machine"

#### Rationale:

Set of shared rules updated with "cpe:/a:machine" platform limitation leading to "notapplicable" evaluation result on OL7.

Note: I might think it could be reasonable to update openscap package default cpe dictionary to include these items otherwise "--cpe" option will be always required for evaluation scans.

#### Testing:
- Checked to work on OL7
- Checked "make all" build to pass.