### PR TITLE
Fix Ansible remediation for PAM

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
@@ -18,7 +18,7 @@
     new_module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny: {{ var_accounts_passwords_pam_faillock_deny }}
+        deny={{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: before
@@ -37,7 +37,7 @@
     new_module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny: {{ var_accounts_passwords_pam_faillock_deny }}
+        deny={{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: after

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
@@ -9,7 +9,7 @@
 
 - name: set auth pam_faillock before pam_unix.so
   pamd:
-    name: system-auth
+    name: "{{ item }}"
     type: auth
     control: sufficient
     module_path: pam_unix.so
@@ -22,32 +22,37 @@
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: before
+  loop:
+    - system-auth
+    - password-auth
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
 - name: set auth pam_faillock after pam_unix.so
   pamd:
-    name: system-auth
+    name: "{{ item }}"
     type: auth
     control: sufficient
     module_path: pam_unix.so
     new_type: auth
     new_control: '[default=die]'
     new_module_path: pam_faillock.so
-    module_arguments: 'preauth
-        silent
+    module_arguments: 'authfail
         deny={{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: after
+  loop:
+    - system-auth
+    - password-auth
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
 - name: set account pam_faillock before pam_unix.so
   pamd:
-    name: system-auth
+    name: "{{ item }}"
     type: account
     control: required
     module_path: pam_unix.so
@@ -55,6 +60,9 @@
     new_control: required
     new_module_path: pam_faillock.so
     state: before
+  loop:
+    - system-auth
+    - password-auth
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
@@ -19,7 +19,7 @@
     module_arguments: 'preauth
         silent
         even_deny_root
-        deny: {{ var_accounts_passwords_pam_faillock_deny }}
+        deny={{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: before
@@ -39,7 +39,7 @@
     module_arguments: 'preauth
         silent
         even_deny_root
-        deny: {{ var_accounts_passwords_pam_faillock_deny }}
+        deny={{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: after

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
@@ -3,11 +3,8 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- (xccdf-var var_accounts_passwords_pam_faillock_deny)
-- (xccdf-var var_accounts_passwords_pam_faillock_unlock_time)
-- (xccdf-var var_accounts_passwords_pam_faillock_fail_interval)
 
-- name: set auth pam_faillock before pam_unix.so
+- name: Add auth pam_faillock preauth even_deny_root before pam_unix.so
   pamd:
     name: "{{ item }}"
     type: auth
@@ -18,10 +15,7 @@
     new_module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        even_deny_root
-        deny={{ var_accounts_passwords_pam_faillock_deny }}
-        unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
-        fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
+        even_deny_root'
     state: before
   loop:
     - system-auth
@@ -30,7 +24,24 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: set auth pam_faillock after pam_unix.so
+- name: Add even_deny_root argument to auth pam_faillock preauth
+  pamd:
+    name: "{{ item }}"
+    type: auth
+    control: required
+    module_path: pam_faillock.so
+    module_arguments: 'preauth
+        silent
+        even_deny_root'
+    state: args_present
+  loop:
+    - system-auth
+    - password-auth
+  tags:
+    @ANSIBLE_TAGS@
+  @ANSIBLE_ENSURE_PLATFORM@
+
+- name: Add auth pam_faillock authfail even_deny_root after pam_unix.so
   pamd:
     name: "{{ item }}"
     type: auth
@@ -40,10 +51,7 @@
     new_control: '[default=die]'
     new_module_path: pam_faillock.so
     module_arguments: 'authfail
-        even_deny_root
-        deny={{ var_accounts_passwords_pam_faillock_deny }}
-        unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
-        fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
+        even_deny_root'
     state: after
   loop:
     - system-auth
@@ -52,7 +60,23 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: set account pam_faillock before pam_unix.so
+- name: Add even_deny_root argument to auth pam_faillock authfail
+  pamd:
+    name: "{{ item }}"
+    type: auth
+    control: '[default=die]'
+    module_path: pam_faillock.so
+    module_arguments: 'authfail
+        even_deny_root'
+    state: args_present
+  loop:
+    - system-auth
+    - password-auth
+  tags:
+    @ANSIBLE_TAGS@
+  @ANSIBLE_ENSURE_PLATFORM@
+
+- name: Add account pam_faillock before pam_unix.so
   pamd:
     name: "{{ item }}"
     type: account

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
@@ -9,7 +9,7 @@
 
 - name: set auth pam_faillock before pam_unix.so
   pamd:
-    name: system-auth
+    name: "{{ item }}"
     type: auth
     control: sufficient
     module_path: pam_unix.so
@@ -23,13 +23,16 @@
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: before
+  loop:
+    - system-auth
+    - password-auth
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
 - name: set auth pam_faillock after pam_unix.so
   pamd:
-    name: system-auth
+    name: "{{ item }}"
     type: auth
     control: sufficient
     module_path: pam_unix.so
@@ -43,13 +46,16 @@
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}
         fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: after
+  loop:
+    - system-auth
+    - password-auth
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
 - name: set account pam_faillock before pam_unix.so
   pamd:
-    name: system-auth
+    name: "{{ item }}"
     type: account
     control: required
     module_path: pam_unix.so
@@ -57,6 +63,9 @@
     new_control: required
     new_module_path: pam_faillock.so
     state: before
+  loop:
+    - system-auth
+    - password-auth
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
@@ -39,8 +39,7 @@
     new_type: auth
     new_control: '[default=die]'
     new_module_path: pam_faillock.so
-    module_arguments: 'preauth
-        silent
+    module_arguments: 'authfail
         even_deny_root
         deny={{ var_accounts_passwords_pam_faillock_deny }}
         unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/bash/shared.sh
@@ -12,20 +12,10 @@ AUTH_FILES[1]="/etc/pam.d/password-auth"
 # The placement of pam_faillock.so entries will not be changed
 # if they are already present
 
-# ensure, that pam.d folder exists
-mkdir -p "/etc/pam.d"
-
 for pamFile in "${AUTH_FILES[@]}"
 do
-	# if auth file is missing, create it and add what this rule needs
+	# if PAM file is missing, system is not using PAM or broken
 	if [ ! -f $pamFile ]; then
-		touch $pamFile
-		echo "
-auth required pam_faillock.so preauth silent even_deny_root deny=3 unlock_time=never fail_interval=900
-auth sufficient pam_unix.so
-auth [default=die] pam_faillock.so authfail silent even_deny_root deny=3 unlock_time=never fail_interval=900
-" >> $pamFile
-		# everything is set, don't check it again
 		continue
 	fi
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/ansible/shared.yml
@@ -3,9 +3,9 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- (xccdf-var var_accounts_passwords_pam_faillock_deny)
+- (xccdf-var var_accounts_passwords_pam_faillock_fail_interval)
 
-- name: Add auth pam_faillock preauth deny before pam_unix.so
+- name: Add auth pam_faillock preauth fail_interval before pam_unix.so
   pamd:
     name: "{{ item }}"
     type: auth
@@ -16,7 +16,7 @@
     new_module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: before
   loop:
     - system-auth
@@ -25,7 +25,7 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: Add deny argument to auth pam_faillock preauth
+- name: Add fail_interval argument to auth pam_faillock preauth
   pamd:
     name: "{{ item }}"
     type: auth
@@ -33,7 +33,7 @@
     module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: args_present
   loop:
     - system-auth
@@ -42,7 +42,7 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: Add auth pam_faillock authfail deny after pam_unix.so
+- name: Add auth pam_faillock aufthfail fail_interval after pam_unix.so
   pamd:
     name: "{{ item }}"
     type: auth
@@ -52,7 +52,7 @@
     new_control: '[default=die]'
     new_module_path: pam_faillock.so
     module_arguments: 'authfail
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: after
   loop:
     - system-auth
@@ -61,15 +61,14 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: Add deny argument to auth pam_faillock authfail
+- name: Add fail_interval argument to auth pam_faillock authfail
   pamd:
     name: "{{ item }}"
     type: auth
-    new_type: auth
     control: '[default=die]'
     module_path: pam_faillock.so
     module_arguments: 'authfail
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        fail_interval={{ var_accounts_passwords_pam_faillock_fail_interval }}'
     state: args_present
   loop:
     - system-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/ansible/shared.yml
@@ -3,9 +3,9 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- (xccdf-var var_accounts_passwords_pam_faillock_deny)
+- (xccdf-var var_accounts_passwords_pam_faillock_unlock_time)
 
-- name: Add auth pam_faillock preauth deny before pam_unix.so
+- name: Add auth pam_faillock preauth unlock_time before pam_unix.so
   pamd:
     name: "{{ item }}"
     type: auth
@@ -16,7 +16,7 @@
     new_module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}'
     state: before
   loop:
     - system-auth
@@ -25,7 +25,7 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: Add deny argument to auth pam_faillock preauth
+- name: Add unlock_time argument to pam_faillock preauth
   pamd:
     name: "{{ item }}"
     type: auth
@@ -33,7 +33,7 @@
     module_path: pam_faillock.so
     module_arguments: 'preauth
         silent
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}'
     state: args_present
   loop:
     - system-auth
@@ -42,7 +42,7 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: Add auth pam_faillock authfail deny after pam_unix.so
+- name: Add auth pam_faillock authfail unlock_interval after pam_unix.so
   pamd:
     name: "{{ item }}"
     type: auth
@@ -52,7 +52,7 @@
     new_control: '[default=die]'
     new_module_path: pam_faillock.so
     module_arguments: 'authfail
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}'
     state: after
   loop:
     - system-auth
@@ -61,15 +61,14 @@
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
-- name: Add deny argument to auth pam_faillock authfail
+- name: Add unlock_time argument to auth pam_faillock authfail
   pamd:
     name: "{{ item }}"
     type: auth
-    new_type: auth
     control: '[default=die]'
     module_path: pam_faillock.so
     module_arguments: 'authfail
-        deny={{ var_accounts_passwords_pam_faillock_deny }}'
+        unlock_time={{ var_accounts_passwords_pam_faillock_unlock_time }}'
     state: args_present
   loop:
     - system-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-system-auth.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-system-auth.fail.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# remediation = bash
+
 . set-up-pamd.sh
 
 set-up-pamd

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-system-auth.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-system-auth.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
-# remediation = bash
-
-. set-up-pamd.sh
-
-set-up-pamd
-rm -f /etc/pam.d/system-auth


### PR DESCRIPTION
#### Description:
1.  Replace ':' by '=' in PAM module_arguments
This ':' was propagated to PAM configuration file. But ':' is not a valid character in PAM configuration in module arguments. Instead, '=' should be used.

2. Apply Ansible remediations for rules `accounts_passwords_pam_faillock_deny_root` and `accounts_passwords_pam_faillock_deny` to both `/etc/pam.d/system-auth` and `/etc/pam.d/password-auth`. The rule descriptions in these rules say that both `system-auth` and `password-auth` should be modified, but Ansible remediations modified only `system-auth`.

3. Aling `pam_faillock.so` settings with OVAL and rule description for rules `accounts_passwords_pam_faillock_deny_root` and `accounts_passwords_pam_faillock_deny`.

4.  Run test scenario `missing-system-auth.fail.sh` only with bash. The Ansible remediation fails if PAM config files aren't present at all.

5. Each Ansible remediation will fix only the argument relevant to its rule.

#### Rationale:
RHBZ https://bugzilla.redhat.com/show_bug.cgi?id=1636392 complains about broken PAM configuration after applying Ansible playbooks.
