### PR TITLE
fix Ansible remediation for 'Disable SSH Support for User Known Hosts' #3645

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
@@ -9,6 +9,8 @@
     dest: /etc/ssh/sshd_config
     regexp: ^IgnoreUserKnownHosts
     line: IgnoreUserKnownHosts yes
+    insertbefore: ^Match
+    firstmatch: yes 
     validate: sshd -t -f %s
   #notify: restart sshd
   tags:


### PR DESCRIPTION
#### Description:
This small patch will fix Ansible remediation for 'Disable SSH Support for User Known Hosts'

N.B.: the `firstmatch` parameter in `lineinfile` module has been added in ansible 2.5. 
Do we specify somewhere a minimum required version for Ansible remediations? By the way, Ansible versions older than 2.5 are unsupported.

#### Rationale:

- Fixes #3645 