### PR TITLE
Use rule title instead of rule ID as a playbook name

### DIFF
--- a/build-scripts/build_rule_playbooks.py
+++ b/build-scripts/build_rule_playbooks.py
@@ -19,6 +19,11 @@ def parse_args():
         "e.g. ~/scap-security-guide/build/fedora/playbooks"
     )
     p.add_argument(
+        "--resolved-rules-dir", required=True,
+        help="Directory that contains preprocessed rules in YAML format "
+        "eg. ~/scap-security-guide/build/fedora/rules"
+    )
+    p.add_argument(
         "--product-yaml", required=True, dest="product_yaml",
         help="YAML file with information about the product we are building. "
         "e.g.: ~/scap-security-guide/rhel7/product.yml"
@@ -41,7 +46,8 @@ def parse_args():
 def main():
     args = parse_args()
     playbook_builder = ssg.playbook_builder.PlaybookBuilder(
-        args.product_yaml, args.input_dir, args.output_dir
+        args.product_yaml, args.input_dir, args.output_dir,
+        args.resolved_rules_dir
     )
     playbook_builder.build(args.profile, args.rule)
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -265,7 +265,7 @@ macro(ssg_build_ansible_playbooks PRODUCT)
     set(ANSIBLE_PLAYBOOKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/playbooks")
     add_custom_command(
         OUTPUT "${ANSIBLE_PLAYBOOKS_DIR}"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --input-dir "${ANSIBLE_FIXES_DIR}" --output-dir "${ANSIBLE_PLAYBOOKS_DIR}" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --input-dir "${ANSIBLE_FIXES_DIR}" --output-dir "${ANSIBLE_PLAYBOOKS_DIR}" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml"
         DEPENDS "${ANSIBLE_FIXES_DIR}"
         DEPENDS generate-internal-${PRODUCT}-ansible-all-fixes
         DEPENDS "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py"

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -16,9 +16,10 @@ COMMENTS_TO_PARSE = ["strategy", "complexity", "disruption"]
 
 
 class PlaybookBuilder():
-    def __init__(self, product_yaml_path, input_dir, output_dir):
+    def __init__(self, product_yaml_path, input_dir, output_dir, rules_dir):
         self.input_dir = input_dir
         self.output_dir = output_dir
+        self.rules_dir = rules_dir
         product_yaml = ssg.yaml.open_raw(product_yaml_path)
         product_dir = os.path.dirname(product_yaml_path)
         relative_guide_dir = ssg.utils.required_key(product_yaml,
@@ -122,6 +123,11 @@ class PlaybookBuilder():
                     variables[xccdf_value.id_] = options
         return variables
 
+    def _find_rule_title(self, rule_id):
+        rule_path = os.path.join(self.rules_dir, rule_id + ".yml")
+        rule_yaml = ssg.yaml.open_raw(rule_path)
+        return rule_yaml["title"]
+
     def create_playbook(self, snippet_path, rule_id, variables,
                         refinements, output_dir):
         """
@@ -149,7 +155,7 @@ class PlaybookBuilder():
             tags |= set(task.pop("tags", []))
 
         play = OrderedDict()
-        play["name"] = rule_id
+        play["name"] = self._find_rule_title(rule_id)
         play["hosts"] = "@@HOSTS@@"
         play["become"] = True
         if len(play_vars) > 0:

--- a/tests/unit/ssg-module/test_playbook_builder.py
+++ b/tests/unit/ssg-module/test_playbook_builder.py
@@ -14,6 +14,7 @@ DATADIR = os.path.join(
 product_yaml = os.path.join(DATADIR, "product.yml")
 input_dir = os.path.join(DATADIR, "fixes")
 output_dir = os.path.join(DATADIR, "playbooks")
+resolved_rules_dir = os.path.join(DATADIR, "rules")
 rule = "selinux_state"
 profile = "ospp"
 
@@ -23,7 +24,7 @@ expected_output_filepath = os.path.join(DATADIR, "selinux_state.yml")
 
 def test_build_rule_playbook():
     playbook_builder = ssg.playbook_builder.PlaybookBuilder(
-        product_yaml, input_dir, output_dir
+        product_yaml, input_dir, output_dir, resolved_rules_dir
     )
     playbook_builder.build(profile, rule)
 

--- a/tests/unit/ssg-module/test_playbook_builder_data/rules/selinux_state.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/rules/selinux_state.yml
@@ -1,0 +1,36 @@
+description: 'The SELinux state should be set to <tt><sub idref="var_selinux_state"
+  /></tt> at
+
+  system boot time.  In the file <tt>/etc/selinux/config</tt>, add or correct the
+
+  following line to configure the system to boot into enforcing mode:
+
+  <pre>SELINUX=<sub idref="var_selinux_state" /></pre>'
+identifiers: {cce@rhel6: 26969-6, cce@rhel7: 27334-2, cce@rhel8: 80869-1}
+ocil: 'Check the file <tt>/etc/selinux/config</tt> and ensure the following line appears:
+
+  <pre>SELINUX=<sub idref="var_selinux_state" /></pre>'
+ocil_clause: SELINUX is not set to enforcing
+oval_external_content: null
+platform: machine
+prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
+rationale: 'Setting the SELinux state to enforcing ensures SELinux is able to confine
+
+  potentially compromised processes to the security policy, which is designed to
+
+  prevent them from causing damage to the system or further elevating their
+
+  privileges.'
+references: {cis: 1.6.1.2, cis-csc: '1,11,12,13,14,15,16,18,3,4,5,6,8,9', cobit5: 'APO01.06,APO11.04,APO13.01,BAI03.05,DSS01.05,DSS03.01,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.02,DSS06.03,DSS06.06,MEA02.01',
+  cui: '3.1.2,3.7.2', disa: '2165,2696', disa@rhel6: '22,26,32', hipaa: '164.308(a)(1)(ii)(D),164.308(a)(3),164.308(a)(4),164.310(b),164.310(c),164.312(a),164.312(e)',
+  isa-62443-2009: '4.2.3.4,4.3.3.2.2,4.3.3.3.9,4.3.3.4,4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4,4.4.3.3',
+  isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR
+    1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.10,SR 2.11,SR 2.12,SR 2.2,SR 2.3,SR
+    2.4,SR 2.5,SR 2.6,SR 2.7,SR 2.8,SR 2.9,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR
+    5.2,SR 5.3,SR 7.1,SR 7.6', iso27001-2013: 'A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.12.1.1,A.12.1.2,A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.7.1,A.13.1.1,A.13.1.2,A.13.1.3,A.13.2.1,A.13.2.2,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.1,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5',
+  nist: 'AC-3,AC-3(3),AC-3(4),AC-4,AC-6,AU-9,SI-6(a)', nist-csf: 'DE.AE-1,ID.AM-3,PR.AC-4,PR.AC-5,PR.AC-6,PR.DS-5,PR.PT-1,PR.PT-3,PR.PT-4',
+  srg: SRG-OS-000445-GPOS-00199, srg@rhel6: SRG-OS-999999, stigid@rhel6: RHEL-06-000020,
+  stigid@rhel7: '020210'}
+severity: high
+title: Ensure SELinux State is Enforcing
+warnings: []

--- a/tests/unit/ssg-module/test_playbook_builder_data/selinux_state.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/selinux_state.yml
@@ -1,4 +1,4 @@
-- name: selinux_state
+- name: Ensure SELinux State is Enforcing
   hosts: '@@HOSTS@@'
   become: true
   vars:


### PR DESCRIPTION



#### Description:
The rule title will be obtained from preprocessed rule YAMLs located at `/build/<product>/rules`.

Replaces #4207

#### Rationale:
Fixes: #4195 