### PR TITLE
Fix for issue #2872

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/oval/shared.xml
@@ -1,18 +1,18 @@
 <def-group>
   <definition class="compliance" id="file_groupowner_efi_grub2_cfg" version="1">
     <metadata>
-      <title>Verify /boot/efi/EFI/redhat/grub.cfg Group Owner</title>
+      <title>Verify the UEFI Boot Loader grub.cfg Group Owner</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>This test makes sure that /boot/efi/EFI/redhat/grub.cfg is group owned by 0.</description>
+      <description>Verify that UEFI Boot Loader grub.cfg is group owned by 0.</description>
     </metadata>
     <criteria operator="OR">
-      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is legacy BIOS" />
+      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
       <criterion comment="Check file group ownership of /boot/efi/EFI/redhat/grub.cfg" test_ref="test_file_groupowner_efi_grub2_cfg" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /boot/efi/EFI/redhat/grub.cfg" id="test_file_groupowner_efi_grub2_cfg" version="1">
+  <unix:file_test check="all" check_existence="all_exist" comment="Verify group ownership of /boot/efi/EFI/redhat/grub.cfg" id="test_file_groupowner_efi_grub2_cfg" version="1">
     <unix:object object_ref="object_file_groupowner_efi_grub2_cfg" />
     <unix:state state_ref="state_file_groupowner_efi_grub2_cfg_gid_0" />
   </unix:file_test>
@@ -20,7 +20,6 @@
     <unix:group_id datatype="int">0</unix:group_id>
   </unix:file_state>
   <unix:file_object comment="/boot/efi/EFI/redhat/grub.cfg" id="object_file_groupowner_efi_grub2_cfg" version="1">
-    <unix:path>/boot/efi/EFI/redhat</unix:path>
-    <unix:filename>grub.cfg</unix:filename>
+    <unix:filepath operation="pattern match">^/boot/efi/EFI/(redhat|fedora)/grub.cfg$</unix:filepath>
   </unix:file_object>
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="file_groupowner_efi_grub2_cfg" version="1">
+    <metadata>
+      <title>Verify /boot/efi/EFI/redhat/grub.cfg Group Owner</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>This test makes sure that /boot/efi/EFI/redhat/grub.cfg is group owned by 0.</description>
+    </metadata>
+    <criteria operator="OR">
+      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is legacy BIOS" />
+      <criterion comment="Check file group ownership of /boot/efi/EFI/redhat/grub.cfg" test_ref="test_file_groupowner_efi_grub2_cfg" />
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /boot/efi/EFI/redhat/grub.cfg" id="test_file_groupowner_efi_grub2_cfg" version="1">
+    <unix:object object_ref="object_file_groupowner_efi_grub2_cfg" />
+    <unix:state state_ref="state_file_groupowner_efi_grub2_cfg_gid_0" />
+  </unix:file_test>
+  <unix:file_state id="state_file_groupowner_efi_grub2_cfg_gid_0" version="1">
+    <unix:group_id datatype="int">0</unix:group_id>
+  </unix:file_state>
+  <unix:file_object comment="/boot/efi/EFI/redhat/grub.cfg" id="object_file_groupowner_efi_grub2_cfg" version="1">
+    <unix:path>/boot/efi/EFI/redhat</unix:path>
+    <unix:filename>grub.cfg</unix:filename>
+  </unix:file_object>
+</def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8,fedora,ol7,ol8
 title: 'Verify the UEFI Boot Loader grub.cfg Group Ownership'
 
 description: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     The file <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should
     be group-owned by the <tt>root</tt> group to prevent
     destruction or modification of the file.
@@ -15,7 +15,7 @@ description: |-
     be group-owned by the <tt>root</tt> group to prevent
     destruction or modification of the file.
     {{{ describe_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
-{{% endif %}}
+{{%- endif %}}
 
 rationale: |-
     The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
@@ -38,15 +38,15 @@ references:
     cis-csc: 12,13,14,15,16,18,3,5
 
 ocil_clause: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     {{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
 {{% else %}}
     {{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
-{{% endif %}}
+{{%- endif %}}
 
 ocil: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     {{{ ocil_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
 {{% else %}}
     {{{ ocil_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
-{{% endif %}}
+{{%- endif %}}

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
@@ -1,14 +1,21 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,ol7,ol8
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
-title: 'Verify /boot/efi/EFI/redhat/grub.cfg Group Ownership'
+title: 'Verify the UEFI Boot Loader grub.cfg Group Ownership'
 
 description: |-
+{{% if product == "fedora" %}}
+    The file <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should
+    be group-owned by the <tt>root</tt> group to prevent
+    destruction or modification of the file.
+    {{{ describe_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
+{{% else %}}
     The file <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should
     be group-owned by the <tt>root</tt> group to prevent
     destruction or modification of the file.
     {{{ describe_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
+{{% endif %}}
 
 rationale: |-
     The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
@@ -30,6 +37,16 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 12,13,14,15,16,18,3,5
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}'
+ocil_clause: |-
+{{% if product == "fedora" %}}
+    {{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
+{{% else %}}
+    {{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
+{{% endif %}}
 
-ocil: '{{{ ocil_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}'
+ocil: |-
+{{% if product == "fedora" %}}
+    {{{ ocil_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
+{{% else %}}
+    {{{ ocil_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
+{{% endif %}}

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="file_groupowner_grub2_cfg" version="1">
+    <metadata>
+      <title>Verify /boot/grub2/grub.cfg Group Owner</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>This test makes sure that /boot/grub2/grub.cfg is group owned by 0.</description>
+    </metadata>
+    <criteria operator="OR">
+      <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />
+      <criterion comment="Check file group ownership of /boot/grub2/grub.cfg" test_ref="test_file_groupowner_grub2_cfg" />
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /boot/grub2/grub.cfg" id="test_file_groupowner_grub2_cfg" version="1">
+    <unix:object object_ref="object_file_groupowner_grub2_cfg" />
+    <unix:state state_ref="state_file_groupowner_grub2_cfg_gid_0" />
+  </unix:file_test>
+  <unix:file_state id="state_file_groupowner_grub2_cfg_gid_0" version="1">
+    <unix:group_id datatype="int">0</unix:group_id>
+  </unix:file_state>
+  <unix:file_object comment="/boot/grub2/grub.cfg" id="object_file_groupowner_grub2_cfg" version="1">
+    <unix:path>/boot/grub2</unix:path>
+    <unix:filename>grub.cfg</unix:filename>
+  </unix:file_object>
+</def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/oval/shared.xml
@@ -5,14 +5,14 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>This test makes sure that /boot/grub2/grub.cfg is group owned by 0.</description>
+      <description>Verify that /boot/grub2/grub.cfg is group owned by gid 0.</description>
     </metadata>
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />
       <criterion comment="Check file group ownership of /boot/grub2/grub.cfg" test_ref="test_file_groupowner_grub2_cfg" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /boot/grub2/grub.cfg" id="test_file_groupowner_grub2_cfg" version="1">
+  <unix:file_test check="all" check_existence="all_exist" comment="Verify group ownership of /boot/grub2/grub.cfg" id="test_file_groupowner_grub2_cfg" version="1">
     <unix:object object_ref="object_file_groupowner_grub2_cfg" />
     <unix:state state_ref="state_file_groupowner_grub2_cfg_gid_0" />
   </unix:file_test>
@@ -20,7 +20,6 @@
     <unix:group_id datatype="int">0</unix:group_id>
   </unix:file_state>
   <unix:file_object comment="/boot/grub2/grub.cfg" id="object_file_groupowner_grub2_cfg" version="1">
-    <unix:path>/boot/grub2</unix:path>
-    <unix:filename>grub.cfg</unix:filename>
+    <unix:filepath>/boot/grub2/grub.cfg</unix:filepath>
   </unix:file_object>
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="file_owner_efi_grub2_cfg" version="1">
+    <metadata>
+      <title>Verify /boot/efi/EFI/redhat/grub.cfg Owner</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>This test makes sure that /boot/efi/EFI/redhat/grub.cfg is owned by 0.</description>
+    </metadata>
+    <criteria operator="OR">
+      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is legacy BIOS" />
+      <criterion comment="Check file ownership of /boot/efi/EFI/redhat/grub.cfg" test_ref="test_file_owner_efi_grub2_cfg" />
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing user ownership of /boot/efi/EFI/redhat/grub.cfg" id="test_file_owner_efi_grub2_cfg" version="1">
+    <unix:object object_ref="object_file_owner_efi_grub2_cfg" />
+    <unix:state state_ref="state_file_owner_efi_grub2_cfg_uid_0" />
+  </unix:file_test>
+  <unix:file_state id="state_file_owner_efi_grub2_cfg_uid_0" version="1">
+    <unix:user_id datatype="int">0</unix:user_id>
+  </unix:file_state>
+  <unix:file_object comment="/boot/efi/EFI/redhat/grub.cfg" id="object_file_owner_efi_grub2_cfg" version="1">
+    <unix:path>/boot/efi/EFI/redhat</unix:path>
+    <unix:filename>grub.cfg</unix:filename>
+  </unix:file_object>
+</def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/oval/shared.xml
@@ -1,18 +1,18 @@
 <def-group>
   <definition class="compliance" id="file_owner_efi_grub2_cfg" version="1">
     <metadata>
-      <title>Verify /boot/efi/EFI/redhat/grub.cfg Owner</title>
+      <title>Verify the UEFI Boot Loader grub.cfg Owner</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>This test makes sure that /boot/efi/EFI/redhat/grub.cfg is owned by 0.</description>
+      <description>Verify that UEFI Boot Loader grub.cfg is owned by uid 0.</description>
     </metadata>
     <criteria operator="OR">
-      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is legacy BIOS" />
+      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
       <criterion comment="Check file ownership of /boot/efi/EFI/redhat/grub.cfg" test_ref="test_file_owner_efi_grub2_cfg" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist" comment="Testing user ownership of /boot/efi/EFI/redhat/grub.cfg" id="test_file_owner_efi_grub2_cfg" version="1">
+  <unix:file_test check="all" check_existence="all_exist" comment="Verify user ownership of /boot/efi/EFI/redhat/grub.cfg" id="test_file_owner_efi_grub2_cfg" version="1">
     <unix:object object_ref="object_file_owner_efi_grub2_cfg" />
     <unix:state state_ref="state_file_owner_efi_grub2_cfg_uid_0" />
   </unix:file_test>
@@ -20,7 +20,6 @@
     <unix:user_id datatype="int">0</unix:user_id>
   </unix:file_state>
   <unix:file_object comment="/boot/efi/EFI/redhat/grub.cfg" id="object_file_owner_efi_grub2_cfg" version="1">
-    <unix:path>/boot/efi/EFI/redhat</unix:path>
-    <unix:filename>grub.cfg</unix:filename>
+    <unix:filepath operation="pattern match">^/boot/efi/EFI/(redhat|fedora)/grub.cfg$</unix:filepath>
   </unix:file_object>
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
@@ -1,14 +1,21 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,ol7,ol8
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
-title: 'Verify /boot/efi/EFI/redhat/grub.cfg User Ownership'
+title: 'Verify the UEFI Boot Loader grub.cfg User Ownership'
 
 description: |-
+{{% if product == "fedora" %}}
+    The file <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should
+    be owned by the <tt>root</tt> user to prevent destruction
+    or modification of the file.
+    {{{ describe_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
+{{% else %}}
     The file <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should
     be owned by the <tt>root</tt> user to prevent destruction
     or modification of the file.
     {{{ describe_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
+{{% endif %}}
 
 rationale: 'Only root should be able to modify important boot parameters.'
 
@@ -28,6 +35,16 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 12,13,14,15,16,18,3,5
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}'
+ocil_clause: |-
+{{% if product == "fedora" %}}
+    {{{ ocil_clause_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
+{{% else %}}
+    {{{ ocil_clause_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
+{{% endif %}}
 
-ocil: '{{{ ocil_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}'
+ocil: |-
+{{% if product == "fedora" %}}
+    {{{ ocil_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
+{{% else %}}
+    {{{ ocil_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
+{{% endif %}}

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8,fedora,ol7,ol8
 title: 'Verify the UEFI Boot Loader grub.cfg User Ownership'
 
 description: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     The file <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should
     be owned by the <tt>root</tt> user to prevent destruction
     or modification of the file.
@@ -15,7 +15,7 @@ description: |-
     be owned by the <tt>root</tt> user to prevent destruction
     or modification of the file.
     {{{ describe_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
-{{% endif %}}
+{{%- endif %}}
 
 rationale: 'Only root should be able to modify important boot parameters.'
 
@@ -36,15 +36,15 @@ references:
     cis-csc: 12,13,14,15,16,18,3,5
 
 ocil_clause: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     {{{ ocil_clause_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
 {{% else %}}
     {{{ ocil_clause_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
-{{% endif %}}
+{{%- endif %}}
 
 ocil: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     {{{ ocil_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
 {{% else %}}
     {{{ ocil_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
-{{% endif %}}
+{{%- endif %}}

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="file_owner_grub2_cfg" version="1">
+    <metadata>
+      <title>Verify /boot/grub2/grub.cfg Owner</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>This test makes sure that /boot/grub2/grub.cfg is owned by 0.</description>
+    </metadata>
+    <criteria operator="OR">
+      <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />
+      <criterion comment="Check file ownership of /boot/grub2/grub.cfg" test_ref="test_file_owner_grub2_cfg" />
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing user ownership of /boot/grub2/grub.cfg" id="test_file_owner_grub2_cfg" version="1">
+    <unix:object object_ref="object_file_owner_grub2_cfg" />
+    <unix:state state_ref="state_file_owner_grub2_cfg_uid_0" />
+  </unix:file_test>
+  <unix:file_state id="state_file_owner_grub2_cfg_uid_0" version="1">
+    <unix:user_id datatype="int">0</unix:user_id>
+  </unix:file_state>
+  <unix:file_object comment="/boot/grub2/grub.cfg" id="object_file_owner_grub2_cfg" version="1">
+    <unix:path>/boot/grub2</unix:path>
+    <unix:filename>grub.cfg</unix:filename>
+  </unix:file_object>
+</def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/oval/shared.xml
@@ -5,7 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>This test makes sure that /boot/grub2/grub.cfg is owned by 0.</description>
+      <description>Verify that /boot/grub2/grub.cfg is owned by uid 0.</description>
     </metadata>
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />
@@ -20,7 +20,6 @@
     <unix:user_id datatype="int">0</unix:user_id>
   </unix:file_state>
   <unix:file_object comment="/boot/grub2/grub.cfg" id="object_file_owner_grub2_cfg" version="1">
-    <unix:path>/boot/grub2</unix:path>
-    <unix:filename>grub.cfg</unix:filename>
+    <unix:filepath>/boot/grub2/grub.cfg</unix:filepath>
   </unix:file_object>
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
@@ -1,14 +1,14 @@
 <def-group>
   <definition class="compliance" id="file_permissions_efi_grub2_cfg" version="1">
     <metadata>
-      <title>File /boot/efi/EFI/redhat/grub.cfg Permissions</title>
+      <title>Verify the UEFI Boot Loader grub.cfg Permissions</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>
-      <description>File permissions for /boot/efi/EFI/redhat/grub.cfg should be set to 0700 (or stronger).</description>
+      <description>Verify that UEFI Boot Loader grub.cfg file permissions set to 0700 (or stronger).</description>
     </metadata>
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
@@ -22,7 +22,7 @@
   </unix:file_test>
 
   <unix:file_object comment="/boot/efi/EFI/redhat/grub.cfg" id="object_file_permissions_efi_grub2_cfg" version="1">
-    <unix:filepath>/boot/efi/EFI/redhat/grub.cfg</unix:filepath>
+    <unix:filepath operation="pattern match">^/boot/efi/EFI/(redhat|fedora)/grub.cfg$</unix:filepath>
   </unix:file_object>
 
   <unix:file_state id="state_file_permissions_efi_grub2_cfg" version="1">

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
@@ -11,7 +11,7 @@
       <description>File permissions for /boot/efi/EFI/redhat/grub.cfg should be set to 0700 (or stronger).</description>
     </metadata>
     <criteria operator="OR">
-      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is legacy BIOS" />
+      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
       <criterion test_ref="test_file_permissions_efi_grub2_cfg" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
@@ -10,7 +10,8 @@
       </affected>
       <description>File permissions for /boot/efi/EFI/redhat/grub.cfg should be set to 0700 (or stronger).</description>
     </metadata>
-    <criteria>
+    <criteria operator="OR">
+      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is legacy BIOS" />
       <criterion test_ref="test_file_permissions_efi_grub2_cfg" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
@@ -5,13 +5,13 @@ prodtype: rhel7,rhel8,fedora,ol7,ol8
 title: 'Verify the UEFI Boot Loader grub.cfg Permissions'
 
 description: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     File permissions for <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should be set to 700.
     {{{ describe_file_permissions(file="/boot/efi/EFI/fedora/grub.cfg", perms="700") }}}
 {{% else %}}
     File permissions for <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should be set to 700.
     {{{ describe_file_permissions(file="/boot/efi/EFI/redhat/grub.cfg", perms="700") }}}
-{{% endif %}}
+{{%- endif %}}
 
 rationale: |-
     Proper permissions ensure that only the root user can modify important boot
@@ -34,13 +34,13 @@ references:
 ocil_clause: 'it does not'
 
 ocil: |-
-{{% if product == "fedora" %}}
+{{%- if product == "fedora" %}}
     To check the permissions of /boot/efi/EFI/fedora/grub.cfg, run the command:
     <pre>$ sudo ls -lL /boot/efi/EFI/fedora/grub.cfg</pre>
 {{% else %}}
     To check the permissions of /boot/efi/EFI/redhat/grub.cfg, run the command:
     <pre>$ sudo ls -lL /boot/efi/EFI/redhat/grub.cfg</pre>
-{{% endif %}}
+{{%- endif %}}
     If properly configured, the output should indicate the following
     permissions: <tt>-rwx------</tt>
 

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
@@ -1,12 +1,17 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,ol7,ol8
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
-title: 'Verify /boot/efi/EFI/redhat/grub.cfg Permissions'
+title: 'Verify the UEFI Boot Loader grub.cfg Permissions'
 
 description: |-
+{{% if product == "fedora" %}}
+    File permissions for <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should be set to 700.
+    {{{ describe_file_permissions(file="/boot/efi/EFI/fedora/grub.cfg", perms="700") }}}
+{{% else %}}
     File permissions for <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should be set to 700.
     {{{ describe_file_permissions(file="/boot/efi/EFI/redhat/grub.cfg", perms="700") }}}
+{{% endif %}}
 
 rationale: |-
     Proper permissions ensure that only the root user can modify important boot
@@ -29,8 +34,13 @@ references:
 ocil_clause: 'it does not'
 
 ocil: |-
+{{% if product == "fedora" %}}
+    To check the permissions of /boot/efi/EFI/fedora/grub.cfg, run the command:
+    <pre>$ sudo ls -lL /boot/efi/EFI/fedora/grub.cfg</pre>
+{{% else %}}
     To check the permissions of /boot/efi/EFI/redhat/grub.cfg, run the command:
     <pre>$ sudo ls -lL /boot/efi/EFI/redhat/grub.cfg</pre>
+{{% endif %}}
     If properly configured, the output should indicate the following
     permissions: <tt>-rwx------</tt>
 

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/oval/shared.xml
@@ -5,16 +5,14 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>This test makes sure that /boot/grub2/grub.cfg has mode 0600.
-      If the target file or directory has an extended ACL, then it will fail the mode check.
-      </description>
+      <description>File permissions for /boot/grub2/grub.cfg should be set to 0600 (or stronger).</description>
     </metadata>
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />      
       <criterion comment="Check file mode of /boot/grub2/grub.cfg" test_ref="test_file_permissions_grub2_cfg" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist" comment="Testing mode of /boot/grub2/grub.cfg" id="test_file_permissions_grub2_cfg" version="1">
+  <unix:file_test check="all" check_existence="all_exist" comment="Verify mode of /boot/grub2/grub.cfg" id="test_file_permissions_grub2_cfg" version="1">
     <unix:object object_ref="object_file_permissions_grub2_cfg" />
     <unix:state state_ref="state_file_permissions_grub2_cfg_mode_0600" />
   </unix:file_test>
@@ -34,7 +32,6 @@
 
   </unix:file_state>
   <unix:file_object comment="/boot/grub2/grub.cfg" id="object_file_permissions_grub2_cfg" version="1">
-    <unix:path>/boot/grub2</unix:path>
-    <unix:filename>grub.cfg</unix:filename>
+    <unix:filepath>/boot/grub2/grub.cfg</unix:filepath>
   </unix:file_object>
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/oval/shared.xml
@@ -1,0 +1,40 @@
+<def-group>
+  <definition class="compliance" id="file_permissions_grub2_cfg" version="1">
+    <metadata>
+      <title>Verify /boot/grub2/grub.cfg Mode Permissions</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>This test makes sure that /boot/grub2/grub.cfg has mode 0600.
+      If the target file or directory has an extended ACL, then it will fail the mode check.
+      </description>
+    </metadata>
+    <criteria operator="OR">
+      <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />      
+      <criterion comment="Check file mode of /boot/grub2/grub.cfg" test_ref="test_file_permissions_grub2_cfg" />
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing mode of /boot/grub2/grub.cfg" id="test_file_permissions_grub2_cfg" version="1">
+    <unix:object object_ref="object_file_permissions_grub2_cfg" />
+    <unix:state state_ref="state_file_permissions_grub2_cfg_mode_0600" />
+  </unix:file_test>
+  <unix:file_state id="state_file_permissions_grub2_cfg_mode_0600" version="1">
+    	<unix:suid datatype="boolean">false</unix:suid>
+	<unix:sgid datatype="boolean">false</unix:sgid>
+	<unix:sticky datatype="boolean">false</unix:sticky>
+	<unix:uread datatype="boolean">true</unix:uread>
+	<unix:uwrite datatype="boolean">true</unix:uwrite>
+	<unix:uexec datatype="boolean">false</unix:uexec>
+	<unix:gread datatype="boolean">false</unix:gread>
+	<unix:gwrite datatype="boolean">false</unix:gwrite>
+	<unix:gexec datatype="boolean">false</unix:gexec>
+	<unix:oread datatype="boolean">false</unix:oread>
+	<unix:owrite datatype="boolean">false</unix:owrite>
+	<unix:oexec datatype="boolean">false</unix:oexec>
+
+  </unix:file_state>
+  <unix:file_object comment="/boot/grub2/grub.cfg" id="object_file_permissions_grub2_cfg" version="1">
+    <unix:path>/boot/grub2</unix:path>
+    <unix:filename>grub.cfg</unix:filename>
+  </unix:file_object>
+</def-group>

--- a/ol7/templates/csv/file_dir_permissions.csv
+++ b/ol7/templates/csv/file_dir_permissions.csv
@@ -2,4 +2,4 @@
 /etc,group,0,0,0644
 /etc,passwd,0,0,0644
 /boot/grub2,grub.cfg,0,0,0600,grub2_cfg
-/boot/efi/EFI/redhat,grub.cfg,0,0,,efi_grub2_cfg
+/boot/efi/EFI/redhat,grub.cfg,0,0,0700,efi_grub2_cfg

--- a/ol8/templates/csv/file_dir_permissions.csv
+++ b/ol8/templates/csv/file_dir_permissions.csv
@@ -2,4 +2,4 @@
 /etc,group,0,0,0644
 /etc,passwd,0,0,0644
 /boot/grub2,grub.cfg,0,0,0600,grub2_cfg
-/boot/efi/EFI/redhat,grub.cfg,0,0,,efi_grub2_cfg
+/boot/efi/EFI/redhat,grub.cfg,0,0,0700,efi_grub2_cfg

--- a/shared/checks/oval/system_boot_mode_is_uefi.xml
+++ b/shared/checks/oval/system_boot_mode_is_uefi.xml
@@ -12,7 +12,7 @@
     </criteria>
   </definition>
 
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="Test if /sys/firmware/efi folder exists" id="test_efi_dir_existence" version="1">
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="Verify if /sys/firmware/efi folder exists" id="test_efi_dir_existence" version="1">
     <unix:object object_ref="object_file_sys_firmware_efi" />
   </unix:file_test>
 

--- a/shared/checks/oval/system_boot_mode_is_uefi.xml
+++ b/shared/checks/oval/system_boot_mode_is_uefi.xml
@@ -1,0 +1,24 @@
+<def-group>
+  <definition class="compliance" id="system_boot_mode_is_uefi" version="1">
+    <metadata>
+      <title>UEFI system boot mode check</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check if system boot mode is UEFI.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_efi_dir_existence" comment="check if /sys/firmware/efi folder exists" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="Test if /sys/firmware/efi folder exists" id="test_efi_dir_existence" version="1">
+    <unix:object object_ref="object_file_sys_firmware_efi" />
+  </unix:file_test>
+
+  <unix:file_object comment="/sys/firmware/efi" id="object_file_sys_firmware_efi" version="1">
+    <unix:path>/sys/firmware/efi</unix:path>
+    <unix:filename xsi:nil="true" />
+  </unix:file_object>
+
+</def-group>

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -477,15 +477,15 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 {{%- macro ocil_clause_file_permissions(file, perms) %}}
-{{{ file }}} has unix mode {{{ perms }}}
+    {{{ file }}} has unix mode {{{ perms }}}
 {{%- endmacro %}}
 
 {{%- macro ocil_clause_file_owner(file, owner) %}}
-{{{ file }}} has owner {{{ owner }}}
+    {{{ file }}} has owner {{{ owner }}}
 {{%- endmacro %}}
 
 {{%- macro ocil_clause_file_group_owner(file, group) %}}
-{{{ file }}} has group owner {{{ group }}}
+    {{{ file }}} has group owner {{{ group }}}
 {{%- endmacro %}}
 
 {{%- macro check_file_permissions(file, perms) %}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -453,7 +453,7 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 
-{{%- macro ocil_file_permissions(file, perms) %}}
+{{%- macro ocil_file_permissions(file, perms) -%}}
     To check the permissions of <code>{{{ file }}}</code>, run the command:
     <pre>$ ls -l {{{ file }}}</pre>
     If properly configured, the output should indicate the following permissions:
@@ -461,7 +461,7 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 
-{{%- macro ocil_file_owner(file, owner) %}}
+{{%- macro ocil_file_owner(file, owner) -%}}
     To check the ownership of <code>{{{ file }}}</code>, run the command:
     <pre>$ ls -lL {{{ file }}}</pre>
     If properly configured, the output should indicate the following owner:
@@ -469,22 +469,22 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{%- endmacro %}}
 
 
-{{%- macro ocil_file_group_owner(file, group) %}}
+{{%- macro ocil_file_group_owner(file, group) -%}}
     To check the group ownership of <code>{{{ file }}}</code>, run the command:
     <pre>$ ls -lL {{{ file }}}</pre>
-    If properly configured, the output should indicate the following group-owner.
+    If properly configured, the output should indicate the following group-owner:
     <code>{{{ group }}}</code>
 {{%- endmacro %}}
 
-{{%- macro ocil_clause_file_permissions(file, perms) %}}
+{{%- macro ocil_clause_file_permissions(file, perms) -%}}
     {{{ file }}} has unix mode {{{ perms }}}
 {{%- endmacro %}}
 
-{{%- macro ocil_clause_file_owner(file, owner) %}}
+{{%- macro ocil_clause_file_owner(file, owner) -%}}
     {{{ file }}} has owner {{{ owner }}}
 {{%- endmacro %}}
 
-{{%- macro ocil_clause_file_group_owner(file, group) %}}
+{{%- macro ocil_clause_file_group_owner(file, group) -%}}
     {{{ file }}} has group owner {{{ group }}}
 {{%- endmacro %}}
 


### PR DESCRIPTION
#### Description:

Implemented UEFI boot mode OVAL check based on '/sys/firmware/efi' existence (assumed to be supported on most of Linux based systems). Extended grub2 ownership/permissions rules to use UEFI OVAL check: pass non-EFI checks on EFI systems and pass EFI checks on non-EFI systems.

#### Rationale:

- Fixes #2872

#### Testing:
- Checked build to pass for all targets
- Checked rules to work on OL7