### PR TITLE
[WIP] Added remediations for rhel8 audit rules which need ordering

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 10"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 7 10 11"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "20 24"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "20 21 24 25"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 10 20 24"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 7 10 11 20 21 24 25"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "8 12"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "8 9 12 13"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "22 26"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "22 23 26 27"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "8 12 22 26"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "8 9 12 13 22 23 26 27"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 10"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 7 10 11"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "20 24"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "20 21 24 25"
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/bash/rhel8.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_unsuccessful_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/bash/rhel8.sh
@@ -1,0 +1,18 @@
+# platform = Red Hat Enterprise Linux 8
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+include_merge_files_by_lines
+
+MASTER_FILE="/usr/share/doc/audit/rules/30-ospp-v42.rules"
+SAMPLE_FILE="/etc/audit/rules.d/30-ospp-v42-remediation.rules"
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+if [ "$(getconf LONG_BIT)" = "32" ]; then
+	# 32 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 10 20 24"
+else
+	# 32 bit and 64 bit rules
+	merge_first_lines_to_second_on_indices $MASTER_FILE $SAMPLE_FILE "6 7 10 11 20 21 24 25"
+fi


### PR DESCRIPTION
#### Description:

* Remediations added by this commit need to configure audit
  rules in the `/etc/audit/rules.d/` and preserve their order.
* The remediations are cherrypicking lines from the
  `/usr/share/doc/audit/rules/30-ospp-v42.rules` master file which
  belongs to the `audit` package and add them into a file in the
  `/etc/audit/rules.d/` folder preserving the specific order from
  the master file.