### PR TITLE
Remove out-of-date crypto rules from RHEL8/Fedora builds

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Use Only Approved Ciphers</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
+        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Oracle Linux 7</platform>
       </affected>
       <description>Limit the ciphers to those which are FIPS-approved.</description>
     </metadata>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6,rhel7,ol7
+
 title: 'Use Only FIPS 140-2 Validated Ciphers'
 
 description: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -3,9 +3,9 @@
     <metadata>
       <title>Use Only FIPS MACs</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
+        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Oracle Linux 7</platform>
       </affected>
       <description>Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.</description>
     </metadata>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6,rhel7,ol7
+
 title: 'Use Only FIPS 140-2 Validated MACs'
 
 description: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
@@ -3,7 +3,9 @@
     <metadata>
       <title>Use Only Strong Ciphers</title>
       <affected family="unix">
-        <platform>multi_platform_all</platform>
+        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Oracle Linux 7</platform>
       </affected>
       <description>Only use strong ciphers.</description>
     </metadata>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6,rhel7,ol7
+
 title: 'Use Only Strong Ciphers'
 
 description: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/oval/shared.xml
@@ -3,7 +3,9 @@
     <metadata>
       <title>Use Only Strong MACs</title>
       <affected family="unix">
-        <platform>multi_platform_all</platform>
+        <platform>Red Hat Enterprise Linux 6</platform>
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Oracle Linux 7</platform>
       </affected>
       <description>Only use strong MACs.</description>
     </metadata>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: rhel6,rhel7,ol7
+
 title: 'Use Only Strong MACs'
 
 description: |-

--- a/ol8/profiles/cjis.profile
+++ b/ol8/profiles/cjis.profile
@@ -99,7 +99,6 @@ selections:
     - sshd_disable_empty_passwords
     - sshd_enable_warning_banner
     - sshd_do_not_permit_user_env
-    - sshd_use_approved_ciphers
     - kernel_module_dccp_disabled
     - kernel_module_sctp_disabled
     - service_firewalld_enabled


### PR DESCRIPTION
- With Crypto policies now shipped in RHEL8/Fedora, the SSH rules that checked
  that ciphers and macs where configured for FIPS are now out-of-date and deprecated.
  They should no longer be built with RHEL8/Fedora content. The rules have been now
  replaced by the configure_ssh_crypto_policy rule.