### PR TITLE
Remove rules that are shadowed by crypto policies rules.

### DIFF
--- a/rhel8/profiles/cjis.profile
+++ b/rhel8/profiles/cjis.profile
@@ -99,7 +99,9 @@ selections:
     - sshd_disable_empty_passwords
     - sshd_enable_warning_banner
     - sshd_do_not_permit_user_env
-    - sshd_use_approved_ciphers
+    - var_system_crypto_policy=fips
+    - configure_crypto_policy
+    - configure_ssh_crypto_policy
     - kernel_module_dccp_disabled
     - kernel_module_sctp_disabled
     - service_firewalld_enabled

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -66,8 +66,9 @@ selections:
     - sshd_set_keepalive
     - sshd_use_priv_separation
     - encrypt_partitions
-    - sshd_use_approved_ciphers
-    - sshd_use_approved_macs
+    - var_system_crypto_policy=fips
+    - configure_crypto_policy
+    - configure_ssh_crypto_policy
     - var_selinux_policy_name=targeted
     - var_selinux_state=enforcing
     - grub2_enable_selinux

--- a/rhel8/profiles/rht-ccp.profile
+++ b/rhel8/profiles/rht-ccp.profile
@@ -96,4 +96,6 @@ selections:
     - sshd_disable_empty_passwords
     - sshd_enable_warning_banner
     - sshd_do_not_permit_user_env
-    - sshd_use_approved_ciphers
+    - var_system_crypto_policy=fips
+    - configure_crypto_policy
+    - configure_ssh_crypto_policy


### PR DESCRIPTION
`sshd_use_approved_ciphers` and `sshd_use_approved_macs` mandated usage of FIPS-enabled algorithms, I have replaced them with FIPS crypto policy setup rules.

Since introduction of crypto policies, those old rules are completely irrelevant - all modifications to the sshd config is overriden by current crypto policy setup in RHEL8 and Fedora.
Those rules were not present in Fedora profiles.