### PR TITLE
Improve error messages of rule based testing

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -85,22 +85,6 @@ def get_file_remote(verbose_path, local_dir, domain_ip, remote_path):
     return success
 
 
-def find_rule_result_in_output(rule_id, output):
-    # oscap --progress options outputs rule results to stdout in following format:
-    # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:pass
-    match = re.findall('^'+rule_id+':(.*)', output, re.MULTILINE)
-    if not match:
-        # When the rule is not selected, it won't match in output
-        return "notselected"
-
-    # When --remediation is executed, there will be two entries in progress output,
-    # one for fail, and one for fixed, e.g.
-    # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:fail
-    # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:fixed
-    # We are interested in the last one
-    return match[-1]
-
-
 def find_result_id_in_output(output):
     match = re.search('result id.*$', output, re.IGNORECASE | re.MULTILINE)
     if match is None:
@@ -451,17 +435,7 @@ class RuleRunner(GenericRunner):
         returncode, self._oscap_output = self.environment.scan(
             self.command_options + self.command_operands, self.verbose_path)
 
-        rule_result = find_rule_result_in_output(self.rule_id, self._oscap_output)
-
-        if rule_result != self.context:
-            msg = (
-                'Rule evaluation resulted in {0}, '
-                'instead of expected {1} during {2} stage '
-                .format(rule_result, self.context, self.stage)
-            )
-            LogHelper.preload_log(logging.ERROR, msg, 'fail')
-            return False
-        return True
+        return self._analyze_output_of_oscap_call()
 
     def final(self):
         success = super(RuleRunner, self).final()
@@ -469,27 +443,44 @@ class RuleRunner(GenericRunner):
 
         return success
 
+
+    def _find_rule_result_in_output(self):
+        # oscap --progress options outputs rule results to stdout in following format:
+        # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:pass
+        match = re.findall('{0}:(.*)$'.format(self.rule_id),
+                                    self._oscap_output,
+                                    re.MULTILINE)
+
+        if not match:
+            # When the rule is not selected, it won't match in output
+            return "notselected"
+
+        # When --remediation is executed, there will be two entries in progress output,
+        # one for fail, and one for fixed, e.g.
+        # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:fail
+        # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:fixed
+        # We are interested in the last one
+        return match[-1]
+
+
     def _analyze_output_of_oscap_call(self):
         local_success = True
         # check expected result
-        actual_results = re.findall('{0}:(.*)$'.format(self.rule_id),
-                                    self._oscap_output,
-                                    re.MULTILINE)
-        if actual_results:
-            if self.context not in actual_results:
-                LogHelper.preload_log(logging.ERROR,
-                                      ('Rule result should have been '
-                                       '"{0}", but is "{1}"!'
-                                       ).format(self.context,
-                                                ', '.join(actual_results)),
-                                      'fail')
-                local_success = False
-        else:
-            msg = (
-                'Rule {0} has not been evaluated! Wrong profile selected?'
-                .format(self.rule_id))
-            LogHelper.preload_log(logging.ERROR, msg, 'fail')
+        rule_result = self._find_rule_result_in_output()
+
+        if rule_result != self.context:
             local_success = False
+            if rule_result is 'notselected':
+                msg = (
+                    'Rule {0} has not been evaluated! Wrong profile selected in test scenario?'
+                    .format(self.rule_id))
+            else:
+                msg = (
+                    'Rule evaluation resulted in {0}, '
+                    'instead of expected {1} during {2} stage '
+                    .format(rule_result, self.context, self.stage)
+                )
+            LogHelper.preload_log(logging.ERROR, msg, 'fail')
         return local_success
 
     def _get_formatting_dict_for_remediation(self):

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -89,8 +89,9 @@ def find_rule_result_in_output(rule_id, output):
     # oscap --progress options outputs rule results to stdout in following format:
     # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:pass
     match = re.findall('^'+rule_id+':(.*)', output, re.MULTILINE)
-    if match is None:
-        return None
+    if not match:
+        # When the rule is not selected, it won't match in output
+        return "notselected"
 
     # When --remediation is executed, there will be two entries in progress output,
     # one for fail, and one for fixed, e.g.

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -443,25 +443,24 @@ class RuleRunner(GenericRunner):
 
         return success
 
-
     def _find_rule_result_in_output(self):
-        # oscap --progress options outputs rule results to stdout in following format:
-        # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:pass
+        # oscap --progress options outputs rule results to stdout in
+        # following format:
+        # xccdf_org....rule_accounts_password_minlen_login_defs:pass
         match = re.findall('{0}:(.*)$'.format(self.rule_id),
-                                    self._oscap_output,
-                                    re.MULTILINE)
+                           self._oscap_output,
+                           re.MULTILINE)
 
         if not match:
             # When the rule is not selected, it won't match in output
             return "notselected"
 
-        # When --remediation is executed, there will be two entries in progress output,
-        # one for fail, and one for fixed, e.g.
-        # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:fail
-        # xccdf_org.ssgproject.content_rule_accounts_password_minlen_login_defs:fixed
+        # When --remediation is executed, there will be two entries in
+        # progress output, one for fail, and one for fixed, e.g.
+        # xccdf_org....rule_accounts_password_minlen_login_defs:fail
+        # xccdf_org....rule_accounts_password_minlen_login_defs:fixed
         # We are interested in the last one
         return match[-1]
-
 
     def _analyze_output_of_oscap_call(self):
         local_success = True
@@ -472,7 +471,8 @@ class RuleRunner(GenericRunner):
             local_success = False
             if rule_result is 'notselected':
                 msg = (
-                    'Rule {0} has not been evaluated! Wrong profile selected in test scenario?'
+                    'Rule {0} has not been evaluated! '
+                    'Wrong profile selected in test scenario?'
                     .format(self.rule_id))
             else:
                 msg = (
@@ -511,7 +511,9 @@ class AnsibleProfileRunner(ProfileRunner):
         formatting['playbook'] = os.path.join(LogHelper.LOG_DIR,
                                               formatting['output_file'])
 
-        return run_stage_remediation_ansible('profile', formatting, self.verbose_path)
+        return run_stage_remediation_ansible('profile',
+                                             formatting,
+                                             self.verbose_path)
 
 
 class BashProfileRunner(ProfileRunner):


### PR DESCRIPTION
#### Description:

- Make explicit what is the expected actual rule result, and what is the
expected rule result.

#### Rationale:

- It is not clear what exit code 0, 1 or 2 means.
- Also, exit code 0 can imply `pass`, `notapplicable` or `fixed`.

##### Example output

```
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/wsato/git/scap-security-guide/tests/logs/rule-custom-2019-02-04-1751/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_configure_bind_crypto_policy
ERROR - Script no_config_file.fail.sh using profile xccdf_org.ssgproject.content_profile_standard found issue:
ERROR - Rule evaluation resulted in notchecked, instead of expected fail during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_configure_bind_crypto_policy'.
ERROR - Script no_config_file.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp found issue:
ERROR - Rule evaluation resulted in notchecked, instead of expected fail during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_configure_bind_crypto_policy'.
ERROR - Script ok.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp found issue:
ERROR - Rule evaluation resulted in notchecked, instead of expected pass during initial stage 
```
Output when test scenario execution is successful did not change.

- Fixes #3630