### PR TITLE
Fix no_files_unowned_by_user OVAL check to use password_object

### DIFF
--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -17,14 +17,12 @@
   </unix:file_state>
 
   <local_variable id="file_permissions_unowned_userid_list" comment="List of valid user ids" datatype="int" version="1">
-    <object_component item_field="subexpression" object_ref="file_permissions_unowned_userid_list_object" />
+    <object_component item_field="user_id" object_ref="file_permissions_unowned_userid_list_object" />
   </local_variable>
 
-  <ind:textfilecontent54_object id="file_permissions_unowned_userid_list_object" version="1">
-    <ind:filepath>/etc/passwd</ind:filepath>
-    <ind:pattern operation="pattern match">^[^:]+:[^:]+:([\d]+):[\d]+:[^:]*:[^:]+:[^:]*$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
+  <unix:password_object id="file_permissions_unowned_userid_list_object" version="1">
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
+  </unix:password_object>
 
   <unix:file_object comment="all local files" id="file_permissions_unowned_object" version="1">
     <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />


### PR DESCRIPTION
- password_object uses getent which would allow checking file ownership for centralized
  users if enumeration or getent is setup properly. If enumeration or getent is not setup
  properly, there is no sane fix to this.
- Fixes #2160