### PR TITLE
Add warning about dependent rule to dconf rules.

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
@@ -28,6 +28,10 @@ rationale: |-
 
 severity: high
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 identifiers:
     cce@rhel7: 80107-6
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
@@ -27,6 +27,10 @@ rationale: |-
 
 severity: medium
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 identifiers:
     cce@rhel7: 80106-8
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
@@ -26,6 +26,10 @@ rationale: |-
 
 severity: medium
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 identifiers:
     cce@rhel7: 80108-4
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/rule.yml
@@ -27,6 +27,10 @@ rationale: |-
 
 severity: medium
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 identifiers:
     cce@rhel7: 80109-2
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
@@ -31,6 +31,10 @@ rationale: |-
 
 severity: unknown
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 identifiers:
     cce@rhel7: 80122-5
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
@@ -30,6 +30,10 @@ rationale: |-
 
 severity: unknown
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 identifiers:
     cce@rhel7: 80123-3
 

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
@@ -24,6 +24,10 @@ rationale: |-
 
 severity: medium
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 identifiers:
     cce@rhel7: 80118-3
 

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
@@ -24,6 +24,10 @@ rationale: |-
     Wireless network connections should not be allowed to be configured by general
     users on a given system as it could open the system to backdoor attacks.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
@@ -22,6 +22,10 @@ rationale: |-
     Username and password prompting is required for remote access. Otherwise, non-authorized
     and nefarious users can access the system freely.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
@@ -22,6 +22,10 @@ rationale: |-
     Open X displays allow an attacker to capture keystrokes and to execute commands
     remotely.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
@@ -29,6 +29,10 @@ rationale: |-
     login session does not have administrator rights and the display station is located in a
     controlled-access area.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/rule.yml
@@ -16,6 +16,10 @@ rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
     of the information system but does not want to logout because of the temporary nature of the absense.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -26,6 +26,10 @@ rationale: |-
     system session prior to vacating the vicinity, GNOME3 can be configured to identify when
     a user's session has idled and take action to initiate a session lock.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -21,6 +21,10 @@ rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
     of the information system but does not want to logout because of the temporary nature of the absense.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -21,6 +21,10 @@ rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
     of the information system but does not want to logout because of the temporary nature of the absense.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
@@ -16,6 +16,10 @@ rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
     of the information system but does not want to logout because of the temporary nature of the absense.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
@@ -21,6 +21,10 @@ rationale: |-
     Setting the screensaver mode to blank-only conceals the
     contents of the display from passersby.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: unknown
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
@@ -23,6 +23,10 @@ rationale: |-
     Setting the splash screen to not reveal the logged in user's name
     conceals who has access to the system from passersby.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: unknown
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
@@ -19,6 +19,10 @@ rationale: |-
     GNOME desktops can be configured to identify when a user's session has idled and take action to initiate the
     session lock. As such, users should not be allowed to change session settings.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
@@ -19,6 +19,10 @@ rationale: |-
     GNOME desktops can be configured to identify when a user's session has idled and take action to initiate the
     session lock. As such, users should not be allowed to change session settings.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
@@ -26,6 +26,10 @@ rationale: |-
     the case of mixed OS environment, this can create the risk of short-term
     loss of availability of systems due to unintentional reboot.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: high
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
@@ -29,6 +29,10 @@ rationale: |-
     Enabling power settings on non-mobile devices could have unintended processing
     consequences on standard systems.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/rule.yml
@@ -24,6 +24,10 @@ rationale: |-
     Enabling power settings on non-mobile devices could have unintended processing
     consequences on standard systems.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
@@ -26,6 +26,10 @@ rationale: |-
     unintended configuration changes as well as a nefarious user the capability to make system
     changes such as adding new accounts, etc.
 
+warnings:
+    - dependency: |-
+        {{{ body_of_dconf_warning_about_dependent_rule() }}}
+
 severity: high
 
 identifiers:

--- a/shared/macros-highlevel.jinja
+++ b/shared/macros-highlevel.jinja
@@ -133,3 +133,10 @@
         JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
+
+
+{{% macro body_of_dconf_warning_about_dependent_rule() -%}}
+	{{{ body_of_warning_about_dependent_rule(
+		rule_id="dconf_use_text_backend",
+		why="<code>dconf</code>-related rules can't be checked by <code>OVAL</code> if <code>dconf</code> is using a binary database as it's data backend. <code>dconf</code> has to be forced to use config files directly as backend, as those config files are checked by <code>OVAL</code> probes.") }}}
+{{%- endmacro %}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -546,3 +546,13 @@ ocil_clause: "the correct value is not returned"
         <a xmlns='http://www.w3.org/1999/xhtml' href='{{{ link }}}'>{{{ link }}}</a>
     {{%- endif %}}
 {{%- endmacro %}}
+
+
+{{% macro body_of_warning_about_dependent_rule(rule_id, why) -%}}
+        When selecting this rule in a profile, 
+        {{%- if why %}}
+            make sure that rule with ID <code>{{{ rule_id }}}</code> is selected as well: {{{ why }}}
+        {{%- else %}}
+            rule <code>{{{ rule_id }}}</code> has to be selected as well.
+        {{%- endif %}}
+{{% endmacro %}}


### PR DESCRIPTION
At the moment, dconf rules are about text config files, while dconf uses binary database as the backend by default. Extending the OVAL of other rules with the backend check is not a good solution, as it complicates tests, remediations and debugging of what went wrong.
Therefore, we thought of a compromise - let's put a warning to the rule description, which this PR does.