### PR TITLE
assign low severity to accounts_logon_fail_delay

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     Increasing the time between a failed authentication attempt and re-prompting to
     enter credentials helps to slow a single-threaded brute force attack.
 
-severity: unknown
+severity: low
 
 identifiers:
     cce@rhel7: 80352-8


### PR DESCRIPTION
Rule currently does not have a severity code. https://github.com/ComplianceAsCode/content/issues/3705 requests alignment to DISA rating of "medium" however this appears to only be low.

Other rules limit false logon attempts, whereas this only effects delay between the logon prompts. Failure to implement this rule could "degrade" protections against DDoS but not leave the system exposed to them (since # inaccurate logins will still lock the account).

While https://github.com/ComplianceAsCode/content/issues/3705 gets figured out, this will at least assign something to severity instead of "unknown"