### PR TITLE
Use rule title instead of rule ID as a playbook name

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -25,7 +25,7 @@ REMEDIATION_TO_EXT_MAP = {
 FILE_GENERATED_HASH_COMMENT = '# THIS FILE IS GENERATED'
 
 REMEDIATION_CONFIG_KEYS = ['complexity', 'disruption', 'platform', 'reboot',
-                           'strategy']
+                           'strategy', 'title']
 REMEDIATION_ELM_KEYS = ['complexity', 'disruption', 'reboot', 'strategy']
 
 
@@ -285,7 +285,9 @@ class AnsibleRemediation(Remediation):
 
         updated_yaml_text = ssg.yaml.ordered_dump(
             remediation_obj.parsed, None, default_flow_style=False)
-        result.contents[:] = updated_yaml_text.split("\n")
+        del result.contents[:]
+        result.contents.append("# title = %s" % remediation_obj.rule.title)
+        result.contents.extend(updated_yaml_text.split("\n"))
 
         return result
 

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -148,8 +148,14 @@ class PlaybookBuilder():
         for task in play_tasks:
             tags |= set(task.pop("tags", []))
 
+        playbook_name = rule_id
+        for line in snippet_str.splitlines():
+            if line.startswith('# title ='):
+                _, v = line.split("=")
+                playbook_name = v.strip()
+
         play = OrderedDict()
-        play["name"] = rule_id
+        play["name"] = playbook_name
         play["hosts"] = "@@HOSTS@@"
         play["become"] = True
         if len(play_vars) > 0:

--- a/tests/unit/ssg-module/test_playbook_builder_data/fixes/selinux_state.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/fixes/selinux_state.yml
@@ -3,6 +3,7 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+# title = Ensure SELinux State is Enforcing
 - (xccdf-var var_selinux_state)
 - name: '@RULE_TITLE@'
   lineinfile:

--- a/tests/unit/ssg-module/test_playbook_builder_data/selinux_state.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/selinux_state.yml
@@ -1,4 +1,4 @@
-- name: selinux_state
+- name: Ensure SELinux State is Enforcing
   hosts: '@@HOSTS@@'
   become: true
   vars:


### PR DESCRIPTION
#### Description:
When rule.yml is parsed it will add the rule title as a comment into snippet in `/build/<product>/fixes/ansible/`. This comment will be parsed while playbooks are created and used as the playbook title.

#### Rationale:
Fixes: #4195

