### PR TITLE
Improve description of Rule enable_fips_mode 

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -16,7 +16,7 @@ description: |-
     <li>Setting the system crypto policy in <tt>/etc/crypto-policies/config</tt> to <tt>FIPS</tt></li>
     <li>Loading the Dracut <tt>fips</tt> module</li>
     </ul>
-    Furthermore, the system running in FIPS mode should be FIPS certified by NIST.
+    Furthermore, for the system to be FIPS compliant the components implementing cryptography have to be FIPS certified by NIST.
 
 rationale: |-
     Use of weak or untested encryption algorithms undermines the purposes of utilizing encryption to


### PR DESCRIPTION
#### Description:

- Improve description of `enable_fips_mode`, per suggestion in https://github.com/ComplianceAsCode/content/pull/3623#discussion_r241686005

#### Rationale:

- Previous description could imply that a system needs to be certified by NIST to be FIPS compliant, while actually the components implementing cryptography need to be FIPS certified by NIST.
