### PR TITLE
Make the man page depend of derivate contents

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -798,6 +798,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
 
     add_custom_target(${DERIVATIVE} ALL)
     add_dependencies(${DERIVATIVE} ${DERIVATIVE}-content)
+    add_dependencies(man_page ${DERIVATIVE})
 
     add_dependencies(
         ${DERIVATIVE}-content


### PR DESCRIPTION
#### Description:

- The man page should also depend on derivative content

#### Rationale:

- Fixes a race condition scenario where the man page build starts before the derivative datastream is finished.
- See build [logs](https://kojipkgs.fedoraproject.org//work/tasks/4965/31424965/build.log).