### PR TITLE
Implement the rule for dconf to use only the textfile data backend.

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -43,6 +43,7 @@ selections:
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_dmesg_restrict
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay

--- a/fedora/profiles/pci-dss.profile
+++ b/fedora/profiles/pci-dss.profile
@@ -98,6 +98,7 @@ selections:
     - account_disable_post_pw_expiration
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/linux_os/guide/system/software/gnome/dconf_use_text_backend/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_use_text_backend/ansible/shared.yml
@@ -1,0 +1,16 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+- name: "Force dconf to use the textfiles instead of a binary DB"
+  lineinfile:
+    path: '/etc/dconf/profile/user'
+    regexp: '^service-db:keyfile/user$'
+    line: 'service-db:keyfile/user'
+    insertbefore: 'BOF'
+    create: yes
+  tags:
+    @ANSIBLE_TAGS@
+  @ANSIBLE_ENSURE_PLATFORM@
+

--- a/linux_os/guide/system/software/gnome/dconf_use_text_backend/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_use_text_backend/ansible/shared.yml
@@ -3,13 +3,24 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
-- name: "Force dconf to use the textfiles instead of a binary DB"
+- name: "Remove the existing \"use textfile backend\" directive from the config - it may not be at the file's very top"
+  lineinfile:
+    path: '/etc/dconf/profile/user'
+    regexp: '^service-db:keyfile/user.*'
+    state: 'absent'
+  check_mode: no
+  tags:
+    @ANSIBLE_TAGS@
+  @ANSIBLE_ENSURE_PLATFORM@
+
+- name: "Insert the \" use textfiles backend\" directive at the top of the config file"
   lineinfile:
     path: '/etc/dconf/profile/user'
     regexp: '^service-db:keyfile/user$'
     line: 'service-db:keyfile/user'
     insertbefore: 'BOF'
     create: yes
+  check_mode: no
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/dconf_use_text_backend/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/dconf_use_text_backend/bash/shared.sh
@@ -1,0 +1,10 @@
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora, multi_platform_ol
+
+mkdir -p /etc/dconf/profile
+
+if test -f /etc/dconf/profile/user
+then
+	sed -i '1s|^|service-db:keyfile/user\n|' /etc/dconf/profile/user
+else
+	echo 'service-db:keyfile/user' > /etc/dconf/profile/user
+fi

--- a/linux_os/guide/system/software/gnome/dconf_use_text_backend/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/dconf_use_text_backend/oval/shared.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="compliance" id="dconf_use_text_backend" version="1">
+    <metadata>
+      <title>{{{ full_name }}}</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>dconf should use text files instead of the binary database.</description>
+    </metadata>
+    <criteria operator="OR">
+      <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <criterion comment="check the text backend config directive" test_ref="test_dconf_backend_directive" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="check the text backend config directive"
+  id="test_dconf_backend_directive" version="1">
+    <ind:object object_ref="obj_dconf_backend_config" />
+    <ind:state state_ref="obj_dconf_backend_first_line" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_dconf_backend_config"
+  version="2">
+    <ind:filepath>/etc/dconf/profile/user</ind:filepath>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="obj_dconf_backend_first_line"
+  version="2">
+    <ind:text>service-db:keyfile/user</ind:text>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/linux_os/guide/system/software/gnome/dconf_use_text_backend/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/dconf_use_text_backend/oval/shared.xml
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="dconf_use_text_backend" version="1">
     <metadata>
-      <title>{{{ full_name }}}</title>
+      <title>Force dconf to use the textfiles instead of a binary DB</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>

--- a/linux_os/guide/system/software/gnome/dconf_use_text_backend/rule.yml
+++ b/linux_os/guide/system/software/gnome/dconf_use_text_backend/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: rhel7,rhel8,fedora,ol7,ol8
+
+title: 'Force dconf to use the textfiles instead of a binary DB'
+
+description: |-
+    By default, DConf uses a binary database as a data backend.
+    The database is compiled from config files by the <pre>dconf update</pre> command.
+
+    dconf can be configured to look into those text files directly by inserting the
+    <pre>service-db:keyfile/user</pre>
+    directive at the beginning of the <pre>/etc/dconf/profile/user</pre> file.
+
+rationale: |-
+    Unlike text config files, the binary database is impossible to check by OVAL.
+    Therefore, in order to evaluate dconf configuration, both have to be true at the same time -
+    configuration files have to be compliant, and dconf has to be forced to use them
+    as the primary settings storage.
+
+severity: high
+
+#identifiers:
+#    cce@rhel7:
+
+ocil_clause: 'DConf uses the binary database as data backend'
+
+ocil: |-
+    To verify that the DConf uses text files as data backend,
+    put the line
+    <pre>service-db:keyfile/user</pre>
+    at the top of the
+    file <pre>/etc/dconf/profile/user</pre>
+
+platform: machine

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -108,6 +108,7 @@ selections:
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
     - account_unique_name
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_enabled

--- a/ol7/profiles/stig-ol7-disa.profile
+++ b/ol7/profiles/stig-ol7-disa.profile
@@ -109,6 +109,7 @@ selections:
     - audit_rules_usergroup_modification_opasswd
     - audit_rules_usergroup_modification_passwd
     - audit_rules_usergroup_modification_shadow
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_activation_locked
     - dconf_gnome_screensaver_idle_delay

--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -42,6 +42,7 @@ selections:
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_dmesg_restrict
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay

--- a/ol8/profiles/pci-dss.profile
+++ b/ol8/profiles/pci-dss.profile
@@ -122,6 +122,7 @@ selections:
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
     - account_unique_name
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_enabled

--- a/rhel7/profiles/C2S.profile
+++ b/rhel7/profiles/C2S.profile
@@ -70,6 +70,7 @@ selections:
     - selinux_confinement_of_daemons
     - banner_etc_issue
     - login_banner_text=usgcb_default
+    - dconf_use_text_backend
     - dconf_gnome_login_banner_text
     - dconf_gnome_banner_enabled
     - security_patches_up_to_date

--- a/rhel7/profiles/cjis.profile
+++ b/rhel7/profiles/cjis.profile
@@ -86,6 +86,7 @@ selections:
     - var_password_pam_retry=5
     - var_accounts_passwords_pam_faillock_deny=5
     - var_accounts_passwords_pam_faillock_unlock_time=600
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -28,6 +28,7 @@ selections:
     - service_debug-shell_disabled
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_burstaction
+    - dconf_use_text_backend
     - dconf_gnome_remote_access_credential_prompt
     - dconf_gnome_remote_access_encryption
     - sshd_disable_empty_passwords

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -401,6 +401,7 @@ selections:
     - network_sniffer_disabled
     - network_ipv6_disable_rpc
     - network_ipv6_privacy_extensions
+    - dconf_use_text_backend
     - dconf_gnome_banner_enabled
     - dconf_gnome_disable_automount
     - dconf_gnome_disable_ctrlaltdel_reboot

--- a/rhel7/profiles/ospp42.profile
+++ b/rhel7/profiles/ospp42.profile
@@ -42,6 +42,7 @@ selections:
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_dmesg_restrict
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay

--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -79,6 +79,7 @@ selections:
     - account_disable_post_pw_expiration
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/rhel7/profiles/stig-rhel7-disa.profile
+++ b/rhel7/profiles/stig-rhel7-disa.profile
@@ -57,6 +57,7 @@ selections:
     - rpm_verify_permissions
     - rpm_verify_ownership
     - rpm_verify_hashes
+    - dconf_use_text_backend
     - dconf_gnome_banner_enabled
     - dconf_gnome_login_banner_text
     - banner_etc_issue

--- a/rhel8/profiles/cjis.profile
+++ b/rhel8/profiles/cjis.profile
@@ -86,6 +86,7 @@ selections:
     - var_password_pam_retry=5
     - var_accounts_passwords_pam_faillock_deny=5
     - var_accounts_passwords_pam_faillock_unlock_time=600
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -28,6 +28,7 @@ selections:
     - service_debug-shell_disabled
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_burstaction
+    - dconf_use_text_backend
     - dconf_gnome_remote_access_credential_prompt
     - dconf_gnome_remote_access_encryption
     - sshd_disable_empty_passwords

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -220,6 +220,7 @@ selections:
     ### FMT_MOF_EXT.1 / AC-11(a)
     ### Enable Screen Lock
     - package_tmux_installed
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_lock_delay

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -98,6 +98,7 @@ selections:
     - account_disable_post_pw_expiration
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
+    - dconf_use_text_backend
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_lock_enabled

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_use_text_backend/bad_config.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_use_text_backend/bad_config.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install dconf
+
+mkdir -p /etc/dconf/profile
+
+echo "Something stupid" > /etc/dconf/profile/user
+echo "service-db:keyfile/user" >> /etc/dconf/profile/user

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_use_text_backend/good_config.pass.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_use_text_backend/good_config.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install dconf
+
+mkdir -p /etc/dconf/profile
+echo "service-db:keyfile/user" > /etc/dconf/profile/user
+echo "system-db:local" >> /etc/dconf/profile/user

--- a/tests/data/group_system/group_software/group_gnome/rule_dconf_use_text_backend/no_config.fail.sh
+++ b/tests/data/group_system/group_software/group_gnome/rule_dconf_use_text_backend/no_config.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+yum -y install dconf
+
+rm -f /etc/dconf/profile/user


### PR DESCRIPTION
The rule contains OVAL, bash and Ansible fix.
There are some test scenarios, the Ansible fix for a config file where the `service-db:keyfile/user` line is present lower in the line is failing. It looks like that the `lineinfile` module is not able to do it's job to a full extent.
Usage of this OVAL check in checks for other rules is not in scope of this PR.
Fixes #3736