### PR TITLE
Add OL support for set of dconf, r_services, network and kerberos rules

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/oval/shared.xml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/oval/shared.xml
@@ -4,6 +4,8 @@
       <title>Use Kerberos Security on All Exports</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Using Kerberos Security allows to cryptography authenticate a
       valid user to an NFS share.</description>

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'Use Kerberos Security on All Exports'
 

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ol
 find /home -maxdepth 2 -type f -name .rhosts -exec rm -f '{}' \;
 
 if [ -f /etc/hosts.equiv ]; then

--- a/linux_os/guide/system/network/network-ipsec/libreswan_approved_tunnels/rule.yml
+++ b/linux_os/guide/system/network/network-ipsec/libreswan_approved_tunnels/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Verify Any Configured IPSec Tunnel Connections'
 

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Configure GNOME3 to require credential prompting for remote access.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Require Credential Prompting for Remote Access in GNOME3'
 

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Configure GNOME3 to require encryption for remote access connections.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Require Encryption for Remote Access in GNOME3'
 


### PR DESCRIPTION
#### Description:

Extended OL support for rules:
- libreswan_approved_tunnels rule
- no_rsh_trust_files remediation scripts 
- gnome_remote_access_settings rules
- use_kerberos_security_all_exports rule
- moved use_kerberos_security_all_exports OVAL to shared

#### Rationale:
OL8 HIPAA profile enabling

#### Testing:
- checked ol8, ol7 and all build targets to pass
- checked rules content and evaluation on target system

