### PR TITLE
Update rhv4 and rhosp13 CPE mappings

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -200,10 +200,11 @@ PRODUCT_TO_CPE_MAPPING = {
         "cpe:/o:redhat:enterprise_linux:8",
     ],
     "rhosp13": [
-        "cpe:/a:redhat:openstack:13.0",
+        "cpe:/a:redhat:openstack:13",
     ],
     "rhv4": [
-        "cpe:/o:redhat:virtualization:4",
+        "cpe:/a:redhat:enterprise_virtualization_manager:4",
+        "cpe:/o:redhat:enterprise_linux:7::hypervisor",
     ],
     "sle11": [
         "cpe:/o:suse:linux_enterprise_server:11",


### PR DESCRIPTION
#### Description:
- There are inconsistent CPEs for RHV4
  - Setting RHV4 CPE to 
    `cpe:/a:redhat:enterprise_virtualization_manager:4` and
    `cpe:/o:redhat:enterprise_linux:7::hypervisor`
- There are inconsistent CPEs for RHOSP13
  - Setting RHOSP13 CPE to `cpe:/a:redhat:openstack:13`

#### Rationale:

- Fixes compliance with SCAP 1.2
- scapval error message:
`SRC-15-1 Every <xccdf:platform> or <cpe2:fact-ref> MUST match as EQUAL or SUPERSET to a CPE in a CPE dictionary component of this data stream.`
