### PR TITLE
Update upload_ansible_roles_to_galaxy.py script

### DIFF
--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -299,7 +299,7 @@ class Role(object):
 
         self.add_variables_to_tasks()
         self.tasks_local_content = yaml.dump(
-            self.tasks_data, width=120, indent=4, default_flow_style=False)
+            self.tasks_data, width=120, default_flow_style=False)
 
         self._reformat_local_content()
         try:

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -230,7 +230,7 @@ class Role(object):
                                        default_flow_style=False)
 
         if vars_local_content != vars_remote_content.decoded_content and \
-            vars_local_content.splitlines()[0] != "null":
+           vars_local_content.splitlines()[0] != "null":
             self.remote_repo.update_file(
                 "/vars/main.yml",
                 "Updates vars/main.yml",
@@ -361,7 +361,6 @@ def locally_clone_and_init_repositories(organization, repo_list):
 
 def main():
     args = parse_args()
-    repo_status = "update"
 
     all_role_whitelist = {"rhel7-role-%s" % p for p in PROFILE_WHITELIST}
     role_whitelist = set(all_role_whitelist)

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -229,7 +229,8 @@ class Role(object):
         vars_local_content = yaml.dump(self.vars_data, width=120, indent=4,
                                        default_flow_style=False)
 
-        if vars_local_content != vars_remote_content.decoded_content:
+        if vars_local_content != vars_remote_content.decoded_content and \
+            vars_local_content.splitlines()[0] != "null":
             self.remote_repo.update_file(
                 "/vars/main.yml",
                 "Updates vars/main.yml",


### PR DESCRIPTION
- Only update readme and meta when the repo is new. Readme and metadata
  will drift from the template to meet new Galaxy 3 ansible formatting
  requirements as well as line up correct repo tagging.
- Use ComplianceAsCode GH site for homepage so that users know
  where to go for ComplianceAsCode issues and content.