### PR TITLE
Remove removed directories from CMake

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -210,15 +210,7 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
     )
     string(REPLACE "\n" ";" LANGUAGE_REMEDIATIONS_OUTPUTS "${LANGUAGE_REMEDIATIONS_OUTPUTS_STR}")
 
-    list(APPEND EXTRA_DEPENDS)
-    list(APPEND EXTRA_SHARED_DEPENDS)
 
-    foreach(LANGUAGE ${LANGUAGES})
-        file(GLOB EXTRA_LANGUAGE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}/*")
-        file(GLOB EXTRA_SHARED_LANGUAGE_DEPENDS "${SSG_SHARED}/fixes/${LANGUAGE}/*")
-        list(APPEND EXTRA_DEPENDS ${EXTRA_LANGUAGE_DEPENDS})
-        list(APPEND EXTRA_SHARED_DEPENDS ${EXTRA_SHARED_LANGUAGE_DEPENDS})
-    endforeach()
 
     add_custom_command(
         OUTPUT ${LANGUAGE_REMEDIATIONS_OUTPUTS}
@@ -229,8 +221,6 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
         DEPENDS "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml"
         DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
         DEPENDS "${SSG_BUILD_SCRIPTS}/generate_from_templates.py"
-        DEPENDS ${EXTRA_DEPENDS}
-        DEPENDS ${EXTRA_SHARED_DEPENDS}
         COMMENT "[${PRODUCT}-content] generating all fixes: ${LANGUAGES}"
     )
     add_custom_target(
@@ -238,19 +228,15 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
         DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
     )
     foreach(LANGUAGE ${LANGUAGES})
-      file(GLOB EXTRA_LANGUAGE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}/*")
-      file(GLOB EXTRA_SHARED_LANGUAGE_DEPENDS "${SSG_SHARED}/fixes/${LANGUAGE}/*")
       set(ALL_FIXES_DIR "${CMAKE_CURRENT_BINARY_DIR}/fixes/${LANGUAGE}")
 
       add_custom_command(
           OUTPUT "${ALL_FIXES_DIR}"
-          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --resolved-rules "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${SSG_SHARED}/fixes/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}" "${CMAKE_CURRENT_SOURCE_DIR}/fixes/${LANGUAGE}"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --resolved-rules "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}"
           DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
           DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
-          DEPENDS ${EXTRA_LANGUAGE_DEPENDS}
           # Acutally we mean that it depends on resolved rules.
           DEPENDS generate-internal-${PRODUCT}-shorthand.xml
-          DEPENDS ${EXTRA_SHARED_LANGUAGE_DEPENDS}
           DEPENDS "${SSG_BUILD_SCRIPTS}/combine_remediations.py"
           DEPENDS generate-internal-language-remedations-${PRODUCT}
           COMMENT "[${PRODUCT}-content] collecting all ${LANGUAGE} fixes"


### PR DESCRIPTION


#### Description
Removes non-existent directories form CMake scripts.

#### Rationale:
In #3817 we removed `/<product>/fixes` directories.
In #3812 we removed `/shared/fixes`.
We don't need to use them in CMake because they don't exist.
