### PR TITLE
Enhance crypto policies checks to handle packages not installed

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
@@ -6,7 +6,7 @@
         <platform>multi_platform_fedora</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
       </affected>
-      <description>BIND is not installed or is configured to use the system-wide crypto policy setting.</description>
+      <description>BIND should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="Check if package bind is not installed" definition_ref="package_bind_removed" />

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
@@ -6,9 +6,10 @@
         <platform>multi_platform_fedora</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
       </affected>
-      <description>BIND should be configured to use the system-wide crypto policy setting.</description>
+      <description>BIND is not installed or is configured to use the system-wide crypto policy setting.</description>
     </metadata>
-    <criteria>
+    <criteria operator="OR">
+      <extend_definition comment="Check if package bind is not installed" definition_ref="package_bind_removed" />
       <criterion test_ref="test_configure_bind_crypto_policy"
       comment="Check that the configuration includes the policy config file." />
     </criteria>

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
@@ -9,8 +9,6 @@ description: |-
     BIND is supported by crypto policy, but the BIND configuration may be
     set up to ignore it.
 
-    Either BIND is not installed, or it is configured to use the system-wide defined crypto policy.
-
     To check that Crypto Policies settings are configured correctly, ensure that the <tt>/etc/named.conf</tt>
     includes the appropriate configuration:
     In the <tt>options</tt> section of <tt>/etc/named.conf</tt>, make sure that the following line
@@ -24,7 +22,7 @@ rationale: |-
 severity: unknown
 
 ocil_clause: |-
-    the BIND config file doesn't contain the
+    BIND is installed and the BIND config file doesn't contain the
     <pre>include "/etc/crypto-policies/back-ends/bind.config";</pre> directive
 
 ocil: |-

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
@@ -9,6 +9,8 @@ description: |-
     BIND is supported by crypto policy, but the BIND configuration may be
     set up to ignore it.
 
+    Either BIND is not installed, or it is configured to use the system-wide defined crypto policy.
+
     To check that Crypto Policies settings are configured correctly, ensure that the <tt>/etc/named.conf</tt>
     includes the appropriate configuration:
     In the <tt>options</tt> section of <tt>/etc/named.conf</tt>, make sure that the following line

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
@@ -6,7 +6,7 @@
         <platform>multi_platform_fedora</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
       </affected>
-      <description>Libreswan is not installed or is configured to use the system-wide crypto policy setting.</description>
+      <description>Libreswan should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria operator="OR">
       <extend_definition comment="Check if package libreswan is not installed" definition_ref="package_libreswan_installed" negate="true" />

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
@@ -6,9 +6,10 @@
         <platform>multi_platform_fedora</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
       </affected>
-      <description>Libreswan should be configured to use the system-wide crypto policy setting.</description>
+      <description>Libreswan is not installed or is configured to use the system-wide crypto policy setting.</description>
     </metadata>
-    <criteria>
+    <criteria operator="OR">
+      <extend_definition comment="Check if package libreswan is not installed" definition_ref="package_libreswan_installed" negate="true" />
       <criterion test_ref="test_configure_libreswan_crypto_policy"
         comment="Check that the libreswan configuration includes the crypto policy config file" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
@@ -9,8 +9,6 @@ description: |-
     Libreswan is supported by system crypto policy, but the Libreswan configuration may be
     set up to ignore it.
 
-    Either Libreswan is not installed, or it is configured to use the system-wide defined crypto policy.
-
     To check that Crypto Policies settings are configured correctly, ensure that the <tt>/etc/ipsec.conf</tt>
     includes the appropriate configuration file.
     In <tt>/etc/ipsec.conf</tt>, make sure that the following line
@@ -25,7 +23,7 @@ rationale: |-
 severity: unknown
 
 ocil_clause: |-
-    <tt>/etc/ipsec.conf</tt> does not contain <tt>include /etc/crypto-policies/back-ends/libreswan.config</tt>
+    Libreswan is installed and <tt>/etc/ipsec.conf</tt> does not contain <tt>include /etc/crypto-policies/back-ends/libreswan.config</tt>
 
 ocil: |-
     To verify that Libreswan uses the system crypto policy, run the following command:

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
@@ -9,6 +9,8 @@ description: |-
     Libreswan is supported by system crypto policy, but the Libreswan configuration may be
     set up to ignore it.
 
+    Either Libreswan is not installed, or it is configured to use the system-wide defined crypto policy.
+
     To check that Crypto Policies settings are configured correctly, ensure that the <tt>/etc/ipsec.conf</tt>
     includes the appropriate configuration file.
     In <tt>/etc/ipsec.conf</tt>, make sure that the following line

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/absent.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/absent.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
+yum install -y bind
+
 BIND_CONF='/etc/named.conf'
 
 cat << EOF > "$BIND_CONF"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/bind_not_installed.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/bind_not_installed.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+yum remove -y bind || true

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/no_config_file.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/no_config_file.fail.sh
@@ -4,6 +4,8 @@
 # We don't remediate anything if the config file is missing completely.
 # remediation = none
 
+yum install -y bind
+
 BIND_CONF='/etc/named.conf'
 
 rm -f "$BIND_CONF"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/ok.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/ok.pass.sh
@@ -3,6 +3,8 @@
 
 BIND_CONF='/etc/named.conf'
 
+yum install -y bind
+
 cat << EOF > "$BIND_CONF"
 options {
 	listen-on port 53 { 127.0.0.1; };

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/overrides.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/overrides.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
+yum install -y bind
+
 BIND_CONF='/etc/named.conf'
 
 cat << EOF > "$BIND_CONF"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/libreswan_not_installed.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/libreswan_not_installed.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_standard
+
+yum remove -y libreswan || true

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_commented.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_commented.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
+yum install -y libreswan
+
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"
 crypto="/etc/crypto-policies/back-ends/libreswan.config"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
+yum install -y libreswan
+
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"
 if ! grep -P '^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:|(?:#.*))$' "$config_file" ; then

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_not_there.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_not_there.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
+yum install -y libreswan
+
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"
 crypto="/etc/crypto-policies/back-ends/libreswan.config"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/wrong_value.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
+yum install -y libreswan
+
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"
 crypto="/etc/crypto-policies/back-ends/libreswan.config"


### PR DESCRIPTION
#### Description:
- Definition `configure_bind_crypto_policy` will pass if Bind is not installed.
- Definition `configure_libreswan_crypto_policy` will pass if Libreswan is not installed.

#### Rationale:

- If Bind is not installed, there is no need to check whether it is overriding system-vide crypto policy configuration
- If Libreswan is not installed, there is no need to check whether it is overriding system-vide crypto policy configuration