### PR TITLE
Simplify CMake macro _ssg_build_remediations_for_language

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -217,7 +217,6 @@ macro(_ssg_build_remediations_for_language PRODUCT LANGUAGES)
       add_custom_command(
           OUTPUT "${ALL_FIXES_DIR}"
           COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_remediations.py" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --remediation-type "${LANGUAGE}" --output-dir "${ALL_FIXES_DIR}" "${BUILD_REMEDIATIONS_DIR}/shared/${LANGUAGE}" "${BUILD_REMEDIATIONS_DIR}/${LANGUAGE}"
-          DEPENDS "${BUILD_REMEDIATIONS_DIR}"
           # Acutally we mean that it depends on resolved rules.
           DEPENDS generate-internal-${PRODUCT}-shorthand.xml
           DEPENDS "${SSG_BUILD_SCRIPTS}/combine_remediations.py"


### PR DESCRIPTION


#### Description:
The list of dependencies doesn't have to be generated at runtime because they're located all in the single directory in the build tree. Moreover, it slows down cmake.



#### Rationale:


Fixes: #3816