### PR TITLE
File regex permissions find use regex

### DIFF
--- a/shared/templates/template_ANSIBLE_file_regex_permissions
+++ b/shared/templates/template_ANSIBLE_file_regex_permissions
@@ -7,6 +7,7 @@
   find:
     paths: "{{{ FILEPATH }}}"
     patterns: "{{{ FILENAME }}}"
+    use_regex: yes
   register: files_found
 
 - name: Set permissions for {{{ FILEPATH }}} file(s)

--- a/tests/data/group_services/group_ssh/rule_file_permissions_sshd_private_key/multiple_keys.fail.sh
+++ b/tests/data/group_services/group_ssh/rule_file_permissions_sshd_private_key/multiple_keys.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
+chmod 0777 $FAKE_KEY
+FAKE_KEY2=$(mktemp -p /etc/ssh/ XXXX_key)
+chmod 0640 $FAKE_KEY2


### PR DESCRIPTION
#### Description:

- Specify in `template_ANSIBLE_file_regex_permissions` that `patterns` is a regular expression.
- Add a test scenario for multiple ssh keys

#### Rationale:

- The pattern in defined in CSV file is a regular expression
https://github.com/ComplianceAsCode/content/blob/95a815314a1d905bef10142445fee3aaa3f2cbc8/rhel7/templates/csv/file_dir_permissions.csv#L9
