### PR TITLE
Save and restore value of IFS

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
@@ -12,7 +12,8 @@ IFS_BKP="$IFS"
 
 # Load /etc/fstab's content with LABEL= and UUID= tags expanded to real
 # device names into FSTAB_REAL_DEVICES array splitting items by newline
-IFS=$'\n' FSTAB_REAL_DEVICES=($(findmnt --fstab --evaluate --noheadings))
+IFS=$'\n'
+FSTAB_REAL_DEVICES=($(findmnt --fstab --evaluate --noheadings))
 
 for line in ${FSTAB_REAL_DEVICES[@]}
 do
@@ -20,7 +21,8 @@ do
     # * squeeze multiple space characters into one,
     # * split line content info four columns (target, source, fstype, and
     #   mount options) by space delimiter
-    IFS=$' ' read TARGET SOURCE FSTYPE MOUNT_OPTIONS <<< "$(echo $line | tr -s ' ')"
+    IFS=$' '
+    read TARGET SOURCE FSTYPE MOUNT_OPTIONS <<< "$(echo $line | tr -s ' ')"
 
     # Filter the targets according to the following criteria:
     # * don't include record for root partition,
@@ -58,7 +60,8 @@ do
             # Split the retrieved value by the hash '#' delimiter to get the
             # row's head & tail (i.e. columns other than mount options) which won't
             # get modified
-            IFS=$'#' read TARGET_HEAD TARGET_OPTS TARGET_TAIL <<< "$FSTAB_TARGET_ROW"
+            IFS=$'#'
+            read TARGET_HEAD TARGET_OPTS TARGET_TAIL <<< "$FSTAB_TARGET_ROW"
             # Replace old mount options for particular /etc/fstab's row (for this target
             # and fstype) with new mount options
             sed -i "s#${TARGET_HEAD}\(.*\)${TARGET_TAIL}#${TARGET_HEAD}${MOUNT_OPTIONS}${TARGET_TAIL}#" /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
@@ -7,6 +7,9 @@
 # Shortened ID for frequently used character class
 SP="[:space:]"
 
+# Backup IFS value
+IFS_BKP="$IFS"
+
 # Load /etc/fstab's content with LABEL= and UUID= tags expanded to real
 # device names into FSTAB_REAL_DEVICES array splitting items by newline
 IFS=$'\n' FSTAB_REAL_DEVICES=($(findmnt --fstab --evaluate --noheadings))
@@ -63,3 +66,6 @@ do
         fi
     fi
 done
+
+# Reset IFS back to default
+IFS="$IFS_BKP"

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -26,11 +26,11 @@ then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
   # Backup IFS value
-  IFS_BKP=$IFS
+  IFS_BKP="$IFS"
   IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '"^fpr' | cut -d ":" -f 10))
   GPG_RESULT=$?
   # Reset IFS back to default
-  IFS=$IFS_BKP
+  IFS="$IFS_BKP"
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -27,7 +27,8 @@ then
   # (to ensure there won't be e.g. CRC error).
   # Backup IFS value
   IFS_BKP="$IFS"
-  IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '"^fpr' | cut -d ":" -f 10))
+  IFS=$'\n'
+  GPG_OUT=($(gpg --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '"^fpr' | cut -d ":" -f 10))
   GPG_RESULT=$?
   # Reset IFS back to default
   IFS="$IFS_BKP"

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -84,7 +84,8 @@ then
 	key=$(expr "$full_rule" : '.*-k[[:space:]]\([^[:space:]]\+\)' '|' "$full_rule" : '.*-F[[:space:]]key=\([^[:space:]]\+\)')
 	IFS_BKP="$IFS"
 	# Check if particular audit rule is already defined
-	IFS=$'\n' matches=($(sed -s -n -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
+	IFS=$'\n'
+	matches=($(sed -s -n -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
 	if [ $? -ne 0 ]
 	then
 		retval=1
@@ -119,7 +120,8 @@ do
 	# * follow the rule pattern, and
 	# * meet the hardware architecture requirement, and
 	# * are current syscall group specific
-	IFS=$'\n' existing_rules=($(sed -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file"))
+	IFS=$'\n'
+	existing_rules=($(sed -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file"))
 	if [ $? -ne 0 ]
 	then
 		retval=1
@@ -171,7 +173,8 @@ do
 				IFS_BKP="$IFS"
 				# 2) Delete syscalls for this group, but keep those from other groups
 				# Convert current rule syscall's string into array splitting by '-S' delimiter
-				IFS=$'-S' read -a rule_syscalls_as_array <<< "$rule_syscalls"
+				IFS=$'-S'
+				read -a rule_syscalls_as_array <<< "$rule_syscalls"
 				# Reset IFS back to default
 				IFS="$IFS_BKP"
 				# Declare new empty string to hold '-S syscall' arguments from other groups

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -82,6 +82,7 @@ elif [ "$tool" == 'augenrules' ]
 then
 	# Extract audit $key from audit rule so we can use it later
 	key=$(expr "$full_rule" : '.*-k[[:space:]]\([^[:space:]]\+\)' '|' "$full_rule" : '.*-F[[:space:]]key=\([^[:space:]]\+\)')
+	IFS_BKP="$IFS"
 	# Check if particular audit rule is already defined
 	IFS=$'\n' matches=($(sed -s -n -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules))
 	if [ $? -ne 0 ]
@@ -89,7 +90,7 @@ then
 		retval=1
 	fi
 	# Reset IFS back to default
-	unset IFS
+	IFS="$IFS_BKP"
 	for match in "${matches[@]}"
 	do
 		files_to_inspect=("${files_to_inspect[@]}" "${match}")
@@ -113,6 +114,7 @@ local append_expected_rule=0
 for audit_file in "${files_to_inspect[@]}"
 do
 
+	IFS_BKP="$IFS"
 	# Filter existing $audit_file rules' definitions to select those that:
 	# * follow the rule pattern, and
 	# * meet the hardware architecture requirement, and
@@ -123,7 +125,7 @@ do
 		retval=1
 	fi
 	# Reset IFS back to default
-	unset IFS
+	IFS="$IFS_BKP"
 
 	# Process rules found case-by-case
 	for rule in "${existing_rules[@]}"
@@ -166,11 +168,12 @@ do
 				then
 					retval=1
 				fi
+				IFS_BKP="$IFS"
 				# 2) Delete syscalls for this group, but keep those from other groups
 				# Convert current rule syscall's string into array splitting by '-S' delimiter
 				IFS=$'-S' read -a rule_syscalls_as_array <<< "$rule_syscalls"
 				# Reset IFS back to default
-				unset IFS
+				IFS="$IFS_BKP"
 				# Declare new empty string to hold '-S syscall' arguments from other groups
 				new_syscalls_for_rule=''
 				# Walk through existing '-S syscall' arguments

--- a/shared/bash_remediation_functions/fix_audit_watch_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_watch_rule.sh
@@ -59,11 +59,14 @@ then
 # If rule isn't defined, add '/etc/audit/rules.d/$key.rules' to list of files for inspection.
 elif [ "$tool" == 'augenrules' ]
 then
+	# Backup IFS value
+	IFS_BKP="$IFS"
 	# Case when particular audit rule is already defined in some of /etc/audit/rules.d/*.rules file
 	# Get pair -- filepath : matching_row into @matches array
 	IFS=$'\n' matches=($(grep -P "[\s]*-w[\s]+$path" /etc/audit/rules.d/*.rules))
 	# Reset IFS back to default
-	unset IFS
+	IFS="$IFS_BKP"
+
 	# For each of the matched entries
 	for match in "${matches[@]}"
 	do

--- a/shared/bash_remediation_functions/fix_audit_watch_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_watch_rule.sh
@@ -63,7 +63,8 @@ then
 	IFS_BKP="$IFS"
 	# Case when particular audit rule is already defined in some of /etc/audit/rules.d/*.rules file
 	# Get pair -- filepath : matching_row into @matches array
-	IFS=$'\n' matches=($(grep -P "[\s]*-w[\s]+$path" /etc/audit/rules.d/*.rules))
+	IFS=$'\n'
+	matches=($(grep -P "[\s]*-w[\s]+$path" /etc/audit/rules.d/*.rules))
 	# Reset IFS back to default
 	IFS="$IFS_BKP"
 

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -19,6 +19,9 @@ function perform_audit_rules_privileged_commands_remediation {
 local tool="$1"
 local min_auid="$2"
 
+# Backup IFS value
+IFS_BKP="$IFS"
+
 # Check sanity of the input
 if [ $# -ne "2" ]
 then
@@ -170,4 +173,7 @@ do
 	done
 
 done
+
+# Reset IFS back to default
+IFS="$IFS_BKP"
 }

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -54,13 +54,15 @@ then
 #   missing rules should be inserted
 elif [ "$tool" == 'augenrules' ]
 then
-	IFS=$'\n' files_to_inspect=($(find /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -print))
+	IFS=$'\n'
+	files_to_inspect=($(find /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -print))
 	output_audit_file="/etc/audit/rules.d/privileged.rules"
 fi
 
 # Obtain the list of SUID/SGID binaries on the particular system (split by newline)
 # into privileged_binaries array
-IFS=$'\n' privileged_binaries=($(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null))
+IFS=$'\n'
+privileged_binaries=($(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null))
 
 # Keep list of SUID/SGID binaries that have been already handled within some previous iteration
 declare -a sbinaries_to_skip=()
@@ -123,8 +125,10 @@ do
 			concrete_rule=$base_search
 
 			# Select all other SUID/SGID binaries possibly also present in the found rule
-			IFS=$'\n' handled_sbinaries=($(grep -o -e "-F path=[^[:space:]]\+" <<< "$concrete_rule"))
-			IFS=$' ' handled_sbinaries=(${handled_sbinaries[@]//-F path=/})
+			IFS=$'\n'
+			handled_sbinaries=($(grep -o -e "-F path=[^[:space:]]\+" <<< "$concrete_rule"))
+			IFS=$' '
+			handled_sbinaries=(${handled_sbinaries[@]//-F path=/})
 
 			# Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
 			sbinaries_to_skip=($(for i in "${sbinaries_to_skip[@]}" "${handled_sbinaries[@]}"; do echo "$i"; done | sort -du))
@@ -134,7 +138,8 @@ do
 			concrete_rule="$(echo "$concrete_rule" | sed -n "s/\(.*\)\+\(-F perm=[rwax]\+\)\+/\1#\2#/p")"
 
 			# Split concrete_rule into head, perm, and tail sections using hash '#' delimiter
-			IFS=$'#' read -r rule_head rule_perm rule_tail <<<  "$concrete_rule"
+			IFS=$'#'
+			read -r rule_head rule_perm rule_tail <<<  "$concrete_rule"
 
 			# Extract already present exact access type [r|w|x|a] from rule's permission section
 			access_type=${rule_perm//-F perm=/}


### PR DESCRIPTION

#### Description:

- Save value of IFS before overwriting it, and restore it after use.

#### Rationale:

- Some bash fix scripts do not set back the orignal value of IFS.
  Correct approach is to save and restore IFS value.

Thanks @matejak for pointing this out.
