### PR TITLE
Remove --quiet from rpm --setperms command

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -13,7 +13,7 @@
   check_mode: no
 
 - name: "Correct file permissions with RPM"
-  shell: "rpm --quiet --setperms $(rpm -qf '{{ item }}')"
+  shell: "rpm --setperms $(rpm -qf '{{ item }}')"
   args:
     warn: False # Ignore ANSIBLE0006, we can't correct permissions using rpm module
   with_items: "{{ files_with_incorrect_permissions.stdout_lines }}"

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
@@ -28,5 +28,5 @@ SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | tr ' ' '\n' | sort -u | t
 # correct values
 for RPM_PACKAGE in "${SETPERMS_RPM_LIST[@]}"
 do
-	rpm --quiet --setperms "${RPM_PACKAGE}"
+	rpm --setperms "${RPM_PACKAGE}"
 done

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -19,7 +19,7 @@ description: |-
     <br />
     Next, run the following command to reset its permissions to
     the correct values:
-    <pre>$ sudo rpm --quiet --setperms <i>PACKAGENAME</i></pre>
+    <pre>$ sudo rpm --setperms <i>PACKAGENAME</i></pre>
 
 rationale: |-
     Permissions on system binaries and configuration files that are too generous


### PR DESCRIPTION
#### Description:

- Command `rpm --setperms` doesn't work with `--quiet`.
  See https://bugzilla.redhat.com/show_bug.cgi?id=1690469.

#### Rationale:

- Permissions are not changed if `--setperms` and `--quiet` are used together.
- Should fix https://bugzilla.redhat.com/show_bug.cgi?id=1662180

#### Others
- This can affect remediation of containers. Lots of warning messages may be printed by `rpm` command.
  Check description of https://github.com/ComplianceAsCode/content/pull/2948#issue-194528674.
