### PR TITLE
Remove a stray greater than in auditd userhelper rule

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7
 
-title: 'Ensure auditd> Collects Information on the Use of Privileged Commands - userhelper'
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - userhelper'
 
 description: |-
     At a minimum, the audit system should collect the execution of


### PR DESCRIPTION
#### Description:

Currently the autid_rules_privileged_commands_userhelper is using a greater than after "auditd" unlike all other auditd rules.

#### Rationale:

To make sure that all auditd rules looks the same in the title field