### PR TITLE
Update the rule security_patches_up_to_date for RHEL8

### DIFF
--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel6,rhel7,rhel8,ubuntu1404,ubuntu1604,ol7,ol8
 title: 'Ensure Software Patches Installed'
 
 description: |-
-{{% if product in ["rhel6", "rhel7"] %}}
+{{% if product in ["rhel6", "rhel7", "rhel8"] %}}
     If the system is joined to the Red Hat Network, a Red Hat Satellite Server,
     or a yum server, run the following command to install updates:
     <pre>$ sudo yum update</pre>
@@ -60,6 +60,8 @@ references:
 oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL6.xml.bz2"
 {{% elif product == "rhel7" %}}
 oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2"
+{{% elif product == "rhel8" %}}
+oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2"
 {{% elif product == "ubuntu1404" %}}
 oval_external_content: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml"
 {{% elif product == "ubuntu1604" %}}
@@ -74,7 +76,7 @@ ocil_clause: 'updates are not installed'
 
 {{# TODO: What about non-rpm systems? #}}
 ocil: |-
-{{% if product in ["rhel6", "rhel7"] %}}
+{{% if product in ["rhel6", "rhel7", "rhel8"] %}}
     If the system is joined to the Red Hat Network, a Red Hat Satellite Server, or
     a yum server which provides updates, invoking the following command will
     indicate if updates are available:
@@ -88,12 +90,12 @@ ocil: |-
     run the following command to list when each package was last updated:
     <pre>$ rpm -qa -last</pre>
     <br /><br />
-{{% if product in ["rhel6", "rhel7"] %}}
+{{% if product in ["rhel6", "rhel7", "rhel8"] %}}
     Compare this to Red Hat Security Advisories (RHSA) listed at
-    {{{ weblink(link="https://access.redhat.com/security/updates/active/") }}}
+    https://access.redhat.com/security/updates/active/
     to determine if the system is missing applicable updates.
 {{% elif product in ["ol7", "ol8"] %}}
     Compare this to Oracle Linux Security Advisories (ELSA) listed at
-    {{{ weblink(link="https://linux.oracle.com/pls/apex/f?p=105:21:::NO:RP::") }}}
+    https://linux.oracle.com/pls/apex/f?p=105:21:::NO:RP::
     to determine if the system is missing applicable updates.
 {{% endif %}}


### PR DESCRIPTION
#### Description:

Adds description, link to RHSA OVAL and OCIL content to RHEL8.

Also removes weblink macros from the OCIL content because they are not processed properly in OCIL.

The URL https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2 doesn't work, because there is no RHEL 8 erratum because RHEL 8 hasn't been released, but we guess that it will be similar as RHEL6 and RHEL7.

#### Rationale:
The rule was missing the description in the result datastream and there was no link to the actual OVAL content which will mean that the rule won't be checked.