### PR TITLE
Add rule for package pcsc-lite installed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+prodtype: rhel7,rhel8,fedora,rhv4
+
+title: 'Install pcsc-lite'
+
+description: |-
+    {{{ describe_package_install(package="pcsc-lite") }}}
+
+rationale: |-
+    The pcsc-lite package must be installed if it is to be available for
+    multifactor authentication using smartcards.
+
+severity: medium
+
+references:
+    disa: "1954"
+    srg: SRG-OS-000375-GPOS-00160
+    vmmsrg: SRG-OS-000377-VMM-001530
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="pcsc-lite") }}}'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,rhv4
 
-title: 'Install pcsc-lite'
+title: 'Install the pcsc-lite package'
 
 description: |-
     {{{ describe_package_install(package="pcsc-lite") }}}

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -387,6 +387,7 @@ selections:
     - configure_opensc_nss_db
     - configure_opensc_card_drivers
     - force_opensc_card_drivers
+    - package_pcsc-lite_installed
     - service_pcscd_enabled
     - sssd_enable_smartcards
     - sssd_memcache_timeout

--- a/rhel7/profiles/rhelh-stig.profile
+++ b/rhel7/profiles/rhelh-stig.profile
@@ -361,6 +361,7 @@ selections:
     - configure_opensc_nss_db
     - configure_opensc_card_drivers
     - force_opensc_card_drivers
+    - package_pcsc-lite_installed
     - service_pcscd_enabled
     - sssd_enable_smartcards
     - sssd_memcache_timeout

--- a/rhel7/profiles/rhelh-vpp.profile
+++ b/rhel7/profiles/rhelh-vpp.profile
@@ -178,6 +178,7 @@ selections:
     - configure_opensc_nss_db
     - configure_opensc_card_drivers
     - force_opensc_card_drivers
+    - package_pcsc-lite_installed
     - service_pcscd_enabled
     - sssd_enable_smartcards
 

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -119,6 +119,7 @@ selections:
     - configure_opensc_nss_db
     - configure_opensc_card_drivers
     - force_opensc_card_drivers
+    - package_pcsc-lite_installed
     - service_pcscd_enabled
     - sssd_enable_smartcards
     - set_password_hashing_algorithm_systemauth

--- a/rhv4/profiles/rhvh-stig.profile
+++ b/rhv4/profiles/rhvh-stig.profile
@@ -361,6 +361,7 @@ selections:
     - configure_opensc_nss_db
     - configure_opensc_card_drivers
     - force_opensc_card_drivers
+    - package_pcsc-lite_installed
     - service_pcscd_enabled
     - sssd_enable_smartcards
     - sssd_memcache_timeout

--- a/rhv4/profiles/rhvh-vpp.profile
+++ b/rhv4/profiles/rhvh-vpp.profile
@@ -178,6 +178,7 @@ selections:
     - configure_opensc_nss_db
     - configure_opensc_card_drivers
     - force_opensc_card_drivers
+    - package_pcsc-lite_installed
     - service_pcscd_enabled
     - sssd_enable_smartcards
 


### PR DESCRIPTION
Select the rule in profiles that select service_pcscd_enabled.

#### Description:

- Add rule for package pcsc-lite installed
- Select the rule in profiles that select service_pcscd_enabled

#### Rationale:

- Rule `service_pcscd_enabled` fails because service doesn't exist when `pcsc-lite` is not installed.

#### Fixes:
```
TASK [Enable service pcscd] ***************************************************************************************************************************************************************************************
fatal: [rhel7.6]: FAILED! => {"changed": false, "msg": "Could not find the requested service pcscd: host"}
	to retry, use: --limit @/home/wsato/git/scap-security-guide/build/roles/ssg-rhel7-role-ospp.retry
```
