### PR TITLE
ensure yum repos have valid section header

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -8,6 +8,7 @@
   find:
     paths: "/etc/yum.repos.d/"
     patterns: "*.repo"
+    contains: ^\[.+]$
   register: yum_find
 
 - name: Ensure gpgcheck Enabled For All {{{ pkg_manager }}} Package Repositories


### PR DESCRIPTION
#### Description:
- This adds a rule to check for a [header] in the file before requiring that gpgcheck=1 is in existence.

#### Rationale:

- Files under yum.repos.d may not have any content (e.g., redhat.repo can be empty), so adding an orphaned gpgcheck=1 will break yum and subsequent tasks.
