### PR TITLE
Exclude Python cache from the source tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,8 @@ set(CPACK_SOURCE_GENERATOR "TBZ2")
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "scap-security-guide-${SSG_VERSION}" CACHE INTERNAL "tarball basename")
 set(CPACK_SOURCE_IGNORE_FILES
 "\\\\.git.*"
+"\\\\.pyc"
+"__pycache__"
 
 "build/"
 "~$"


### PR DESCRIPTION
#### Description:
The released tarball for ComplianceAsCode 0.1.43 contains many `.pyc` files (precompiled Python cache) and also `__pycache__` directories. Those files and directories shouldn't be a part of upstream release tarball because they're platform dependent. Moreover, downstream distributions need to explicitly exclude these files in their spec files.

#### Rationale:
Fixes #4042