### PR TITLE
Enable OL support for new rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf
       to none to prevent a reboot if Ctrl-Alt-Delete is pressed more than 7 times in 2 seconds.</description>

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'Disable Ctrl-Alt-Del Burst Action'
 

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,7 +1,9 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 {{%- if init_system == "systemd" -%}}
+{{% if product in ["rhel7", "rhel8"] %}}
 # The process to disable ctrl+alt+del has changed in RHEL7. 
 # Reference: https://access.redhat.com/solutions/1123873
+{{% endif %}}
 systemctl mask ctrl-alt-del.target
 {{%- else -%}}
 # If system does not contain control-alt-delete.override,

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
@@ -8,6 +8,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>By default, the system will reboot when the
       Ctrl-Alt-Del key sequence is pressed.</description>

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Disable Ctrl-Alt-Del Reboot Activation'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_flush
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Auditd priority for flushing data to disk</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The setting for flush in /etc/audit/auditd.conf</description>
     </metadata>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Configure auditd flush priority'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Disable Modprobe Loading of USB Storage Driver'
 

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8
 
 title: 'Encrypt Partitions'
 
@@ -29,7 +29,7 @@ description: |-
     <br /><br />
     Detailed information on encrypting partitions using LUKS or LUKS ciphers can be found on
     the {{{ full_name }}} Documentation web site:<br />
-    {{% if product == "ol7" %}}
+    {{% if product in ["ol7", "ol8"] %}}
         {{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54670/html/ol7-encrypt-sec.html") }}}.
     {{% else %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html") }}}.

--- a/ol7/templates/csv/kernel_modules_disabled.csv
+++ b/ol7/templates/csv/kernel_modules_disabled.csv
@@ -1,3 +1,4 @@
 bluetooth
 dccp
 sctp
+usb-storage

--- a/ol7/templates/csv/sysctl_values.csv
+++ b/ol7/templates/csv/sysctl_values.csv
@@ -1,5 +1,6 @@
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
+fs.suid_dumpable,0
 kernel.dmesg_restrict,1
 kernel.kexec_load_disabled,1
 kernel.kptr_restrict,1

--- a/ol8/templates/csv/kernel_modules_disabled.csv
+++ b/ol8/templates/csv/kernel_modules_disabled.csv
@@ -1,3 +1,4 @@
 bluetooth
 dccp
 sctp
+usb-storage

--- a/ol8/templates/csv/sysctl_values.csv
+++ b/ol8/templates/csv/sysctl_values.csv
@@ -1,5 +1,6 @@
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
+fs.suid_dumpable,0
 kernel.dmesg_restrict,1
 kernel.kexec_load_disabled,1
 kernel.kptr_restrict,1


### PR DESCRIPTION
#### Description:
Extended OL support for rules:
- sysctl_fs_suid_dumpable rule
- auditd_data_retention_flush rule
- kernel_module_usb-storage_disabled rule
- encrypt_partitions rule
- disable_ctrlaltdel rules set

#### Rationale:
Extend OL rules set for planned profiles

#### Testing
- checked ol8, ol7 and all build targets to pass
- checked rules content and evaluation results on target system
