### PR TITLE
SSSD Ansible tasks don't break sssd service

### DIFF
--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
@@ -16,6 +16,7 @@
     path: /etc/sssd/sssd.conf
     create: yes
     line: "[domain/default]\nldap_tls_cacertdir = {{ var_sssd_ldap_tls_ca_dir }}\n"
+    mode: 0600
   when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAPs path to CA directory"
@@ -24,4 +25,5 @@
     regexp: '^\s*ldap_tls_cacertdir'
     insertafter: '\s*\[domain\/[^]]*]'
     line: 'ldap_tls_cacertdir = {{ var_sssd_ldap_tls_ca_dir }}'
+    mode: 0600
 

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
@@ -12,11 +12,17 @@
   changed_when: False
 
 - name: "Add default domain group and set CA directory (if no domain there)"
-  lineinfile:
+  ini_file:
     path: /etc/sssd/sssd.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
     create: yes
-    line: "[domain/default]\nldap_tls_cacertdir = {{ var_sssd_ldap_tls_ca_dir }}\n"
     mode: 0600
+  with_items:
+    - { section: sssd, option: domains, value: default}
+    - { section: domain/default, option: id_provider, value: files }
+    - { section: domain/default, option: ldap_tls_cacertdir, value: "{{ var_sssd_ldap_tls_ca_dir }}" }
   when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAPs path to CA directory"

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
@@ -20,10 +20,11 @@
   when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAPs path to CA directory"
-  lineinfile:
+  ini_file:
     path: /etc/sssd/sssd.conf
-    regexp: '^\s*ldap_tls_cacertdir'
-    insertafter: '\s*\[domain\/[^]]*]'
-    line: 'ldap_tls_cacertdir = {{ var_sssd_ldap_tls_ca_dir }}'
+    section: "{{ test_grep_domain.stdout | regex_replace('\\[(.*)\\]','\\1') }}"
+    option: ldap_tls_cacertdir
+    value: "{{ var_sssd_ldap_tls_ca_dir }}"
+    create: yes
     mode: 0600
-
+  when: test_grep_domain.stdout != ""

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -35,7 +35,7 @@
 - name: "Configure LDAP to use STARTTLS"
   ini_file:
     path: /etc/sssd/sssd.conf
-    section: "{{ test_grep_domain.stdout | regex_replace('[(.*)]','\\1') }}"
+    section: "{{ test_grep_domain.stdout | regex_replace('\\[(.*)\\]','\\1') }}"
     option: ldap_id_use_start_tls
     value: true
     create: yes

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -25,9 +25,12 @@
   when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAP to use STARTTLS"
-  lineinfile:
+  ini_file:
     path: /etc/sssd/sssd.conf
-    regexp: '^\s*ldap_id_use_start_tls'
-    insertafter: '\s*\[domain\/[^]]*]'
-    line: 'ldap_id_use_start_tls = True'
+    section: "{{ test_grep_domain.stdout | regex_replace('[(.*)]','\\1') }}"
+    option: ldap_id_use_start_tls
+    value: true
+    create: yes
     mode: 0600
+  when: test_grep_domain.stdout != ""
+

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -18,10 +18,18 @@
   changed_when: False
 
 - name: "Add default domain group and use STARTTLS (if no domain there)"
-  lineinfile:
+  ini_file:
     path: /etc/sssd/sssd.conf
-    line: "[domain/default]\nldap_id_use_start_tls = True\n"
+    section: domain/default
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: yes
     mode: 0600
+  with_items:
+    - { section: sssd, option: domains, value: default}
+    - { section: domain/default, option: id_provider, value: files }
+    - { section: domain/default, option: ldap_id_use_start_tls, value: true}
   when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAP to use STARTTLS"

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -21,6 +21,7 @@
   lineinfile:
     path: /etc/sssd/sssd.conf
     line: "[domain/default]\nldap_id_use_start_tls = True\n"
+    mode: 0600
   when: test_grep_domain.stdout == ""
 
 - name: "Configure LDAP to use STARTTLS"
@@ -29,3 +30,4 @@
     regexp: '^\s*ldap_id_use_start_tls'
     insertafter: '\s*\[domain\/[^]]*]'
     line: 'ldap_id_use_start_tls = True'
+    mode: 0600

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -3,6 +3,24 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
+- name: "Test for domain group"
+  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  register: test_grep_domain
+  ignore_errors: yes
+  changed_when: False
+
+- name: "Add default domain group (if no domain there)"
+  ini_file:
+    path: /etc/sssd/sssd.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: yes
+    mode: 0600
+  with_items:
+    - { section: sssd, option: domains, value: default}
+    - { section: domain/default, option: id_provider, value: files }
+  when: test_grep_domain.stdout == ""
 - name: "Enable Smartcards in SSSD"
   ini_file:
     dest: /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -10,3 +10,4 @@
     option: pam_cert_auth
     value: true
     create: yes
+    mode: 0600

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -12,3 +12,4 @@
     option: memcache_timeout
     value: "{{ var_sssd_memcache_timeout }}"
     create: yes
+    mode: 0600

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -5,6 +5,25 @@
 # disruption = medium
 - (xccdf-var var_sssd_memcache_timeout)
 
+- name: "Test for domain group"
+  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  register: test_grep_domain
+  ignore_errors: yes
+  changed_when: False
+
+- name: "Add default domain group (if no domain there)"
+  ini_file:
+    path: /etc/sssd/sssd.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: yes
+    mode: 0600
+  with_items:
+    - { section: sssd, option: domains, value: default}
+    - { section: domain/default, option: id_provider, value: files }
+  when: test_grep_domain.stdout == ""
+
 - name: "Configure SSSD's Memory Cache to Expire"
   ini_file:
     dest: /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -3,6 +3,25 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
+- name: "Test for domain group"
+  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  register: test_grep_domain
+  ignore_errors: yes
+  changed_when: False
+
+- name: "Add default domain group (if no domain there)"
+  ini_file:
+    path: /etc/sssd/sssd.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: yes
+    mode: 0600
+  with_items:
+    - { section: sssd, option: domains, value: default}
+    - { section: domain/default, option: id_provider, value: files }
+  when: test_grep_domain.stdout == ""
+
 - name: "Configure SSD to Expire Offline Credentials"
   ini_file:
     dest: /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -10,3 +10,4 @@
     option: offline_credentials_expiration
     value: 1
     create: yes
+    mode: 0600

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -5,6 +5,25 @@
 # disruption = medium
 - (xccdf-var sshd_idle_timeout_value)
 
+- name: "Test for domain group"
+  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  register: test_grep_domain
+  ignore_errors: yes
+  changed_when: False
+
+- name: "Add default domain group (if no domain there)"
+  ini_file:
+    path: /etc/sssd/sssd.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    create: yes
+    mode: 0600
+  with_items:
+    - { section: sssd, option: domains, value: default}
+    - { section: domain/default, option: id_provider, value: files }
+  when: test_grep_domain.stdout == ""
+
 - name: "Configure SSSD to Expire SSH Known Hosts"
   ini_file:
     dest: /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -10,3 +10,4 @@
     option: ssh_known_hosts_timeout
     value: 86400
     create: yes
+    mode: 0600

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -3,11 +3,13 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
+- (xccdf-var sshd_idle_timeout_value)
+
 - name: "Configure SSSD to Expire SSH Known Hosts"
   ini_file:
     dest: /etc/sssd/sssd.conf
     section: ssh
     option: ssh_known_hosts_timeout
-    value: 86400
+    value: "{{ sshd_idle_timeout_value }}"
     create: yes
     mode: 0600


### PR DESCRIPTION
#### Description:

- Ansible tasks for SSSD won't break service config, and service can start
- Use variable for `sshd_idle_timeout_value`
- Updated tasks to use `ini_file` module instead of `lineinfile`

#### Rationale:

- Service SSSD wouldn't start after any remediation
- This PR is mostly about not breaking `sssd.conf`

