### PR TITLE
Add change_when false to tasks that won't ever make changes

### DIFF
--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
@@ -9,6 +9,7 @@
   shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
+  changed_when: False
 
 - name: "Add default domain group and set CA directory (if no domain there)"
   lineinfile:

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -15,6 +15,7 @@
   shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
+  changed_when: False
 
 - name: "Add default domain group and use STARTTLS (if no domain there)"
   lineinfile:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -8,6 +8,7 @@
   shell: "find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null | cat"
   check_mode: no
   register: find_result
+  changed_when: false
 
 # Inserts/replaces the rule in /etc/audit/rules.d
 

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -18,6 +18,7 @@
       warn: False # Ignore ANSIBLE0006, we can't fetch current mount options with mount module
     register: device_cur_mountoption
     check_mode: no
+    changed_when: False
 
   - name: get back device fstype
     shell: mount | grep ' {{{ MOUNTPOINT }}} ' | cut -d ' ' -f 5
@@ -25,6 +26,7 @@
       warn: False # Ignore ANSIBLE0006, we can't fetch fstype with mount module
     register: device_fstype
     check_mode: no
+    changed_when: False
 
   - name: Ensure permission {{{ MOUNTOPTION }}} are set on {{{ MOUNTPOINT }}}
     mount:

--- a/shared/templates/template_ANSIBLE_mount_option_var
+++ b/shared/templates/template_ANSIBLE_mount_option_var
@@ -20,6 +20,7 @@
       warn: False # Ignore ANSIBLE0006, we can't fetch mount options with mount module
     register: device_cur_mountoption
     check_mode: no
+    changed_when: False
 
   - name: get back device fstype
     shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | cut -d ' ' -f 5
@@ -27,6 +28,7 @@
       warn: False # Ignore ANSIBLE0006, we can't fetch fstype with mount module
     register: device_fstype
     check_mode: no
+    changed_when: False
 
   - name: Ensure permission {{{ MOUNTOPTION }}} are set on {{{ MOUNTPOINT }}}
     mount:


### PR DESCRIPTION
#### Description:

- Add `changed_when: false` to shell tasks that won't ever make changes

#### Rationale:

- The `find` and `grep` commands won't make changes in the system.
  Their goal is to collect info.
