### PR TITLE
New Test Suite backend that uses Podman

### DIFF
--- a/Dockerfiles/test_suite-centos
+++ b/Dockerfiles/test_suite-centos
@@ -1,4 +1,4 @@
-# This Dockerfile is a minimal example for a RHEL-based SSG test suite target container.
+# This Dockerfile is a minimal example for a CentOS-based SSG test suite target container.
 FROM centos
 
 ENV AUTH_KEYS=/root/.ssh/authorized_keys
@@ -12,9 +12,10 @@ RUN true \
         && true
 
 RUN true \
-        && for key_type in rsa ecdsa ed25519; do sshd-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && for key_type in rsa ecdsa ed25519; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
 && true
 

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -16,5 +16,6 @@ RUN true \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
 && true
 

--- a/Dockerfiles/test_suite-rhel
+++ b/Dockerfiles/test_suite-rhel
@@ -12,8 +12,9 @@ RUN true \
         && true
 
 RUN true \
-        && for key_type in rsa ecdsa ed25519; do sshd-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && for key_type in rsa ecdsa ed25519; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
 && true

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -6,8 +6,6 @@ import os
 import time
 import subprocess
 
-import docker
-
 import ssg_test_suite
 from ssg_test_suite.virt import SnapshotStack
 from ssg_test_suite import common
@@ -273,6 +271,10 @@ class DockerTestEnv(ContainerTestEnv):
 
     def __init__(self, mode, image_name):
         super(DockerTestEnv, self).__init__(mode, image_name)
+        try:
+            import docker
+        except ImportError:
+            raise RuntimeError("Can't import Docker, Docker backend will not work.")
         try:
             self.client = docker.from_env(version="auto")
             self.client.ping()

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -151,9 +151,6 @@ class VMTestEnv(TestEnv):
         state = self.snapshot_stack.revert(delete=False)
         return state
 
-    def discard_running_state(self, state_handle):
-        pass
-
     def _save_state(self, state_name):
         state = self.snapshot_stack.create(state_name)
         return state
@@ -238,9 +235,6 @@ class ContainerTestEnv(TestEnv):
         associated_image = self.created_images.pop()
         assert associated_image == image
         self._remove_image(associated_image)
-
-    def discard_running_state(self, state_handle):
-        self._terminate_current_running_container_if_applicable()
 
     def offline_scan(self, args, verbose_path):
         command_list = self._local_oscap_check_base_arguments() + args

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -242,22 +242,22 @@ class ContainerTestEnv(TestEnv):
         return common.run_cmd_local(command_list, verbose_path)
 
     def _commit(self, container, image):
-        pass
+        raise NotImplementedError
 
     def _new_container_from_image(self, image_name, container_name):
-        pass
+        raise NotImplementedError
 
     def _get_container_ip(self, container):
-        pass
+        raise NotImplementedError
 
     def _terminate_current_running_container_if_applicable(self):
-        pass
+        raise NotImplementedError
 
     def _remove_image(self, image):
-        pass
+        raise NotImplementedError
 
     def _local_oscap_check_base_arguments(self):
-        pass
+        raise NotImplementedError
 
 
 class DockerTestEnv(ContainerTestEnv):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -30,6 +30,9 @@ def parse_args():
     backends.add_argument(
         "--docker", dest="docker", metavar="BASE_IMAGE",
         help="Use Docker test environment with this base image.")
+    backends.add_argument(
+        "--container", dest="container", metavar="BASE_IMAGE",
+        help="Use container test environment with this base image.")
 
     backends.add_argument(
         "--libvirt", dest="libvirt", metavar="HYPERVISOR DOMAIN", nargs=2,
@@ -163,6 +166,12 @@ def normalize_passed_arguments(options):
         logging.info(
             "The base image option has been specified, "
             "choosing Docker-based test environment.")
+    elif options.container:
+        options.test_env = ssg_test_suite.test_env.PodmanTestEnv(
+            options.scanning_mode, options.container)
+        logging.info(
+            "The base image option has been specified, "
+            "choosing Podman-based test environment.")
     else:
         hypervisor, domain_name = options.libvirt
         options.test_env = ssg_test_suite.test_env.VMTestEnv(


### PR DESCRIPTION
#### Description:
Introduces Podman backend to SSG Test Suite harness.

The Podman backend works similar way as the Docker backend. However, it's implemented by invoking podman CLI calls (subprocess) instead of using Python 3 bindings, because as of python3-podman version 0.12.1.2 it doesn't allow to run, inspect and commit containers. Users will use
this backend using `--container` cmdline option.

The Docker backend and Podman backend are very similar because both of them are a specific implementation of a generic container backend.  We introduce a new parent class ContainerTestEnv that contains common code. Then, DockerTestEnv and PodmanTestEnv will inherit from ContainerTestEnv.

The documentation in `tests/README.md` is updated accordingly.

The Dockerfiles fot SSG test suite are updated this way:
- It's more appopriate to describe CentOS container as CentOS-based than RHEL based.
- The utility that generates SSH keys is ssh-keygen, not sshd-keygen which is a legacy service.
- We remove pam_loginuid.so from SSHD PAM configuration in the container as it prevents users to log in via ssh to the container. As our test suite doesn't check if oscap scans produce audit messages, we can simply remove that.

#### Rationale:
On RHEL8, Docker isn't available and it's replaced by Podman. Therefore, we need to implement a backend for Podman to run container-based tests in SSG Test suite.

For more details, please see the respective commit messages of each commit.