### PR TITLE
Unify command line arguments terminology

### DIFF
--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -19,27 +19,27 @@ import ssg.xml
 def parse_args():
     p = argparse.ArgumentParser()
     p.add_argument(
-        "--build-config-yaml", required=True, dest="build_config_yaml",
+        "--build-config-yaml", required=True,
         help="YAML file with information about the build configuration. "
         "e.g.: ~/scap-security-guide/build/build_config.yml"
     )
     p.add_argument(
-        "--product-yaml", required=True, dest="product_yaml",
+        "--product-yaml", required=True,
         help="YAML file with information about the product we are building. "
         "e.g.: ~/scap-security-guide/rhel7/product.yml"
     )
     p.add_argument(
-        "--resolved-rules", required=True,
+        "--resolved-rules-dir", required=True,
         help="Directory with <rule-id>.yml resolved rule YAMLs"
     )
-    p.add_argument("--remediation_type", required=True,
+    p.add_argument("--remediation-type", required=True,
                    help="language or type of the remediations we are combining."
                    "example: ansible")
     p.add_argument(
-        "--output_dir", required=True,
+        "--output-dir", required=True,
         help="output directory where all remediations will be saved"
     )
-    p.add_argument("fixdirs", metavar="FIX_DIR", nargs="+",
+    p.add_argument("fix_dirs", metavar="FIX_DIR", nargs="+",
                    help="directory(ies) from which we will collect "
                    "remediations to combine.")
 
@@ -63,14 +63,14 @@ def main():
     remediation_cls = remediation.REMEDIATION_TO_CLASS[args.remediation_type]
 
     fixes = dict()
-    for fixdir in args.fixdirs:
+    for fixdir in args.fix_dirs:
         if os.path.isdir(fixdir):
             for filename in os.listdir(fixdir):
                 file_path = os.path.join(fixdir, filename)
                 fix_name, _ = os.path.splitext(filename)
 
                 remediation_obj = remediation_cls(
-                    env_yaml, args.resolved_rules, product, file_path, fix_name)
+                    env_yaml, args.resolved_rules_dir, product, file_path, fix_name)
                 # Fixes gets updated with the contents of the fix, if it is applicable
                 remediation_obj.process(fixes)
 
@@ -84,7 +84,7 @@ def main():
             # (i.e., the value of _dir) to create the fix_name
 
             remediation_obj = remediation_cls(
-                env_yaml, args.resolved_rules, product, _path, rule_id)
+                env_yaml, args.resolved_rules_dir, product, _path, rule_id)
             # Fixes gets updated with the contents of the fix, if it is applicable
             remediation_obj.process(fixes)
 

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -18,16 +18,16 @@ def parse_args():
         "(benchmark, rules, groups) to XCCDF Shorthand Format"
     )
     parser.add_argument(
-        "--build-config-yaml", required=True, dest="build_config_yaml",
+        "--build-config-yaml", required=True,
         help="YAML file with information about the build configuration. "
         "e.g.: ~/scap-security-guide/build/build_config.yml"
     )
     parser.add_argument(
-        "--product-yaml", required=True, dest="product_yaml",
+        "--product-yaml", required=True,
         help="YAML file with information about the product we are building. "
         "e.g.: ~/scap-security-guide/rhel7/product.yml"
     )
-    parser.add_argument("--bash_remediation_fns", required=True,
+    parser.add_argument("--bash-remediation-fns", required=True,
                         help="XML with the XCCDF Group containing all bash "
                         "remediation functions stored as values."
                         "e.g.: build/bash-remediation-functions.xml")
@@ -37,7 +37,7 @@ def parse_args():
     parser.add_argument("action",
                         choices=["build", "list-inputs", "list-outputs"],
                         help="Which action to perform.")
-    parser.add_argument("--resolve-rules-into", "-l",
+    parser.add_argument("--resolved-rules-dir", "-l",
                         help="To which directory to put processed rule YAMLs.")
     return parser.parse_args()
 
@@ -64,7 +64,8 @@ def main():
 
     if args.action == "build":
         loader = ssg.build_yaml.BuildLoader(
-            profiles_root, args.bash_remediation_fns, env_yaml, args.resolve_rules_into)
+            profiles_root, args.bash_remediation_fns, env_yaml,
+            args.resolved_rules_dir)
         loader.process_directory_tree(benchmark_root)
         loader.export_group_to_file(args.output)
     elif args.action == "list-inputs":

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -91,7 +91,7 @@ endmacro()
 
 macro(ssg_build_shorthand_xml PRODUCT)
     execute_process(
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash_remediation_fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" list-inputs
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash-remediation-fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" list-inputs
         OUTPUT_VARIABLE SHORTHAND_INPUTS_STR
     )
     string(REPLACE "\n" ";" SHORTHAND_INPUTS "${SHORTHAND_INPUTS_STR}")
@@ -100,7 +100,7 @@ macro(ssg_build_shorthand_xml PRODUCT)
         # The command also produces the directory with rules, but this is done before the the shorthand XML.
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/rules"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --resolve-rules-into "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash_remediation_fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" build
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --bash-remediation-fns "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" build
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         DEPENDS ${SHORTHAND_INPUTS}
         DEPENDS generate-internal-bash-remediation-functions.xml
@@ -232,7 +232,7 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
 
       add_custom_command(
           OUTPUT "${ALL_FIXES_DIR}"
-          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --resolved-rules "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation_type "${LANGUAGE}" --output_dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}"
+          COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation-type "${LANGUAGE}" --output-dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}"
           DEPENDS ${LANGUAGE_REMEDIATIONS_DEPENDS}
           DEPENDS ${LANGUAGE_REMEDIATIONS_OUTPUTS}
           # Acutally we mean that it depends on resolved rules.


### PR DESCRIPTION
#### Description:
Changes `--resolved-rules` in `combine_remediations.py` and `--resolve-rules-into` in `yaml_to_shorthand.py` both to `--resolved-rules-dir`, because they are both describing the same directory. 

Also changes `--output_dir` in `combine_remediations.py` to `--output-dir` to use dashes consistently in the CLI interface.


Also updates the invocations of these scripts in CMake accordingly.


#### Rationale:
Resolves inconsistency created by  #3827 in whichthe directory with resolved rules is referred to as `--resolved-rules`, which differs from the `yaml_to_shorthand` script, which uses more accurate `--resolved-rules-dir`.
Fixes #4027 