### PR TITLE
Added crypto policies info to related rules.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -41,6 +41,14 @@ rationale: |-
     utilize authentication that meets industry and government requirements. For government systems, this allows
     Security Levels 1, 2, 3, or 4 for use on {{{ full_name }}}.
 
+{{% if product in ["fedora", "rhel8","ol8"] %}}
+warnings:
+    - general: |-
+        This rule seems to be included in a benchmark of a platform that supports crypto policies.
+        Crypto policies centralise crypto algorithms configuration across the whole system, and unless overriden in a very specific way, they take priority over legacy configuration, such as one described by this rule.
+        Therefore, this rule is irrelevant and shouldn't even be part of the {{{ full_name }}} benchmark at all.
+{{% endif %}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -31,6 +31,14 @@ rationale: |-
     DoD Information Systems are required to use FIPS-approved cryptographic hash
     functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
 
+{{% if product in ["fedora", "rhel8","ol8"] %}}
+warnings:
+    - general: |-
+        This rule seems to be included in a benchmark of a platform that supports crypto policies.
+        Crypto policies centralise crypto algorithms configuration across the whole system, and unless overriden in a very specific way, they take priority over legacy configuration, such as one described by this rule.
+        Therefore, this rule is irrelevant and shouldn't even be part of the {{{ full_name }}} benchmark at all.
+{{% endif %}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
@@ -19,6 +19,14 @@ rationale: |-
     mode algorithms (as described in RFC4344) were designed that are not vulnerable to these
     types of attacks and these algorithms are now recommended for standard use.
 
+{{% if product in ["fedora", "rhel8","ol8"] %}}
+warnings:
+    - general: |-
+        This rule seems to be included in a benchmark of a platform that supports crypto policies.
+        Crypto policies centralise crypto algorithms configuration across the whole system, and unless overriden in a very specific way, they take priority over legacy configuration, such as one described by this rule.
+        Therefore, this rule is irrelevant and shouldn't even be part of the {{{ full_name }}} benchmark at all.
+{{% endif %}}
+
 severity: medium
 
 references:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/rule.yml
@@ -15,6 +15,14 @@ rationale: |-
     attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the
     SSH tunnel and capture credentials and information
 
+{{% if product in ["fedora", "rhel8","ol8"] %}}
+warnings:
+    - general: |-
+        This rule seems to be included in a benchmark of a platform that supports crypto policies.
+        Crypto policies centralise crypto algorithms configuration across the whole system, and unless overriden in a very specific way, they take priority over legacy configuration, such as one described by this rule.
+        Therefore, this rule is irrelevant and shouldn't even be part of the {{{ full_name }}} benchmark at all.
+{{% endif %}}
+
 severity: medium
 
 ocil_clause: 'MACs option is commented out or not using strong hash algorithms'

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/rule.yml
@@ -10,6 +10,10 @@ description: |-
     algorithm for password hashing:
     <pre>crypt_style = sha512</pre>
 
+    {{% if product in ["fedora", "rhel8","ol8"] %}}
+    Although this rule involves settings related to crypto algorithms, it does not overlap with system-wide Crypto Policies and can be safely used on systems where system-wide Crypto Policies are enabled s.a. {{{ full_name }}}.
+    {{% endif %}}
+
 rationale: |-
     Passwords need to be protected at all times, and encryption is the standard
     method for protecting passwords. If passwords are not encrypted, they can

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
@@ -9,6 +9,10 @@ description: |-
     the system will use SHA-512 as the hashing algorithm:
     <pre>ENCRYPT_METHOD SHA512</pre>
 
+    {{% if product in ["fedora", "rhel8","ol8"] %}}
+    Although this rule involves settings related to crypto algorithms, it does not overlap with system-wide Crypto Policies and can be safely used on systems where system-wide Crypto Policies are enabled s.a. {{{ full_name }}}.
+    {{% endif %}}
+
 rationale: |-
     Passwords need to be protected at all times, and encryption is the standard method for protecting passwords.
     If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised. Passwords

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -18,6 +18,10 @@ description: |-
     the new passwords will be generated using the SHA-512 algorithm. This is
     the default.
 
+    {{% if product in ["fedora", "rhel8","ol8"] %}}
+    Although this rule involves settings related to crypto algorithms, it does not overlap with system-wide Crypto Policies and can be safely used on systems where system-wide Crypto Policies are enabled s.a. {{{ full_name }}}.
+    {{% endif %}}
+
 rationale: |-
     Passwords need to be protected at all times, and encryption is the standard
     method for protecting passwords. If passwords are not encrypted, they can


### PR DESCRIPTION
This PR aims to expand description of rules on systems that feature system-wide crypto policies. We have rules that are either shadowed by it, or they are not, although one could fear so:

* The `sshd_use_...` rules are shadowed by the system crypto policy.
* The `set_password_hashing_algorithm_...` rules have no relation to the crypto policy, although they may look so.