### PR TITLE
Use separate rule for each audit syscall in pci-dss

### DIFF
--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -77,15 +77,28 @@ selections:
     - audit_rules_dac_modification_lsetxattr
     - audit_rules_dac_modification_removexattr
     - audit_rules_dac_modification_setxattr
-    - audit_rules_login_events
+    - audit_rules_login_events_faillock
+    - audit_rules_login_events_lastlog
+    - audit_rules_login_events_tallylog
     - audit_rules_session_events
-    - audit_rules_unsuccessful_file_modification
+    - audit_rules_unsuccessful_file_modification_creat
+    - audit_rules_unsuccessful_file_modification_open
+    - audit_rules_unsuccessful_file_modification_openat
+    - audit_rules_unsuccessful_file_modification_open_by_handle_at
+    - audit_rules_unsuccessful_file_modification_truncate
+    - audit_rules_unsuccessful_file_modification_ftruncate
     - audit_rules_privileged_commands
     - audit_rules_media_export
     - audit_rules_file_deletion_events
     - audit_rules_sysadmin_actions
     - audit_rules_immutable
-    - audit_rules_kernel_module_loading
+    - audit_rules_kernel_module_loading_create
+    - audit_rules_kernel_module_loading_delete
+    - audit_rules_kernel_module_loading_finit
+    - audit_rules_kernel_module_loading_init
+    - audit_rules_kernel_module_loading_insmod
+    - audit_rules_kernel_module_loading_modprobe
+    - audit_rules_kernel_module_loading_rmmod
     - audit_rules_usergroup_modification
     - ensure_logrotate_activated
     - sshd_idle_timeout_value=15_minutes

--- a/ol8/profiles/pci-dss.profile
+++ b/ol8/profiles/pci-dss.profile
@@ -77,7 +77,9 @@ selections:
     - audit_rules_dac_modification_lsetxattr
     - audit_rules_dac_modification_removexattr
     - audit_rules_dac_modification_setxattr
-    - audit_rules_login_events
+    - audit_rules_login_events_faillock
+    - audit_rules_login_events_lastlog
+    - audit_rules_login_events_tallylog
     - audit_rules_session_events
     - audit_rules_unsuccessful_file_modification_creat
     - audit_rules_unsuccessful_file_modification_ftruncate


### PR DESCRIPTION
#### Description:
Use separate rule for each audit syscall in pci-dss

#### Rationale:
Follow combined rules warnings to use separate rules. As a result it makes syscall rules OVAL and remediation content easier to maintain.