### PR TITLE
Test scenarios for rules checking file /etc/cron.allow

### DIFF
--- a/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_groupowner_cron_allow/file_not_there.pass.sh
+++ b/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_groupowner_cron_allow/file_not_there.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+rm -f /etc/cron.allow

--- a/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_groupowner_cron_allow/is_root.pass.sh
+++ b/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_groupowner_cron_allow/is_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+touch /etc/cron.allow
+chgrp root /etc/cron.allow

--- a/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_groupowner_cron_allow/other_group.fail.sh
+++ b/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_groupowner_cron_allow/other_group.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+GROUP=ssgttgroup
+
+groupadd ${GROUP}
+touch /etc/cron.allow
+chgrp ${GROUP} /etc/cron.allow

--- a/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_owner_cron_allow/file_not_there.pass.sh
+++ b/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_owner_cron_allow/file_not_there.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+rm -f /etc/cron.allow

--- a/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_owner_cron_allow/is_root.pass.sh
+++ b/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_owner_cron_allow/is_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+touch /etc/cron.allow
+chown root /etc/cron.allow

--- a/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_owner_cron_allow/other_user.fail.sh
+++ b/tests/data/group_services/group_cron_and_at/group_restrict_at_cron_users/rule_file_owner_cron_allow/other_user.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+USER=ssgttuser
+
+useradd ${USER}
+touch /etc/cron.allow
+chown ${USER} /etc/cron.allow


### PR DESCRIPTION
#### Description:

- Add test scenarios for file_groupowner_cron_allow 
- Add test scenarios for file_owner_cron_allow 

#### Rationale:
- Extend test coverage of rules