### PR TITLE
Regex match test scenarios to run

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -132,6 +132,10 @@ def parse_args():
                              dest="dont_clean",
                              action="store_true",
                              help="Do not remove html reports of successful runs")
+    parser_rule.add_argument("--scenarios",
+                             dest="scenarios_regex",
+                             default=None,
+                             help="Regular expression matching test scenarios to run")
 
     return parser.parse_args()
 


### PR DESCRIPTION
#### Description:

- Add `--scenarios` argument to Test Suite
  - Value of argument is used as matching pattern for Test Scenario names.
- Example usage:
  - `$ ./test_suite.py rule --libvirt qemu:///system rhel7.6  --datastream ../build/ssg-rhel7-ds.xml --scenarios ".*pass.sh" privileged_commands_sudo`
  - `$ ./test_suite.py rule --libvirt qemu:///system rhel7.6  --datastream ../build/ssg-rhel7-ds.xml --scenarios ".*duplicate*" privileged_commands_sudo`
  - `$ ./test_suite.py rule --libvirt qemu:///system rhel7.6  --datastream ../build/ssg-rhel7-ds.xml --scenarios ".*dupli|sep_files*" privileged_commands_sudo`

#### Rationale:

- Sometimes you just quickly want to run a specific test scenario


