### PR TITLE
Update crypto-policy check for nss.config

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -55,11 +55,11 @@
       {{{ crypto_policy_symlink_criterion(library="java") }}}
       {{{ crypto_policy_symlink_criterion(library="krb5") }}}
       {{{ crypto_policy_symlink_criterion(library="libreswan") }}}
-      {{{ crypto_policy_symlink_criterion(library="nss") }}}
       {{{ crypto_policy_symlink_criterion(library="openssh") }}}
       {{{ crypto_policy_symlink_criterion(library="opensshserver") }}}
       {{{ crypto_policy_symlink_criterion(library="openssl") }}}
   {{% endif %}}
+      <criterion comment="Check if /etc/crypto-policies/back-ends/nss.config exists" test_ref="test_crypto_policy_nss_config" />
     </criteria>
   </definition>
 
@@ -145,6 +145,13 @@ id="object_crypto_policies_config_file_modified_time" version="1">
   {{{ crypto_policy_symlink_check(library="opensshserver") }}}
   {{{ crypto_policy_symlink_check(library="openssl") }}}
 {{% endif %}}
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Check if /etc/crypto-policies/back-ends/nss.config exists" id="test_crypto_policy_nss_config" version="1">
+    <unix:object object_ref="object_crypto_policy_nss_config" />
+  </unix:file_test>
+  <unix:file_object id="object_crypto_policy_nss_config" version="1">
+    <unix:filepath>/etc/crypto-policies/back-ends/nss.config</unix:filepath>
+  </unix:file_object>
 
   <external_variable comment="defined crypto policy" datatype="string"
   id="var_system_crypto_policy" version="1" />

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_nss_config.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/missing_nss_config.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+update-crypto-policies --set "FIPS"
+
+rm -f "/etc/crypto-policies/back-ends/nss.config"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/nss_config_as_file.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/nss_config_as_file.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+update-crypto-policies --set "FIPS"
+
+CRYPTO_POLICY_LIB_FILE="/etc/crypto-policies/back-ends/nss.config"
+SYMLINK_TO_FOLDER="/usr/share/crypto-policies/FIPS/"
+SYMLINK_TO_FILE="nss.txt"
+rm -f $CRYPTO_POLICY_LIB_FILE
+mkdir -p $SYMLINK_TO_FOLDER
+cp $SYMLINK_TO_FOLDER$SYMLINK_TO_FILE $CRYPTO_POLICY_LIB_FILE

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/nss_config_as_symlink.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/nss_config_as_symlink.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = multi_platform_fedora, Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+update-crypto-policies --set "FIPS"
+
+CRYPTO_POLICY_LIB_FILE="/etc/crypto-policies/back-ends/nss.config"
+SYMLINK_TO_FOLDER="/usr/share/crypto-policies/FIPS/"
+SYMLINK_TO_FILE="nss.txt"
+rm -f $CRYPTO_POLICY_LIB_FILE
+mkdir -p $SYMLINK_TO_FOLDER
+ln -s $SYMLINK_TO_FOLDER$SYMLINK_TO_FILE $CRYPTO_POLICY_LIB_FILE


### PR DESCRIPTION
#### Description:

- Change rule `configure_crypto_policy` to only check for existence of `/etc/crypto-policies/back-ends/nss.config`.
- The rule will pass if `/etc/crypto-policies/back-ends/nss.config` exists, be it a symlink or a file.

#### Rationale:
- Crypto-policy configuration for `NSS` doesn't use symlinks anymore, it copies the back-end policy file.