### PR TITLE
Remove legacy ensure_gpgcheck_repo_metadata rule from profiles

### DIFF
--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -88,7 +88,6 @@ selections:
     - ensure_redhat_gpgkey_installed
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
-    - ensure_gpgcheck_repo_metadata
     - ensure_gpgcheck_local_packages
     - grub2_audit_argument
     - service_auditd_enabled

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -396,7 +396,6 @@ selections:
     - ensure_redhat_gpgkey_installed
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
-    - ensure_gpgcheck_repo_metadata
     - ensure_gpgcheck_local_packages
     - network_sniffer_disabled
     - network_ipv6_disable_rpc


### PR DESCRIPTION
This was removed from other profiles -- didn't realize it was still lingering 