### PR TITLE
fix variable definitions

### DIFF
--- a/ocp3/profiles/opencis-ocp-node.profile
+++ b/ocp3/profiles/opencis-ocp-node.profile
@@ -22,8 +22,6 @@ selections:
     - file_permissions_openshift_node_service
     - file_owner_openshift_node_service
     - file_groupowner_openshift_node_service
-    - var_kube_authorization_mode=default
-    - var_streaming_connection_timeouts=default
     - kubelet_configure_client_ca
     - kubelet_configure_event_creation
     - kubelet_configure_tls_cert


### PR DESCRIPTION
resolves
`````

OpenSCAP Error: Attempt to get non-existent selector "default" from variable "xccdf_org.ssgproject.content_value_var_streaming_connection_timeouts" [xccdf_policy.c:463]
Attempt to get non-existent selector "default" from variable "xccdf_org.ssgproject.content_value_var_kube_authorization_mode" [xccdf_policy.c:463]
Invalid selector 'default' for xccdf:value/@id='xccdf_org.ssgproject.content_value_var_kube_authorization_mode'. Using null value instead. [xccdf_policy.c:2127]
Invalid selector 'default' for xccdf:value/@id='xccdf_org.ssgproject.content_value_var_streaming_connection_timeouts'. Using null value instead. [xccdf_policy.c:2127]

`````