### PR TITLE
Remove SSH option 'GSSAPIAuthentication=no' from the test suite

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -143,7 +143,7 @@ def main():
         print("sudo virsh domifaddr {0}\n".format(data.domain))
     else:
         print("arp -n | grep $(virsh -q domiflist {0} | awk '{{print $5}}')\n".format(data.domain))
-    print("To connect to the {0} VM use:\nssh {1} root@IP".format(data.domain, "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GSSAPIAuthentication=no"))
+    print("To connect to the {0} VM use:\nssh {1} root@IP".format(data.domain, "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"))
     print("If you have used the `--ssh-pubkey` also add '-o IdentityFile=PATH_TO_PRIVATE_KEY' option to your ssh command")
     print("and export the SSH_ADDITIONAL_OPTIONS='-o IdentityFile=PATH_TO_PRIVATE_KEY' before running the SSG Test Suite.")
     if data.libvirt == "qemu:///system":

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -24,7 +24,6 @@ except AttributeError:
 SSH_ADDITIONAL_OPTS = (
     "-o", "StrictHostKeyChecking=no",
     "-o", "UserKnownHostsFile=/dev/null",
-    "-o", "GSSAPIAuthentication=no",
 ) + SSH_ADDITIONAL_OPTS
 
 


### PR DESCRIPTION
#### Description:

- The `GSSAPIAuthentication=no` ssh option set by the test suite is causing that in some cases it is needed to enter a password when accessing a VM.