### PR TITLE
Remove prodtype from group.yml

### DIFF
--- a/linux_os/guide/services/base/group.yml
+++ b/linux_os/guide/services/base/group.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
-
 title: 'Base Services'
 
 description: |-

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/group.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/group.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,ol7,ol8
-
 title: Xinetd
 
 description: |-

--- a/linux_os/guide/services/sssd/group.yml
+++ b/linux_os/guide/services/sssd/group.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
-
 title: 'System Security Services Daemon'
 
 description: |-

--- a/linux_os/guide/services/sssd/sssd-ldap/group.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/group.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
-
 title: 'System Security Services Daemon (SSSD) - LDAP'
 
 description: |-


### PR DESCRIPTION
- Existing use of prodtype in group.yml under the linux_os tree doesn't make much sense and isn't heavily used.
- Fixes #3558