### PR TITLE
Update applicability of crypto policy tests

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -203,3 +203,9 @@ selections:
     - mount_option_dev_shm_nodev
     - mount_option_dev_shm_noexec
     - mount_option_dev_shm_nosuid
+    - configure_ssh_crypto_policy
+    - configure_libreswan_crypto_policy
+    - configure_openssl_crypto_policy
+    - configure_kerberos_crypto_policy
+    - configure_bind_crypto_policy
+    - configure_crypto_policy

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/absent.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/absent.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 BIND_CONF='/etc/named.conf'
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/no_config_file.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/no_config_file.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # 
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 # We don't remediate anything if the config file is missing completely.
 # remediation = none
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/ok.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/ok.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 BIND_CONF='/etc/named.conf'
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/overrides.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/overrides.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 BIND_CONF='/etc/named.conf'
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/bad_symlink.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/bad_symlink.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 CRYPTO_POLICY_LIB_FILE="/etc/crypto-policies/back-ends/gnutls.config"
 SYMLINK_TO="/tmp/some_file"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_policy.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_policy.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 sed -i "1d" /etc/crypto-policies/config

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_policy_file.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_policy_file.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm /etc/crypto-policies/state/current

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_symlink.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_symlink.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm -f /etc/crypto-policies/back-ends/openssl.config

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_default_set.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_default_set.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
 update-crypto-policies --set "DEFAULT"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_fips_set.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_fips_set.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+update-crypto-policies --set "FIPS"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/symlink_to_wrong_policy.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/symlink_to_wrong_policy.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 CRYPTO_POLICY_LIB_FILE="/etc/crypto-policies/back-ends/openssh.config"
 SYMLINK_TO_FOLDER="/usr/share/crypto-policies/LEGACY/"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/wrong_policy.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/wrong_policy.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 sed -i "1s/.*/LEGACY/" /etc/crypto-policies/config

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_correct_policy.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_correct_policy.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm -f /etc/krb5.conf.d/crypto-policies
 ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_missing_policy.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_missing_policy.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm -f /etc/krb5.conf.d/crypto-policies

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_wrong_policy.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_kerberos_crypto_policy/kerberos_wrong_policy.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm -f /etc/krb5.conf.d/crypto-policies
 ln -s /etc/crypto-policies/back-ends/openssh.config /etc/krb5.conf.d/crypto-policies

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_commented.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_commented.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_not_there.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_not_there.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/wrong_value.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/wrong_value.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/nothing.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/nothing.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 . common.sh
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/ok.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/ok.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 . common.sh
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/section_not_include.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_openssl_crypto_policy/section_not_include.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 . common.sh
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/absent.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/absent.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/comment.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/comment.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/no_config_file.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/no_config_file.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/overrides.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_ssh_crypto_policy/overrides.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 


### PR DESCRIPTION
#### Description:

- Restrict tests for system-wide crypto policy to platforms Fedora and RHEL8 using profiles OSPP and standard.
- Select crypto policy rules in Fedora OSPP profile.

#### Rationale:

- Makes it easier to test crypto policy rules.
