### PR TITLE
Update Ansible section in Developer Guide

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -882,11 +882,14 @@ Remediations also carry metadata that should be present at the beginning of the 
 
 IMPORTANT: The minimum version of Ansible must be at the latest supported version. See https://access.redhat.com/support/policy/updates/ansible-engine for information on the supported Ansible versions.
 
-Ansible remediations are stored as yml files in directory _/template/static/ansible_ under the targeted platform. They are meant to be executed by Ansible itself when requested by openscap, so they are
-written using link:ttp://docs.ansible.com/ansible/latest/intro.html[Ansible's own language] with the following exceptions:
+Ansible remediations are either:
+- stored as `.yml` files in directory `ansible` in the rule directory
+- generated from templates
+
+They are meant to be executed by Ansible itself when requested by openscap, so they are
+written using link:http://docs.ansible.com/ansible/latest/intro.html[Ansible's own language] with the following exceptions:
 
 - The remediation content must be only the _tasks_ section of what would be a playbook
-- The _tags_ section must be present in each task as shown in the example, it'll be replaced during the building process
 - Notifications and handlers are not supported
 
 Here is an example of a Ansible remediation that ensures the SELinux is enabled in grub:
@@ -901,9 +904,15 @@ Here is an example of a Ansible remediation that ensures the SELinux is enabled 
   replace:
     dest: /etc/default/grub
     regexp: selinux=0
-  tags:
-    @ANSIBLE_TAGS@
 ----
+
+The Ansible remediation will get included by our build system to the SCAP datastream in the `fix` element of respective rule.
+
+The build system generates an Ansible Playbook from the remediation for all profiles.
+The generated Playbook is located in `/build/<product>/playbooks/<profile_id>/<rule_id>.yml`.
+
+We also build profile Playbook that contains tasks for all rules in the profile.
+The Playbook is generated in `/build/roles/ssg-<product>-role-<profile_id>.yml`.
 
 ==== Bash
 


### PR DESCRIPTION
#### Description:
After recent changes, tags section are no longer required.
Also adds explanation where the Ansible remediations are used in the build process.

#### Rationale:
#3824 has enabled to generate separate playbooks for each rule and #3827 has removed the need to put tags and other placeholders into the Ansible remediation. We need to reflect those changes in documentation.

