### PR TITLE
Fix PCI-DSS profile description grammar issue.

### DIFF
--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 7'
 
 description: |-
-    Ensures PCI-DSS v3.2.1 related security configuration settings are applied.
+    Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
 selections:
     - var_password_pam_unix_remember=4

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 8'
 
 description: |-
-    Ensures PCI-DSS v3.2.1-related security configuration settings are applied.
+    Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
 selections:
     - var_password_pam_unix_remember=4

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 8'
 
 description: |-
-    Ensures PCI-DSS v3.2.1 related security configuration settings are applied.
+    Ensures PCI-DSS v3.2.1-related security configuration settings are applied.
 
 selections:
     - var_password_pam_unix_remember=4


### PR DESCRIPTION
#### Description:

- Fix PCI-DSS profile description grammar issue. This fix was suggested by someone with documentation expertise.

#### Rationale:

- When using the word "related", some occasions require the use of hyphen. This is one of the cases.
More details on: https://english.stackexchange.com/questions/2908/should-i-use-related-or-related
