### PR TITLE
Add OVAL namespace to oval/metadata/reference

### DIFF
--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -180,7 +180,7 @@ class OVALFileLinker(FileLinker):
             if is_cce_format_valid(xccdfcceid) and is_cce_value_valid(xccdfcceid):
                 # Then append the <reference source="CCE" ref_id="CCE-ID" /> element right
                 # after <description> element of specific OVAL check
-                ccerefelem = ET.Element('reference', ref_id=xccdfcceid,
+                ccerefelem = ET.Element('{%s}reference' % self.CHECK_NAMESPACE, ref_id=xccdfcceid,
                                         source="CCE")
                 metadata = rule.find(".//{%s}metadata" % self.CHECK_NAMESPACE)
                 metadata.append(ccerefelem)

--- a/ssg/id_translate.py
+++ b/ssg/id_translate.py
@@ -74,7 +74,7 @@ class IDTranslator(object):
                     if metadata is None:
                         metadata = ElementTree.SubElement(element, "metadata")
                     defnam = ElementTree.Element(
-                        "reference", ref_id=idname, source=self.content_id)
+                        "{%s}reference" % oval_ns, ref_id=idname, source=self.content_id)
                     metadata.append(defnam)
 
                 # set the element to the new identifier


### PR DESCRIPTION
#### Description:

- Add `reference` element in OVAL namespace.

#### Rationale:

- The oval definitions should have `metadata/reference` in OVAL namespace.

- Content diff

From:
```xml
          <oval:metadata>
            <oval:title>Send Logs to a Remote Loghost</oval:title>
            <oval:affected family="unix">
              <oval:platform>Red Hat Enterprise Linux 7</oval:platform>
            </oval:affected>
            <oval:description>Syslog logs should be sent to a remote loghost</oval:description>
            <oval:reference ref_id="CCE-27343-3" source="CCE"/>
            <oval:reference ref_id="rsyslog_remote_loghost" source="ssg"/>
          </oval:metadata>
```
to:
```xml
          <oval:metadata>
            <oval:title>Send Logs to a Remote Loghost</oval:title>
            <oval:affected family="unix">
              <oval:platform>Red Hat Enterprise Linux 7</oval:platform>
            </oval:affected>
            <oval:description>Syslog logs should be sent to a remote loghost</oval:description>
            <reference ref_id="CCE-27343-3" source="CCE"/>
            <reference ref_id="rsyslog_remote_loghost" source="ssg"/>
          </oval:metadata>
```