### PR TITLE
Fix #4112: All tests return 'notapplicable' for oscap against Ubuntu 18

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -352,6 +352,7 @@ sle12
 tests
 ubuntu1404
 ubuntu1604
+ubuntu1804
 utils
 wrlinux
 ----

--- a/linux_os/guide/services/ssh/service_sshd_disabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_disabled/rule.yml
@@ -5,7 +5,7 @@ title: 'Disable SSH Server If Possible (Unusual)'
 description: |-
     The SSH server service, sshd, is commonly needed.
     However, if it can be disabled, do so.
-    {{% if product in ['debian8', 'ubuntu1404', 'ubuntu1604'] %}}
+    {{% if product in ['debian8', 'ubuntu1404', 'ubuntu1604', 'ubuntu1804'] %}}
     {{{ describe_service_disable(service="sshd") }}}
     {{% else %}}
     {{{ describe_service_disable(service="sshd") }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -8,13 +8,14 @@
         <platform>Debian 8</platform>
         <platform>Ubuntu 1404</platform>
         <platform>Ubuntu 1604</platform>
+	<platform>Ubuntu 1804</platform>
         <platform>multi_platform_ol</platform>
       </affected>
       <description>File permissions for all syslog log files should be set correctly.</description>
     </metadata>
 
     <criteria operator="AND">
-      {{% if product in ["debian8", "ubuntu1404", "ubuntu1604"] %}}
+      {{% if product in ["debian8", "ubuntu1404", "ubuntu1604", "ubuntu1804"] %}}
       <extend_definition comment="rsyslog daemon is used as local logging daemon" definition_ref="package_rsyslog_installed" />
       {{% endif %}}
       <criterion comment="Check permissions of all system log files" test_ref="test_rsyslog_files_permissions" />
@@ -96,7 +97,7 @@
   <unix:file_state id="state_rsyslog_files_permissions" version="1">
     <unix:type operation="equals">regular</unix:type>
     <unix:uexec datatype="boolean">false</unix:uexec>
-    {{% if product in ["debian8", "ubuntu1404", "ubuntu1604"] %}}
+    {{% if product in ["debian8", "ubuntu1404", "ubuntu1604", "ubuntu1804"] %}}
     <unix:gread datatype="boolean">true</unix:gread>
     {{% else %}}
     <unix:gread datatype="boolean">false</unix:gread>

--- a/shared/checks/oval/sshd_version_higher_than_74.xml
+++ b/shared/checks/oval/sshd_version_higher_than_74.xml
@@ -28,6 +28,7 @@
         <criteria comment="System uses RPM based packages" operator="OR">
           <extend_definition comment="Ubuntu 1404 OS installed" definition_ref="installed_OS_is_ubuntu1404" />
           <extend_definition comment="Ubuntu 1604 OS installed" definition_ref="installed_OS_is_ubuntu1604" />
+          <extend_definition comment="Ubuntu 1804 OS installed" definition_ref="installed_OS_is_ubuntu1804" />
           <extend_definition comment="Debian 8 OS installed" definition_ref="installed_OS_is_debian8" />
         </criteria>
         <criterion comment="Check DEB version of OpenSSH Server is equal or higher than 7.4"

--- a/shared/templates/template_OVAL_sysctl_ipv6
+++ b/shared/templates/template_OVAL_sysctl_ipv6
@@ -8,7 +8,7 @@
       <description>The "{{{ SYSCTLVAR }}}" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
     </metadata>
     <criteria comment="IPv6 disabled or {{{ SYSCTLVAR }}} set correctly" operator="OR">
-{{% if product in ["rhel6", "debian8", "ubuntu1404", "ubuntu1604"] %}}
+{{% if product in ["rhel6", "debian8", "ubuntu1404", "ubuntu1604", "ubuntu1804"] %}}
       <extend_definition comment="is IPv6 enabled?" definition_ref="kernel_module_ipv6_option_disabled" />
 {{% else %}}
       <extend_definition comment="is IPv6 enabled?" definition_ref="sysctl_kernel_ipv6_disable" />

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -6,8 +6,9 @@ import os.path
 
 product_directories = ['debian8', 'fedora', 'ol7', 'ol8', 'opensuse', 'rhel6',
                        'rhel7', 'rhel8', 'sle11', 'sle12', 'ubuntu1404',
-                       'ubuntu1604', 'wrlinux', 'rhosp13', 'chromium',
-                       'eap6', 'firefox', 'fuse6', 'jre', 'ocp3', 'example']
+                       'ubuntu1604', 'ubuntu1804', 'wrlinux', 'rhosp13',
+                       'chromium', 'eap6', 'firefox', 'fuse6', 'jre', 'ocp3',
+                       'example']
 
 JINJA_MACROS_BASE_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros.jinja")

--- a/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
+++ b/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
@@ -2,7 +2,7 @@
 <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
-          <cpe-item name="cpe:/o:canonical:ubuntu_linux:16.04">
+          <cpe-item name="cpe:/o:canonical:ubuntu_linux:18.04">
             <title xml:lang="en-us">Ubuntu release 18.04 (Bionic Beaver)</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_ubuntu1804</check>

--- a/utils/duplicated_prodtypes.py
+++ b/utils/duplicated_prodtypes.py
@@ -12,7 +12,8 @@ def _create_profile_cache(ssg_root):
     profile_cache = {}
 
     product_list = ['debian8', 'fedora', 'ol7', 'opensuse', 'rhel6', 'rhel7',
-                    'sle11', 'sle12', 'ubuntu1404', 'ubuntu1604', 'wrlinux']
+                    'sle11', 'sle12', 'ubuntu1404', 'ubuntu1604', 'ubuntu1804',
+                    'wrlinux']
 
     for product in product_list:
         found_obj_name = False
@@ -181,7 +182,7 @@ def find_profiles(ssg_root, path, obj_name):
 
     more_than_two = len(used_products) >= 3
     uses_wrlinux = 'wrlinux' in used_products
-    uses_debian_like_distro = 'debian8' in used_products or 'ubuntu1404' in used_products or 'ubuntu1604' in used_products
+    uses_debian_like_distro = 'debian8' in used_products or 'ubuntu1404' in used_products or 'ubuntu1604' in used_products or 'ubuntu1804' in used_products
     uses_rhel_like_distro = 'rhel6' in used_products or 'rhel7' in used_products or 'ol7' in used_products
     uses_sles_like_distro = 'opensuse' in used_products or 'sle11' in used_products or 'sle12' in used_products
     uses_two_distros = (uses_debian_like_distro and uses_rhel_like_distro) or (uses_debian_like_distro and uses_sles_like_distro) or (uses_rhel_like_distro and uses_sles_like_distro)

--- a/utils/fix_file_ocilclause.py
+++ b/utils/fix_file_ocilclause.py
@@ -12,7 +12,8 @@ def _create_profile_cache(ssg_root):
     profile_cache = {}
 
     product_list = ['debian8', 'fedora', 'ol7', 'opensuse', 'rhel6', 'rhel7',
-                    'sle11', 'sle12', 'ubuntu1404', 'ubuntu1604', 'wrlinux']
+                    'sle11', 'sle12', 'ubuntu1404', 'ubuntu1604', 'ubuntu1804',
+                    'wrlinux']
 
     for product in product_list:
         found_obj_name = False


### PR DESCRIPTION
#### Description:

In trying to build a set of security guides for Ubuntu 18.04, all tests run with `oscap` have result `notapplicable`.

#### Rationale:

- Fixes #4112
