### PR TITLE
Check existence of pkcs11-switch

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
@@ -3,17 +3,22 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+-   name: Check existence of pkcs11-switch
+    stat:
+        path: /usr/bin/pkcs11-switch
+    register: pkcs11switch
 
 - name: Get NSS database smart card configuration
   command: /usr/bin/pkcs11-switch
   changed_when: True
   register: pkcsw_output
+  when: pkcs11switch.stat.exists
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "@RULE_TITLE@"
   command: /usr/bin/pkcs11-switch opensc
-  when: pkcsw_output.stdout != "opensc" and @ANSIBLE_PLATFORM_CONDITION@
+  when: pkcs11switch.stat.exists and pkcsw_output.stdout != "opensc" and @ANSIBLE_PLATFORM_CONDITION@
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- Check existence of pkcs11-switch

#### Rationale:

- If system does not have pkcs11-switch, it cannot run the preceding tasks which rely on that file. This checks for the existence first.