### PR TITLE
Ansible ssh remediation validate

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: "^Protocol [0-9]"
     line: "Protocol 2"
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: :reload ssh
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: (?i)^#?compression
     line: Compression delayed
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^PermitEmptyPasswords
     line: PermitEmptyPasswords no
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: (?i)^#?gssapiauthentication
     line: GSSAPIAuthentication no
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: sshd -t -f %s
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: (?i)^#?kerberosauthentication
     line: KerberosAuthentication no
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^IgnoreRhosts
     line: IgnoreRhosts yes
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^RhostsRSAAuthentication
     line: RhostsRSAAuthentication no
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
@@ -10,7 +10,7 @@
     regexp: "^PermitRootLogin"
     line: "PermitRootLogin no"
     insertafter: '(?i)^#?authentication'
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
@@ -11,7 +11,7 @@
     line: IgnoreUserKnownHosts yes
     insertbefore: ^Match
     firstmatch: yes 
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^PermitUserEnvironment
     line: PermitUserEnvironment no
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: (?i)^#?strictmodes
     line: StrictModes yes
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^Banner
     line: Banner /etc/issue
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^X11Forwarding
     line: X11Forwarding yes
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   tags:
     @ANSIBLE_TAGS@
   @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/ansible/shared.yml
@@ -5,7 +5,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^PrintLastLog
     line: PrintLastLog yes
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -11,7 +11,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^ClientAliveInterval
     line: "ClientAliveInterval {{ sshd_idle_timeout_value }}"
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/ansible/shared.yml
@@ -11,7 +11,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^ClientAliveCountMax
     line: 'ClientAliveCountMax {{ var_sshd_set_keepalive }}'
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^Ciphers
     line: Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
@@ -11,7 +11,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^MACs
     line: "MACs {{ sshd_approved_macs }}"
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
@@ -9,7 +9,7 @@
     dest: /etc/ssh/sshd_config
     regexp: (?i)^#?useprivilegeseparation
     line: UsePrivilegeSeparation sandbox
-    validate: sshd -t -f %s
+    validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
   tags:
     @ANSIBLE_TAGS@


### PR DESCRIPTION
#### Description:

- All ansible remediation using validate: sshd -t -f %s fails because full path of sshd must be specified.

#### Rationale:

- Validate line fails because full path of sshd is not specified.  Added full path to sshd.

- Fixes #3803
