### PR TITLE
Fix handling of key in remediation of audit rules privileged commands

### DIFF
--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -107,8 +107,8 @@ do
 	
 		base_search=$(sed -e '/-a always,exit/!d' -e '/-F path='"${sbinary_esc}"'/!d'		\
 				-e '/-F path=[^[:space:]]\+/!d'   -e '/-F perm=.*/!d'						\
-				-e '/-F auid>='"${min_auid}"'/!d' -e '/-F auid!=\(?:4294967295\|unset\)/!d'	\
-				-e '/-k privileged/!d' "$afile")
+				-e '/-F auid>='"${min_auid}"'/!d' -e '/-F auid!=\(4294967295\|unset\)/!d'	\
+				-e '/-k \|-F key=/!d' "$afile")
 
 		# Increase the count of inspected files for this sbinary
 		count_of_inspected_files=$((count_of_inspected_files + 1))

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_auditctl_default.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_auditctl_default.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 6
 
 # auditctl is default for rhel6
-# This is a trick to fail setup of this test in rhel7 systems
-ls /etc/sysconfig/auditd

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_auditctl_rules_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_auditctl_rules_configured.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 6
 
 ./generate_privileged_commands_rule.sh 500 privileged /etc/audit/audit.rules
-# This is a trick to fail setup of this test in rhel7 systems
-ls /etc/sysconfig/auditd

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_augenrules_default.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_augenrules_default.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 6
 
 sed -i "s/USE_AUGENRULES=.*/USE_AUGENRULES=\"yes\"/" /etc/sysconfig/auditd

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_augenrules_rules_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel6_augenrules_rules_configured.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 6
 
 ./generate_privileged_commands_rule.sh 500 privileged /etc/audit/rules.d/privileged.rules
 sed -i "s/USE_AUGENRULES=.*/USE_AUGENRULES=\"yes\"/" /etc/sysconfig/auditd

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_default.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_default.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_missing_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_missing_rule.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
 sed -i '/newgrp/d' /etc/audit/audit.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_one_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_one_rule.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_rules_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_auditctl_rules_configured.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_default.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_default.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 # augenrules is default for rhel7
-# This is a trick to fail setup of this test in rhel6 systems
-ls  /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_missing_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_missing_rule.fail.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
  sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_one_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_one_rule.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_remove_all_rules.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_remove_all_rules.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
-# remediation = bash
-
-rm -f /etc/audit/rules.d/*
-> /etc/audit/audit.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured_mixed_keys.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7
+
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+# change key of rules for binaries in /usr/sbin
+# A mixed conbination of -k and -F key= should be accepted
+sed -i '/sbin/s/-k /-F key=/g' /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_two_rules_mixed_keys.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_two_rules_mixed_keys.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7
+
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_rules_with_own_key.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_rules_with_own_key.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 ./generate_privileged_commands_rule.sh 1000 own_key /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service


### PR DESCRIPTION
#### Description:

- Drop redundant `remove_all_rules.fail` test scenario
- Update platform of test scenarios
- Add new test scenarios to handle audit rules whose keys are specified using both `-k mykey` and `-F key=mykey`. Both settings should be accepted.
  - two_rules_mixed_keys: The remediation script should be able to handle mixed keys
  - rules_configured_mixed_keys: The OVAL should be able to recognize mixed keys

#### Rationale:

- Bash fix did not recognize correct audit rules with keys specified using `-F key=` syntax.
- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1667108.
