### PR TITLE
Add extended CCE validation per XPath definition

### DIFF
--- a/applications/openshift/etcd/etcd_max_wals/rule.yml
+++ b/applications/openshift/etcd/etcd_max_wals/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 severity: medium
 
 identifiers:
-   cce@ocp3: 80584-5
+    cce@ocp3: 80584-6
 
 references:
     cis: 1.5.8

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -425,7 +425,7 @@ def verify_correct_form_of_referenced_cce_identifiers(xccdftree):
         identcce = _find_identcce(rule)
         if identcce is not None:
             cceid = identcce.text
-            if not is_cce_valid(cceid):
+            if not is_cce_format_valid(cceid):
                 print("Warning: CCE '{0}' is invalid for rule '{1}'. Removing CCE..."
                       .format(cceid, rule.get("id"), file=sys.stderr))
                 rule.remove(identcce)

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -9,7 +9,7 @@ from .parse_oval import resolve_definition, find_extending_defs, get_container_g
 from .xml import parse_file, map_elements_to_their_ids
 
 
-from .checks import get_content_ref_if_exists_and_not_remote, is_cce_valid
+from .checks import get_content_ref_if_exists_and_not_remote, is_cce_value_valid, is_cce_format_valid
 from .utils import SSGError
 from .xml import ElementTree as ET
 oval_ns = oval_namespace
@@ -177,7 +177,7 @@ class OVALFileLinker(FileLinker):
                 "OVAL rule '{0}' doesn't have a description, which is mandatory".format(ovalid)
 
             xccdfcceid = idmappingdict[ovalid]
-            if is_cce_valid(xccdfcceid):
+            if is_cce_format_valid(xccdfcceid) and is_cce_value_valid(xccdfcceid):
                 # Then append the <reference source="CCE" ref_id="CCE-ID" /> element right
                 # after <description> element of specific OVAL check
                 ccerefelem = ET.Element('reference', ref_id=xccdfcceid,

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -586,7 +586,7 @@ class Rule(object):
                     raise ValueError("CCE Identifier format must be valid: invalid format '%s' for CEE '%s'"
                                      " in file '%s'" % (ident_val, ident_type, yaml_file))
                 if not is_cce_value_valid("CCE-" + ident_val):
-                    raise ValueError("CCE Identifier value must be valid: invalid value '%s' for CEE '%s'"
+                    raise ValueError("CCE Identifier value is not a valid checksum: invalid value '%s' for CEE '%s'"
                                      " in file '%s'" % (ident_val, ident_type, yaml_file))
 
     def validate_references(self, yaml_file):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -12,7 +12,7 @@ from .constants import XCCDF_PLATFORM_TO_CPE
 from .constants import PRODUCT_TO_CPE_MAPPING
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 
-from .checks import is_cce_valid
+from .checks import is_cce_format_valid, is_cce_value_valid
 from .yaml import open_and_expand, open_and_macro_expand
 from .utils import required_key
 
@@ -582,9 +582,12 @@ class Rule(object):
                 raise ValueError("Identifiers must not be empty: %s in file %s"
                                  % (ident_type, yaml_file))
             if ident_type[0:3] == 'cce':
-                if not is_cce_valid("CCE-" + ident_val):
-                    raise ValueError("CCE Identifiers must be valid: value %s for cce %s"
-                                     " in file %s" % (ident_val, ident_type, yaml_file))
+                if not is_cce_format_valid("CCE-" + ident_val):
+                    raise ValueError("CCE Identifier format must be valid: invalid format '%s' for CEE '%s'"
+                                     " in file '%s'" % (ident_val, ident_type, yaml_file))
+                if not is_cce_value_valid("CCE-" + ident_val):
+                    raise ValueError("CCE Identifier value must be valid: invalid value '%s' for CEE '%s'"
+                                     " in file '%s'" % (ident_val, ident_type, yaml_file))
 
     def validate_references(self, yaml_file):
         if self.references is None:

--- a/ssg/checks.py
+++ b/ssg/checks.py
@@ -45,7 +45,7 @@ def is_content_href_remote(check_content_ref):
     return hrefattr.startswith("http://") or hrefattr.startswith("https://")
 
 
-def is_cce_valid(cceid):
+def is_cce_format_valid(cceid):
     """
     IF CCE ID IS IN VALID FORM (either 'CCE-XXXX-X' or 'CCE-XXXXX-X'
     where each X is a digit, and the final X is a check-digit)
@@ -54,15 +54,16 @@ def is_cce_valid(cceid):
     http://people.redhat.com/swells/nist-scap-validation/scap-val-requirements-1.2.html
     """
     match = re.match(r'^CCE-\d{4,5}-\d$', cceid)
-    if match is None:
-        return False
+    return match is not None
 
+
+def is_cce_value_valid(cceid):
     # For context, see:
     # https://github.com/ComplianceAsCode/content/issues/3044#issuecomment-420844095
 
     # concat(substr ... , substr ...) -- just remove non-digit characters.
     # Since we've already validated format, this hack suffices:
-    cce = cceid.replace('-', '')[3:]
+    cce = re.sub(r'(CCE|-)', '', cceid)
 
     # (string-to-codepoints - 48) is the same as int. Add in the reverse too.
     # Double list cast is necessary: map isn't reversible, and generator

--- a/ssg/checks.py
+++ b/ssg/checks.py
@@ -65,20 +65,23 @@ def is_cce_value_valid(cceid):
     # Since we've already validated format, this hack suffices:
     cce = re.sub(r'(CCE|-)', '', cceid)
 
-    # (string-to-codepoints - 48) is the same as int. Add in the reverse too.
-    # Double list cast is necessary: map isn't reversible, and generator
-    # isn't indexable.
-    digits = list(reversed(list(map(int, cce))))
+    # The below is an implementation of Luhn's algorithm as this is what the
+    # XPath code does.
+
+    # First, map string numbers to integers. List cast is necessary to be able
+    # to index it.
+    digits = list(map(int, cce))
 
     # Even indices are doubled. Coerce to list for list addition. However,
     # XPath uses 1-indexing so "evens" and "odds" are swapped from Python.
-    evens = list(map(lambda i: i*2, digits[1::2]))
-    odds = digits[0::2]
+    # We handle both the idiv and the mod here as well; note that we only
+    # hvae to do this for evens: no single digit is above 10, so the idiv
+    # always returns 0 and the mod always returns the original number.
+    evens = list(map(lambda i: (i*2)//10 + (i*2) % 10, digits[-2::-2]))
+    odds = digits[-1::-2]
 
-    # XPath flattens the for loop's return into a single list; do this in
-    # via a double sum.
-    tuples = map(lambda j: [j % 10, j // 10], evens + odds)
-    value = sum(sum(tuples, [])) % 10
+    # The checksum value is now the sum of the evens and the odds.
+    value = sum(evens + odds) % 10
 
     # Valid CCE <=> value == 0
     return value == 0

--- a/tests/unit/ssg-module/test_checks.py
+++ b/tests/unit/ssg-module/test_checks.py
@@ -32,14 +32,23 @@ def test_get_oval_path():
                                  "missing_ovals")
 
 
-def test_is_cce_valid():
-    icv = ssg.checks.is_cce_valid
+def test_is_cce_format_valid():
+    icv = ssg.checks.is_cce_format_valid
     assert icv("CCE-27191-6")
     assert icv("CCE-7223-7")
 
     assert not icv("not-valid")
     assert not icv("1234-5")
-    assert not icv("12345-6")
     assert not icv("TBD")
     assert not icv("CCE-TBD")
     assert not icv("CCE-abcde-f")
+
+
+def test_is_cce_value_valid():
+    icv = ssg.checks.is_cce_value_valid
+    assert icv("CCE-27191-6")
+    assert icv("CCE-7223-7")
+
+    assert not icv("1234-5")
+    assert not icv("12345-6")
+

--- a/tests/unit/ssg-module/test_checks.py
+++ b/tests/unit/ssg-module/test_checks.py
@@ -47,7 +47,7 @@ def test_is_cce_format_valid():
 def test_is_cce_value_valid():
     icv = ssg.checks.is_cce_value_valid
     assert icv("CCE-27191-6")
-    assert icv("CCE-7223-7")
+    assert icv("CCE-27223-7")
 
     assert not icv("1234-5")
     assert not icv("12345-6")

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -38,8 +38,8 @@ def has_prefix_cce(yaml_file, product_yaml=None):
         for i_type, i_value in rule['identifiers'].items():
             if i_type[0:3] == 'cce':
                 has_prefix = i_value[0:3].upper() == 'CCE'
-                remainder_valid = ssgcommon.is_cce_valid("CCE-" + i_value[3:])
-                remainder_valid |= ssgcommon.is_cce_valid("CCE-" + i_value[4:])
+                remainder_valid = ssgcommon.is_cce_format_valid("CCE-" + i_value[3:])
+                remainder_valid |= ssgcommon.is_cce_format_valid("CCE-" + i_value[4:])
                 return has_prefix and remainder_valid
     return False
 
@@ -49,7 +49,7 @@ def has_invalid_cce(yaml_file, product_yaml=None):
     if 'identifiers' in rule and rule['identifiers'] is not None:
         for i_type, i_value in rule['identifiers'].items():
             if i_type[0:3] == 'cce':
-                if not ssgcommon.is_cce_valid("CCE-" + i_value):
+                if not ssgcommon.is_cce_value_valid("CCE-" + i_value):
                     return True
     return False
 
@@ -231,9 +231,9 @@ def rewrite_value_remove_prefix(line):
     key = line[0:key_end]
     value = line[key_end+1:].strip()
     new_value = value
-    if ssgcommon.is_cce_valid("CCE-" + value[3:]):
+    if ssgcommon.is_cce_format_valid("CCE-" + value[3:]):
         new_value = value[3:]
-    elif ssgcommon.is_cce_valid("CCE-" + value[4:]):
+    elif ssgcommon.is_cce_format_valid("CCE-" + value[4:]):
         new_value = value[4:]
     return key + ": " + new_value
 
@@ -307,8 +307,8 @@ def fix_prefix_cce(file_contents, yaml_contents):
         for i_type, i_value in yaml_contents[section].items():
             if i_type[0:3] == 'cce':
                 has_prefix = i_value[0:3].upper() == 'CCE'
-                remainder_valid = ssgcommon.is_cce_valid("CCE-" + i_value[3:])
-                remainder_valid |= ssgcommon.is_cce_valid("CCE-" + i_value[4:])
+                remainder_valid = ssgcommon.is_cce_format_valid("CCE-" + i_value[3:])
+                remainder_valid |= ssgcommon.is_cce_format_valid("CCE-" + i_value[4:])
                 if has_prefix and remainder_valid:
                     prefixed_identifiers.append(i_type)
 
@@ -324,7 +324,7 @@ def fix_invalid_cce(file_contents, yaml_contents):
     if yaml_contents[section] is not None:
         for i_type, i_value in yaml_contents[section].items():
             if i_type[0:3] == 'cce':
-                if not ssgcommon.is_cce_valid("CCE-" + i_value):
+                if not ssgcommon.is_cce_value_valid("CCE-" + i_value):
                     invalid_identifiers.append(i_type)
 
     return remove_section_keys(file_contents, yaml_contents, section, invalid_identifiers)


### PR DESCRIPTION
#### Description:

Per the [specification](https://github.com/ComplianceAsCode/content/issues/3044#issuecomment-419526562) given by @redhatrises, adds extended validation to our CCE identifiers. 

As a result of this however, some CCEs in our files are not valid, either in this implementation or in the XPath canonical implementation. This cannot be merged until these are fixed.

In particular, I found this one:

```
ValueError: CCE Identifiers must be valid: value 80335-1 for cce cce@rhel7 in file /home/cipherboy/GitHub/cipherboy/scap-security-guide/fedora/../linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
```

Testing it [here](http://xpather.com/) with the following code gives a return value of 8:
```XPath
  sum (
    for $j in (
      for $i in reverse(
        string-to-codepoints(
          concat(
            substring("CCE-80335-1", 5, string-length("CCE-80335-1")-6),
            substring("CCE-80335-1", string-length("CCE-80335-1"), 1)
          )
        )
      )[position() mod 2 = 0] return ($i - 48) * 2,
      for $i in reverse(
        string-to-codepoints(
          concat(
            substring("CCE-80335-1", 5, string-length("CCE-80335-1")-6),
            substring("CCE-80335-1", string-length("CCE-80335-1"), 1)
          )
        )
      )[position() mod 2 = 1] return ($i - 48)
    ) return ($j mod 10, $j idiv 10)
  ) mod 10
```

#### Rationale:

- Better ensures integrity and correctness of our CCE identifiers. 

Resolves: #3044

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`
