### PR TITLE
Direct root Logins Not Allowed - do not compare int and str

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
@@ -10,4 +10,4 @@
 
 - name: "Direct root Logins Not Allowed"
   shell: echo > /etc/securetty
-  changed_when: securetty_empty.stat.size > "1"
+  changed_when: securetty_empty.stat.size > 1


### PR DESCRIPTION

#### Description:

- Fix value of comparison for `securetty_empty.stat.size`

#### Rationale:

- `securetty_empty.stat.siz`e is int type.

- Fixes
```
TASK [Direct root Logins Not Allowed] *****************************************************************************************************************************************************************************
fatal: [rhel7.6]: FAILED! => {"msg": "The conditional check 'securetty_empty.stat.size > \"1\"' failed. The error was: Unexpected templating type error occurred on ({% if securetty_empty.stat.size > \"1\" %} True {% else %} False {% endif %}): '>' not supported between instances of 'int' and 'str'"}
	to retry, use: --limit @/home/wsato/git/scap-security-guide/build/roles/ssg-rhel7-role-ospp.retry
```
