### PR TITLE
rsyslog_remote_loghost rule update for ANSSI NT28 profile

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -42,7 +42,7 @@ identifiers:
 
 references:
     cis@debian8: 5.1.5
-    anssi@debian8: NT28(R5)
+    anssi: NT28(R7)
     stigid@rhel6: RHEL-06-000136
     srg@rhel6: SRG-OS-000043,SRG-OS-000215
     cis: 4.2.1.4

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -8,4 +8,5 @@ description: 'Draft profile for ANSSI compliance at the enhanced level. ANSSI st
 
 extends: anssi_nt28_intermediary
 
-selections: []
+selections:
+    - rsyslog_remote_loghost

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -18,7 +18,6 @@ selections:
     - rsyslog_files_ownership
     - rsyslog_files_groupownership
     - rsyslog_files_permissions
-    - "!rsyslog_remote_loghost"
     - ensure_logrotate_activated
     - sysctl_fs_suid_dumpable
     - sysctl_kernel_randomize_va_space


### PR DESCRIPTION
#### Description:

* Fixed rsyslog_remote_loghost rule recommendation ID from NT28(R5)
  to the NT28(R7) and moved it to the intermediary level profile.
* For details see:
  https://www.ssi.gouv.fr/uploads/2015/10/NP_Linux_Configuration.pdf