### PR TITLE
Test suite libvirt fix and Dockerfiles refresh.

### DIFF
--- a/Dockerfiles/test_suite-centos
+++ b/Dockerfiles/test_suite-centos
@@ -6,9 +6,12 @@ ENV AUTH_KEYS=/root/.ssh/authorized_keys
 ARG CLIENT_PUBLIC_KEY
 ARG ADDITIONAL_PACKAGES
 
+# Insall Python so Ansible remediations can work
+# Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner $ADDITIONAL_PACKAGES \
-        && yum clean all \
+        && yum install -y openssh-clients openssh-server openscap-scanner \
+		python \
+		$ADDITIONAL_PACKAGES \
         && true
 
 RUN true \

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -6,9 +6,12 @@ ENV AUTH_KEYS=/root/.ssh/authorized_keys
 ARG CLIENT_PUBLIC_KEY
 ARG ADDITIONAL_PACKAGES
 
+# Insall Python so Ansible remediations can work
+# Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner $ADDITIONAL_PACKAGES \
-        && yum clean all \
+        && yum install -y openssh-clients openssh-server openscap-scanner \
+		python \
+		$ADDITIONAL_PACKAGES \
         && true
 
 RUN true \

--- a/Dockerfiles/test_suite-rhel
+++ b/Dockerfiles/test_suite-rhel
@@ -6,9 +6,12 @@ ENV AUTH_KEYS=/root/.ssh/authorized_keys
 ARG CLIENT_PUBLIC_KEY
 ARG ADDITIONAL_PACKAGES
 
+# Insall Python so Ansible remediations can work
+# Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner $ADDITIONAL_PACKAGES \
-        && yum clean all \
+        && yum install -y openssh-clients openssh-server openscap-scanner \
+		python \
+		$ADDITIONAL_PACKAGES \
         && true
 
 RUN true \

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -134,14 +134,15 @@ class VMTestEnv(TestEnv):
         self._origin = None
 
     def start(self):
-        self.domain = ssg_test_suite.virt.connect_domain(
+        from ssg_test_suite import virt
+
+        self.domain = virt.connect_domain(
             self.hypervisor, self.domain_name)
 
-        from ssg_test_suite.virt import SnapshotStack
-        self.snapshot_stack = SnapshotStack(self.domain)
+        self.snapshot_stack = virt.SnapshotStack(self.domain)
 
-        ssg_test_suite.virt.start_domain(self.domain)
-        self.domain_ip = ssg_test_suite.virt.determine_ip(self.domain)
+        virt.start_domain(self.domain)
+        self.domain_ip = virt.determine_ip(self.domain)
 
         self._origin = self._save_state("origin")
 


### PR DESCRIPTION
Fixed incorrect virt module usage - this was causing crashes when the libvirt backend was required.

Next, Improve Dockerfiles of test suite images:

- Don't remove yum package cache.
- Install Python to enable Ansible operations.