### PR TITLE
Add remediation metadata to the generated playbooks

### DIFF
--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -101,7 +101,11 @@ class AnsibleRemediation(object):
         if "disruption" in self.config:
             tags.append("{0}_disruption".format(self.config["disruption"]))
         if "reboot" in self.config:
-            tags.append("{0}_reboot".format(self.config["reboot"]))
+            if self.config["reboot"] == "true":
+                reboot_tag = "reboot_required"
+            else:
+                reboot_tag = "no_reboot_needed"
+            tags.append(reboot_tag)
         to_update["tags"] = tags
 
     def update_tags_from_rule(self, platform, to_update):

--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -100,6 +100,8 @@ class AnsibleRemediation(object):
             tags.append("{0}_complexity".format(self.config["complexity"]))
         if "disruption" in self.config:
             tags.append("{0}_disruption".format(self.config["disruption"]))
+        if "reboot" in self.config:
+            tags.append("{0}_reboot".format(self.config["reboot"]))
         to_update["tags"] = tags
 
     def update_tags_from_rule(self, platform, to_update):

--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -88,7 +88,7 @@ class AnsibleRemediation(object):
         self.contents = contents
         self.config = config
 
-        self.parsed = yaml.ordered_load("\n".join(contents))
+        self.parsed = yaml.ordered_load(contents)
 
         self.rule = None
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -168,12 +168,12 @@ def get_populate_replacement(remediation_type, text):
     sys.exit(1)
 
 
-def _split_remediation_content_and_metadata(fix_file_lines):
+def split_remediation_content_and_metadata(fix_file):
     remediation_contents = []
     config = defaultdict(lambda: None)
 
     # Assignment automatically escapes shell characters for XML
-    for line in fix_file_lines:
+    for line in fix_file.splitlines():
         if line.startswith(FILE_GENERATED_HASH_COMMENT):
             continue
 
@@ -205,8 +205,8 @@ def parse_from_file_with_jinja(file_path, env_yaml):
     update ssg.fixes.parse_platform(...).
     """
 
-    fix_file_lines = jinja_process_file(file_path, env_yaml).splitlines()
-    return _split_remediation_content_and_metadata(fix_file_lines)
+    fix_file = jinja_process_file(file_path, env_yaml)
+    return split_remediation_content_and_metadata(fix_file)
 
 
 def parse_from_file_without_jinja(file_path):
@@ -216,8 +216,8 @@ def parse_from_file_without_jinja(file_path):
     are already resolved.
     """
     with open(file_path, "r") as f:
-        lines = f.read().splitlines()
-        return _split_remediation_content_and_metadata(lines)
+        f_str = f.read()
+        return split_remediation_content_and_metadata(f_str)
 
 
 class Remediation(object):

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -131,7 +131,8 @@ class PlaybookBuilder():
 
         with open(snippet_path, "r") as snippet_file:
             snippet_str = snippet_file.read()
-        snippet_yaml = ssg.yaml.ordered_load(snippet_str)
+        fix = ssg.build_remediations.split_remediation_content_and_metadata(snippet_str)
+        snippet_yaml = ssg.yaml.ordered_load(fix.contents)
 
         play_tasks, play_vars = self.get_data_from_snippet(
             snippet_yaml, variables, refinements
@@ -161,6 +162,9 @@ class PlaybookBuilder():
         playbook = [play]
         playbook_path = os.path.join(output_dir, rule_id + ".yml")
         with open(playbook_path, "w") as playbook_file:
+            # write remediation metadata (complexity, strategy, etc.) first
+            for k, v in fix.config.items():
+                playbook_file.write("# %s = %s\n" % (k, v))
             ssg.yaml.ordered_dump(
                 playbook, playbook_file, default_flow_style=False
             )

--- a/tests/unit/ssg-module/data/ansible-resolved.yml
+++ b/tests/unit/ssg-module/data/ansible-resolved.yml
@@ -9,7 +9,7 @@
     - configure_strategy
     - low_complexity
     - low_disruption
-    - false_reboot
+    - no_reboot_needed
     - CCE-26860-7
     - NIST-800-53-AC-6(7)
     - NIST-800-171-3.4.5
@@ -29,7 +29,7 @@
     - configure_strategy
     - low_complexity
     - low_disruption
-    - false_reboot
+    - no_reboot_needed
     - CCE-26860-7
     - NIST-800-53-AC-6(7)
     - NIST-800-171-3.4.5

--- a/tests/unit/ssg-module/data/ansible-resolved.yml
+++ b/tests/unit/ssg-module/data/ansible-resolved.yml
@@ -9,6 +9,7 @@
     - configure_strategy
     - low_complexity
     - low_disruption
+    - false_reboot
     - CCE-26860-7
     - NIST-800-53-AC-6(7)
     - NIST-800-171-3.4.5
@@ -28,6 +29,7 @@
     - configure_strategy
     - low_complexity
     - low_disruption
+    - false_reboot
     - CCE-26860-7
     - NIST-800-53-AC-6(7)
     - NIST-800-171-3.4.5

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -25,7 +25,6 @@ def test_is_supported_file_name():
 def do_test_contents(remediation, config):
     assert 'do_something_magical' in remediation
     assert '# a random comment' in remediation
-    assert len(remediation) == 3
 
     assert 'platform' in config
     assert 'reboot' in config


### PR DESCRIPTION
#### Description:
This will add the remedaition metadata in form of comments s.a.
```
# reboot = false
...
```
because are not present in generated per-rule playbooks.


Also adds reboot tag to generated snippets.

#### Rationale:
Fixes: #4194
