### PR TITLE
Detect podman as container environment 

### DIFF
--- a/shared/checks/oval/installed_env_is_a_container.xml
+++ b/shared/checks/oval/installed_env_is_a_container.xml
@@ -5,19 +5,28 @@
        <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>Check if file /.dockerenv exists, if it does then we consider to be a docker filesystem.</description>
+      <description>Check for presence of files characterizing container filesystems.</description>
       <reference ref_id="cpe:/a:container" source="CPE" />
     </metadata>
-    <criteria>
-      <criterion comment="Check if /.dockerenv exists" test_ref="installed_env_is_a_container" />
+    <criteria operator="OR">
+      <criterion comment="Check if /.dockerenv exists" test_ref="test_installed_env_is_a_docker_container" />
+      <criterion comment="Check if /run/.containerenv exists" test_ref="test_installed_env_is_a_podman_container" />
     </criteria>
   </definition>
 
-  <unix:file_test check="all" check_existence="all_exist" comment="Check if /.dockerenv exists" id="installed_env_is_a_container" version="1">
-    <unix:object object_ref="installed_env_is_a_container" />
+  <unix:file_test check="all" check_existence="all_exist" comment="Check if /.dockerenv exists" id="test_installed_env_is_a_docker_container" version="1">
+    <unix:object object_ref="object_installed_env_is_a_docker_container" />
   </unix:file_test>
 
-  <unix:file_object comment="Check file /.dockerenv" id="installed_env_is_a_container" version="1">
+  <unix:file_object comment="Check file /.dockerenv" id="object_installed_env_is_a_docker_container" version="1">
     <unix:filepath datatype="string">/.dockerenv</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Check if /run/.containerenv exists" id="test_installed_env_is_a_podman_container" version="1">
+    <unix:object object_ref="object_installed_env_is_a_podman_container" />
+  </unix:file_test>
+
+  <unix:file_object comment="Check file /run/.containerenv" id="object_installed_env_is_a_podman_container" version="1">
+     <unix:filepath datatype="string">/run/.containerenv</unix:filepath>
   </unix:file_object>
 </def-group>

--- a/shared/checks/oval/installed_env_is_a_machine.xml
+++ b/shared/checks/oval/installed_env_is_a_machine.xml
@@ -5,19 +5,12 @@
        <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>Check if file /.dockerenv exists, if it doesn't then we consider to be host filesystem or virtual machine.</description>
+      <description>Check for absence of files characterizing container filesystems.</description>
       <reference ref_id="cpe:/a:machine" source="CPE" />
     </metadata>
     <criteria>
-      <criterion comment="Check if /.dockerenv exists" test_ref="installed_env_is_a_machine" negate="true" />
+      <extend_definition comment="If environment is not a container, it is machine" definition_ref="installed_env_is_a_container" negate="true" />
     </criteria>
   </definition>
 
-  <unix:file_test check="all" check_existence="all_exist" comment="Check if /.dockerenv exists" id="installed_env_is_a_machine" version="1">
-    <unix:object object_ref="installed_env_is_a_machine" />
-  </unix:file_test>
-
-  <unix:file_object comment="Check file /.dockerenv" id="installed_env_is_a_machine" version="1">
-    <unix:filepath datatype="string">/.dockerenv</unix:filepath>
-  </unix:file_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- Extend `installed_env_is_a_container` to detect podman environment as a container.
- `installed_env_is_a_machine` extends and negates `installed_env_is_a_container`.

#### Rationale:

- Contents that are not for containers should not run on podman container
- An environment which is not a container is a machine environment.
