### PR TITLE
Remove the sshd_disable_rhosts_rsa rule from RHEL8 and Fedora profiles.

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -72,7 +72,6 @@ selections:
     - disable_host_auth
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth
-    - sshd_disable_rhosts_rsa
     - sshd_disable_rhosts
     - sshd_disable_user_known_hosts
     - var_accounts_passwords_pam_faillock_deny=3

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -57,7 +57,6 @@ selections:
     - sshd_disable_compression
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth
-    - sshd_disable_rhosts_rsa
     - sshd_disable_rhosts
     - sshd_disable_user_known_hosts
     - sshd_do_not_permit_user_env

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -67,7 +67,6 @@ selections:
     - disable_host_auth
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth
-    - sshd_disable_rhosts_rsa
     - sshd_disable_rhosts
     - sshd_disable_user_known_hosts
     - var_accounts_passwords_pam_faillock_deny=3


### PR DESCRIPTION
The rule references a sshd configuration option that is not relevant for up-to-date RHEL>=7 systems.

There is no mention of `RhostsRSAAuthentication` in the manpage of `sshd_config` on RHEL 7.6, RHEL 8 and Fedora. On RHEL 6.10, it says that the `RhostsRSAAuthentication` is off by default, and that it applies to SSH v1 only.
As I don't know how the situation is e.g. on RHEL 7.1, I kept it in RHEL 7 profiles, but I am pretty sure that it is redundant in RHEL 8 and Fedora.