### PR TITLE
Enable OL selinux rules

### DIFF
--- a/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>
         Check if selinux=0 OR enforcing=0 within the GRUB2 configuration files, fail if found.

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Ensure SELinux Not Disabled in /etc/default/grub'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'Disable the selinuxuser_execheap SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execmod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'Enable the selinuxuser_execmod SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'disable the selinuxuser_execstack SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/var_selinuxuser_execstack.var
+++ b/linux_os/guide/system/selinux/selinux-booleans/var_selinuxuser_execstack.var
@@ -14,6 +14,6 @@ operator: equals
 interactive: false
 
 options:
-    default: true
+    default: false
     off: false
     on: true

--- a/ol7/templates/csv/selinux_booleans.csv
+++ b/ol7/templates/csv/selinux_booleans.csv
@@ -1,0 +1,5 @@
+# Add <selinux_boolean_name, desired_value> to generate hard-coded OVAL content.
+# Add <selinux_boolean_name, use_var> to generate OVAL content that use XCCDF values.
+selinuxuser_execheap,use_var
+selinuxuser_execmod,use_var
+selinuxuser_execstack,use_var

--- a/ol8/templates/csv/selinux_booleans.csv
+++ b/ol8/templates/csv/selinux_booleans.csv
@@ -1,0 +1,5 @@
+# Add <selinux_boolean_name, desired_value> to generate hard-coded OVAL content.
+# Add <selinux_boolean_name, use_var> to generate OVAL content that use XCCDF values.
+selinuxuser_execheap,use_var
+selinuxuser_execmod,use_var
+selinuxuser_execstack,use_var

--- a/shared/templates/template_ANSIBLE_sebool
+++ b/shared/templates/template_ANSIBLE_sebool
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/template_ANSIBLE_sebool_var
+++ b/shared/templates/template_ANSIBLE_sebool_var
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/template_BASH_sebool
+++ b/shared/templates/template_BASH_sebool
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/template_BASH_sebool_var
+++ b/shared/templates/template_BASH_sebool_var
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/template_OVAL_sebool
+++ b/shared/templates/template_OVAL_sebool
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The SELinux "{{{ SEBOOLID }}}" boolean should be set in the system configuration.</description>
     </metadata>

--- a/shared/templates/template_OVAL_sebool_var
+++ b/shared/templates/template_OVAL_sebool_var
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>The SELinux "{{{ SEBOOLID }}}" boolean should be set in the system configuration.</description>
     </metadata>


### PR DESCRIPTION
#### Description:

Added OL support to selinux rules set

Changes:
- Added ol7, ol8 prodtype to applicable rules
- Added OL support to selinux templates
- Fixed var_selinuxuser_execstack.var default value

#### Testing:
- checked ol8, ol7 and all build targets to pass
- checked rules content and evaluation on target system

