### PR TITLE
Minor tests documentation update

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -47,7 +47,7 @@ according to the requirements, including configuration of a key for SSH login.
 
 Common usage looks like:
 ```
-$ ./install_vm.py --domain test-suite-fedora --distro fedora
+$ python install_vm.py --domain test-suite-fedora --distro fedora
 ```
 
 By default, the key at `~/.ssh/id_rsa.pub` is used. You can change default key used via `--ssh-pubkey` option.


### PR DESCRIPTION

#### Description:

- Update documentation test on how to use install_vm.py script.

#### Rationale:

- Since test script install_vm.py does not use shebang for python anymore, when running install_vm.py, the python interpreter must be explicitly used.
