### PR TITLE
[WIP][RFC] Add grub2 ownership rules to check UEFI and non-UEFI systems

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_config/bash/shared.sh
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_config/bash/shared.sh
@@ -1,0 +1,14 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+GRUB2_CONF_NON_EFI=/boot/grub2/grub.cfg
+GRUB2_CONF_EFI=/boot/efi/EFI/redhat/grub.cfg
+
+if [ -f $GRUB2_CONF_EFI ]; then
+    chgrp 0 $GRUB2_CONF_EFI
+elif [ -f $GRUB2_CONF_NON_EFI ]; then
+    chgrp 0 $GRUB2_CONF_NON_EFI
+fi

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_config/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_config/oval/shared.xml
@@ -1,0 +1,20 @@
+<def-group>
+  <definition class="compliance" id="file_groupowner_grub2_config" version="1">
+    <metadata>
+      <title>Grub2 configuration file Owned By root User</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>Grub2 configuration file /boot/efi/EFI/redhat/grub.cfg on UEFI systems 
+        or /boot/efi/EFI/redhat/grub.cfg on non-UEFI systems should be owned by the root group</description>
+    </metadata>
+
+    <criteria operator="OR">
+      <extend_definition comment="/boot/efi/EFI/redhat/grub.cfg owned by the root group" definition_ref="file_groupowner_efi_grub2_cfg" />
+      <extend_definition comment="/boot/grub2/grub.cfg owned by the root group" definition_ref="file_groupowner_grub2_cfg" />
+    </criteria>
+  </definition>
+</def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_config/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_config/rule.yml
@@ -1,0 +1,43 @@
+documentation_complete: true
+
+prodtype: rhel7,rhel8,fedora,ol7,ol8
+
+title: 'Verify GRUB 2 Configuration File Group Ownership'
+
+description: |-
+    GRUB 2 configuration file <tt>/boot/efi/EFI/redhat/grub.cfg</tt> on UEFI systems
+    or <tt>/boot/grub2/grub.cfg</tt> on non-UEFI systems should
+    be owned by the <tt>root</tt> group to prevent destruction
+    or modification of the file.
+    <br /><br />
+    {{{ describe_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
+    <br /><br />
+    {{{ describe_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}
+
+rationale: |-
+    The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
+    file should not have any access privileges anyway.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 26812-8
+    cce@rhel8: 80800-6
+
+references:
+    cis: 1.4.1
+    cjis: 5.5.2.2
+    cui: 3.4.5
+    disa: "225"
+    hipaa: 164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)
+    nist: AC-6(7)
+    nist-csf: PR.AC-4,PR.DS-5
+    pcidss: Req-7.1
+    isa-62443-2013: 'SR 2.1,SR 5.2'
+    isa-62443-2009: 4.3.3.7.3
+    cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
+    cis-csc: 12,13,14,15,16,18,3,5
+
+ocil: |-
+    The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this file should not have any access privileges anyway.

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_config/bash/shared.sh
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_config/bash/shared.sh
@@ -1,0 +1,14 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+GRUB2_CONF_NON_EFI=/boot/grub2/grub.cfg
+GRUB2_CONF_EFI=/boot/efi/EFI/redhat/grub.cfg
+
+if [ -f $GRUB2_CONF_EFI ]; then
+    chown 0 $GRUB2_CONF_EFI
+elif [ -f $GRUB2_CONF_NON_EFI ]; then
+    chown 0 $GRUB2_CONF_NON_EFI
+fi

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_config/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_config/oval/shared.xml
@@ -1,0 +1,20 @@
+<def-group>
+  <definition class="compliance" id="file_owner_grub2_config" version="1">
+    <metadata>
+      <title>Grub2 configuration file Owned By root User</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>Grub2 configuration file /boot/efi/EFI/redhat/grub.cfg on UEFI systems 
+        or /boot/efi/EFI/redhat/grub.cfg on non-UEFI systems should be owned by the root user</description>
+    </metadata>
+
+    <criteria operator="OR">
+      <extend_definition comment="/boot/efi/EFI/redhat/grub.cfg owned by the root user" definition_ref="file_owner_efi_grub2_cfg" />
+      <extend_definition comment="/boot/grub2/grub.cfg owned by the root user" definition_ref="file_owner_grub2_cfg" />
+    </criteria>
+  </definition>
+</def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_config/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_config/rule.yml
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+prodtype: rhel7,rhel8,fedora,ol7,ol8
+
+title: 'Verify GRUB 2 Configuration File User Ownership'
+
+description: |-
+    Grub2 configuration file <tt>/boot/efi/EFI/redhat/grub.cfg</tt> on UEFI systems
+    or <tt>/boot/grub2/grub.cfg</tt> on non-UEFI systems should
+    be owned by the <tt>root</tt> user to prevent destruction
+    or modification of the file.
+    <br /><br />
+    {{{ describe_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
+    <br /><br />
+    {{{ describe_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}
+
+rationale: 'Only root should be able to modify important boot parameters.'
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 26860-7
+    cce@rhel8: 80805-5
+
+references:
+    cis: 1.4.1
+    cjis: 5.5.2.2
+    cui: 3.4.5
+    disa: "225"
+    hipaa: 164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)
+    nist: AC-6(7)
+    nist-csf: PR.AC-4,PR.DS-5
+    pcidss: Req-7.1
+    isa-62443-2013: 'SR 2.1,SR 5.2'
+    isa-62443-2009: 4.3.3.7.3
+    cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
+    cis-csc: 12,13,14,15,16,18,3,5
+
+ocil: |-
+    Only <tt>root</tt> should be able to modify important boot parameters.


### PR DESCRIPTION
#### Description:
Existing rules file_permissions_grub_cfg, file_groupowner_grub2_cfg and file_owner_grub2_cfg
don't work on UEFI systems, see #2872 for details. 

This PR addresses ownership rules - suggested to add conditional rules which extend existing grub2 cfg file template definitions. 

Please leave your feedback if proposed fix works for grub2 rules on UEFI and non-UEFI systems.

#### Rationale:
- Fixes #2872
