### PR TITLE
Made the test suite easier to use:

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -1,7 +1,6 @@
 import logging
 import subprocess
 from collections import namedtuple
-import enum
 import functools
 from ssg.constants import MULTI_PLATFORM_MAPPING
 from ssg.constants import PRODUCT_TO_CPE_MAPPING
@@ -21,7 +20,7 @@ IGNORE_KNOWN_HOSTS_OPTIONS = (
 )
 
 
-class Stage(enum.IntEnum):
+class Stage(object):
     NONE = 0
     PREPARATION = 1
     INITIAL_SCAN = 2

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -339,10 +339,10 @@ class GenericRunner(object):
         raise NotImplementedError()
 
     def initial(self):
-        self.command_options += [
+        self.command_options = [
                 '--verbose', 'DEVEL',
                 '--results', self.results_path
-        ]
+        ] + self.command_options
         result = self.make_oscap_call()
         return result
 

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -5,7 +5,6 @@ import logging
 
 
 import ssg_test_suite.oscap
-import ssg_test_suite.virt
 from ssg_test_suite.rule import get_viable_profiles
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -9,8 +9,7 @@ import subprocess
 import collections
 import json
 
-import ssg_test_suite.oscap as oscap
-import ssg_test_suite.virt
+from ssg_test_suite import oscap
 from ssg_test_suite import xml_operations
 from ssg_test_suite import test_env
 from ssg_test_suite import common
@@ -168,7 +167,7 @@ def _get_scenarios(rule_dir, scripts, benchmark_cpes):
     return scenarios
 
 
-class RuleChecker(ssg_test_suite.oscap.Checker):
+class RuleChecker(oscap.Checker):
     """
     Rule checks generally work like this -
     for every profile that supports that rule:
@@ -204,7 +203,7 @@ class RuleChecker(ssg_test_suite.oscap.Checker):
             "Script {0} using profile {1} found issue:".format(scenario.script, profile),
             log_target='fail')
 
-        runner_cls = ssg_test_suite.oscap.REMEDIATION_RULE_RUNNERS[self.remediate_using]
+        runner_cls = oscap.REMEDIATION_RULE_RUNNERS[self.remediate_using]
         runner = runner_cls(
             self.test_env, profile, self.datastream, self.benchmark_id,
             rule_id, scenario.script, self.dont_clean, self.manual_debug)

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -7,7 +7,6 @@ import time
 import subprocess
 
 import ssg_test_suite
-from ssg_test_suite.virt import SnapshotStack
 from ssg_test_suite import common
 
 
@@ -120,6 +119,12 @@ class VMTestEnv(TestEnv):
 
     def __init__(self, mode, hypervisor, domain_name):
         super(VMTestEnv, self).__init__(mode)
+
+        try:
+            import libvirt
+        except ImportError:
+            raise RuntimeError("Can't import libvirt module, libvirt backend will therefore not work.")
+
         self.domain = None
 
         self.hypervisor = hypervisor
@@ -131,6 +136,8 @@ class VMTestEnv(TestEnv):
     def start(self):
         self.domain = ssg_test_suite.virt.connect_domain(
             self.hypervisor, self.domain_name)
+
+        from ssg_test_suite.virt import SnapshotStack
         self.snapshot_stack = SnapshotStack(self.domain)
 
         ssg_test_suite.virt.start_domain(self.domain)
@@ -268,7 +275,7 @@ class DockerTestEnv(ContainerTestEnv):
         try:
             import docker
         except ImportError:
-            raise RuntimeError("Can't import Docker, Docker backend will not work.")
+            raise RuntimeError("Can't import the docker module, Docker backend will not work.")
         try:
             self.client = docker.from_env(version="auto")
             self.client.ping()


### PR DESCRIPTION
- Expanded the Readme on ssh key creation.
- Modified the test suite to be oscap 1.2-1.3 compatible by fixing the --verbose option.
- Removed usage of `Enum`.
- Made the test suite runnable when the `libvirt` module is not installed.