### PR TITLE
Fixed bind and libreswan crypto policy test scenarios

### DIFF
--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/bind_not_installed.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_bind_crypto_policy/bind_not_installed.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum remove -y bind || true

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/libreswan_not_installed.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/libreswan_not_installed.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum remove -y libreswan || true


### PR DESCRIPTION
#### Description:

- `bind` and `libreswan` test scenarios did not have applicability set.
  This commit adds Fedora and RHEL8 to platforms and missing OSPP
  profile to the profiles section.