### PR TITLE
rpm_verify_hashes - changes in config files can be expected

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/oval/shared.xml
@@ -36,7 +36,7 @@
   </linux:rpmverifyfile_object>
   <linux:rpmverifyfile_state id="state_files_fail_md5_hash" version="1" operator="AND">
     <linux:md5_differs>fail</linux:md5_differs>
-    <!-- <linux:configuration_file datatype="boolean">false</linux:configuration_file> -->
+    <linux:configuration_file datatype="boolean">false</linux:configuration_file>
     <!-- <linux:documentation_file datatype="boolean">false</linux:documentation_file> -->
     <!-- <linux:ghost_file datatype="boolean">false</linux:ghost_file> -->
     <!-- <linux:license_file datatype="boolean">false</linux:license_file> -->

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/oval/shared.xml
@@ -38,7 +38,7 @@
     <linux:md5_differs>fail</linux:md5_differs>
     <linux:configuration_file datatype="boolean">false</linux:configuration_file>
     <!-- <linux:documentation_file datatype="boolean">false</linux:documentation_file> -->
-    <!-- <linux:ghost_file datatype="boolean">false</linux:ghost_file> -->
+    <linux:ghost_file datatype="boolean">false</linux:ghost_file>
     <!-- <linux:license_file datatype="boolean">false</linux:license_file> -->
     <!-- <linux:readme_file datatype="boolean">false</linux:readme_file> -->
   </linux:rpmverifyfile_state>


### PR DESCRIPTION
#### Description:

- Ignore changes in RPM's config files

#### Rationale:

- This should help reduce false positives.

Still, some files make the rule fail.
For example, remediation for `require_singleuser_auth` edits `/usr/lib/systemd/system/rescue.service` and breaks its "integrity".
Not sure if `/usr/lib/systemd/system/rescue.service` can be considered a config file.
After remediation from fresh install of RHEL8.
```
[root@localhost ~]# rpm -Va | grep '..5'
S.5....T.  c /var/lib/unbound/root.key
S.5....T.  c /etc/profile
S.5....T.  c /etc/audit/audit-stop.rules
S.5....T.  c /etc/dnf/dnf.conf
S.5....T.  c /etc/security/pwquality.conf
S.5....T.  c /etc/pki/tls/openssl.cnf
S.5....T.  c /etc/issue
S.5....T.  c /etc/rsyslog.conf
S.5....T.  c /etc/ssh/sshd_config
S.5....T.  c /etc/login.defs
S.5....T.  c /etc/pam.d/password-auth
S.5....T.  c /etc/pam.d/system-auth
S.5....T.  c /etc/sysctl.conf
S.5....T.    /usr/lib/systemd/system/rescue.service
S.5....T.  c /etc/crypto-policies/config
```