### PR TITLE
Splits combine_remediations.py into 2 scripts

### DIFF
--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -34,6 +34,8 @@ def parse_args():
     p.add_argument("--build_dir", required=True,
                    help="where is the cmake build directory. pass value of "
                    "$CMAKE_BINARY_DIR.")
+    p.add_argument("--output_dir", required=True,
+            help="output directory where all remediations will be saved")
     p.add_argument("--output", type=argparse.FileType("wb"), required=True)
     p.add_argument("fixdirs", metavar="FIX_DIR", nargs="+",
                    help="directory(ies) from which we will collect "
@@ -81,6 +83,8 @@ def main():
 
     remediation.write_fixes_to_xml(args.remediation_type, args.build_dir,
                             args.output, fixes)
+
+    remediation.write_fixes_to_dir(fixes, args.output_dir)
 
     sys.stderr.write("Merged %d %s remediations.\n" % (len(fixes), args.remediation_type))
 

--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -31,12 +31,8 @@ def parse_args():
     p.add_argument("--remediation_type", required=True,
                    help="language or type of the remediations we are combining."
                    "example: ansible")
-    p.add_argument("--build_dir", required=True,
-                   help="where is the cmake build directory. pass value of "
-                   "$CMAKE_BINARY_DIR.")
     p.add_argument("--output_dir", required=True,
             help="output directory where all remediations will be saved")
-    p.add_argument("--output", type=argparse.FileType("wb"), required=True)
     p.add_argument("fixdirs", metavar="FIX_DIR", nargs="+",
                    help="directory(ies) from which we will collect "
                    "remediations to combine.")
@@ -81,12 +77,9 @@ def main():
             remediation.process_fix(fixes, args.remediation_type, env_yaml,
                                     product, _path, rule_id)
 
-    remediation.write_fixes_to_xml(args.remediation_type, args.build_dir,
-                            args.output, fixes)
-
     remediation.write_fixes_to_dir(fixes, args.output_dir)
 
-    sys.stderr.write("Merged %d %s remediations.\n" % (len(fixes), args.remediation_type))
+    sys.stderr.write("Collected %d %s remediations.\n" % (len(fixes), args.remediation_type))
 
     sys.exit(0)
 

--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -77,7 +77,8 @@ def main():
             remediation.process_fix(fixes, args.remediation_type, env_yaml,
                                     product, _path, rule_id)
 
-    remediation.write_fixes_to_dir(fixes, args.output_dir)
+    remediation.write_fixes_to_dir(fixes, args.remediation_type,
+            args.output_dir)
 
     sys.stderr.write("Collected %d %s remediations.\n" % (len(fixes), args.remediation_type))
 

--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -31,8 +31,10 @@ def parse_args():
     p.add_argument("--remediation_type", required=True,
                    help="language or type of the remediations we are combining."
                    "example: ansible")
-    p.add_argument("--output_dir", required=True,
-            help="output directory where all remediations will be saved")
+    p.add_argument(
+        "--output_dir", required=True,
+        help="output directory where all remediations will be saved"
+    )
     p.add_argument("fixdirs", metavar="FIX_DIR", nargs="+",
                    help="directory(ies) from which we will collect "
                    "remediations to combine.")
@@ -78,7 +80,7 @@ def main():
                                     product, _path, rule_id)
 
     remediation.write_fixes_to_dir(fixes, args.remediation_type,
-            args.output_dir)
+                                   args.output_dir)
 
     sys.stderr.write("Collected %d %s remediations.\n" % (len(fixes), args.remediation_type))
 

--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -79,7 +79,7 @@ def main():
             remediation.process_fix(fixes, args.remediation_type, env_yaml,
                                     product, _path, rule_id)
 
-    remediation.write_fixes(args.remediation_type, args.build_dir,
+    remediation.write_fixes_to_xml(args.remediation_type, args.build_dir,
                             args.output, fixes)
 
     sys.stderr.write("Merged %d %s remediations.\n" % (len(fixes), args.remediation_type))

--- a/build-scripts/generate_fixes_xml.py
+++ b/build-scripts/generate_fixes_xml.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python2
+
+import sys
+import os
+import os.path
+import re
+import errno
+import argparse
+import codecs
+
+import ssg.build_remediations as remediation
+import ssg.rules
+import ssg.jinja
+import ssg.yaml
+import ssg.utils
+import ssg.xml
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--build-config-yaml", required=True, dest="build_config_yaml",
+        help="YAML file with information about the build configuration. "
+        "e.g.: ~/scap-security-guide/build/build_config.yml"
+    )
+    p.add_argument(
+        "--product-yaml", required=True, dest="product_yaml",
+        help="YAML file with information about the product we are building. "
+        "e.g.: ~/scap-security-guide/rhel7/product.yml"
+    )
+    p.add_argument("--remediation_type", required=True,
+                   help="language or type of the remediations we are combining."
+                   "example: ansible")
+    p.add_argument("--build_dir", required=True,
+                   help="where is the cmake build directory. pass value of "
+                   "$CMAKE_BINARY_DIR.")
+    p.add_argument("--output", type=argparse.FileType("wb"), required=True)
+    p.add_argument("fixdir", metavar="FIX_DIR",
+                   help="directory from which we will collect "
+                   "remediations to combine.")
+
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    env_yaml = ssg.yaml.open_environment(
+        args.build_config_yaml, args.product_yaml)
+
+    if not os.path.isdir(args.fixdir):
+        sys.stderr.write("Directory %s does not exist" % args.fixdir)
+        sys.exit(1)
+
+    fixes = dict()
+    for filename in os.listdir(args.fixdir):
+        file_path = os.path.join(args.fixdir, filename)
+        fix_name, _ = os.path.splitext(filename)
+        result = remediation.parse_from_file(file_path, env_yaml)
+        fixes[fix_name] = result
+
+    remediation.write_fixes_to_xml(args.remediation_type, args.build_dir,
+                            args.output, fixes)
+
+    sys.stderr.write("Merged %d %s remediations.\n" % (len(fixes), args.remediation_type))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/build-scripts/generate_fixes_xml.py
+++ b/build-scripts/generate_fixes_xml.py
@@ -4,9 +4,7 @@ import sys
 import os
 import os.path
 import re
-import errno
 import argparse
-import codecs
 
 import ssg.build_remediations as remediation
 import ssg.rules
@@ -55,7 +53,7 @@ def main():
     for filename in os.listdir(args.fixdir):
         file_path = os.path.join(args.fixdir, filename)
         fix_name, _ = os.path.splitext(filename)
-        result = remediation.parse_from_file(file_path, env_yaml)
+        result = remediation.parse_from_file_without_jinja(file_path)
         fixes[fix_name] = result
 
     remediation.write_fixes_to_xml(args.remediation_type, args.build_dir,

--- a/build-scripts/generate_fixes_xml.py
+++ b/build-scripts/generate_fixes_xml.py
@@ -44,7 +44,7 @@ def main():
         fixes[fix_name] = result
 
     remediation.write_fixes_to_xml(args.remediation_type, args.build_dir,
-                            args.output, fixes)
+                                   args.output, fixes)
 
     sys.stderr.write("Merged %d %s remediations.\n" % (len(fixes), args.remediation_type))
 

--- a/build-scripts/generate_fixes_xml.py
+++ b/build-scripts/generate_fixes_xml.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import os.path
-import re
 import argparse
 
 import ssg.build_remediations as remediation
@@ -16,16 +15,6 @@ import ssg.xml
 
 def parse_args():
     p = argparse.ArgumentParser()
-    p.add_argument(
-        "--build-config-yaml", required=True, dest="build_config_yaml",
-        help="YAML file with information about the build configuration. "
-        "e.g.: ~/scap-security-guide/build/build_config.yml"
-    )
-    p.add_argument(
-        "--product-yaml", required=True, dest="product_yaml",
-        help="YAML file with information about the product we are building. "
-        "e.g.: ~/scap-security-guide/rhel7/product.yml"
-    )
     p.add_argument("--remediation_type", required=True,
                    help="language or type of the remediations we are combining."
                    "example: ansible")
@@ -42,8 +31,6 @@ def parse_args():
 
 def main():
     args = parse_args()
-    env_yaml = ssg.yaml.open_environment(
-        args.build_config_yaml, args.product_yaml)
 
     if not os.path.isdir(args.fixdir):
         sys.stderr.write("Directory %s does not exist" % args.fixdir)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -241,7 +241,7 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
 
       add_custom_command(
           OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml"
-          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" --output_dir "${CMAKE_CURRENT_BINARY_DIR}/all_fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
           DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
           DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
           DEPENDS ${EXTRA_LANGUAGE_DEPENDS}

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -238,10 +238,11 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
     foreach(LANGUAGE ${LANGUAGES})
       file(GLOB EXTRA_LANGUAGE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}/*")
       file(GLOB EXTRA_SHARED_LANGUAGE_DEPENDS "${SSG_SHARED}/fixes/${LANGUAGE}/*")
+      set(ALL_FIXES_DIR "${CMAKE_CURRENT_BINARY_DIR}/all_fixes/${LANGUAGE}")
 
       add_custom_command(
           OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml"
-          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" --output_dir "${CMAKE_CURRENT_BINARY_DIR}/all_fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
           DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
           DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
           DEPENDS ${EXTRA_LANGUAGE_DEPENDS}

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -194,7 +194,7 @@ macro(ssg_build_ocil_unlinked PRODUCT)
 endmacro()
 
 macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
-    set(BUILD_REMEDIATIONS_DIR "${CMAKE_CURRENT_BINARY_DIR}/fixes")
+    set(BUILD_REMEDIATIONS_DIR "${CMAKE_CURRENT_BINARY_DIR}/fixes_from_templates")
 
     execute_process(
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_from_templates.py" --languages ${LANGUAGES} --input "${CMAKE_CURRENT_SOURCE_DIR}/templates" "${SSG_SHARED}/templates" --output "${BUILD_REMEDIATIONS_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared" --shared "${SSG_SHARED}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" list-inputs
@@ -238,7 +238,7 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
     foreach(LANGUAGE ${LANGUAGES})
       file(GLOB EXTRA_LANGUAGE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}/*")
       file(GLOB EXTRA_SHARED_LANGUAGE_DEPENDS "${SSG_SHARED}/fixes/${LANGUAGE}/*")
-      set(ALL_FIXES_DIR "${CMAKE_CURRENT_BINARY_DIR}/all_fixes/${LANGUAGE}")
+      set(ALL_FIXES_DIR "${CMAKE_CURRENT_BINARY_DIR}/fixes/${LANGUAGE}")
 
       add_custom_command(
           OUTPUT "${ALL_FIXES_DIR}"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -258,7 +258,7 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
 
       add_custom_command(
           OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml"
-          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_fixes_xml.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" "${ALL_FIXES_DIR}"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_fixes_xml.py" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" "${ALL_FIXES_DIR}"
           DEPENDS "${SSG_BUILD_SCRIPTS}/generate_fixes_xml.py"
           DEPENDS generate-internal-${PRODUCT}-${LANGUAGE}-all-fixes
           COMMENT "[${PRODUCT}-content] generating ${LANGUAGE}-fixes.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -249,7 +249,7 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
           DEPENDS ${EXTRA_SHARED_LANGUAGE_DEPENDS}
           DEPENDS "${SSG_BUILD_SCRIPTS}/combine_remediations.py"
           DEPENDS generate-internal-language-remedations-${PRODUCT}
-          COMMENT "[${PRODUCT}-content] collectiong all ${LANGUAGE} fixes"
+          COMMENT "[${PRODUCT}-content] collecting all ${LANGUAGE} fixes"
       )
       add_custom_target(
           generate-internal-${PRODUCT}-${LANGUAGE}-all-fixes

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -241,14 +241,26 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
       set(ALL_FIXES_DIR "${CMAKE_CURRENT_BINARY_DIR}/all_fixes/${LANGUAGE}")
 
       add_custom_command(
-          OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml"
-          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
+          OUTPUT "${ALL_FIXES_DIR}"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
           DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
           DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
           DEPENDS ${EXTRA_LANGUAGE_DEPENDS}
           DEPENDS ${EXTRA_SHARED_LANGUAGE_DEPENDS}
           DEPENDS "${SSG_BUILD_SCRIPTS}/combine_remediations.py"
           DEPENDS generate-internal-language-remedations-${PRODUCT}
+          COMMENT "[${PRODUCT}-content] collectiong all ${LANGUAGE} fixes"
+      )
+      add_custom_target(
+          generate-internal-${PRODUCT}-${LANGUAGE}-all-fixes
+          DEPENDS "${ALL_FIXES_DIR}"
+      )
+
+      add_custom_command(
+          OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_fixes_xml.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --build_dir "${CMAKE_BINARY_DIR}" --output "${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml" "${ALL_FIXES_DIR}"
+          DEPENDS "${SSG_BUILD_SCRIPTS}/generate_fixes_xml.py"
+          DEPENDS generate-internal-${PRODUCT}-${LANGUAGE}-all-fixes
           COMMENT "[${PRODUCT}-content] generating ${LANGUAGE}-fixes.xml"
       )
       add_custom_target(

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -192,7 +192,7 @@ def _split_remediation_content_and_metadata(fix_file_lines):
     return remediation(remediation_contents, config)
 
 
-def parse_from_file(file_path, env_yaml):
+def parse_from_file_with_jinja(file_path, env_yaml):
     """
     Parses a remediation from a file. As remediations contain jinja macros,
     we need a env_yaml context to process these. In practice, no remediations
@@ -229,7 +229,7 @@ def process_fix(fixes, remediation_type, env_yaml, product, file_path, fix_name)
     if not is_supported_filename(remediation_type, file_path):
         return
 
-    result = parse_from_file(file_path, env_yaml)
+    result = parse_from_file_with_jinja(file_path, env_yaml)
 
     if not result.config['platform']:
         raise RuntimeError(

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -260,6 +260,9 @@ def write_fixes_to_xml(remediation_type, build_dir, output_path, fixes):
 
 
 def write_fixes_to_dir(fixes, output_dir):
+    """
+    Writes fixes as files to output_dir, each fix as a separate file
+    """
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     for fix_name in fixes:

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -259,15 +259,20 @@ def write_fixes_to_xml(remediation_type, build_dir, output_path, fixes):
     tree.write(output_path)
 
 
-def write_fixes_to_dir(fixes, output_dir):
+def write_fixes_to_dir(fixes, remediation_type, output_dir):
     """
     Writes fixes as files to output_dir, each fix as a separate file
     """
+    try:
+        extension = REMEDIATION_TO_EXT_MAP[remediation_type]
+    except KeyError:
+        raise ValueError("Unknown remediation type %s." % remediation_type)
+
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     for fix_name in fixes:
         fix_contents, config = fixes[fix_name]
-        fix_path = os.path.join(output_dir, fix_name)
+        fix_path = os.path.join(output_dir, fix_name + extension)
         with open(fix_path, "w") as f:
             for k, v in config.items():
                 f.write("# %s = %s\n" % (k, v))

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -165,22 +165,9 @@ def get_populate_replacement(remediation_type, text):
                      % (remediation_type))
     sys.exit(1)
 
-
-def parse_from_file(file_path, env_yaml):
-    """
-    Parses a remediation from a file. As remediations contain jinja macros,
-    we need a env_yaml context to process these. In practice, no remediations
-    use jinja in the configuration, so for extracting only the configuration,
-    env_yaml can be an abritrary product.yml dictionary.
-
-    If the logic of configuration parsing changes significantly, please also
-    update ssg.fixes.parse_platform(...).
-    """
-
+def _parse_remediation(fix_file_lines):
     mod_file = []
     config = defaultdict(lambda: None)
-
-    fix_file_lines = jinja_process_file(file_path, env_yaml).splitlines()
 
     # Assignment automatically escapes shell characters for XML
     for line in fix_file_lines:
@@ -202,6 +189,21 @@ def parse_from_file(file_path, env_yaml):
 
     remediation = namedtuple('remediation', ['contents', 'config'])
     return remediation(mod_file, config)
+
+
+def parse_from_file(file_path, env_yaml):
+    """
+    Parses a remediation from a file. As remediations contain jinja macros,
+    we need a env_yaml context to process these. In practice, no remediations
+    use jinja in the configuration, so for extracting only the configuration,
+    env_yaml can be an abritrary product.yml dictionary.
+
+    If the logic of configuration parsing changes significantly, please also
+    update ssg.fixes.parse_platform(...).
+    """
+
+    fix_file_lines = jinja_process_file(file_path, env_yaml).splitlines()
+    return _parse_remediation(fix_file_lines)
 
 
 def process_fix(fixes, remediation_type, env_yaml, product, file_path, fix_name):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -166,7 +166,7 @@ def get_populate_replacement(remediation_type, text):
     sys.exit(1)
 
 
-def _parse_remediation(fix_file_lines):
+def _split_remediation_content_and_metadata(fix_file_lines):
     remediation_contents = []
     config = defaultdict(lambda: None)
 
@@ -204,7 +204,7 @@ def parse_from_file(file_path, env_yaml):
     """
 
     fix_file_lines = jinja_process_file(file_path, env_yaml).splitlines()
-    return _parse_remediation(fix_file_lines)
+    return _split_remediation_content_and_metadata(fix_file_lines)
 
 
 def parse_from_file_without_jinja(file_path):
@@ -215,7 +215,7 @@ def parse_from_file_without_jinja(file_path):
     """
     with open(file_path, "r") as f:
         lines = f.read().splitlines()
-        return _parse_remediation(lines)
+        return _split_remediation_content_and_metadata(lines)
 
 
 def process_fix(fixes, remediation_type, env_yaml, product, file_path, fix_name):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -284,8 +284,8 @@ def write_fixes_to_dir(fixes, remediation_type, output_dir):
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    for fix_name in fixes:
-        fix_contents, config = fixes[fix_name]
+    for fix_name, fix in fixes.items():
+        fix_contents, config = fix
         fix_path = os.path.join(output_dir, fix_name + extension)
         with open(fix_path, "w") as f:
             for k, v in config.items():

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -259,6 +259,18 @@ def write_fixes_to_xml(remediation_type, build_dir, output_path, fixes):
     tree.write(output_path)
 
 
+def write_fixes_to_dir(fixes, output_dir):
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    for fix_name in fixes:
+        fix_contents, config = fixes[fix_name]
+        fix_path = os.path.join(output_dir, fix_name)
+        with open(fix_path, "w") as f:
+            for k, v in config.items():
+                f.write("# %s = %s\n" % (k, v))
+            f.write("\n".join(fix_contents))
+
+
 def expand_xccdf_subs(fix, remediation_type, remediation_functions):
     """For those remediation scripts utilizing some of the internal SCAP
     Security Guide remediation functions expand the selected shell variables

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -205,6 +205,15 @@ def parse_from_file(file_path, env_yaml):
     fix_file_lines = jinja_process_file(file_path, env_yaml).splitlines()
     return _parse_remediation(fix_file_lines)
 
+def parse_from_file_without_jinja(file_path):
+    """
+    Parses a remediation from a file. Doesn't process the Jinja macros.
+    This function is useful in build phases in which all the Jinja macros
+    are already resolved.
+    """
+    with open(file_path, "r") as f:
+        lines = f.read().splitlines()
+        return _parse_remediation(lines)
 
 def process_fix(fixes, remediation_type, env_yaml, product, file_path, fix_name):
     """

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -226,7 +226,7 @@ def process_fix(fixes, remediation_type, env_yaml, product, file_path, fix_name)
         fixes[fix_name] = result
 
 
-def write_fixes(remediation_type, build_dir, output_path, fixes):
+def write_fixes_to_xml(remediation_type, build_dir, output_path, fixes):
     """
     Builds a fix-content XML tree from the contents of fixes
     and writes it to output_path.

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -167,7 +167,7 @@ def get_populate_replacement(remediation_type, text):
 
 
 def _parse_remediation(fix_file_lines):
-    mod_file = []
+    remediation_contents = []
     config = defaultdict(lambda: None)
 
     # Assignment automatically escapes shell characters for XML
@@ -186,10 +186,10 @@ def _parse_remediation(fix_file_lines):
         # begins with a '#' and contains an equals sign, but
         # the "key" isn't one of the known keys from
         # REMEDIATION_CONFIG_KEYS.
-        mod_file.append(line)
+        remediation_contents.append(line)
 
     remediation = namedtuple('remediation', ['contents', 'config'])
-    return remediation(mod_file, config)
+    return remediation(remediation_contents, config)
 
 
 def parse_from_file(file_path, env_yaml):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -165,6 +165,7 @@ def get_populate_replacement(remediation_type, text):
                      % (remediation_type))
     sys.exit(1)
 
+
 def _parse_remediation(fix_file_lines):
     mod_file = []
     config = defaultdict(lambda: None)
@@ -205,6 +206,7 @@ def parse_from_file(file_path, env_yaml):
     fix_file_lines = jinja_process_file(file_path, env_yaml).splitlines()
     return _parse_remediation(fix_file_lines)
 
+
 def parse_from_file_without_jinja(file_path):
     """
     Parses a remediation from a file. Doesn't process the Jinja macros.
@@ -214,6 +216,7 @@ def parse_from_file_without_jinja(file_path):
     with open(file_path, "r") as f:
         lines = f.read().splitlines()
         return _parse_remediation(lines)
+
 
 def process_fix(fixes, remediation_type, env_yaml, product, file_path, fix_name):
     """

--- a/ssg/fixes.py
+++ b/ssg/fixes.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import os
 import re
 
-from .build_remediations import parse_from_file
+from .build_remediations import parse_from_file_with_jinja
 from .constants import XCCDF11_NS
 from .rule_yaml import parse_prodtype
 from .utils import read_file_list
@@ -45,7 +45,7 @@ def get_fix_contents(rule_obj, lang, fix_id):
 
 
 def applicable_platforms(fix_path):
-    _, config = parse_from_file(fix_path, {})
+    _, config = parse_from_file_with_jinja(fix_path, {})
 
     if not 'platform' in config:
         raise ValueError("Malformed fix: missing platform" % fix_path)
@@ -63,7 +63,8 @@ def parse_platform(fix_contents):
     this and does not return the current value of the platform.
 
     If the configuration specification changes any, please update the
-    corresponding parsing in ssg.build_remediations.parse_from_file(...).
+    corresponding parsing in ssg.build_remediations.parse_from_file_with_jinja
+    (...).
     """
 
     matched_line = None

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -44,8 +44,8 @@ def do_test_contents(remediation, config):
     assert 'low' == config['disruption']
 
 
-def test_parse_from_file():
-    remediation, config = sbr.parse_from_file(rhel_bash, {})
+def test_parse_from_file_with_jinja():
+    remediation, config = sbr.parse_from_file_with_jinja(rhel_bash, {})
     do_test_contents(remediation, config)
 
 

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -132,7 +132,9 @@ def handle_remediations(product_list, product_yamls, rule_obj):
                 prod_type = r_product
             product_yaml = product_yamls[prod_type]
 
-            _, config = ssg.build_remediations.parse_from_file(r_path, product_yaml)
+            _, config = ssg.build_remediations.parse_from_file_with_jinja(
+                r_path, product_yaml
+            )
             platforms = config['platform']
             if not platforms:
                 print(config['platform'])


### PR DESCRIPTION
#### Description:
Splits combine_remediations.py into 2 scripts.

First script (combine_remediations.py) gathers all remediation snippets, resolves Jinja macros and outputs all of the snippets to a single directory, currently set to CMake as `build/<product>/all_fixes/<language>`.

Second script (generate_fixes_xml.py) merges all the remediation snippets from this directory into a single XML file `<language>-fixes.xml`.  The scripts are called by CMake during the build and generate_fixes_xml.py depends on outputs of combine_remediations.py.

#### Rationale:
We will use this when we will generate Ansible playbook for each rule for each profile.
