### PR TITLE
Avoid duplication of audit rules

### DIFF
--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -71,7 +71,7 @@ declare -a sbinaries_to_skip=()
 for sbinary in "${privileged_binaries[@]}"
 do
 
-	# Check if this sbinary wasn't already handled in some of the previous iterations
+	# Check if this sbinary wasn't already handled in some of the previous sbinary iterations
 	# Return match only if whole sbinary definition matched (not in the case just prefix matched!!!)
 	if [[ $(sed -ne "\|${sbinary}|p" <<< "${sbinaries_to_skip[*]}") ]]
 	then
@@ -169,9 +169,15 @@ do
 		elif [ "$tool" == "auditctl" ] || [[ "$tool" == "augenrules" && $count_of_inspected_files -eq "${#files_to_inspect[@]}" ]]
 		then
 
-			# Current audit rules file's content doesn't contain expected rule for this
-			# SUID/SGID binary yet => append it
-			echo "$expected_rule" >> "$output_audit_file"
+			# Check if this sbinary wasn't already handled in some of the previous afile iterations
+			# Return match only if whole sbinary definition matched (not in the case just prefix matched!!!)
+			if [[ ! $(sed -ne "\|${sbinary}|p" <<< "${sbinaries_to_skip[*]}") ]]
+			then
+				# Current audit rules file's content doesn't contain expected rule for this
+				# SUID/SGID binary yet => append it
+				echo "$expected_rule" >> "$output_audit_file"
+			fi
+
 			continue
 		fi
 

--- a/shared/templates/template_BASH_audit_rules_privileged_commands
+++ b/shared/templates/template_BASH_audit_rules_privileged_commands
@@ -5,6 +5,8 @@
 
 PATTERN="-a always,exit -F path={{{ PATH }}}\\s\\+.*"
 GROUP="privileged"
+# Although the fix doesn't use ARCH, we reset it because it could have been set by some other remediation
+ARCH=""
 FULL_RULE="-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -28,22 +28,22 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit augenrules {{{ NAME }}}" id="test_{{{ ID }}}_augenrules" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit augenrules {{{ NAME }}}" id="test_{{{ ID }}}_augenrules" version="1">
     <ind:object object_ref="object_{{{ ID }}}_augenrules" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit auditctl {{{ NAME }}}" id="test_{{{ ID }}}_auditctl" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit auditctl {{{ NAME }}}" id="test_{{{ ID }}}_auditctl" version="1">
     <ind:object object_ref="object_{{{ ID }}}_auditctl" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
 </def-group>

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_default.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_default.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7,Fedora
 
 # augenrules is default for rhel7

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_duplicated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_duplicated.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_pci-dss
+# Remediation for this rule cannot remove the duplicates
+# remediation = none
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+./generate_privileged_commands_rule.sh 1000 privileged /tmp/privileged.rules
+
+cp /tmp/privileged.rules /etc/audit/rules.d/privileged.rules
+sed 's/unset/4294967295/' /tmp/privileged.rules >> /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_missing_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_missing_rule.fail.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
  sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_one_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_one_rule.fail.sh
@@ -3,4 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 
+mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured_mixed_keys.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
 # change key of rules for binaries in /usr/sbin
 # A mixed conbination of -k and -F key= should be accepted

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_two_rules_mixed_keys.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_two_rules_mixed_keys.fail.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
 echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_two_rules_sep_files.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_augenrules_two_rules_sep_files.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_rules_with_own_key.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands/rhel7_rules_with_own_key.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
-# platform = Red Hat Enterprise Linux 7
+# platform = Red Hat Enterprise Linux 7,Fedora
 
 ./generate_privileged_commands_rule.sh 1000 own_key /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_auditctl_4294967295_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_auditctl_4294967295_configured.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_auditctl_unset_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_auditctl_unset_configured.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7
 
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_4294967295_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_4294967295_configured.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_duplicated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_duplicated.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_remove_all_rules.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_remove_all_rules.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_substring_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_substring_rule.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_superstring_rule.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_superstring_rule.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_unset_configured.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_augenrules_unset_configured.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
 
+mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_rules_with_own_key.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_privileged_commands/rule_audit_rules_privileged_commands_sudo/rhel7_rules_with_own_key.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
 
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k own_key" >> /etc/audit/rules.d/privileged.rules
-# This is a trick to fail setup of this test in rhel6 systems
-ls /usr/lib/systemd/system/auditd.service


### PR DESCRIPTION
#### Description:

- Update `template_OVAL_audit_rules_privileged_commands` to fail if a duplicate rule is found.
- Fix bug in `template_BASH_audit_rules_privileged_commands`
  -  the value of `ARCH` set in previous remediation was being used
- Fix bug in `perform_audit_rules_privileged_commands_remediation.sh`
  - the function wasn't identifying correctly if an audit rule was already present in a previously checked file
- Adds tests for the scenarios 

#### Rationale:

- Fixes #4104
