### PR TITLE
Auto select test suite xccdf-id

### DIFF
--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -13,6 +13,20 @@ NAMESPACES = {
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
+def get_all_xccdf_ids_in_datastream(datastream):
+    root = ET.parse(datastream).getroot()
+
+    checklists_node = root.find(".//ds:checklists", NAMESPACES)
+    if checklists_node is None:
+        logging.error(
+            "Checklists not found within DataStream")
+
+    all_checklist_components = checklists_node.findall('ds:component-ref',
+                                                       NAMESPACES)
+    xccdf_ids = [component.get("id") for component in all_checklist_components]
+    return xccdf_ids
+
+
 def infer_benchmark_id_from_component_ref_id(datastream, ref_id):
     root = ET.parse(datastream).getroot()
     component_ref_node = root.find("*//ds:component-ref[@id='{0}']"

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -159,6 +159,10 @@ def auto_select_xccdf_id(datastream, bench_number):
     xccdf_ids = xml_operations.get_all_xccdf_ids_in_datastream(datastream)
     n_xccdf_ids = len(xccdf_ids)
 
+    if n_xccdf_ids == 0:
+        msg = ("The provided DataStream doesn't contain any Benchmark")
+        raise RuntimeError(msg)
+
     if n_xccdf_ids > 1:
         logging.info("The DataStream contains {0} "
                      "Benchmarks".format(n_xccdf_ids))

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -45,13 +45,14 @@ def parse_args():
                                required=True,
                                help=("Path to the Source DataStream on this "
                                      "machine which is going to be tested"))
-    common_parser.add_argument("--xccdf-id",
+    benchmarks = common_parser.add_mutually_exclusive_group()
+    benchmarks.add_argument("--xccdf-id",
                                dest="xccdf_id",
                                metavar="REF-ID",
                                default=None,
                                help="Reference ID related to benchmark to "
                                     "be used.")
-    common_parser.add_argument("--xccdf-id-number",
+    benchmarks.add_argument("--xccdf-id-number",
                                dest="xccdf_id_number",
                                metavar="REF-ID-SELECT",
                                type=int,

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -155,6 +155,10 @@ def get_logging_dir(options):
 
     return logging_dir
 
+def _print_available_benchmarks(xccdf_ids, n_xccdf_ids):
+    logging.info("The DataStream contains {0} Benchmarks".format(n_xccdf_ids))
+    for i in range(0, n_xccdf_ids):
+        logging.info("{0} - {1}".format(i, xccdf_ids[i]))
 
 def auto_select_xccdf_id(datastream, bench_number):
     xccdf_ids = xml_operations.get_all_xccdf_ids_in_datastream(datastream)
@@ -164,17 +168,17 @@ def auto_select_xccdf_id(datastream, bench_number):
         msg = ("The provided DataStream doesn't contain any Benchmark")
         raise RuntimeError(msg)
 
-    if n_xccdf_ids > 1:
-        logging.info("The DataStream contains {0} "
-                     "Benchmarks".format(n_xccdf_ids))
-        for i in range(0, n_xccdf_ids):
-            logging.info("{0} - {1}".format(i, xccdf_ids[i]))
-
+    if bench_number < 0 or bench_number >= n_xccdf_ids:
+        _print_available_benchmarks(xccdf_ids, n_xccdf_ids)
         logging.info("Selected Benchmark is {0}".format(bench_number))
-        if bench_number < 0 or bench_number >= n_xccdf_ids:
-            msg = ("Please select a Benchmark number "
-                   "between 0 and {0}.".format(n_xccdf_ids-1))
-            raise RuntimeError(msg)
+
+        msg = ("Please select a valid Benchmark number")
+        raise RuntimeError(msg)
+
+    if n_xccdf_ids > 1:
+        _print_available_benchmarks(xccdf_ids, n_xccdf_ids)
+        logging.info("Selected Benchmark is {0}".format(bench_number))
+
         logging.info("To select a different Benchmark, "
                      "use --xccdf-id-number option.")
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -48,7 +48,7 @@ def parse_args():
     common_parser.add_argument("--xccdf-id",
                                dest="xccdf_id",
                                metavar="REF-ID",
-                               required=True,
+                               default=None,
                                help="Reference ID related to benchmark to be used."
                                     " Get one using 'oscap info <datastream>'.")
     common_parser.add_argument("--loglevel",
@@ -148,11 +148,22 @@ def get_logging_dir(options):
     return logging_dir
 
 
+def auto_select_xccdf_id(datastream):
+    xccdf_ids = xml_operations.get_all_xccdf_ids_in_datastream(datastream)
+    if len(xccdf_ids) > 1:
+        logging.info("{0} Benchmarks found in DataStream, "
+                     "we will default to the first one: "
+                     "{1}".format(len(xccdf_ids), xccdf_ids[0]))
+    return xccdf_ids[0]
+
+
 def normalize_passed_arguments(options):
     if 'ALL' in options.target:
         options.target = ['ALL']
 
     try:
+        if options.xccdf_id is None:
+            options.xccdf_id = auto_select_xccdf_id(options.datastream)
         bench_id = xml_operations.infer_benchmark_id_from_component_ref_id(
             options.datastream, options.xccdf_id)
         options.benchmark_id = bench_id


### PR DESCRIPTION
#### Description:

- TestSuite will default to first Benchmark in DataStream
- TestSuite offers non-interactive numeric selection of Benchmark

#### Rationale:

- Dealing with `xccdf-ids` is cumbersome and tedious.
