### PR TITLE
Fix dracut-fips check indentation

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
@@ -7,6 +7,6 @@
   package:
     name: dracut-fips
     state: present
-    when: ansible_distribution == 'Red Hat Enterprise Linux' and @ANSIBLE_PLATFORM_CONDITION@
+  when: ansible_distribution == 'Red Hat Enterprise Linux' and @ANSIBLE_PLATFORM_CONDITION@
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- Removes incorrect indention on when conditional.

#### Rationale:

- Indention for the when conditional was incorrect, causing this task to fail.