### PR TITLE
adding ansible remediation for auditing create module with rhel7

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
@@ -1,0 +1,66 @@
+# platform = multi_platform_rhel
+# reboot = false
+# complexity = low
+
+# What architecture are we on?
+
+- name: Set architecture for audit create_module tasks
+  set_fact:
+    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+
+# Inserts/replaces the rule in /etc/audit/rules.d
+
+- name: Search /etc/audit/rules.d for audit rule entries
+  find:
+    paths: /etc/audit/rules.d
+    recurse: false
+    contains: ^.*create_module.*$
+    patterns: '*.rules'
+  register: find_create_module
+- name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
+  set_fact:
+    all_files:
+    - /etc/audit/rules.d/privileged.rules
+  when: find_create_module.matched == 0
+- name: Use matched file as the recipient for the rule
+  set_fact:
+    all_files:
+    - '{{ find_create_module.files | map(attribute=''path'') | list | first }}'
+  when: find_create_module.matched > 0
+- name: Inserts/replaces the create_module rule in rules.d
+  lineinfile:
+    path: '{{ all_files[0] }}'
+    line: '-a always,exit -F arch=b32 -S create_module -k module-change'
+    state: present
+    create: true
+  tags:
+    @ANSIBLE_TAGS@
+  @ANSIBLE_ENSURE_PLATFORM@
+- name: Inserts/replaces the create_module rule in rules.d on x86_64
+  lineinfile:
+    path: '{{ all_files[0] }}'
+    line: '-a always,exit -F arch=b64 -S create_module -k module-change'
+    state: present
+    create: true
+  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
+  tags:
+    @ANSIBLE_TAGS@
+
+# Inserts/replaces the create_modules rule in /etc/audit/audit.rules
+
+- name: Inserts/replaces the create_module rule in audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-a always,exit -F arch=b32 -S create_module -k module-change'
+    create: true
+  tags:
+    @ANSIBLE_TAGS@
+  @ANSIBLE_ENSURE_PLATFORM@
+- name: Inserts/replaces the create_module rule in audit.rules when on x86_64
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-a always,exit -F arch=b64 -S create_module -k module-change'
+    create: true
+  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
+  tags:
+    @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- Created Ansible remediation/fix content tasks based on template_ANSIBLE_audit_rules template to add relevant rules into /etc/audit/audit.rules and /etc/audit/rules.d/ as per DISA STIG RHEL-07-030819

#### Rationale:

- No previous Ansible remediation/fix content existed

- Adds Ansible remediation/fix content for #3464
