### PR TITLE
Enhance configure_kerberos_crypto_policy check

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
@@ -1,5 +1,5 @@
 {{%- if target_oval_version == [5, 11] -%}}
-{{# there is no good alternative for symlink_test for OVAL 5.10 #}}
+{{# there is no good alternative for symlink_object for OVAL 5.10 #}}
 <def-group>
   <definition class="compliance" id="configure_kerberos_crypto_policy" version="1">
     <metadata>
@@ -11,33 +11,39 @@
       <description>Kerberos should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria>
-      <criterion comment="kerberos crypto-policy softlink exists" test_ref="test_configure_kerberos_crypto_policy" />
+      <criterion comment="kerberos crypto-policy configuration links to same file as kerberos crypto-policy backend" test_ref="test_configure_kerberos_crypto_policy" />
     </criteria>
   </definition>
 
-  <external_variable comment="defined crypto policy" datatype="string" id="var_system_crypto_policy" version="1" />
+  <!-- Due to the fact that symlink_test goes all the way through to the canonical path,
+  and it ignores any intermediary symlink,
+  we check that both, /etc/krb5.conf.d/crypto-policies and,
+  /etc/crypto-policies/back-ends/krb5.config point to the same file -->
 
-  <!-- As the oval symlink_test goes all the way through to the canonical path,
-  and the canonical path is the actual selected policy configuration,
-  we need to know the targeted crypto policy to check if kerberos crypto policy is linked correctly -->
-  <local_variable id="var_kerberos_policy_regex" datatype="string" comment="regex variable for canonical path to targeted kerberos policy" version="1">
-    <concat>
-      <literal_component>^/usr/share/crypto-policies/</literal_component>
-      <variable_component var_ref="var_system_crypto_policy"/>
-      <literal_component>/krb5.txt$</literal_component>
-    </concat>
-  </local_variable>
+  <ind:variable_test id="test_configure_kerberos_crypto_policy" check="all" check_existence="all_exist" comment="Check if kerberos configuration symlink and crypto policy kerberos backend symlink point to same file" version="1">
+    <ind:object object_ref="object_symlink_kerberos_crypto_policy_configuration" />
+    <ind:state state_ref="state_symlink_kerberos_crypto_policy_backend" />
+  </ind:variable_test>
+  <ind:variable_object id="object_symlink_kerberos_crypto_policy_configuration" version="1">
+    <ind:var_ref>var_symlink_kerberos_crypto_policy_configuration</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state id="state_symlink_kerberos_crypto_policy_backend" version="1">
+    <ind:value datatype="string" operation="equals" var_ref="var_symlink_kerberos_crypto_policy_backend"/>
+  </ind:variable_state>
 
-  <unix:symlink_test check="all" check_existence="all_exist" comment="kerberos crypto-policy softlink exists" id="test_configure_kerberos_crypto_policy" version="1">
-    <unix:object object_ref="object_configure_kerberos_crypto_policy" />
-    <unix:state state_ref="state_configure_kerberos_crypto_policy" />
-  </unix:symlink_test>
-  <unix:symlink_object comment="kerberos crypto-policy softlink exists" id="object_configure_kerberos_crypto_policy" version="1">
+  <unix:symlink_object comment="kerberos crypto-policy configuration softlink" id="object_kerberos_crypto_policy_configuration" version="1">
     <unix:filepath>/etc/krb5.conf.d/crypto-policies</unix:filepath>
   </unix:symlink_object>
-  <unix:symlink_state comment="kerberos crypto-policy is linked to crypto-policy kerberos config" id="state_configure_kerberos_crypto_policy" version="1">
-    <unix:filepath>/etc/krb5.conf.d/crypto-policies</unix:filepath>
-    <unix:canonical_path operation="pattern match" var_ref="var_kerberos_policy_regex"/>
-  </unix:symlink_state>
+  <local_variable id="var_symlink_kerberos_crypto_policy_configuration" datatype="string" comment="regex variable for canonical path to targeted kerberos policy" version="1">
+    <object_component item_field="canonical_path" object_ref="object_kerberos_crypto_policy_configuration"/>
+  </local_variable>
+
+  <unix:symlink_object comment="kerberos crypto-policy backend softlink" id="object_kerberos_crypto_policy_backend" version="1">
+      <unix:filepath>/etc/crypto-policies/back-ends/krb5.config</unix:filepath>
+  </unix:symlink_object>
+  <local_variable id="var_symlink_kerberos_crypto_policy_backend" datatype="string" comment="regex variable for canonical path to targeted kerberos policy" version="1">
+    <object_component item_field="canonical_path" object_ref="object_kerberos_crypto_policy_backend"/>
+  </local_variable>
+
 </def-group>
 {{%- endif -%}}


### PR DESCRIPTION
#### Description:

- Update OVAL definition to:
  - Check that `/etc/krb5.conf.d/crypto-policies` is a symlink 
  - Check that `/etc/crypto-policies/back-ends/krb5.config` is a symlink
  - Check that both point to the same file.

#### Rationale:

The goal of this check is to verify that `/etc/krb5.conf.d/crypto-policies` is
a symlink, and points to `/etc/crypto-policies/back-ends/krb5.config`.

As the `symlink_test` goes all the way through to the canonical path,
and the canonical path is the actual selected policy configuration, the check
was dependent on selected policy and was failing when symlink was
correct but selected crypto policy was wrong.

Making sure that /etc/krb5.conf.d/crypto-polices links to correct crypto-policy
is not the point of this check. With this changes, the check is now
verifying the symlink independently of the selected crypto policy.
