### PR TITLE
Linearize rules

### DIFF
--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -37,6 +37,8 @@ def parse_args():
     parser.add_argument("action",
                         choices=["build", "list-inputs", "list-outputs"],
                         help="Which action to perform.")
+    parser.add_argument("--resolve-rules-into", "-l",
+                        help="To which directory to put processed rule YAMLs.")
     return parser.parse_args()
 
 

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -49,7 +49,6 @@ def main():
         print(args.output)
         sys.exit(0)
 
-
     env_yaml = ssg.yaml.open_environment(
         args.build_config_yaml, args.product_yaml)
     base_dir = os.path.dirname(args.product_yaml)
@@ -63,9 +62,17 @@ def main():
     if not os.path.isabs(profiles_root):
         profiles_root = os.path.join(base_dir, profiles_root)
 
-    ssg.build_yaml.add_from_directory(args.action, None, benchmark_root,
-                                      profiles_root, args.bash_remediation_fns,
-                                      args.output, env_yaml)
+    if args.action == "build":
+        loader = ssg.build_yaml.BuildLoader(
+            profiles_root, args.bash_remediation_fns, env_yaml, args.resolve_rules_into)
+        loader.process_directory_tree(benchmark_root)
+        loader.export_group_to_file(args.output)
+    elif args.action == "list-inputs":
+        loader = ssg.build_yaml.ListInputsLoader(
+            profiles_root, args.bash_remediation_fns, env_yaml)
+        loader.process_directory_tree(benchmark_root)
+    else:
+        RuntimeError("Invalid action: {action}".format(action=args.action))
 
 
 if __name__ == "__main__":

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -97,8 +97,8 @@ macro(ssg_build_shorthand_xml PRODUCT)
     string(REPLACE "\n" ";" SHORTHAND_INPUTS "${SHORTHAND_INPUTS_STR}")
 
     add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash_remediation_fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" build
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/rules"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --resolve-rules-into "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash_remediation_fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" build
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         DEPENDS ${SHORTHAND_INPUTS}
         DEPENDS generate-internal-bash-remediation-functions.xml

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -495,7 +495,7 @@ class Rule(object):
         self.identifiers = {}
         self.ocil_clause = None
         self.ocil = None
-        self.external_oval = None
+        self.oval_external_content = None
         self.warnings = []
         self.platform = None
 
@@ -523,7 +523,7 @@ class Rule(object):
         rule.identifiers = yaml_contents.pop("identifiers", {})
         rule.ocil_clause = yaml_contents.pop("ocil_clause", None)
         rule.ocil = yaml_contents.pop("ocil", None)
-        rule.external_oval = yaml_contents.pop("oval_external_content", None)
+        rule.oval_external_content = yaml_contents.pop("oval_external_content", None)
         rule.warnings = yaml_contents.pop("warnings", [])
         rule.platform = yaml_contents.pop("platform", None)
 
@@ -538,6 +538,25 @@ class Rule(object):
         rule.validate_identifiers(yaml_file)
         rule.validate_references(yaml_file)
         return rule
+
+    def to_contents_dict(self):
+        """
+        Returns a dictionary that is the same schema as the dict obtained when loading rule YAML.
+        """
+        interesting_keys = [
+            "prodtype", "title", "description", "rationale",
+            "severity", "references", "identifiers",
+            "ocil_clause", "ocil", "oval_external_content",
+            "warnings", "platform",
+        ]
+
+        yaml_contents = dict()
+        for key in interesting_keys:
+            yaml_contents[key] = getattr(self, key)
+
+        yaml_contents["documentation_complete"] = True
+
+        return yaml_contents
 
     def validate_identifiers(self, yaml_file):
         if self.identifiers is None:
@@ -610,11 +629,11 @@ class Rule(object):
         if main_ref.attrib:
             rule.append(main_ref)
 
-        if self.external_oval:
+        if self.oval_external_content:
             check = ET.SubElement(rule, 'check')
             check.set("system", "http://oval.mitre.org/XMLSchema/oval-definitions-5")
             external_content = ET.SubElement(check, "check-content-ref")
-            external_content.set("href", self.external_oval)
+            external_content.set("href", self.oval_external_content)
         else:
             # TODO: This is pretty much a hack, oval ID will be the same as rule ID
             #       and we don't want the developers to have to keep them in sync.

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -6,6 +6,8 @@ import os.path
 import datetime
 import sys
 
+import yaml
+
 from .constants import XCCDF_PLATFORM_TO_CPE
 from .constants import PRODUCT_TO_CPE_MAPPING
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
@@ -554,8 +556,6 @@ class Rule(object):
         for key in interesting_keys:
             yaml_contents[key] = getattr(self, key)
 
-        yaml_contents["documentation_complete"] = True
-
         return yaml_contents
 
     def validate_identifiers(self, yaml_file):
@@ -664,107 +664,166 @@ class Rule(object):
         tree.write(file_name)
 
 
-def load_benchmark_or_group(group_file, benchmark_file, guide_directory, action,
-                            profiles_dir, env_yaml, bash_remediation_fns):
-    """
-    Loads a given benchmark or group from the specified benchmark_file or
-    group_file, in the context of guide_directory, action, profiles_dir,
-    env_yaml, and bash_remediation_fns.
+class DirectoryLoader(object):
+    def __init__(self, profiles_dir, bash_remediation_fns, env_yaml):
+        self.benchmark_file = None
+        self.group_file = None
+        self.loaded_group = None
+        self.rules = []
+        self.values = []
+        self.subdirectories = []
 
-    Returns the loaded group or benchmark.
-    """
-    group = None
-    if group_file and benchmark_file:
-        raise ValueError("A .benchmark file and a .group file were found in "
-                         "the same directory '%s'" % (guide_directory))
+        self.profiles_dir = profiles_dir
+        self.bash_remediation_fns = bash_remediation_fns
+        self.env_yaml = env_yaml
 
-    # we treat benchmark as a special form of group in the following code
-    if benchmark_file:
-        group = Benchmark.from_yaml(
-            benchmark_file, 'product-name', env_yaml
-        )
-        if profiles_dir:
-            group.add_profiles_from_dir(action, profiles_dir, env_yaml)
-        group.add_bash_remediation_fns_from_file(action, bash_remediation_fns)
-        if action == "list-inputs":
-            print(benchmark_file)
+        self.parent_group = None
 
-    if group_file:
-        group = Group.from_yaml(group_file, env_yaml)
-        if action == "list-inputs":
-            print(group_file)
+    def _collect_items_to_load(self, guide_directory):
+        for dir_item in os.listdir(guide_directory):
+            dir_item_path = os.path.join(guide_directory, dir_item)
+            _, extension = os.path.splitext(dir_item)
 
-    return group
+            if extension == '.var':
+                self.values.append(dir_item_path)
+            elif dir_item == "benchmark.yml":
+                if self.benchmark_file:
+                    raise ValueError("Multiple benchmarks in one directory")
+                self.benchmark_file = dir_item_path
+            elif dir_item == "group.yml":
+                if self.group_file:
+                    raise ValueError("Multiple groups in one directory")
+                self.group_file = dir_item_path
+            elif extension == '.rule':
+                self.rules.append(dir_item_path)
+            elif is_rule_dir(dir_item_path):
+                self.rules.append(get_rule_dir_yaml(dir_item_path))
+            elif dir_item != "tests":
+                if os.path.isdir(dir_item_path):
+                    self.subdirectories.append(dir_item_path)
+                else:
+                    sys.stderr.write(
+                        "Encountered file '%s' while recursing, extension '%s' "
+                        "is unknown. Skipping..\n"
+                        % (dir_item, extension)
+                    )
+
+    def load_benchmark_or_group(self, guide_directory):
+        """
+        Loads a given benchmark or group from the specified benchmark_file or
+        group_file, in the context of guide_directory, action, profiles_dir,
+        env_yaml, and bash_remediation_fns.
+
+        Returns the loaded group or benchmark.
+        """
+        group = None
+        if self.group_file and self.benchmark_file:
+            raise ValueError("A .benchmark file and a .group file were found in "
+                             "the same directory '%s'" % (guide_directory))
+
+        # we treat benchmark as a special form of group in the following code
+        if self.benchmark_file:
+            group = Benchmark.from_yaml(
+                self.benchmark_file, 'product-name', self.env_yaml
+            )
+            if self.profiles_dir:
+                group.add_profiles_from_dir(self.action, self.profiles_dir, self.env_yaml)
+            group.add_bash_remediation_fns_from_file(self.action, self.bash_remediation_fns)
+
+        if self.group_file:
+            group = Group.from_yaml(self.group_file, self.env_yaml)
+
+        return group
+
+    def _load_group_process_and_recurse(self, guide_directory):
+        self.loaded_group = self.load_benchmark_or_group(guide_directory)
+
+        if self.loaded_group:
+            if self.parent_group:
+                self.parent_group.add_group(self.loaded_group)
+
+            self._process_values()
+            self._recurse_into_subdirs()
+            self._process_rules()
+
+    def process_directory_tree(self, start_dir):
+        self._collect_items_to_load(start_dir)
+        self._load_group_process_and_recurse(start_dir)
+
+    def _recurse_into_subdirs(self):
+        for subdir in self.subdirectories:
+            loader = self._get_new_loader()
+            loader.parent_group = self.loaded_group
+            loader.process_directory_tree(subdir)
+
+    def _get_new_loader(self):
+        raise NotImplementedError()
+
+    def _process_values(self):
+        raise NotImplementedError()
+
+    def _process_rules(self):
+        raise NotImplementedError()
 
 
-def add_from_directory(action, parent_group, guide_directory, profiles_dir,
-                       bash_remediation_fns, output_file, env_yaml):
-    """
-    Process Variables, Benchmarks, and Rules in a given subdirectory,
-    recursing as necessary.
+class BuildLoader(DirectoryLoader):
+    def __init__(self, profiles_dir, bash_remediation_fns, env_yaml, resolved_rules_dir=None):
+        super(BuildLoader, self).__init__(profiles_dir, bash_remediation_fns, env_yaml)
 
-    Behavior is dependent upon the value of action.
-    """
-    benchmark_file = None
-    group_file = None
-    rules = []
-    values = []
-    subdirectories = []
-    for dir_item in os.listdir(guide_directory):
-        dir_item_path = os.path.join(guide_directory, dir_item)
-        _, extension = os.path.splitext(dir_item)
+        self.action = "build"
 
-        if extension == '.var':
-            values.append(dir_item_path)
-        elif dir_item == "benchmark.yml":
-            if benchmark_file:
-                raise ValueError("Multiple benchmarks in one directory")
-            benchmark_file = dir_item_path
-        elif dir_item == "group.yml":
-            if group_file:
-                raise ValueError("Multiple groups in one directory")
-            group_file = dir_item_path
-        elif extension == '.rule':
-            rules.append(dir_item_path)
-        elif is_rule_dir(dir_item_path):
-            rules.append(get_rule_dir_yaml(dir_item_path))
-        elif dir_item != "tests":
-            if os.path.isdir(dir_item_path):
-                subdirectories.append(dir_item_path)
-            else:
-                sys.stderr.write(
-                    "Encountered file '%s' while recursing, extension '%s' "
-                    "is unknown. Skipping..\n"
-                    % (dir_item, extension)
-                )
+        self.resolved_rules_dir = resolved_rules_dir
+        if resolved_rules_dir and not os.path.isdir(resolved_rules_dir):
+            os.mkdir(resolved_rules_dir)
 
-    group = load_benchmark_or_group(group_file, benchmark_file, guide_directory, action,
-                                    profiles_dir, env_yaml, bash_remediation_fns)
+    def _process_values(self):
+        for value_yaml in self.values:
+            value = Value.from_yaml(value_yaml, self.env_yaml)
+            self.loaded_group.add_value(value)
 
-    if group is not None:
-        if parent_group:
-            parent_group.add_group(group)
-        for value_yaml in values:
-            if action == "list-inputs":
-                print(value_yaml)
-            else:
-                value = Value.from_yaml(value_yaml, env_yaml)
-                group.add_value(value)
+    def _process_rules(self):
+        for rule_yaml in self.rules:
+            rule = Rule.from_yaml(rule_yaml, self.env_yaml)
+            if self.resolved_rules_dir:
+                output_for_rule = os.path.join(
+                    self.resolved_rules_dir, "{id_}.yml".format(id_=rule.id_))
+                with open(output_for_rule, "w") as f:
+                    yaml.dump(rule.to_contents_dict(), f)
+            self.loaded_group.add_rule(rule)
 
-        for subdir in subdirectories:
-            add_from_directory(action, group, subdir, profiles_dir,
-                               bash_remediation_fns, output_file,
-                               env_yaml)
+    def _get_new_loader(self):
+        return BuildLoader(
+            self.profiles_dir, self.bash_remediation_fns, self.env_yaml, self.resolved_rules_dir)
 
-        for rule_yaml in rules:
-            if action == "list-inputs":
-                print(rule_yaml)
-            else:
-                rule = Rule.from_yaml(rule_yaml, env_yaml)
-                group.add_rule(rule)
+    def export_group_to_file(self, filename):
+        return self.loaded_group.to_file(filename)
 
-        if not parent_group:
-            # We are on the top level!
-            # Lets dump the XCCDF group or benchmark to a file
-            if action == "build":
-                group.to_file(output_file)
+
+class ListInputsLoader(DirectoryLoader):
+    def __init__(self, profiles_dir, bash_remediation_fns, env_yaml):
+        super(ListInputsLoader, self).__init__(profiles_dir, bash_remediation_fns, env_yaml)
+
+        self.action = "list-inputs"
+
+    def _process_values(self):
+        for value_yaml in self.values:
+            print(value_yaml)
+
+    def _process_rules(self):
+        for rule_yaml in self.rules:
+            print(rule_yaml)
+
+    def _get_new_loader(self):
+        return ListInputsLoader(
+            self.profiles_dir, self.bash_remediation_fns, self.env_yaml)
+
+    def load_benchmark_or_group(self, guide_directory):
+        result = super(ListInputsLoader, self).load_benchmark_or_group(guide_directory)
+
+        if self.benchmark_file:
+            print(self.benchmark_file)
+
+        if self.group_file:
+            print(self.group_file)
+
+        return result

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+
+import yaml
+
+import ssg.build_yaml
+
+
+PROJECT_ROOT = os.path.join(os.path.dirname(__file__), "..", "..", "..", )
+
+
+def test_serialize_rule():
+    filename = PROJECT_ROOT + "/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml"
+    rule_ds = ssg.build_yaml.Rule.from_yaml(filename)
+    rule_as_dict = rule_ds.to_contents_dict()
+
+    with tempfile.NamedTemporaryFile("w+", delete=True) as f:
+        yaml.dump(rule_as_dict, f)
+        rule_ds_reloaded = ssg.build_yaml.Rule.from_yaml(f.name)
+
+    reloaded_dict = rule_ds_reloaded.to_contents_dict()
+
+    # Those two should be really equal if there are no jinja macros in the rule def.
+    assert rule_as_dict == reloaded_dict


### PR DESCRIPTION
This PR extends capabilities of the `yaml_to_shorthand.py` script to save rules into product directories after template expansion (e.g. into `build/rhel7/rules/...`).

Why:
* To move the intermediate representation away from XML-based,
* To be able to work with rule definitions during the build process easily.
* To debug template/yaml format-related issues with content input - the yaml in the build tree is result of all template expansions yaml interpretations.

As we use templating in yaml source, it may be that individual definitions may vary between products, so this has to be done for each product separately.

As a side-task, the build functionality has been refactored in order to reduce the complexity of the code - adding more `if`s would make it a huge mess.