### PR TITLE
Mount option add entry to fstab

### DIFF
--- a/fedora/templates/csv/mount_options.csv
+++ b/fedora/templates/csv/mount_options.csv
@@ -9,9 +9,9 @@
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed
-/dev/shm,nodev,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,noexec,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,nosuid,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /tmp,nodev
 /tmp,noexec
 /tmp,nosuid

--- a/fedora/templates/csv/mount_options.csv
+++ b/fedora/templates/csv/mount_options.csv
@@ -1,11 +1,12 @@
 # format:
-# <mount_point>,<mount_option>[,create_fstab_entry_if_needed]
+# <mount_point>,<mount_option>[,create_fstab_entry_if_needed,<fileystem>,<type>]
 # - mount point mounted with specified option. for more than
 #     one option, use multiple lines with the same <mount_point>, use the 
 #     variable name (i.e. name beginning with var_, without the leading
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
-#  add the 'create_fstab_entry_if_needed' literal string as the third argument.
+#  add the 'create_fstab_entry_if_needed' literal string as the third argument,
+#  followed by filesystem and type of the mount_point.
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed

--- a/ol7/templates/csv/mount_options.csv
+++ b/ol7/templates/csv/mount_options.csv
@@ -1,11 +1,12 @@
 # format:
-# <mount_point>,<mount_option>[,create_fstab_entry_if_needed]
+# <mount_point>,<mount_option>[,create_fstab_entry_if_needed,<fileystem>,<type>]
 # - mount point mounted with specified option. for more than
 #     one option, use multiple lines with the same <mount_point>, use the
 #     variable name (i.e. name beginning with var_, without the leading
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
-#  add the 'create_fstab_entry_if_needed' literal string as the third argument.
+#  add the 'create_fstab_entry_if_needed' literal string as the third argument,
+#  followed by filesystem and type of the mount_point.
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed

--- a/ol7/templates/csv/mount_options.csv
+++ b/ol7/templates/csv/mount_options.csv
@@ -9,6 +9,6 @@
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed
-/dev/shm,nodev,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,noexec,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,nosuid,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda

--- a/ol8/templates/csv/mount_options.csv
+++ b/ol8/templates/csv/mount_options.csv
@@ -1,11 +1,12 @@
 # format:
-# <mount_point>,<mount_option>[,create_fstab_entry_if_needed]
+# <mount_point>,<mount_option>[,create_fstab_entry_if_needed,<fileystem>,<type>]
 # - mount point mounted with specified option. for more than
 #     one option, use multiple lines with the same <mount_point>, use the
 #     variable name (i.e. name beginning with var_, without the leading
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
-#  add the 'create_fstab_entry_if_needed' literal string as the third argument.
+#  add the 'create_fstab_entry_if_needed' literal string as the third argument,
+#  followed by filesystem and type of the mount_point.
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed

--- a/ol8/templates/csv/mount_options.csv
+++ b/ol8/templates/csv/mount_options.csv
@@ -9,6 +9,6 @@
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed
-/dev/shm,nodev,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,noexec,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,nosuid,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda

--- a/rhel7/templates/csv/mount_options.csv
+++ b/rhel7/templates/csv/mount_options.csv
@@ -1,11 +1,12 @@
 # format:
-# <mount_point>,<mount_option>[,create_fstab_entry_if_needed]
+# <mount_point>,<mount_option>[,create_fstab_entry_if_needed,<fileystem>,<type>]
 # - mount point mounted with specified option. for more than
 #     one option, use multiple lines with the same <mount_point>, use the 
 #     variable name (i.e. name beginning with var_, without the leading
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
-#  add the 'create_fstab_entry_if_needed' literal string as the third argument.
+#  add the 'create_fstab_entry_if_needed' literal string as the third argument,
+#  followed by filesystem and type of the mount_point.
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed

--- a/rhel7/templates/csv/mount_options.csv
+++ b/rhel7/templates/csv/mount_options.csv
@@ -9,9 +9,9 @@
 
 # /dev/shm is created by systemd and is not available at install time
 # /dev/shm may not be in /etc/fstab, add entry if needed
-/dev/shm,nodev,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,noexec,create_fstab_entry_if_needed #except-for:anaconda
-/dev/shm,nosuid,create_fstab_entry_if_needed #except-for:anaconda
+/dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /home,nosuid
 /home,nodev
 /tmp,nodev

--- a/rhel8/templates/csv/mount_options.csv
+++ b/rhel8/templates/csv/mount_options.csv
@@ -1,11 +1,13 @@
 # format:
-# <mount_point>,<mount_option>[,create_fstab_entry_if_needed]
+# <mount_point>,<mount_option>[,create_fstab_entry_if_needed,<fileystem>,<type>]
 # - mount point mounted with specified option. for more than
 #     one option, use multiple lines with the same <mount_point>, use the 
 #     variable name (i.e. name beginning with var_, without the leading
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
-#  add the 'create_fstab_entry_if_needed' literal string as the third argument.
+#  add the 'create_fstab_entry_if_needed' literal string as the third argument,
+#  followed by filesystem and type of the mount_point.
+
 /dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda

--- a/rhel8/templates/csv/mount_options.csv
+++ b/rhel8/templates/csv/mount_options.csv
@@ -6,9 +6,9 @@
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
 #  add the 'create_fstab_entry_if_needed' literal string as the third argument.
-/dev/shm,nodev #except-for:anaconda
-/dev/shm,noexec #except-for:anaconda
-/dev/shm,nosuid #except-for:anaconda
+/dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /tmp,nodev
 /tmp,noexec
 /tmp,nosuid

--- a/shared/bash_remediation_functions/include_mount_options_functions.sh
+++ b/shared/bash_remediation_functions/include_mount_options_functions.sh
@@ -26,7 +26,7 @@ function ensure_mount_option_in_fstab {
 	_mount_point_match_regexp="$(get_mount_point_regexp "$_mount_point")"
 
 	if [ $(grep -c "$_mount_point_match_regexp" /etc/fstab ) -eq 0 ]; then
-        echo "${_filesystem} ${_mount_point} ${_type} defaults,${_new_opt} 0 0" >> /etc/fstab
+		echo "${_filesystem} ${_mount_point} ${_type} defaults,${_new_opt} 0 0" >> /etc/fstab
 	elif [ $(grep "$_mount_point_match_regexp" /etc/fstab | grep -c "$_new_opt" ) -eq 0 ]; then
 		_previous_mount_opts=$(grep "$_mount_point_match_regexp" /etc/fstab | awk '{print $4}')
 		sed -i "s|\(${_mount_point_match_regexp}.*${_previous_mount_opts}\)|\1,${_new_opt}|" /etc/fstab

--- a/shared/templates/create_mount_options.py
+++ b/shared/templates/create_mount_options.py
@@ -167,4 +167,4 @@ class MountOptionsGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: "
-               "<mount_point>,<mount_option>[,create_fstab_entry_if_needed])")
+               "<mount_point>,<mount_option>[,create_fstab_entry_if_needed,<filesystem>,<type>])")

--- a/shared/templates/csv/mount_options.csv
+++ b/shared/templates/csv/mount_options.csv
@@ -10,6 +10,6 @@
 var_removable_partition,nodev #except-for:anaconda
 var_removable_partition,nosuid #except-for:anaconda
 var_removable_partition,noexec #except-for:anaconda
-remote_filesystems,nodev,create_fstab_entry_if_needed
-remote_filesystems,nosuid,create_fstab_entry_if_needed
-remote_filesystems,noexec,create_fstab_entry_if_needed
+remote_filesystems,nodev
+remote_filesystems,nosuid
+remote_filesystems,noexec

--- a/shared/templates/csv/mount_options.csv
+++ b/shared/templates/csv/mount_options.csv
@@ -7,9 +7,9 @@
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
 #  add the 'create_fstab_entry_if_needed' literal string as the third argument.
 
-var_removable_partition,nodev,create_fstab_entry_if_needed #except-for:anaconda
-var_removable_partition,nosuid,create_fstab_entry_if_needed #except-for:anaconda
-var_removable_partition,noexec,create_fstab_entry_if_needed #except-for:anaconda
+var_removable_partition,nodev #except-for:anaconda
+var_removable_partition,nosuid #except-for:anaconda
+var_removable_partition,noexec #except-for:anaconda
 remote_filesystems,nodev,create_fstab_entry_if_needed
 remote_filesystems,nosuid,create_fstab_entry_if_needed
 remote_filesystems,noexec,create_fstab_entry_if_needed

--- a/shared/templates/csv/mount_options.csv
+++ b/shared/templates/csv/mount_options.csv
@@ -1,11 +1,12 @@
 # format:
-# <mount_point>,<mount_option>[,create_fstab_entry_if_needed]
+# <mount_point>,<mount_option>[,create_fstab_entry_if_needed,<fileystem>,<type>]
 # - mount point mounted with specified option. for more than
 #     one option, use multiple lines with the same <mount_point>, use the 
 #     variable name (i.e. name beginning with var_, without the leading
 #     '$' to reference a variable, e.g. var_removable_partition,nodev)
 #  If the remediation can create (i.e. not just modify) an /etc/fstab line,
-#  add the 'create_fstab_entry_if_needed' literal string as the third argument.
+#  add the 'create_fstab_entry_if_needed' literal string as the third argument,
+#  followed by filesystem and type of the mount_point.
 
 var_removable_partition,nodev #except-for:anaconda
 var_removable_partition,nosuid #except-for:anaconda

--- a/shared/templates/template_BASH_mount_option
+++ b/shared/templates/template_BASH_mount_option
@@ -11,7 +11,7 @@ function perform_remediation {
 		assert_mount_point_in_fstab {{{ MOUNTPOINT }}} || { echo "Not remediating, because there is no record of {{{ MOUNTPOINT }}} in /etc/fstab" >&2; return 1; }
 	fi
 
-	ensure_mount_option_in_fstab "{{{ MOUNTPOINT }}}" "{{{ MOUNTOPTION }}}"
+	ensure_mount_option_in_fstab "{{{ MOUNTPOINT }}}" "{{{ MOUNTOPTION }}}" "{{{ FILESYSTEM }}}" "{{{ TYPE }}}"
 
 	ensure_partition_is_mounted "{{{ MOUNTPOINT }}}"
 }

--- a/shared/templates/template_BASH_mount_option_remote_filesystems
+++ b/shared/templates/template_BASH_mount_option_remote_filesystems
@@ -3,4 +3,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 include_mount_options_functions
 
-ensure_mount_option_for_vfstype "nfs[4]?" "{{{ MOUNTOPTION }}}"
+ensure_mount_option_for_vfstype "nfs[4]?" "{{{ MOUNTOPTION }}}" "{{{ FILESYSTEM }}}" "nfs4"

--- a/shared/templates/template_BASH_mount_option_var
+++ b/shared/templates/template_BASH_mount_option_var
@@ -14,7 +14,7 @@ function perform_remediation {
 		assert_mount_point_in_fstab "${{{ MOUNTPOINT }}}" || { echo "Not remediating, because there is no record of ${{{ MOUNTPOINT }}} in /etc/fstab" >&2; return 1; }
 	fi
 
-	ensure_mount_option_in_fstab "${{{ MOUNTPOINT }}}" "{{{ MOUNTOPTION }}}"
+	ensure_mount_option_in_fstab "${{{ MOUNTPOINT }}}" "{{{ MOUNTOPTION }}}" "{{{ FILESYSTEM }}}" "{{{ TYPE }}}"
 
 	ensure_partition_is_mounted "${{{ MOUNTPOINT }}}"
 }


### PR DESCRIPTION
#### Description:

- Creates a mount point entry in `/etc/fstab` when needed.
- Rule `mount_option_dev_shm_noexec` can remediate, by creating an entry in `/etc/fstab`.
- Disable creation of `fstab` for removable partitions and remote filesystems, we don't have enough information for that.

#### Rationale:

- By default `/dev/shm/` is mounted by systemd with `nosuid` and `nodev` options.

#### Issues

After a scan and remediation, `/etc/fstab` contains only `noexec` option, because rules `mount_option_dev_shm_nosuid` and `mount_option_dev_shm_nodev` pass, and therefore, remediation script is not run.
~There is some concurrence/caching occurring, either on scanner side or kernel side.~

~The `noexec` rule is the first to run, and its remediation should cause the other two rules to detect the mount as *without* `nosuid` and `nodev` options. But the scanner evaluates the old table and passes.~

Edit: There is no caching issue. The`nosuid` and `nodev` rules are not remediated because they **passed** during scan, so no remediation is performed.

**Again** we have issues with rule inter dependency.
If the scanner did "scan rule/fix rule" instead of doing "scan all rules/fix all rules", this would be merged already. :D