### PR TITLE
Produce resolved Ansible snippets early in the build process.

### DIFF
--- a/applications/openshift/etcd/etcd_auto_tls/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^ETCD_AUTO_TLS='
     line: "ETCD_AUTO_TLS=false"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_cert_file/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_cert_file/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: '^ETCD_CERT_FILE'
     line: "ETCD_CERT_FILE /etc/etcd/server.crt"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_client_cert_auth/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^ETCD_CLIENT_CERT_AUTH='
     line: "ETCD_CLIENT_CERT_AUTH=true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_key_file/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_key_file/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: '^ETCD_KEY_FILE='
     line: "ETCD_KEY_FILE /etc/etcd/server.key"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_max_wals/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_max_wals/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^ETCD_MAX_WALS='
     line: "ETCD_MAX_WALS=0"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_peer_auto_tls/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^ETCD_PEER_AUTO_TLS='
     line: "ETCD_PEER_AUTO_TLS=false"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_peer_cert_file/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: '^ETCD_PEER_CERT_FILE'
     line: "ETCD_PEER_CERT_FILE /etc/etcd/peer.crt"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^ETCD_PEER_CLIENT_CERT_AUTH='
     line: "ETCD_PEER_CLIENT_CERT_AUTH=true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_peer_key_file/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: '^ETCD_PEER_KEY_FILE'
     line: "ETCD_PEER_KEY_FILE /etc/etcd/peer.key"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_unique_ca/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^ETCD_TRUSTED_CA_FILE='
     line: "ETCD_TRUSTED_CA_FILE=/etc/etcd/ca.crt"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/applications/openshift/etcd/etcd_wal_dir/ansible/shared.yml
+++ b/applications/openshift/etcd/etcd_wal_dir/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^ETCD_WAL_DIR='
     line: "ETCD_WAL_DIR=/var/lib/etcd/member/wal"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -97,7 +97,8 @@ macro(ssg_build_shorthand_xml PRODUCT)
     string(REPLACE "\n" ";" SHORTHAND_INPUTS "${SHORTHAND_INPUTS_STR}")
 
     add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/rules"
+        # The command also produces the directory with rules, but this is done before the the shorthand XML.
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --resolve-rules-into "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash_remediation_fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" build
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         DEPENDS ${SHORTHAND_INPUTS}
@@ -242,10 +243,12 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
 
       add_custom_command(
           OUTPUT "${ALL_FIXES_DIR}"
-          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --resolved-rules "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
           DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
           DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
           DEPENDS ${EXTRA_LANGUAGE_DEPENDS}
+          # Acutally we mean that it depends on resolved rules.
+          DEPENDS generate-internal-${PRODUCT}-shorthand.xml
           DEPENDS ${EXTRA_SHARED_LANGUAGE_DEPENDS}
           DEPENDS "${SSG_BUILD_SCRIPTS}/combine_remediations.py"
           DEPENDS generate-internal-language-remedations-${PRODUCT}

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -99,6 +99,7 @@ macro(ssg_build_shorthand_xml PRODUCT)
     add_custom_command(
         # The command also produces the directory with rules, but this is done before the the shorthand XML.
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
+        COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/rules"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --resolve-rules-into "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash_remediation_fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" build
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         DEPENDS ${SHORTHAND_INPUTS}

--- a/jre/guide/java/java_jre_configure_crypto_policy/ansible/shared.yml
+++ b/jre/guide/java/java_jre_configure_crypto_policy/ansible/shared.yml
@@ -9,5 +9,3 @@
     dest: "/usr/lib/jvm/jre/lib/security/java.security"
     regexp: '^\s*#?\s*security.useSystemPropertiesFile=true'
     line: 'security.useSystemPropertiesFile=true'
-  tags:
-    @ANSIBLE_TAGS@

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
@@ -9,14 +9,9 @@
   register: points_register
   check_mode: no
   changed_when: False
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Add Kerberos security to mount points"
   shell: awk '$2=="{{ item }}"{$4=$4",sec=krb5:krb5i:krb5p"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
   with_items:
     - "{{ points_register.stdout_lines }}"
-  when: (points_register.stdout | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (points_register.stdout | length > 0)

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
@@ -17,6 +17,4 @@
           path: "{{ item.path }}"
           state: absent
       with_items: "{{ shosts_equiv_locations.files }}"
-      when: shosts_equiv_locations and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+      when: shosts_equiv_locations

--- a/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing/ansible/shared.yml
+++ b/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing/ansible/shared.yml
@@ -7,9 +7,6 @@
   stat:
     path: /etc/samba/smb.conf
   register: st_smb
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Require Client SMB Packet Signing, if using smbclient
   lineinfile:
@@ -17,6 +14,4 @@
     line: client signing = mandatory
     state: present
     insertafter: [global]
-  when: st_smb.stat.exists and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: st_smb.stat.exists

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/ansible/shared.yml
@@ -9,6 +9,3 @@
     dest: /etc/ssh/sshd_config
     regexp: ^HostbasedAuthentication
     line: HostbasedAuthentication no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
@@ -10,9 +10,6 @@
     state: present
   with_items:
     - firewalld
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - (xccdf-var sshd_listening_port)
 
@@ -21,15 +18,11 @@
     port: "{{ sshd_listening_port }}/tcp"
     permanent: yes
     state: enabled
-  when: sshd_listening_port != 22 and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: sshd_listening_port != 22
 
 - name: Enable SSHD in firewalld (default port)
   firewalld:
     service: ssh
     permanent: yes
     state: enabled
-  when: sshd_listening_port == 22 and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: sshd_listening_port == 22

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: "Protocol 2"
     validate: /usr/sbin/sshd -t -f %s
   #notify: :reload ssh
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: Compression delayed
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^PermitEmptyPasswords
     line: PermitEmptyPasswords no
     validate: /usr/sbin/sshd -t -f %s
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: GSSAPIAuthentication no
     validate: /usr/sbin/sshd -t -f %s
   #notify: sshd -t -f %s
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: KerberosAuthentication no
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^IgnoreRhosts
     line: IgnoreRhosts yes
     validate: /usr/sbin/sshd -t -f %s
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^RhostsRSAAuthentication
     line: RhostsRSAAuthentication no
     validate: /usr/sbin/sshd -t -f %s
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
@@ -12,6 +12,3 @@
     insertafter: '(?i)^#?authentication'
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
@@ -13,6 +13,3 @@
     firstmatch: yes 
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^PermitUserEnvironment
     line: PermitUserEnvironment no
     validate: /usr/sbin/sshd -t -f %s
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: StrictModes yes
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^Banner
     line: Banner /etc/issue
     validate: /usr/sbin/sshd -t -f %s
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^X11Forwarding
     line: X11Forwarding yes
     validate: /usr/sbin/sshd -t -f %s
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/ansible/shared.yml
@@ -7,6 +7,3 @@
     line: PrintLastLog yes
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -13,6 +13,3 @@
     line: "ClientAliveInterval {{ sshd_idle_timeout_value }}"
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/ansible/shared.yml
@@ -13,6 +13,3 @@
     line: 'ClientAliveCountMax {{ var_sshd_set_keepalive }}'
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
@@ -13,7 +13,4 @@
     line: "MACs {{ sshd_approved_macs }}"
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: UsePrivilegeSeparation sandbox
     validate: /usr/sbin/sshd -t -f %s
   #notify: restart sshd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
@@ -9,18 +9,13 @@
   shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Add default domain group and set CA directory (if no domain there)"
   lineinfile:
     path: /etc/sssd/sssd.conf
     create: yes
     line: "[domain/default]\nldap_tls_cacertdir = {{ var_sssd_ldap_tls_ca_dir }}\n"
-  when: test_grep_domain.stdout == "" and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAPs path to CA directory"
   lineinfile:
@@ -28,7 +23,4 @@
     regexp: '^\s*ldap_tls_cacertdir'
     insertafter: '\s*\[domain\/[^]]*]'
     line: 'ldap_tls_cacertdir = {{ var_sssd_ldap_tls_ca_dir }}'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -10,25 +10,17 @@
     regexp: '^USELDAPAUTH='
     line: 'USELDAPAUTH=yes'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Test for domain group"
   shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Add default domain group and use STARTTLS (if no domain there)"
   lineinfile:
     path: /etc/sssd/sssd.conf
     line: "[domain/default]\nldap_id_use_start_tls = True\n"
-  when: test_grep_domain.stdout == "" and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAP to use STARTTLS"
   lineinfile:
@@ -36,6 +28,3 @@
     regexp: '^\s*ldap_id_use_start_tls'
     insertafter: '\s*\[domain\/[^]]*]'
     line: 'ldap_id_use_start_tls = True'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -10,6 +10,3 @@
     option: pam_cert_auth
     value: true
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -12,6 +12,3 @@
     option: memcache_timeout
     value: "{{ var_sssd_memcache_timeout }}"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -10,6 +10,3 @@
     option: offline_credentials_expiration
     value: 1
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -10,6 +10,3 @@
     option: ssh_known_hosts_timeout
     value: 86400
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: banner-message-enable
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME banner-message-enabled"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/login-screen/banner-message-enable'
     line: '/org/gnome/login-screen/banner-message-enable'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
@@ -15,9 +15,6 @@
   with_items:
     - gdm.d
     - gdm.d/locks
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "@RULE_TITLE@"
   file:
@@ -29,9 +26,6 @@
   with_items:
     - 00-security-settings
     - locks/00-security-settings-lock
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "@RULE_TITLE@"
   ini_file:
@@ -40,9 +34,6 @@
     option: banner-message-text
     value: string '{{ login_banner_text }}'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of the GNOME3 Login Warning Banner Text"
   lineinfile:
@@ -51,6 +42,3 @@
     line: 'org/gnome/login-screen/banner-message-text'
     create: yes
     state: present
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -11,9 +11,6 @@
     follow: yes
     regexp: '^(password\s+sufficient\s+pam_unix\.so\s.*remember\s*=\s*)(\S+)(.*)$'
     replace: '\g<1>{{ var_password_pam_unix_remember }}\g<3>'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Do not allow users to reuse recent passwords - system-auth (add)"
   replace:
@@ -21,6 +18,3 @@
     follow: yes
     regexp: '^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$'
     replace: '\g<0> remember={{ var_password_pam_unix_remember }}'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
@@ -21,9 +21,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add deny argument to auth pam_faillock preauth
   pamd:
@@ -38,9 +35,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add auth pam_faillock authfail deny after pam_unix.so
   pamd:
@@ -57,9 +51,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add deny argument to auth pam_faillock authfail
   pamd:
@@ -74,9 +65,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add account pam_faillock before pam_unix.so
   pamd:
@@ -91,6 +79,3 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/ansible/shared.yml
@@ -20,9 +20,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add even_deny_root argument to auth pam_faillock preauth
   pamd:
@@ -37,9 +34,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add auth pam_faillock authfail even_deny_root after pam_unix.so
   pamd:
@@ -56,9 +50,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add even_deny_root argument to auth pam_faillock authfail
   pamd:
@@ -72,9 +63,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add account pam_faillock before pam_unix.so
   pamd:
@@ -89,6 +77,3 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/ansible/shared.yml
@@ -21,9 +21,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add fail_interval argument to auth pam_faillock preauth
   pamd:
@@ -38,9 +35,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add auth pam_faillock aufthfail fail_interval after pam_unix.so
   pamd:
@@ -57,9 +51,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add fail_interval argument to auth pam_faillock authfail
   pamd:
@@ -73,9 +64,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add account pam_faillock before pam_unix.so
   pamd:
@@ -90,6 +78,3 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/ansible/shared.yml
@@ -21,9 +21,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add unlock_time argument to pam_faillock preauth
   pamd:
@@ -38,9 +35,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add auth pam_faillock authfail unlock_interval after pam_unix.so
   pamd:
@@ -57,9 +51,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add unlock_time argument to auth pam_faillock authfail
   pamd:
@@ -73,9 +64,6 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Add account pam_faillock before pam_unix.so
   pamd:
@@ -90,6 +78,3 @@
   loop:
     - system-auth
     - password-auth
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -11,9 +11,6 @@
     follow: yes
     regexp: '(^.*\spam_pwquality.so\s.*retry\s*=\s*)(\S+)(.*$)'
     replace: '\g<1>{{ var_password_pam_retry }}\g<3>'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Set Password Retry Prompts Permitted Per-Session - system-auth (add)"
   replace:
@@ -21,6 +18,3 @@
     follow: yes
     regexp: '^.*\spam_pwquality.so\s(?!.*retry\s*=\s*).*$'
     replace: '\g<0> retry={{ var_password_pam_retry }}'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^#?crypt_style
     line: crypt_style = sha512
     state: present
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
@@ -9,6 +9,3 @@
       regexp: ^#?ENCRYPT_METHOD
       line: ENCRYPT_METHOD SHA512
       state: present
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
@@ -10,7 +10,4 @@
     state: present
     regexp: ^CtrlAltDelBurstAction
     line: "CtrlAltDelBurstAction=none"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -8,7 +8,4 @@
   systemd:
     name: ctrl-alt-del.target
     masked: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
@@ -9,12 +9,6 @@
     dest: /etc/default/grub
     regexp: systemd.confirm_spawn=(1|yes|true|on)
     replace: systemd.confirm_spawn=no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Verify that Interactive Boot is Disabled (runtime)
   command: /sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
@@ -17,6 +17,3 @@
     regexp: '(^\s+#|^)\s+card_drivers\s+=\s+.*'
     state: present
   when: opensc_conf_cd.stat.exists    
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
@@ -13,12 +13,7 @@
   changed_when: True
   register: pkcsw_output
   when: pkcs11switch.stat.exists
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "@RULE_TITLE@"
   command: /usr/bin/pkcs11-switch opensc
-  when: pkcs11switch.stat.exists and pkcsw_output.stdout != "opensc" and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: pkcs11switch.stat.exists and pkcsw_output.stdout != "opensc"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
@@ -17,6 +17,3 @@
     regexp: '(^\s+#|^)\s+force_card_driver\s+=\s+.*'
     state: present
   when: opensc_conf_fcd.stat.exists    
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
@@ -11,6 +11,3 @@
     dest: /etc/default/useradd
     regexp: ^INACTIVE
     line: "INACTIVE={{ var_account_disable_post_pw_expiration }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
@@ -11,6 +11,3 @@
     dest: /etc/login.defs
     regexp: ^#?PASS_MAX_DAYS
     line: "PASS_MAX_DAYS {{ var_accounts_maximum_age_login_defs }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/ansible/shared.yml
@@ -11,6 +11,3 @@
       dest: /etc/login.defs
       regexp: ^#?PASS_MIN_DAYS
       line: "PASS_MIN_DAYS {{ var_accounts_minimum_age_login_defs }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
@@ -11,6 +11,3 @@
     regexp: "^PASS_MIN_LEN *[0-9]*"
     state: present
     line: "PASS_MIN_LEN        {{ var_accounts_password_minlen_login_defs }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
@@ -11,6 +11,3 @@
     regexp: "^PASS_WARN_AGE *[0-9]*"
     state: present
     line: "PASS_WARN_AGE        {{ var_accounts_password_warn_age_login_defs }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -8,16 +8,10 @@
     dest: /etc/pam.d/system-auth
     follow: yes
     regexp: 'nullok'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent Log In to Accounts With Empty Password - password-auth"
   replace:
     dest: /etc/pam.d/password-auth
     follow: yes
     regexp: 'nullok'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
@@ -11,6 +11,3 @@
 - name: "Direct root Logins Not Allowed"
   shell: echo > /etc/securetty
   changed_when: securetty_empty.stat.size > "1"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/ansible/shared.yml
@@ -8,6 +8,3 @@
     dest: /etc/securetty
     regexp: 'ttyS[0-9]'
     state: absent
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/ansible/shared.yml
@@ -8,6 +8,3 @@
     dest: /etc/securetty
     regexp: '^vc'
     state: absent
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
@@ -6,7 +6,4 @@
     dest: /etc/login.defs
     regexp: ^FAIL_DELAY
     line: "FAIL_DELAY {{ var_accounts_fail_delay }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
@@ -12,6 +12,3 @@
     insertbefore: "^# End of file"
     regexp: "^#?\\*.*maxlogins"
     line: "*           hard    maxlogins     {{ var_accounts_max_concurrent_login_sessions }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -11,6 +11,3 @@
       dest: /etc/profile
       regexp: ^#?TMOUT
       line: "TMOUT={{ var_accounts_tmout }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
@@ -6,25 +6,19 @@
 - name: "Fail if user is not root"
   fail:
     msg: 'Root account required to read root $PATH'
-  when: ansible_user != "root" and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: ansible_user != "root"
 
 - name: "Get root paths which are not symbolic links"
   shell: 'tr ":" "\n" <<< "$PATH" | xargs -I% find % -maxdepth 0 -type d'
   changed_when: False
   failed_when: False
   register: root_paths
-  when: ansible_user == "root" and @ANSIBLE_PLATFORM_CONDITION@
+  when: ansible_user == "root"
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
 
 - name: "Disable writability to root directories"
   file:
     path: "{{ item }}"
     mode: "g-w,o-w"
   with_items: "{{ root_paths.stdout_lines }}"
-  when: root_paths.stdout_lines is defined and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: root_paths.stdout_lines is defined

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -11,6 +11,3 @@
     dest: /etc/login.defs
     regexp: ^UMASK
     line: "UMASK {{ var_accounts_user_umask }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
@@ -33,18 +33,13 @@
     line: '-a always,exit -F arch=b32 -S create_module -k module-change'
     state: present
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the create_module rule in rules.d on x86_64
   lineinfile:
     path: '{{ all_files[0] }}'
     line: '-a always,exit -F arch=b64 -S create_module -k module-change'
     state: present
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'
 
 # Inserts/replaces the create_modules rule in /etc/audit/audit.rules
 
@@ -53,14 +48,9 @@
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b32 -S create_module -k module-change'
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the create_module rule in audit.rules when on x86_64
   lineinfile:
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b64 -S create_module -k module-change'
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
@@ -33,18 +33,13 @@
     line: '-a always,exit -F arch=b32 -S delete_module -k module-change'
     state: present
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the delete_module rule in rules.d on x86_64
   lineinfile:
     path: '{{ all_files[0] }}'
     line: '-a always,exit -F arch=b64 -S delete_module -k module-change'
     state: present
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'
 
 # Inserts/replaces the delete_modules rule in /etc/audit/audit.rules
 
@@ -53,14 +48,9 @@
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b32 -S delete_module -k module-change'
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the delete_module rule in audit.rules when on x86_64
   lineinfile:
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b64 -S delete_module -k module-change'
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
@@ -33,18 +33,13 @@
     line: '-a always,exit -F arch=b32 -S finit_module -k module-change'
     state: present
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the finit_module rule in rules.d on x86_64
   lineinfile:
     path: '{{ all_files[0] }}'
     line: '-a always,exit -F arch=b64 -S finit_module -k module-change'
     state: present
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'
 
 # Inserts/replaces the finit_modules rule in /etc/audit/audit.rules
 
@@ -53,14 +48,9 @@
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b32 -S finit_module -k module-change'
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the finit_module rule in audit.rules when on x86_64
   lineinfile:
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b64 -S finit_module -k module-change'
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
@@ -33,18 +33,13 @@
     line: '-a always,exit -F arch=b32 -S init_module -k module-change'
     state: present
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the init_module rule in rules.d on x86_64
   lineinfile:
     path: '{{ all_files[0] }}'
     line: '-a always,exit -F arch=b64 -S init_module -k module-change'
     state: present
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'
 
 # Inserts/replaces the init_modules rule in /etc/audit/audit.rules
 
@@ -53,14 +48,9 @@
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b32 -S init_module -k module-change'
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 - name: Inserts/replaces the init_module rule in audit.rules when on x86_64
   lineinfile:
     path: /etc/audit/audit.rules
     line: '-a always,exit -F arch=b64 -S init_module -k module-change'
     create: true
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -8,9 +8,6 @@
   shell: "find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null | cat"
   check_mode: no
   register: find_result
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 # Inserts/replaces the rule in /etc/audit/rules.d
 
@@ -23,9 +20,6 @@
   with_items:
     - "{{ find_result.stdout_lines }}"
   register: files_result
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Overwrites the rule in rules.d
   lineinfile:
@@ -36,9 +30,6 @@
   with_subelements:
     - "{{ files_result.results }}"
     - files
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Adds the rule in rules.d
   lineinfile:
@@ -47,9 +38,7 @@
     create: yes
   with_items:
     - "{{ files_result.results }}"
-  when: item.matched == 0 and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: item.matched == 0
 
 # Adds/overwrites the rule in /etc/audit/audit.rules
 
@@ -61,6 +50,3 @@
     regexp: "^.*path={{ item.item }} .*$"
   with_items:
     - "{{ files_result.results }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: ^\s*enable_krb5\s*=\s*.*$
     state: present
     create: true
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
@@ -12,6 +12,3 @@
     regexp: '^\s*disk_error_action\s*=\s*.*$'
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
@@ -12,6 +12,3 @@
     regexp: '^\s*disk_full_action\s*=\s*.*$'
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -11,6 +11,3 @@
     line: "action_mail_acct = {{ var_auditd_action_mail_acct }}"
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
@@ -12,6 +12,3 @@
     regexp: '^\s*admin_space_left_action\s*=\s*.*$'
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
@@ -12,6 +12,3 @@
     line: "flush = {{ var_auditd_flush }}"
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
@@ -12,6 +12,3 @@
     line: "max_log_file = {{ var_auditd_max_log_file }}"
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
@@ -12,6 +12,3 @@
     regexp: '^\s*max_log_file_action\s*=\s*.*$'
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
@@ -12,6 +12,3 @@
     regexp: '^\s*num_logs\s*=\s*.*$'
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
@@ -12,6 +12,3 @@
     regexp: '^\s*space_left\s*=\s*.*$'
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
@@ -12,6 +12,3 @@
     regexp: '^\s*space_left_action\s*=\s*.*$'
     state: present
   #notify: reload auditd
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/auditing/grub_legacy_audit_argument/ansible/rhel6.yml
+++ b/linux_os/guide/system/auditing/grub_legacy_audit_argument/ansible/rhel6.yml
@@ -5,6 +5,3 @@
 # disruption = low
 - name: "Enable Auditing for Processes Which Start Prior to the Audit Daemon"
   shell: /sbin/grubby --update-kernel=ALL --args="audit=1"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
@@ -11,7 +11,4 @@
     regexp: "^\\*\\.\\*"
     line: "*.* @@{{ rsyslog_remote_loghost_address }}"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
@@ -9,15 +9,10 @@
   changed_when: False
   failed_when: False
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Set ownership to root of system executables"
   file:
     path: "{{ item }}"
     owner: "root"
   with_items: "{{ no_root_system_executables.stdout_lines }}"
-  when: no_root_system_executables.stdout_lines | length > 0 and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: no_root_system_executables.stdout_lines | length > 0

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
@@ -9,15 +9,10 @@
   changed_when: False
   failed_when: False
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Set ownership of system libraries to root"
   file:
     path: "{{ item }}"
     owner: "root"
   with_items: "{{ libraries_not_owned_by_root.stdout_lines }}"
-  when: libraries_not_owned_by_root | length > 0 and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: libraries_not_owned_by_root | length > 0

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
@@ -9,15 +9,10 @@
   changed_when: False
   failed_when: False
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Remove world/group writability of system executables"
   file:
     path: "{{ item }}"
     mode: "go-w"
   with_items: "{{ world_writable_library_files.stdout_lines }}"
-  when: world_writable_library_files.stdout_lines | length > 0 and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: world_writable_library_files.stdout_lines | length > 0

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
@@ -9,15 +9,10 @@
   changed_when: False
   failed_when: False
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Disable world/group writability to library files"
   file:
     path: "{{ item }}"
     mode: "go-w"
   with_items: "{{ world_writable_library_files.stdout_lines }}"
-  when: world_writable_library_files.stdout_lines | length > 0 and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: world_writable_library_files.stdout_lines | length > 0

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
@@ -7,6 +7,3 @@
   replace:
     dest: /etc/default/grub
     regexp: selinux=0
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/selinux/selinux_policytype/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_policytype/ansible/shared.yml
@@ -11,6 +11,3 @@
     regexp: '^SELINUXTYPE='
     line: "SELINUXTYPE={{ var_selinux_policy_name }}"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
@@ -11,6 +11,3 @@
     regexp: '^SELINUX='
     line: "SELINUX={{ var_selinux_state }}"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/dconf_use_text_backend/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_use_text_backend/ansible/shared.yml
@@ -9,9 +9,6 @@
     regexp: '^service-db:keyfile/user.*'
     state: 'absent'
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Insert the \" use textfiles backend\" directive at the top of the config file"
   lineinfile:
@@ -21,7 +18,4 @@
     insertbefore: 'BOF'
     create: yes
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: disable-restart-buttons
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME disablement of Login Restart and Shutdown Buttons"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/login-screen/disable-restart-buttons'
     line: '/org/gnome/login-screen/disable-restart-buttons'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: disable-user-list
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 disablement of Login User List"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/login-screen/disable-user-list'
     line: '/org/gnome/login-screen/disable-user-list'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: enable-smartcard-authentication
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 disablement of Smartcard Authentication"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/login-screen/enable-smartcard-authentication'
     line: '/org/gnome/login-screen/enable-smartcard-authentication'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: allowed-failures
     value: "3"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Login Number of Failures"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/login-screen/allowed-failures'
     line: '/org/gnome/login-screen/allowed-failures'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
@@ -11,6 +11,3 @@
     value: "false"
     no_extra_spaces: yes
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/ansible/shared.yml
@@ -11,6 +11,3 @@
     value: "false"
     no_extra_spaces: yes
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: automount
     value: "false"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Automounting - automount"
   lineinfile:
@@ -20,9 +17,6 @@
     regexp: '^/org/gnome/desktop/media-handling/automount'
     line: '/org/gnome/desktop/media-handling/automount'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Disable GNOME3 Automounting - automount-open"
   ini_file:
@@ -31,9 +25,6 @@
     option: automount-open
     value: "false"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Automounting - automount-open"
   lineinfile:
@@ -41,9 +32,6 @@
     regexp: '^/org/gnome/desktop/media-handling/automount-open'
     line: '/org/gnome/desktop/media-handling/automount-open'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Disable GNOME3 Automounting - autorun-never"
   ini_file:
@@ -52,9 +40,6 @@
     option: autorun-never
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Automounting - autorun-never"
   lineinfile:
@@ -62,7 +47,4 @@
     regexp: '^/org/gnome/desktop/media-handling/autorun-never'
     line: '/org/gnome/desktop/media-handling/autorun-never'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: disable-all
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Thumbnailers"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/desktop/thumbnailers/disable-all'
     line: '/org/gnome/desktop/thumbnailers/disable-all'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: disable-wifi-create
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/nm-applet/disable-wifi-create'
     line: '/org/gnome/nm-applet/disable-wifi-create'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: suppress-wireless-networks-available
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/nm-applet/suppress-wireless-networks-available'
     line: '/org/gnome/nm-applet/suppress-wireless-networks-available'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: authentication-methods
     value: "['vnc']"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Credential Prompting for Remote Access"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/Vino/authentication-methods'
     line: '/org/gnome/Vino/authentication-methods'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: require-encryption
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Encryption for Remote Access"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/Vino/require-encryption'
     line: '/org/gnome/Vino/require-encryption'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: idle_activation_enabled
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME idle_activation_enabled"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -12,9 +12,6 @@
     option: idle-delay
     value: "{{ inactivity_timeout_value }}"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME idle-delay"
   lineinfile:
@@ -22,6 +19,3 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-delay'
     line: '/org/gnome/desktop/screensaver/idle-delay'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: lock-delay
     value: uint32 5
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME lock-delay"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-delay'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: lock-enabled
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME lock-enabled"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: picture-uri
     value: string ''
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME picture-uri"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/desktop/screensaver/picture-uri'
     line: '/org/gnome/desktop/screensaver/picture-uri'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: show-full-name-in-top-bar
     value: "false"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME show-full-name-in-top-bar"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     line: '/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
@@ -9,6 +9,3 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-delay'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
@@ -10,6 +10,3 @@
     regexp: '^/org/gnome/desktop/session/idle-delay'
     line: '/org/gnome/desktop/session/idle-delay'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: logout
     value: string ''
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME disablement of Ctrl-Alt-Del"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/settings-daemon/plugins/media-keys/logout'
     line: '/org/gnome/settings-daemon/plugins/media-keys/logout'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: enabled
     value: "false"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Disable Geolocation in GNOME3 - clock location tracking"
   ini_file:
@@ -28,9 +25,6 @@
     regexp: '^/org/gnome/system/location/enabled'
     line: '/org/gnome/system/location/enabled'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME geolocation - clock location tracking"
   lineinfile:
@@ -38,6 +32,3 @@
     regexp: '^/org/gnome/clocks/geolocation'
     line: '/org/gnome/clocks/geolocation'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
@@ -10,9 +10,6 @@
     option: user-administration-disabled
     value: "true"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Prevent user modification of GNOME3 Thumbnailers"
   lineinfile:
@@ -20,6 +17,3 @@
     regexp: '^/org/gnome/desktop/lockdown/user-administration-disabled'
     line: '/org/gnome/desktop/lockdown/user-administration-disabled'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
@@ -11,9 +11,6 @@
     regexp: '^(?!#)(\S+)$'
     line: "{{ var_system_crypto_policy }}"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Verify that Crypto Policy is Set (runtime)
   shell: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/shared.yml
@@ -9,5 +9,3 @@
     src: /etc/crypto-policies/back-ends/krb5.config
     path: /etc/krb5.conf.d/crypto-policies
     state: link
-  tags:
-    @ANSIBLE_TAGS@

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
@@ -9,5 +9,3 @@
     path: /etc/ipsec.conf
     line: "include /etc/crypto-policies/back-ends/libreswan.config"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
@@ -9,5 +9,3 @@
     dest: /etc/sysconfig/sshd
     state: absent
     regexp: ^\s*CRYPTO_POLICY.*$
-  tags:
-    @ANSIBLE_TAGS@

--- a/linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml
@@ -7,15 +7,10 @@
   stat:
     path: /etc/sysconfig/prelink
   register: prelink_exists
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: disable prelinking
   lineinfile:
     path: /etc/sysconfig/prelink
     regexp: '^PRELINKING='
     line: 'PRELINKING=no'
-  when: prelink_exists.stat.exists and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: prelink_exists.stat.exists

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
@@ -7,6 +7,4 @@
   package:
     name: dracut-fips
     state: present
-  when: ansible_distribution == 'Red Hat Enterprise Linux' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: ansible_distribution == 'Red Hat Enterprise Linux'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -9,25 +9,16 @@
     state: present
   with_items:
     - aide
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Build and Test AIDE Database"
   command: /usr/sbin/aide --init
   changed_when: True
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 # mainly to allow ansible's check mode to work
 - name: "Check whether the stock AIDE Database exists"
   stat:
     path: /var/lib/aide/aide.db.new.gz
   register: aide_database_stat
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Stage AIDE Database"
   copy:
@@ -35,6 +26,4 @@
     dest: /var/lib/aide/aide.db.gz
     backup: yes
     remote_src: yes
-  when: (aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists)

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -9,9 +9,6 @@
     state: present
   with_items:
     - aide
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "@RULE_TITLE@"
   cron:
@@ -21,6 +18,3 @@
     weekday: 0
     user: root
     job: "/usr/sbin/aide --check"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -6,16 +6,12 @@
 - name: "Set fact: Package manager reinstall command (dnf)"
   set_fact:
     package_manager_reinstall_cmd: dnf reinstall -y
-  when: ansible_distribution == "Fedora" and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: ansible_distribution == "Fedora"
 
 - name: "Set fact: Package manager reinstall command (yum)"
   set_fact:
     package_manager_reinstall_cmd: yum reinstall -y
-  when: (ansible_distribution == "RedHat" or ansible_distribution == "OracleLinux") and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (ansible_distribution == "RedHat" or ansible_distribution == "OracleLinux")
 
 - name: "Read files with incorrect hash"
   shell: "rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/' | awk '{print $NF}'"
@@ -23,16 +19,12 @@
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect hash using rpm module
   register: files_with_incorrect_hash
   changed_when: False
-  when: (package_manager_reinstall_cmd is defined) and @ANSIBLE_PLATFORM_CONDITION@
+  when: (package_manager_reinstall_cmd is defined)
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
 
 - name: "Reinstall packages of files with incorrect hash"
   shell: "{{ package_manager_reinstall_cmd }} $(rpm -qf '{{ item }}')"
   args:
     warn: False # Ignore ANSIBLE0006, this task is flexible with regards to package manager
   with_items: "{{ files_with_incorrect_hash.stdout_lines }}"
-  when: (package_manager_reinstall_cmd is defined and (files_with_incorrect_hash.stdout_lines | length > 0)) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (package_manager_reinstall_cmd is defined and (files_with_incorrect_hash.stdout_lines | length > 0))

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -11,24 +11,17 @@
   failed_when: False
   changed_when: False
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Create list of uniq packages
   shell: "rpm -qf {{ files_with_incorrect_ownership.stdout_lines }}|sort |uniq"
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch packages with files with incorrect ownership using rpm module
   register: uniq_list_of_packages
-  when: (files_with_incorrect_ownership.stdout_lines | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (files_with_incorrect_ownership.stdout_lines | length > 0)
 
 - name: "Correct file ownership with RPM"
   shell: "rpm --quiet --setugids '{{ item }}'"
   args:
     warn: False # Ignore ANSIBLE0006, we can't correct ownership using rpm module
   with_items: "{{ uniq_list_of_packages.stdout_lines }}"
-  when: (files_with_incorrect_ownership.stdout_lines | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (files_with_incorrect_ownership.stdout_lines | length > 0)

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -11,15 +11,10 @@
   failed_when: False
   changed_when: False
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Correct file permissions with RPM"
   shell: "rpm --quiet --setperms $(rpm -qf '{{ item }}')"
   args:
     warn: False # Ignore ANSIBLE0006, we can't correct permissions using rpm module
   with_items: "{{ files_with_incorrect_permissions.stdout_lines }}"
-  when: (files_with_incorrect_permissions.stdout_lines | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (files_with_incorrect_permissions.stdout_lines | length > 0)

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
@@ -9,6 +9,3 @@
       regexp: ^#?clean_requirements_on_remove
       line: clean_requirements_on_remove=1
       insertafter: '\[main\]'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
@@ -19,9 +19,7 @@
     option: gpgcheck
     value: 1
     create: False
-  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or yum_config_file.stat.exists) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or yum_config_file.stat.exists)
 
 - name: Ensure GPG check is globally activated (dnf)
   ini_file:
@@ -30,6 +28,4 @@
     option: gpgcheck
     value: 1
     create: False
-  when: ansible_distribution == "Fedora" and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: ansible_distribution == "Fedora"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
@@ -19,9 +19,7 @@
     option: localpkg_gpgcheck
     value: 1
     create: True
-  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or yum_config_file.stat.exists) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or yum_config_file.stat.exists)
 
 - name: Ensure GPG check Enabled for Local Packages (DNF)
   ini_file:
@@ -30,6 +28,4 @@
     option: localpkg_gpgcheck
     value: 1
     create: True
-  when: ansible_distribution == "Fedora" and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: ansible_distribution == "Fedora"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -18,6 +18,3 @@
     dest: "{{ item.path }}"
     regexp: '^gpgcheck'
     line: 'gpgcheck=1'
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -8,9 +8,6 @@
     path: /etc/pki/rpm-gpg/
   register: gpg_key_directory_permission
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 # It should fail if it doesn't find any fingerprints in file - maybe file was not parsed well.
 
@@ -24,26 +21,17 @@
   changed_when: False
   register: gpg_fingerprints
   check_mode: no
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Set Fact - Valid fingerprints
   set_fact:
      gpg_valid_fingerprints: ("567E347AD0044ADE55BA8A5F199E2F91FD431D51" "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0")
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Import RedHat GPG key
   rpm_key:
     state: present
     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
   when:
-    (gpg_key_directory_permission.stat.mode <= '0755')
-    and (( gpg_fingerprints.stdout_lines | difference(gpg_valid_fingerprints)) | length == 0)
-    and (gpg_fingerprints.stdout_lines | length > 0)
-    and (ansible_distribution == "RedHat")
-    and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+   - gpg_key_directory_permission.stat.mode <= '0755'
+   - ( gpg_fingerprints.stdout_lines | difference(gpg_valid_fingerprints)) | length == 0
+   - gpg_fingerprints.stdout_lines | length > 0
+   - ansible_distribution == "RedHat"

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/ansible/shared.yml
@@ -9,6 +9,4 @@
     state: "latest"
   tags:
     - skip_ansible_lint # [ANSIBLE0010] Skipping lint because ANSIBLE0010 is a bad security practice
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_accounts_password
+++ b/shared/templates/template_ANSIBLE_accounts_password
@@ -21,7 +21,4 @@
     regexp: '^#?\s*{{{ VARIABLE }}}'
     line: "{{{ VARIABLE }}} = {{ var_password_pam_{{{ VARIABLE }}} }}"
 {{% endif %}}
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_audit_rules_dac_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_dac_modification
@@ -39,18 +39,13 @@
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
     create: yes
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
@@ -59,9 +54,6 @@
     line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
     state: present
     dest: /etc/audit/audit.rules
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in audit.rules when on x86_64
   lineinfile:
@@ -69,6 +61,4 @@
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'

--- a/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
@@ -39,18 +39,13 @@
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
     create: yes
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
@@ -59,9 +54,6 @@
     line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
     state: present
     dest: /etc/audit/audit.rules
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:
@@ -69,6 +61,4 @@
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'

--- a/shared/templates/template_ANSIBLE_audit_rules_login_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_login_events
@@ -39,9 +39,6 @@
     path: "{{ all_files[0] }}"
     line: "-w {{{ PATH }}} -p wa -k logins"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
@@ -51,6 +48,3 @@
     line: "-w {{{ PATH }}} -p wa -k logins"
     state: present
     dest: /etc/audit/audit.rules
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
+++ b/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
@@ -31,9 +31,6 @@
     path: "{{ all_files[0] }}"
     line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 # Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
 
@@ -42,6 +39,3 @@
     path: /etc/audit/audit.rules
     line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
@@ -42,9 +42,6 @@
   with_items:
     - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
     - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
   lineinfile:
@@ -54,9 +51,7 @@
   with_items:
     - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
     - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
@@ -68,9 +63,6 @@
   with_items:
     - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
     - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:
@@ -81,6 +73,4 @@
   with_items:
     - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
     - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-  when: audit_arch == 'b64' and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: audit_arch == 'b64'

--- a/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
@@ -39,9 +39,6 @@
     path: "{{ all_files[0] }}"
     line: "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification"
     create: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
@@ -51,6 +48,3 @@
     line: "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification"
     state: present
     dest: /etc/audit/audit.rules
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/shared/templates/template_ANSIBLE_file_groupowner
+++ b/shared/templates/template_ANSIBLE_file_groupowner
@@ -12,6 +12,4 @@
   file:
     path: {{{ FILEPATH }}}
     group: {{{ FILEGID }}}
-  when: file_exists.stat.exists and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: file_exists.stat.exists

--- a/shared/templates/template_ANSIBLE_file_owner
+++ b/shared/templates/template_ANSIBLE_file_owner
@@ -12,6 +12,4 @@
   file:
     path: {{{ FILEPATH }}}
     owner: {{{ FILEUID }}}
-  when: file_exists.stat.exists and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: file_exists.stat.exists

--- a/shared/templates/template_ANSIBLE_file_permissions
+++ b/shared/templates/template_ANSIBLE_file_permissions
@@ -12,6 +12,4 @@
   file:
     path: {{{ FILEPATH }}}
     mode: {{{ FILEMODE }}}
-  when: file_exists.stat.exists and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: file_exists.stat.exists

--- a/shared/templates/template_ANSIBLE_file_regex_permissions
+++ b/shared/templates/template_ANSIBLE_file_regex_permissions
@@ -8,8 +8,6 @@
     paths: "{{{ FILEPATH }}}"
     patterns: "{{{ FILENAME }}}"
   register: files_found
-  tags:
-    @ANSIBLE_TAGS@
 
 - name: Set permissions for {{{ FILEPATH }}} file(s)
   file:
@@ -17,7 +15,4 @@
     mode: {{{ FILEMODE }}}
   with_items:
     - "{{ files_found.files }}"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_kernel_module_disabled
+++ b/shared/templates/template_ANSIBLE_kernel_module_disabled
@@ -9,7 +9,4 @@
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: '{{{ KERNMODULE }}}'
     line: "install {{{ KERNMODULE }}} /bin/true"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -10,9 +10,6 @@
   register: device_name
   check_mode: no
   changed_when: False
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - block:
   - name: get back device previous mount option
@@ -36,6 +33,4 @@
       opts: "{{ device_cur_mountoption.stdout }},{{{ MOUNTOPTION }}}"
       state: "mounted"
       fstype: "{{ device_fstype.stdout }}"
-  when: (device_name.stdout | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (device_name.stdout | length > 0)

--- a/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
+++ b/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
@@ -9,14 +9,9 @@
   register: points_register
   check_mode: no
   changed_when: False
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - name: "Add {{{ MOUNTOPTION }}} to mount points"
   shell: awk '$2=="{{ item }}"{$4=$4",{{{ MOUNTOPTION }}}"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
   with_items:
     - "{{ points_register.stdout_lines }}"
-  when: (points_register.stdout | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (points_register.stdout | length > 0)

--- a/shared/templates/template_ANSIBLE_mount_option_var
+++ b/shared/templates/template_ANSIBLE_mount_option_var
@@ -12,9 +12,6 @@
   register: device_name
   check_mode: no
   changed_when: False
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 - block:
   - name: get back device previous mount option
@@ -38,6 +35,4 @@
       opts: "{{ device_cur_mountoption.stdout }},{{{ MOUNTOPTION }}}"
       state: "mounted"
       fstype: "{{ device_fstype.stdout }}"
-  when: (device_name.stdout | length > 0) and @ANSIBLE_PLATFORM_CONDITION@
-  tags:
-    @ANSIBLE_TAGS@
+  when: (device_name.stdout | length > 0)

--- a/shared/templates/template_ANSIBLE_package_installed
+++ b/shared/templates/template_ANSIBLE_package_installed
@@ -7,7 +7,4 @@
   package:
     name: {{{ PKGNAME }}}
     state: present
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_package_removed
+++ b/shared/templates/template_ANSIBLE_package_removed
@@ -7,7 +7,4 @@
   package:
     name: {{{ PKGNAME }}}
     state: absent
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_permissions
+++ b/shared/templates/template_ANSIBLE_permissions
@@ -15,6 +15,3 @@
     {{% if FILEGID != "" %}}
     group: {{{ FILEGID }}}
     {{% endif %}}
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@

--- a/shared/templates/template_ANSIBLE_sebool
+++ b/shared/templates/template_ANSIBLE_sebool
@@ -8,7 +8,4 @@
     name: {{{ SEBOOLID }}}
     state: {{{ SEBOOL_BOOL }}}
     persistent: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_sebool_var
+++ b/shared/templates/template_ANSIBLE_sebool_var
@@ -9,15 +9,10 @@
   package:
     name: libsemanage-python
     state: latest
-  tags:
-    - skip_ansible_lint # [ANSIBLE0010] Skipping lint because ANSIBLE0010 is a bad security practice
 
 - name: Set SELinux boolean {{{ SEBOOLID }}} accordingly
   seboolean:
     name: {{{ SEBOOLID }}}
     state: "{{ var_{{{ SEBOOLID }}} }}"
     persistent: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -10,9 +10,6 @@
     state: "stopped"
   register: service_result
   failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 
 {{% if init_system == "systemd" %}}
 - name: Disable socket of service {{{ SERVICENAME }}} if applicable
@@ -22,7 +19,4 @@
     state: "stopped"
   register: socket_result
   failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 {{% endif %}}

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -8,7 +8,4 @@
     name: {{{ DAEMONNAME }}}
     enabled: "yes"
     state: "started"
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_sysctl
+++ b/shared/templates/template_ANSIBLE_sysctl
@@ -9,7 +9,4 @@
     value: {{{ SYSCTLVAL }}}
     state: present
     reload: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/templates/template_ANSIBLE_sysctl_var
+++ b/shared/templates/template_ANSIBLE_sysctl_var
@@ -11,7 +11,4 @@
     value: "{{ sysctl_{{{ SYSCTLID }}}_value }}"
     state: present
     reload: yes
-  tags:
-    @ANSIBLE_TAGS@
-  @ANSIBLE_ENSURE_PLATFORM@
 

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -56,33 +56,7 @@
   <xsl:param name="fix"/>
   <xsl:variable name="rep0" select="."/>
 
-  <xsl:variable name="platform_cpe">
-    <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rule/xccdf:platform/@idref"/>
-      <xsl:with-param name="replace" select="'cpe:/a:'"/>
-      <xsl:with-param name="with" select="''"/>
-    </xsl:call-template>
-  </xsl:variable>
   <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
-  <xsl:variable name="ref_nist800_53" select="$rule/xccdf:reference[starts-with(@href, 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53')]/text()"/>
-  <xsl:variable name="ref_nist800_171" select="$rule/xccdf:reference[starts-with(@href, 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171')]/text()"/>
-  <xsl:variable name="ref_pci_dss" select="$rule/xccdf:reference[starts-with(@href, 'https://www.pcisecuritystandards.org/')]/text()"/>
-  <xsl:variable name="ref_cjis" select="$rule/xccdf:reference[starts-with(@href, 'https://www.fbi.gov/file-repository/cjis-security-policy')]/text()"/>
-  <xsl:variable name="ref_disa_ossrg" select="$rule/xccdf:reference[starts-with(@href, 'http://iase.disa.mil/stigs/srgs/Pages/index.aspx')]/text()"/>
-  <xsl:variable name="ref_disa_stigid" select="$rule/xccdf:reference[starts-with(@href, 'http://iase.disa.mil/stigs/os/unix-linux/Pages/index.aspx')]/text()"/>
-
-  <xsl:variable name="ansible_tags">- <xsl:value-of select="$rule/@id"/>
-    - <xsl:value-of select="$rule/@severity"/>_severity<xsl:if test="$fix/@strategy">
-    - <xsl:value-of select="$fix/@strategy"/>_strategy</xsl:if><xsl:if test="$fix/@complexity">
-    - <xsl:value-of select="$fix/@complexity"/>_complexity</xsl:if><xsl:if test="$fix/@disruption">
-    - <xsl:value-of select="$fix/@disruption"/>_disruption</xsl:if><xsl:for-each select="$ident_cce">
-    - <xsl:value-of select="."/></xsl:for-each><xsl:for-each select="$ref_nist800_53">
-    - NIST-800-53-<xsl:value-of select="."/></xsl:for-each><xsl:for-each select="$ref_nist800_171">
-    - NIST-800-171-<xsl:value-of select="."/></xsl:for-each><xsl:for-each select="$ref_pci_dss">
-    - PCI-DSS-<xsl:value-of select="."/></xsl:for-each><xsl:for-each select="$ref_cjis">
-    - CJIS-<xsl:value-of select="."/></xsl:for-each><xsl:for-each select="$ref_disa_ossrg">
-    - DISA-<xsl:value-of select="."/></xsl:for-each><xsl:for-each select="$ref_disa_stigid">
-    - DISA-STIG-<xsl:value-of select="."/></xsl:for-each></xsl:variable>
 
   <xsl:variable name="rep1">
     <xsl:call-template name="find-and-replace">
@@ -92,17 +66,9 @@
     </xsl:call-template>
   </xsl:variable>
 
-  <xsl:variable name="rep2">
-    <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rep1"/>
-      <xsl:with-param name="replace" select="'@ANSIBLE_TAGS@'"/>
-      <xsl:with-param name="with" select="$ansible_tags"/>
-    </xsl:call-template>
-  </xsl:variable>
-
   <xsl:variable name="rep3">
     <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rep2"/>
+      <xsl:with-param name="text" select="$rep1"/>
       <xsl:with-param name="replace" select="'@RULE_ID@'"/>
       <xsl:with-param name="with" select="$rule/@id"/>
     </xsl:call-template>
@@ -116,57 +82,7 @@
     </xsl:call-template>
   </xsl:variable>
 
-  <xsl:variable name='newline'><xsl:text>
-</xsl:text></xsl:variable>
-
-  <xsl:variable name="rep5">
-    <xsl:variable name="platform_condition">
-      <xsl:choose>
-        <xsl:when test="$rule/xccdf:platform">
-          <xsl:choose>
-            <xsl:when test="$platform_cpe = 'machine'">
-              <xsl:value-of select="concat('when:  # Bare-metal/VM task, not applicable for containers', $newline, '    - (ansible_virtualization_role != &quot;guest&quot; or ansible_virtualization_type != &quot;docker&quot;)')"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="concat('# Error ensuring that the platform is applicable - unknown platform CPE spec encountered: &quot;', $platform_cpe, '&quot;')"/>
-            </xsl:otherwise>
-	  </xsl:choose>
-        </xsl:when>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rep4"/>
-      <xsl:with-param name="replace" select="'@ANSIBLE_ENSURE_PLATFORM@'"/>
-      <xsl:with-param name="with" select="$platform_condition"/>
-    </xsl:call-template>
-  </xsl:variable>
-
-  <xsl:variable name="rep6">
-    <xsl:variable name="platform_condition">
-      <xsl:choose>
-        <xsl:when test="$rule/xccdf:platform">
-          <xsl:choose>
-            <xsl:when test="$platform_cpe = 'machine'">
-              <xsl:value-of select="'(ansible_virtualization_role != &quot;guest&quot; or ansible_virtualization_type != &quot;docker&quot;)'"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:value-of select="concat(' # Error ensuring that the platform is applicable - unknown platform CPE spec encountered: &quot;', $platform_cpe, '&quot;')"/>
-            </xsl:otherwise>
-	  </xsl:choose>
-        </xsl:when>
-        <xsl:otherwise>
-	  <xsl:value-of select="'True'"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
-    <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rep5"/>
-      <xsl:with-param name="replace" select="'@ANSIBLE_PLATFORM_CONDITION@'"/>
-      <xsl:with-param name="with" select="$platform_condition"/>
-    </xsl:call-template>
-  </xsl:variable>
-
-  <xsl:value-of select="$rep6"/>
+  <xsl:value-of select="$rep4"/>
 </xsl:template>
 
 <xsl:template match="@* | node()" mode="fix_contents">

--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -5,9 +5,15 @@ Common functions for processing Ansible in SSG
 from __future__ import absolute_import
 from __future__ import print_function
 
+import re
+
+from collections import OrderedDict
+
 from .constants import ansible_version_requirement_pre_task_name
 from .constants import min_ansible_version
-import re
+from ssg import build_yaml
+from ssg import build_remediations
+from ssg import yaml
 
 
 def add_minimum_version(ansible_src):
@@ -50,3 +56,137 @@ def remove_trailing_whitespace(ansible_src):
     Removes trailing whitespace in an Ansible script
     """
     return re.sub(r'[ \t]+$', '', ansible_src, 0, flags=re.M)
+
+
+def _strings_to_list(one_or_more_strings):
+    """
+    Output a list, that either contains one string, or a list of strings.
+    In Python, strings can be cast to lists without error, but with unexpected result.
+    """
+    if isinstance(one_or_more_strings, str):
+        return [one_or_more_strings]
+    else:
+        return list(one_or_more_strings)
+
+
+def update_yaml_list_or_string(current_contents, new_contents):
+    result = []
+    if current_contents:
+        result += _strings_to_list(current_contents)
+    if new_contents:
+        result += _strings_to_list(new_contents)
+    if not result:
+        result = ""
+    if len(result) == 1:
+        result = result[0]
+    return result
+
+
+class AnsibleRemediation(object):
+
+    def __init__(self, contents, config):
+        self.contents = contents
+        self.config = config
+
+        self.parsed = yaml.ordered_load("\n".join(contents))
+
+        self.rule = None
+
+    def update_tags_from_config(self, to_update):
+        tags = to_update.get("tags", [])
+        if "strategy" in self.config:
+            tags.append("{0}_strategy".format(self.config["strategy"]))
+        if "complexity" in self.config:
+            tags.append("{0}_complexity".format(self.config["complexity"]))
+        if "disruption" in self.config:
+            tags.append("{0}_disruption".format(self.config["disruption"]))
+        to_update["tags"] = tags
+
+    def update_tags_from_rule(self, platform, to_update):
+        if not self.rule:
+            raise RuntimeError("The Ansible snippet has no rule loaded.")
+
+        tags = to_update.get("tags", [])
+        tags.insert(0, "{0}_severity".format(self.rule.severity))
+        tags.insert(0, self.rule.id_)
+
+        cce_num = self._get_cce(platform)
+        if cce_num:
+            tags.append("CCE-{0}".format(cce_num))
+
+        refs = self.get_references(platform)
+        tags.extend(refs)
+        to_update["tags"] = tags
+
+    def _get_cce(self, platform):
+        our_cce = None
+        for cce, val in self.rule.identifiers.items():
+            if cce.endswith(platform):
+                our_cce = val
+                break
+        return our_cce
+
+    def get_references(self, platform):
+        if not self.rule:
+            raise RuntimeError("The Ansible snippet has no rule loaded.")
+        # see xccdf-addremediations.xslt <- shared_constants.xslt <- shared_shorthand2xccdf.xslt
+        # if you want to know how the map was constructed
+        platform_id_map = {
+            "rhel6": "RHEL-06",
+            "rhel7": "RHEL-07",
+            "rhel8": "RHEL-08",
+        }
+        stig_platform_id = "DISA-STIG-{id}".format(id=platform_id_map.get(platform, None))
+        ref_prefix_map = {
+            "nist": "NIST-800-53",
+            "cui": "NIST-800-171",
+            "pcidss": "PCI-DSS",
+            "cjis": "CJIS",
+            "stigid@{platform}".format(platform=platform): stig_platform_id
+        }
+        result = []
+        for ref_class, prefix in ref_prefix_map.items():
+            refs = self._get_rule_reference(ref_class)
+            result.extend(["{prefix}-{value}".format(prefix=prefix, value=v) for v in refs])
+        return result
+
+    def _get_rule_reference(self, ref_class):
+        refs = self.rule.references.get(ref_class, "")
+        if refs:
+            return refs.split(",")
+        else:
+            return []
+
+    def update_when_from_rule(self, to_update):
+        additional_when = ""
+        if self.rule.platform == "machine":
+            additional_when = ('ansible_virtualization_role != "guest" '
+                               'or ansible_virtualization_type != "docker"')
+        to_update.setdefault("when", "")
+        new_when = update_yaml_list_or_string(to_update["when"], additional_when)
+        if not new_when:
+            to_update.pop("when")
+        else:
+            to_update["when"] = new_when
+
+    def update(self, platform):
+        for p in self.parsed:
+            if not isinstance(p, dict):
+                continue
+            self.update_when_from_rule(p)
+            self.update_tags_from_config(p)
+            self.update_tags_from_rule(platform, p)
+
+    @classmethod
+    def from_snippet_and_rule(cls, snippet_fname, rule_fname):
+        rule = build_yaml.Rule.from_yaml(rule_fname)
+        result = cls.from_snippet(snippet_fname)
+        result.rule = rule
+        return result
+
+    @classmethod
+    def from_snippet(cls, snippet_fname):
+        parsed = build_remediations.parse_from_file_without_jinja(snippet_fname)
+        result = cls(parsed.contents, parsed.config)
+        return result
+

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -14,7 +14,7 @@ from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 
 from .checks import is_cce_valid
 from .yaml import open_and_expand, open_and_macro_expand
-from .utils import required_key
+from .utils import required_key, mkdir_p
 
 from .xml import ElementTree as ET
 from .shims import unicode_func
@@ -810,6 +810,7 @@ class BuildLoader(DirectoryLoader):
             if self.resolved_rules_dir:
                 output_for_rule = os.path.join(
                     self.resolved_rules_dir, "{id_}.yml".format(id_=rule.id_))
+                mkdir_p(self.resolved_rules_dir)
                 with open(output_for_rule, "w") as f:
                     yaml.dump(rule.to_contents_dict(), f)
 

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import multiprocessing
+import errno
+import os
 
 
 class SSGError(RuntimeError):
@@ -83,3 +85,14 @@ def write_list_file(path, contents):
     _f.write(_contents)
     _f.flush()
     _f.close()
+
+
+# Taken from https://stackoverflow.com/a/600612/592892
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -6,6 +6,8 @@ import yaml
 import sys
 import re
 
+from collections import OrderedDict
+
 from .jinja import extract_substitutions_dict_from_template, process_file
 from .constants import (PKG_MANAGER_TO_SYSTEM,
                         PKG_MANAGER_TO_CONFIG_FILE,
@@ -139,3 +141,34 @@ def open_environment(build_config_yaml, product_yaml):
     contents.update(open_raw(product_yaml))
     contents.update(_get_implied_properties(contents))
     return contents
+
+
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+    """
+    Drop-in replacement for yaml.load(), but preserves order of dictionaries
+    """
+    class OrderedLoader(Loader):
+        pass
+
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    return yaml.load(stream, OrderedLoader)
+
+
+def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
+    """
+    Drop-in replacement for yaml.dump(), but preserves order of dictionaries
+    """
+    class OrderedDumper(Dumper):
+        pass
+
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            data.items())
+    OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    return yaml.dump(data, stream, OrderedDumper, **kwds)

--- a/tests/unit/ssg-module/data/ansible-resolved.yml
+++ b/tests/unit/ssg-module/data/ansible-resolved.yml
@@ -1,0 +1,35 @@
+- name: Test for existence /boot/grub2/grub.cfg
+  stat:
+    path: /boot/grub2/grub.cfg
+  register: file_exists
+  when: ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
+  tags:
+    - file_owner_grub2_cfg
+    - medium_severity
+    - configure_strategy
+    - low_complexity
+    - low_disruption
+    - CCE-26860-7
+    - NIST-800-53-AC-6(7)
+    - NIST-800-171-3.4.5
+    - PCI-DSS-Req-7.1
+    - CJIS-5.5.2.2
+
+- name: Ensure owner 0 on /boot/grub2/grub.cfg
+  file:
+    path: /boot/grub2/grub.cfg
+    owner: 0
+  when:
+    - file_exists.stat.exists
+    - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
+  tags:
+    - file_owner_grub2_cfg
+    - medium_severity
+    - configure_strategy
+    - low_complexity
+    - low_disruption
+    - CCE-26860-7
+    - NIST-800-53-AC-6(7)
+    - NIST-800-171-3.4.5
+    - PCI-DSS-Req-7.1
+    - CJIS-5.5.2.2

--- a/tests/unit/ssg-module/data/ansible.yml
+++ b/tests/unit/ssg-module/data/ansible.yml
@@ -1,0 +1,17 @@
+# File processed by the build system, i.e. retrieved from the build/rhel7/fixes/ansible/file_owner_grub2_cfg.yml
+#
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+- name: Test for existence /boot/grub2/grub.cfg
+  stat:
+    path: /boot/grub2/grub.cfg
+  register: file_exists
+
+- name: Ensure owner 0 on /boot/grub2/grub.cfg
+  file:
+    path: /boot/grub2/grub.cfg
+    owner: 0
+  when: file_exists.stat.exists

--- a/tests/unit/ssg-module/data/file_owner_grub2_cfg.yml
+++ b/tests/unit/ssg-module/data/file_owner_grub2_cfg.yml
@@ -1,0 +1,30 @@
+# File processed by the build system, i.e. retrieved from the build/rhel7/rules/file_owner_grub2_cfg.yml
+#
+description: 'The file <tt>/boot/grub2/grub.cfg</tt> should
+
+  be owned by the <tt>root</tt> user to prevent destruction
+
+  or modification of the file.
+
+
+  To properly set the owner of <code>/boot/grub2/grub.cfg</code>, run the command:
+
+  <pre>$ sudo chown root /boot/grub2/grub.cfg </pre>'
+identifiers: {cce@rhel7: 26860-7, cce@rhel8: 80805-5}
+ocil: ' To check the ownership of <code>/boot/grub2/grub.cfg</code>, run the command:
+  <pre>$ ls -lL /boot/grub2/grub.cfg</pre> If properly configured, the output should
+  indicate the following owner: <code>root</code>'
+ocil_clause: ' /boot/grub2/grub.cfg has owner root'
+oval_external_content: null
+platform: machine
+# TODO: Make Rule get this from group, so it can be saved here
+# platform: null
+prodtype: rhel7,rhel8,fedora,ol7,ol8
+rationale: Only root should be able to modify important boot parameters.
+references: {cis: 1.4.1, cis-csc: '12,13,14,15,16,18,3,5', cjis: 5.5.2.2, cobit5: 'APO01.06,DSS05.04,DSS05.07,DSS06.02',
+  cui: 3.4.5, disa: '225', hipaa: '164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)',
+  isa-62443-2009: 4.3.3.7.3, isa-62443-2013: 'SR 2.1,SR 5.2', iso27001-2013: 'A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5',
+  nist: AC-6(7), nist-csf: 'PR.AC-4,PR.DS-5', pcidss: Req-7.1}
+severity: medium
+title: Verify /boot/grub2/grub.cfg User Ownership
+warnings: []

--- a/tests/unit/ssg-module/test_ansible.py
+++ b/tests/unit/ssg-module/test_ansible.py
@@ -1,10 +1,16 @@
-import pytest
-
 import os
 import re
 import textwrap
+from collections import OrderedDict
+
+import pytest
+
 import ssg.ansible
 from ssg.constants import min_ansible_version
+from ssg.yaml import ordered_load
+
+
+DATADIR = os.path.join(os.path.dirname(__file__), "data")
 
 
 def strings_equal_except_whitespaces(left, right):
@@ -61,3 +67,78 @@ def test_add_minimum_version():
     assert ssg.ansible.add_minimum_version(unknown_snippet) == unknown_snippet
 
     assert ssg.ansible.add_minimum_version(processed_snippet) == processed_snippet
+
+
+def test_when_update():
+    assert ssg.ansible.update_yaml_list_or_string(
+        "",
+        "",
+    ) == ""
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        "something",
+        "",
+    ) == "something"
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        ["something"],
+        "",
+    ) == "something"
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        "",
+        "else",
+    ) == "else"
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        "something",
+        "else",
+    ) == ["something", "else"]
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        "",
+        ["something", "else"],
+    ) == ["something", "else"]
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        ["something", "else"],
+        "",
+    ) == ["something", "else"]
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        "something",
+        ["entirely", "else"],
+    ) == ["something", "entirely", "else"]
+
+    assert ssg.ansible.update_yaml_list_or_string(
+        ["something", "entirely"],
+        ["entirely", "else"],
+    ) == ["something", "entirely", "entirely", "else"]
+
+
+def test_ansible_class():
+    remediation = ssg.ansible.AnsibleRemediation.from_snippet_and_rule(
+        os.path.join(DATADIR, "ansible.yml"), os.path.join(DATADIR, "file_owner_grub2_cfg.yml")
+    )
+
+    assert remediation.config["reboot"] == 'false'
+    assert remediation.config["strategy"] == 'configure'
+    assert remediation.config["complexity"] == 'low'
+    assert remediation.config["disruption"] == 'low'
+
+
+def test_ansible_conformance():
+    remediation = ssg.ansible.AnsibleRemediation.from_snippet_and_rule(
+        os.path.join(DATADIR, "ansible.yml"), os.path.join(DATADIR, "file_owner_grub2_cfg.yml")
+    )
+    ref_remediation_dict = ordered_load(open(os.path.join(DATADIR, "ansible-resolved.yml")))
+
+    remediation.update("rhel7")
+
+    # The comparison has to be done this way due to possible order variations,
+    # which don't matter, but they make tests to fail.
+    assert set(remediation.parsed[0]["tags"]) == set(ref_remediation_dict[0]["tags"])
+    assert set(remediation.parsed[1]["tags"]) == set(ref_remediation_dict[1]["tags"])
+    assert set(remediation.parsed[0]["when"]) == set(ref_remediation_dict[0]["when"])
+    assert set(remediation.parsed[1]["when"]) == set(ref_remediation_dict[1]["when"])
+    assert set(remediation.parsed[0]["name"]) == set(ref_remediation_dict[0]["name"])

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -50,8 +50,13 @@ def test_parse_from_file_with_jinja():
 
 
 def test_process_fix():
+    remediation_cls = sbr.REMEDIATION_TO_CLASS["bash"]
+
     fixes = {}
-    sbr.process_fix(fixes, 'bash', {}, 'rhel7', rhel_bash, 'rule_dir')
+
+    remediation_obj = remediation_cls(
+        {}, "", "rhel7", rhel_bash, "rule_dir")
+    remediation_obj.process(fixes)
 
     assert 'rule_dir' in fixes
     assert len(fixes['rule_dir']) == 2


### PR DESCRIPTION
This PR changes the Ansible remediations generation process. It aims to make build more transparent and reusable by exposing almost-ready remediations as individual files in the build directory. Next, it gets rid of `@ANSIBLE_TAGS@` and other placeholders and slightly reduces the amount of XSLT transforms performed during the build.

Past state:
* Ansible remediations were aggregated to the huge `fixes-ansible.xml` file as templates - they have contained those `@ANSIBLE_TAGS@` and other placeholders, they weren't valid YAML snippets.
* Later in the build process, an XSLT transform expanded those snippets to valid Ansible/YAML.

New state:
* The `@ANSIBLE_TAGS@` and some (not all) other placeholders were removed, as they are not meant to be used.
* Individual snippets are exported to `build/<product>/fixes/ansible/<rule-id>.yml` in form of valid YAML files, with `tags` and `when` populated correctly.

Regressions:
At this stage, no regressions are expected. As `pyyaml` is used in part of the processing, the indentation, quotation and interpretation of boolean values changed, so it is not trivial to compare new and old remediations. I have used profile roles with leading whitespace trimmed, which allows for quite nice comparison.

How it has been done:
* The remediation build has been slightly refactored by introducing classes - now e.g. Bash and Ansible remediations are quite different, and method override is a convenient way how to introduce additional steps to remediation build.
* The `AnsibleRemediation` class in `ssg.ansible` reads the remediation stub, looks up the resolved rule in the build directory, and adds metadata to the remediation.
* This happens during the remediation collection phase, i.e. before embedding remediations in huge XML files.
* Some XSLT is still performed later in the build, but the scope of it is now very limited.

The ugly:
There is now an `AnsibleRemediation` class in `ssg.ansible` and `ssg.build_remediations`. Although there is no code duplication, those two classes should be merged.
See also #3830.