### PR TITLE
Replace legacy @RULE_ID@ AND @RULE_TITLE@ substitutions with jinja

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - (xccdf-var login_banner_text)
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   file:
     path: "/etc/dconf/db/{{ item }}"
     owner: root
@@ -16,7 +16,7 @@
     - gdm.d
     - gdm.d/locks
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   file:
     path: "/etc/dconf/db/gdm.d/{{ item }}"
     owner: root
@@ -27,7 +27,7 @@
     - 00-security-settings
     - locks/00-security-settings-lock
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   ini_file:
     dest: /etc/dconf/db/gdm.d/00-security-settings
     section: org/gnome/login-screen

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
@@ -10,7 +10,7 @@
     path: /etc/opensc-{{ ansible_architecture }}.conf
   register: opensc_conf_cd
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   lineinfile:
     path: /etc/opensc-{{ ansible_architecture }}.conf
     line: '        card_drivers = {{ var_smartcard_drivers }}'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
@@ -14,6 +14,6 @@
   register: pkcsw_output
   when: pkcs11switch.stat.exists
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   command: /usr/bin/pkcs11-switch opensc
   when: pkcs11switch.stat.exists and pkcsw_output.stdout != "opensc"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
@@ -10,7 +10,7 @@
     path: /etc/opensc-{{ ansible_architecture }}.conf
   register: opensc_conf_fcd
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   lineinfile:
     path: /etc/opensc-{{ ansible_architecture }}.conf
     line: '        force_card_driver = {{ var_smartcard_drivers }}'

--- a/linux_os/guide/system/selinux/selinux_policytype/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_policytype/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 - (xccdf-var var_selinux_policy_name)
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   lineinfile:
     path: /etc/sysconfig/selinux
     regexp: '^SELINUXTYPE='

--- a/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 - (xccdf-var var_selinux_state)
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   lineinfile:
     path: /etc/sysconfig/selinux
     regexp: '^SELINUX='

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 - (xccdf-var var_system_crypto_policy)
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   lineinfile:
     path: /etc/crypto-policies/config
     regexp: '^(?!#)(\S+)$'

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   file:
     src: /etc/crypto-policies/back-ends/krb5.config
     path: /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   lineinfile:
     path: /etc/ipsec.conf
     line: "include /etc/crypto-policies/back-ends/libreswan.config"

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   lineinfile:
     dest: /etc/sysconfig/sshd
     state: absent

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -10,7 +10,7 @@
   with_items:
     - aide
 
-- name: "@RULE_TITLE@"
+- name: "{{{ rule_title }}}"
   cron:
     name: "run AIDE check"
     minute: 05

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -66,23 +66,7 @@
     </xsl:call-template>
   </xsl:variable>
 
-  <xsl:variable name="rep3">
-    <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rep1"/>
-      <xsl:with-param name="replace" select="'@RULE_ID@'"/>
-      <xsl:with-param name="with" select="$rule/@id"/>
-    </xsl:call-template>
-  </xsl:variable>
-
-  <xsl:variable name="rep4">
-    <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rep3"/>
-      <xsl:with-param name="replace" select="'@RULE_TITLE@'"/>
-      <xsl:with-param name="with" select="$rule/xccdf:title[1]/text()"/>
-    </xsl:call-template>
-  </xsl:variable>
-
-  <xsl:value-of select="$rep4"/>
+  <xsl:value-of select="$rep1"/>
 </xsl:template>
 
 <xsl:template match="@* | node()" mode="fix_contents">

--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -7,13 +7,8 @@ from __future__ import print_function
 
 import re
 
-from collections import OrderedDict
-
 from .constants import ansible_version_requirement_pre_task_name
 from .constants import min_ansible_version
-from ssg import build_yaml
-from ssg import build_remediations
-from ssg import yaml
 
 
 def add_minimum_version(ansible_src):
@@ -195,4 +190,3 @@ class AnsibleRemediation(object):
         parsed = build_remediations.parse_from_file_without_jinja(snippet_fname)
         result = cls(parsed.contents, parsed.config)
         return result
-

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -11,10 +11,9 @@ from .constants import oval_namespace as oval_ns
 from .constants import oval_footer
 from .constants import oval_header
 from .constants import MULTI_PLATFORM_LIST
-from .products import parse_name, map_name
 from .jinja import process_file
 from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs
-from .utils import required_key
+from . import utils
 from .xml import ElementTree
 
 
@@ -23,7 +22,7 @@ def _check_is_applicable_for_product(oval_check_def, product):
     OVAL check is applicable for this product. Return 'True' if so, 'False'
     otherwise"""
 
-    product, product_version = parse_name(product)
+    product, product_version = utils.parse_name(product)
 
     # Define general platforms
     multi_platforms = ['<platform>multi_platform_all',
@@ -43,7 +42,7 @@ def _check_is_applicable_for_product(oval_check_def, product):
 
     for afftype in affected_type_elements:
         # Get official name for product (prefixed with content of afftype)
-        product_name = afftype + map_name(product)
+        product_name = afftype + utils.map_name(product)
         # Append the product version to the official name
         if product_version is not None:
             product_name += ' ' + product_version
@@ -75,8 +74,8 @@ def finalize_affected_platforms(xml_tree, env_yaml):
             affected.remove(product)
 
         final = ElementTree.SubElement(
-            affected, "{%s}%s" % (oval_ns, required_key(env_yaml, "type")))
-        final.text = required_key(env_yaml, "full_name")
+            affected, "{%s}%s" % (oval_ns, utils.required_key(env_yaml, "type")))
+        final.text = utils.required_key(env_yaml, "full_name")
 
     return xml_tree
 
@@ -256,13 +255,13 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
     """
 
     body = []
-    product = required_key(env_yaml, "product")
+    product = utils.required_key(env_yaml, "product")
     included_checks_count = 0
     reversed_dirs = oval_dirs[::-1]  # earlier directory has higher priority
     already_loaded = dict()  # filename -> oval_version
 
     product_dir = os.path.dirname(yaml_path)
-    relative_guide_dir = required_key(env_yaml, "benchmark_root")
+    relative_guide_dir = utils.required_key(env_yaml, "benchmark_root")
     guide_dir = os.path.abspath(os.path.join(product_dir, relative_guide_dir))
 
     for _dir_path in find_rule_dirs(guide_dir):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -330,18 +330,19 @@ class AnsibleRemediation(Remediation):
         # see xccdf-addremediations.xslt <- shared_constants.xslt <- shared_shorthand2xccdf.xslt
         # if you want to know how the map was constructed
         platform_id_map = {
-            "rhel6": "RHEL-06",
-            "rhel7": "RHEL-07",
-            "rhel8": "RHEL-08",
+            "rhel7": "DISA-STIG-RHEL-07",
+            "rhel8": "DISA-STIG-RHEL-08",
         }
-        stig_platform_id = "DISA-STIG-{id}".format(id=platform_id_map.get(product, None))
+        # RHEL6 is a special case, in our content,
+        # we have only stig IDs for RHEL6 that include the literal 'RHEL-06'
+        stig_platform_id = platform_id_map.get(product, "DISA-STIG")
 
         ref_prefix_map = {
             "nist": "NIST-800-53",
             "cui": "NIST-800-171",
             "pcidss": "PCI-DSS",
             "cjis": "CJIS",
-            "stigid".format(product=product): stig_platform_id
+            "stigid@{product}".format(product=product): stig_platform_id,
         }
         result = []
         for ref_class, prefix in ref_prefix_map.items():

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -10,10 +10,11 @@ from collections import defaultdict, namedtuple
 
 
 import ssg.yaml
+from . import build_yaml
+from . import rules
+from . import utils
 from .jinja import process_file as jinja_process_file
 from .xml import ElementTree
-from .products import parse_name, map_name
-from .constants import MULTI_PLATFORM_LIST
 
 REMEDIATION_TO_EXT_MAP = {
     'anaconda': '.anaconda',
@@ -27,44 +28,6 @@ FILE_GENERATED_HASH_COMMENT = '# THIS FILE IS GENERATED'
 REMEDIATION_CONFIG_KEYS = ['complexity', 'disruption', 'platform', 'reboot',
                            'strategy']
 REMEDIATION_ELM_KEYS = ['complexity', 'disruption', 'reboot', 'strategy']
-
-
-def is_applicable_for_product(platform, product):
-    """Based on the platform dict specifier of the remediation script to
-    determine if this remediation script is applicable for this product.
-    Return 'True' if so, 'False' otherwise"""
-
-    # If the platform is None, platform must not exist in the config, so exit with False.
-    if not platform:
-        return False
-
-    product, product_version = parse_name(product)
-
-    # Define general platforms
-    multi_platforms = ['multi_platform_all',
-                       'multi_platform_' + product]
-
-    # First test if platform isn't for 'multi_platform_all' or
-    # 'multi_platform_' + product
-    for _platform in multi_platforms:
-        if _platform in platform and product in MULTI_PLATFORM_LIST:
-            return True
-
-    product_name = ""
-    # Get official name for product
-    if product_version is not None:
-        product_name = map_name(product) + ' ' + product_version
-    else:
-        product_name = map_name(product)
-
-    # Test if this is for the concrete product version
-    for _name_part in platform.split(','):
-        if product_name == _name_part.strip():
-            return True
-
-    # Remediation script isn't neither a multi platform one, nor isn't
-    # applicable for this product => return False to indicate that
-    return False
 
 
 def get_available_functions(build_dir):
@@ -222,86 +185,222 @@ def parse_from_file_without_jinja(file_path):
 
 
 class Remediation(object):
-    def __init__(self, env_yaml, resolved_rules, product, file_path, fix_name, remediation_type):
-        self.env_yaml = env_yaml
-        self.resolved_rules = resolved_rules
-        self.product = product
+    def __init__(self, file_path, remediation_type):
         self.file_path = file_path
-        self.fix_name = fix_name
+        self.local_env_yaml = dict()
+
+        self.metadata = defaultdict(lambda: None)
+
         self.remediation_type = remediation_type
+        self.associated_rule = None
 
-    def process(self, fixes):
-        """
-        Process a fix, adding it to fixes iff the file is of a valid extension
-        for the remediation type and the fix is valid for the current product.
+    def load_associated_rule(self, resolved_rules_dir, rule_id):
+        rule_path = os.path.join(
+            resolved_rules_dir, rule_id + ".yml")
+        return self.load_rule_from(rule_path)
 
-        Note that platform is a required field in the contents of the fix.
-        """
+    def load_rule_from(self, rule_path):
+        if not os.path.isfile(rule_path):
+            msg = ("{lang} remediation snippet can't load the "
+                   "respective rule YML at {rule_fname}"
+                   .format(rule_fname=rule_path,
+                           lang=self.remediation_type))
+            print(msg, file=sys.stderr)
+        else:
+            self.associated_rule = build_yaml.Rule.from_yaml(rule_path)
+            self.expand_env_yaml_from_rule()
 
-        if not is_supported_filename(self.remediation_type, self.file_path):
+    def expand_env_yaml_from_rule(self):
+        if not self.associated_rule:
             return
 
-        result = parse_from_file_with_jinja(self.file_path, self.env_yaml)
+        self.local_env_yaml["rule_title"] = self.associated_rule.title
+        self.local_env_yaml["rule_id"] = self.associated_rule.id_
 
-        if not result.config['platform']:
-            raise RuntimeError(
-                "The '%s' remediation script does not contain the "
-                "platform identifier!" % (self.file_path))
+    def parse_from_file_with_jinja(self, env_yaml):
+        return parse_from_file_with_jinja(self.file_path, env_yaml)
 
-        if is_applicable_for_product(result.config['platform'], self.product):
-            fixes[self.fix_name] = result
 
-        return result
+def process(remediation, env_yaml, fixes, rule_id):
+    """
+    Process a fix, adding it to fixes iff the file is of a valid extension
+    for the remediation type and the fix is valid for the current product.
+
+    Note that platform is a required field in the contents of the fix.
+    """
+    if not is_supported_filename(remediation.remediation_type, remediation.file_path):
+        return
+
+    result = remediation.parse_from_file_with_jinja(env_yaml)
+
+    if not result.config['platform']:
+        raise RuntimeError(
+            "The '%s' remediation script does not contain the "
+            "platform identifier!" % (remediation.file_path))
+
+    product = env_yaml["product"]
+    if utils.is_applicable_for_product(result.config['platform'], product):
+        fixes[rule_id] = result
+
+    return result
 
 
 class BashRemediation(Remediation):
-    def __init__(self, env_yaml, resolved_rules, product, file_path, fix_name):
-        super(BashRemediation, self).__init__(
-            env_yaml, resolved_rules, product, file_path, fix_name, "bash")
+    def __init__(self, file_path):
+        super(BashRemediation, self).__init__(file_path, "bash")
+
+    def load_associated_rule(self, resolved_rules_dir, rule_id):
+        # No point in loading rule for this remediation type as of now
+        pass
 
 
 class AnsibleRemediation(Remediation):
-    def __init__(self, env_yaml, resolved_rules, product, file_path, fix_name):
+    def __init__(self, file_path):
         super(AnsibleRemediation, self).__init__(
-            env_yaml, resolved_rules, product, file_path, fix_name, "ansible")
+            file_path, "ansible")
 
-    def process(self, fixes):
-        result = super(AnsibleRemediation, self).process(fixes)
+        self.body = None
 
-        rule_path = os.path.join(
-            self.resolved_rules, self.fix_name + ".yml")
-        if not os.path.isfile(rule_path):
-            msg = ("Ansible snippet for rule {rule_id} "
-                   "doesn't have respective rule YML at {rule_fname}"
-                   .format(rule_id=os.path.splitext(self.fix_name)[0], rule_fname=rule_path))
-            print(msg, file=sys.stderr)
+    def parse_from_file_with_jinja(self, env_yaml):
+        self.local_env_yaml.update(env_yaml)
+        result = super(AnsibleRemediation, self).parse_from_file_with_jinja(self.local_env_yaml)
+
+        if not self.associated_rule:
             return result
 
-        import ssg.ansible
-        from ssg import build_yaml
+        parsed = ssg.yaml.ordered_load(result.contents)
 
-        remediation_obj = ssg.ansible.AnsibleRemediation(result.contents, result.config)
-        remediation_obj.rule = build_yaml.Rule.from_yaml(rule_path)
-        remediation_obj.update(self.product)
+        current_product = env_yaml.get("product")
+        if current_product:
+            self.update(parsed, result.config, current_product)
 
         updated_yaml_text = ssg.yaml.ordered_dump(
-            remediation_obj.parsed, None, default_flow_style=False)
+            parsed, None, default_flow_style=False)
         result = result._replace(contents=updated_yaml_text)
 
-        fixes[self.fix_name] = result
+        self.body = parsed
+        self.metadata = result.config
+
+        return result
+
+    def update_tags_from_config(self, to_update, config):
+        tags = to_update.get("tags", [])
+        if "strategy" in config:
+            tags.append("{0}_strategy".format(config["strategy"]))
+        if "complexity" in config:
+            tags.append("{0}_complexity".format(config["complexity"]))
+        if "disruption" in config:
+            tags.append("{0}_disruption".format(config["disruption"]))
+        if "reboot" in config:
+            if config["reboot"] == "true":
+                reboot_tag = "reboot_required"
+            else:
+                reboot_tag = "no_reboot_needed"
+            tags.append(reboot_tag)
+        to_update["tags"] = tags
+
+    def update_tags_from_rule(self, product, to_update):
+        if not self.associated_rule:
+            raise RuntimeError("The Ansible snippet has no rule loaded.")
+
+        tags = to_update.get("tags", [])
+        tags.insert(0, "{0}_severity".format(self.associated_rule.severity))
+        tags.insert(0, self.associated_rule.id_)
+
+        cce_num = self._get_cce(product)
+        if cce_num:
+            tags.append("CCE-{0}".format(cce_num))
+
+        refs = self.get_references(product)
+        tags.extend(refs)
+        to_update["tags"] = tags
+
+    def _get_cce(self, product):
+        our_cce = None
+        for cce, val in self.associated_rule.identifiers.items():
+            if cce.endswith(product):
+                our_cce = val
+                break
+        return our_cce
+        return self.associated_rule.identifiers.get("cce", None)
+
+    def get_references(self, product):
+        if not self.associated_rule:
+            raise RuntimeError("The Ansible snippet has no rule loaded.")
+        # see xccdf-addremediations.xslt <- shared_constants.xslt <- shared_shorthand2xccdf.xslt
+        # if you want to know how the map was constructed
+        platform_id_map = {
+            "rhel6": "RHEL-06",
+            "rhel7": "RHEL-07",
+            "rhel8": "RHEL-08",
+        }
+        stig_platform_id = "DISA-STIG-{id}".format(id=platform_id_map.get(product, None))
+
+        ref_prefix_map = {
+            "nist": "NIST-800-53",
+            "cui": "NIST-800-171",
+            "pcidss": "PCI-DSS",
+            "cjis": "CJIS",
+            "stigid".format(product=product): stig_platform_id
+        }
+        result = []
+        for ref_class, prefix in ref_prefix_map.items():
+            refs = self._get_rule_reference(ref_class)
+            result.extend(["{prefix}-{value}".format(prefix=prefix, value=v) for v in refs])
+        return result
+
+    def _get_rule_reference(self, ref_class):
+        refs = self.associated_rule.references.get(ref_class, "")
+        if refs:
+            return refs.split(",")
+        else:
+            return []
+
+    def update_when_from_rule(self, to_update):
+        additional_when = ""
+        if self.associated_rule.platform == "machine":
+            additional_when = ('ansible_virtualization_role != "guest" '
+                               'or ansible_virtualization_type != "docker"')
+        to_update.setdefault("when", "")
+        new_when = ssg.yaml.update_yaml_list_or_string(to_update["when"], additional_when)
+        if not new_when:
+            to_update.pop("when")
+        else:
+            to_update["when"] = new_when
+
+    def update(self, parsed, config, product):
+        for p in parsed:
+            if not isinstance(p, dict):
+                continue
+            self.update_when_from_rule(p)
+            self.update_tags_from_config(p, config)
+            self.update_tags_from_rule(product, p)
+
+    @classmethod
+    def from_snippet_and_rule(cls, snippet_fname, rule_fname):
+        result = cls(snippet_fname)
+        result.load_rule_from(rule_fname)
         return result
 
 
 class AnacondaRemediation(Remediation):
-    def __init__(self, env_yaml, resolved_rules, product, file_path, fix_name):
+    def __init__(self, file_path):
         super(AnacondaRemediation, self).__init__(
-            env_yaml, resolved_rules, product, file_path, fix_name, "anaconda")
+            file_path, "anaconda")
+
+    def load_associated_rule(self, resolved_rules_dir):
+        # No point in loading rule for this remediation type as of now
+        pass
 
 
 class PuppetRemediation(Remediation):
-    def __init__(self, env_yaml, resolved_rules, product, file_path, fix_name):
+    def __init__(self, file_path):
         super(PuppetRemediation, self).__init__(
-            env_yaml, resolved_rules, product, file_path, fix_name, "puppet")
+            file_path, "puppet")
+
+    def load_associated_rule(self, resolved_rules_dir):
+        # No point in loading rule for this remediation type as of now
+        pass
 
 
 REMEDIATION_TO_CLASS = {
@@ -362,6 +461,41 @@ def write_fixes_to_dir(fixes, remediation_type, output_dir):
             for k, v in config.items():
                 f.write("# %s = %s\n" % (k, v))
             f.write(fix_contents)
+
+
+def get_rule_dir_remediations(dir_path, remediation_type, product=None):
+    """
+    Gets a list of remediations of type remediation_type contained in a
+    rule directory. If product is None, returns all such remediations.
+    If product is not None, returns applicable remediations in order of
+    priority:
+
+        {{{ product }}}.ext -> shared.ext
+
+    Only returns remediations which exist.
+    """
+
+    if not rules.is_rule_dir(dir_path):
+        return []
+
+    remediations_dir = os.path.join(dir_path, remediation_type)
+    has_remediations_dir = os.path.isdir(remediations_dir)
+    ext = REMEDIATION_TO_EXT_MAP[remediation_type]
+    if not has_remediations_dir:
+        return []
+
+    results = []
+    for remediation_file in os.listdir(remediations_dir):
+        file_name, file_ext = os.path.splitext(remediation_file)
+        remediation_path = os.path.join(remediations_dir, remediation_file)
+
+        if file_ext == ext and rules.applies_to_product(file_name, product):
+            if file_name == 'shared':
+                results.append(remediation_path)
+            else:
+                results.insert(0, remediation_path)
+
+    return results
 
 
 def expand_xccdf_subs(fix, remediation_type, remediation_functions):

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -378,5 +378,27 @@ XCCDF_PLATFORM_TO_CPE = {
     "container": "cpe:/a:container"
 }
 
+# _version_name_map = {
+MAKEFILE_ID_TO_PRODUCT_MAP = {
+    'chromium': 'Google Chromium Browser',
+    'fedora': 'Fedora',
+    'firefox': 'Mozilla Firefox',
+    'jre': 'Java Runtime Environment',
+    'rhosp': 'Red Hat OpenStack Platform',
+    'rhel': 'Red Hat Enterprise Linux',
+    'rhv': 'Red Hat Virtualization',
+    'debian': 'Debian',
+    'ubuntu': 'Ubuntu',
+    'eap': 'JBoss Enterprise Application Platform',
+    'fuse': 'JBoss Fuse',
+    'opensuse': 'openSUSE',
+    'sle': 'SUSE Linux Enterprise',
+    'wrlinux': 'Wind River Linux',
+    'example': 'Example Linux Content',
+    'ol': 'Oracle Linux',
+    'ocp': 'Red Hat OpenShift Container Platform',
+}
+
+
 # Application constants
 DEFAULT_UID_MIN = 1000

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -1,56 +1,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import re
 import os
 from collections import namedtuple
 
 from .constants import product_directories
 from .yaml import open_raw
-from .constants import MULTI_PLATFORM_LIST
-
-
-# SSG Makefile to official product name mapping
-_version_name_map = {
-    'chromium': 'Google Chromium Browser',
-    'fedora': 'Fedora',
-    'firefox': 'Mozilla Firefox',
-    'jre': 'Java Runtime Environment',
-    'rhosp': 'Red Hat OpenStack Platform',
-    'rhel': 'Red Hat Enterprise Linux',
-    'rhv': 'Red Hat Virtualization',
-    'debian': 'Debian',
-    'ubuntu': 'Ubuntu',
-    'eap': 'JBoss Enterprise Application Platform',
-    'fuse': 'JBoss Fuse',
-    'opensuse': 'openSUSE',
-    'sle': 'SUSE Linux Enterprise',
-    'wrlinux': 'Wind River Linux',
-    'example': 'Example Linux Content',
-    'ol': 'Oracle Linux',
-    'ocp': 'Red Hat OpenShift Container Platform',
-}
-
-PRODUCT_NAME_PARSER = re.compile(r"([a-zA-Z\-]+)([0-9]+)")
-
-
-def parse_name(product):
-    """
-    Returns a namedtuple of (name, version) from parsing a given product;
-    e.g., "rhel7" -> ("rhel", "7")
-    """
-
-    prod_tuple = namedtuple('product', ['name', 'version'])
-
-    _product = product
-    _product_version = None
-    match = PRODUCT_NAME_PARSER.match(product)
-
-    if match:
-        _product = match.group(1)
-        _product_version = match.group(2)
-
-    return prod_tuple(_product, _product_version)
 
 
 def get_all(ssg_root):
@@ -78,26 +33,3 @@ def get_all(ssg_root):
 
     products = namedtuple('products', ['linux', 'other'])
     return products(linux_products, other_products)
-
-
-def map_name(version):
-    """Maps SSG Makefile internal product name to official product name"""
-
-    if version.startswith("multi_platform_"):
-        trimmed_version = version[len("multi_platform_"):]
-        if trimmed_version not in MULTI_PLATFORM_LIST:
-            raise RuntimeError(
-                "%s is an invalid product version. If it's multi_platform the "
-                "suffix has to be from (%s)."
-                % (version, ", ".join(MULTI_PLATFORM_LIST))
-            )
-        return map_name(trimmed_version)
-
-    # By sorting in reversed order, keys which are a longer version of other keys are
-    # visited first (e.g., rhosp vs. rhel)
-    for key in sorted(_version_name_map, reverse=True):
-        if version.startswith(key):
-            return _version_name_map[key]
-
-    raise RuntimeError("Can't map version '%s' to any known product!"
-                       % (version))

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -4,32 +4,6 @@ from __future__ import print_function
 import os
 
 
-from .build_remediations import REMEDIATION_TO_EXT_MAP as REMEDIATION_MAP
-from .build_remediations import is_applicable_for_product
-
-
-def is_applicable(platform, product):
-    """
-    Function to check if a platform is applicable for the product.
-    Handles when a platform is really a list of products, i.e., a
-    prodtype field from a rule.yml.
-
-    Returns true iff product is applicable for the platform or list
-    of products
-    """
-
-    if platform == 'all' or platform == 'multi_platform_all':
-        return True
-
-    if is_applicable_for_product(platform, product):
-        return True
-
-    if 'osp7' in product and 'osp7' in platform:
-        return True
-
-    return product in platform.split(',')
-
-
 def get_rule_dir_yaml(dir_path):
     """
     Returns the path to the yaml metadata for a rule directory,
@@ -66,7 +40,7 @@ def is_rule_dir(dir_path):
     return is_dir and has_rule_yaml
 
 
-def _applies_to_product(file_name, product):
+def applies_to_product(file_name, product):
     """
     A OVAL or fix is filtered by product iff product is Falsy, file_name is
     "shared", or file_name is product. Note that this does not filter by
@@ -100,46 +74,11 @@ def get_rule_dir_ovals(dir_path, product=None):
         file_name, ext = os.path.splitext(oval_file)
         oval_path = os.path.join(oval_dir, oval_file)
 
-        if ext == ".xml" and _applies_to_product(file_name, product):
+        if ext == ".xml" and applies_to_product(file_name, product):
             if file_name == 'shared':
                 results.append(oval_path)
             else:
                 results.insert(0, oval_path)
-
-    return results
-
-
-def get_rule_dir_remediations(dir_path, remediation_type, product=None):
-    """
-    Gets a list of remediations of type remediation_type contained in a
-    rule directory. If product is None, returns all such remediations.
-    If product is not None, returns applicable remediations in order of
-    priority:
-
-        {{{ product }}}.ext -> shared.ext
-
-    Only returns remediations which exist.
-    """
-
-    if not is_rule_dir(dir_path):
-        return []
-
-    remediations_dir = os.path.join(dir_path, remediation_type)
-    has_remediations_dir = os.path.isdir(remediations_dir)
-    ext = REMEDIATION_MAP[remediation_type]
-    if not has_remediations_dir:
-        return []
-
-    results = []
-    for remediation_file in os.listdir(remediations_dir):
-        file_name, file_ext = os.path.splitext(remediation_file)
-        remediation_path = os.path.join(remediations_dir, remediation_file)
-
-        if file_ext == ext and _applies_to_product(file_name, product):
-            if file_name == 'shared':
-                results.append(remediation_path)
-            else:
-                results.insert(0, remediation_path)
 
     return results
 

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -183,3 +183,28 @@ def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
         return stream.write(formatted_yaml)
     else:
         return formatted_yaml
+    return yaml.dump(data, stream, OrderedDumper, **kwds)
+
+
+def _strings_to_list(one_or_more_strings):
+    """
+    Output a list, that either contains one string, or a list of strings.
+    In Python, strings can be cast to lists without error, but with unexpected result.
+    """
+    if isinstance(one_or_more_strings, str):
+        return [one_or_more_strings]
+    else:
+        return list(one_or_more_strings)
+
+
+def update_yaml_list_or_string(current_contents, new_contents):
+    result = []
+    if current_contents:
+        result += _strings_to_list(current_contents)
+    if new_contents:
+        result += _strings_to_list(new_contents)
+    if not result:
+        result = ""
+    if len(result) == 1:
+        result = result[0]
+    return result

--- a/tests/test_parse_platform.py
+++ b/tests/test_parse_platform.py
@@ -41,7 +41,7 @@ def main():
 
         for rule_dir in ssg.rules.find_rule_dirs(guide_dir):
             for lang in REMEDIATION_LANGS:
-                for fix in ssg.rules.get_rule_dir_remediations(rule_dir, lang):
+                for fix in ssg.build_remediations.get_rule_dir_remediations(rule_dir, lang):
                     fix_contents = ssg.utils.read_file_list(fix)
                     results = ssg.fixes.parse_platform(fix_contents)
 

--- a/tests/unit/ssg-module/data/ansible-resolved.yml
+++ b/tests/unit/ssg-module/data/ansible-resolved.yml
@@ -1,4 +1,4 @@
-- name: Test for existence /boot/grub2/grub.cfg
+- name: Test for existence /boot/grub2/grub.cfg in name of file_owner_grub2_cfg
   stat:
     path: /boot/grub2/grub.cfg
   register: file_exists
@@ -16,7 +16,7 @@
     - PCI-DSS-Req-7.1
     - CJIS-5.5.2.2
 
-- name: Ensure owner 0 on /boot/grub2/grub.cfg
+- name: "Verify /boot/grub2/grub.cfg User Ownership: Ensure owner 0 on /boot/grub2/grub.cfg"
   file:
     path: /boot/grub2/grub.cfg
     owner: 0

--- a/tests/unit/ssg-module/data/ansible.yml
+++ b/tests/unit/ssg-module/data/ansible.yml
@@ -5,12 +5,12 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-- name: Test for existence /boot/grub2/grub.cfg
+- name: Test for existence /boot/grub2/grub.cfg in name of {{{ rule_id }}}
   stat:
     path: /boot/grub2/grub.cfg
   register: file_exists
 
-- name: Ensure owner 0 on /boot/grub2/grub.cfg
+- name: "{{{ rule_title }}}: Ensure owner 0 on /boot/grub2/grub.cfg"
   file:
     path: /boot/grub2/grub.cfg
     owner: 0

--- a/tests/unit/ssg-module/data/sshd_disable_root_login.yml
+++ b/tests/unit/ssg-module/data/sshd_disable_root_login.yml
@@ -1,0 +1,47 @@
+# File processed by the build system, i.e. retrieved from the build/rhel7/rules/sshd_disable_root_login.yml
+description: 'The root user should never be allowed to login to a
+
+  system directly over a network.
+
+  To disable root login via SSH, add or correct the following line
+
+  in <tt>/etc/ssh/sshd_config</tt>:
+
+  <pre>PermitRootLogin no</pre>'
+identifiers: {cce@rhel6: 27100-7, cce@rhel7: 27445-6, cce@rhel8: 80901-2}
+ocil: 'To determine how the SSH daemon''s <tt>PermitRootLogin</tt> option is set,
+  run the following command:
+
+  <pre>$ sudo grep -i PermitRootLogin /etc/ssh/sshd_config</pre>
+
+
+  If a line indicating <tt>no</tt> is returned, then the required value is set.
+
+  '
+ocil_clause: the required value is not set
+oval_external_content: null
+platform: null
+prodtype: all
+rationale: 'Even though the communications channel may be encrypted, an additional
+  layer of
+
+  security is gained by extending the policy of not logging directly on as root.
+
+  In addition, logging in with a user-specific account provides individual
+
+  accountability of actions performed on the system and also helps to minimize
+
+  direct attack attempts on root''s password.'
+references: {anssi@debian8: NT007(R21), cis: 5.2.8, cis-csc: '1,11,12,13,14,15,16,18,3,5',
+  cjis: 5.5.6, cobit5: 'APO01.06,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.02,DSS06.03,DSS06.06,DSS06.10',
+  cui: '3.1.1, 3.1.5', disa: '366', disa@rhel6: '770', hipaa: '164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)',
+  isa-62443-2009: '4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4',
+  isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR
+    1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7,SR
+    5.2', iso27001-2013: 'A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.18.1.4,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5',
+  nist: 'AC-3,AC-6(2),AC-17(b),IA-2,IA-2(5)', nist-csf: 'PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.DS-5,PR.PT-3',
+  ospp: FIA_AFL.1, srg: SRG-OS-000480-GPOS-00227, srg@rhel6: SRG-OS-000109, stigid@rhel6: RHEL-06-000237,
+  stigid@rhel7: '040370', vmmsrg: SRG-OS-000480-VMM-002000}
+severity: medium
+title: Disable SSH Root Login
+warnings: []

--- a/tests/unit/ssg-module/test_ansible.py
+++ b/tests/unit/ssg-module/test_ansible.py
@@ -7,10 +7,6 @@ import pytest
 
 import ssg.ansible
 from ssg.constants import min_ansible_version
-from ssg.yaml import ordered_load
-
-
-DATADIR = os.path.join(os.path.dirname(__file__), "data")
 
 
 def strings_equal_except_whitespaces(left, right):
@@ -67,78 +63,3 @@ def test_add_minimum_version():
     assert ssg.ansible.add_minimum_version(unknown_snippet) == unknown_snippet
 
     assert ssg.ansible.add_minimum_version(processed_snippet) == processed_snippet
-
-
-def test_when_update():
-    assert ssg.ansible.update_yaml_list_or_string(
-        "",
-        "",
-    ) == ""
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        "something",
-        "",
-    ) == "something"
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        ["something"],
-        "",
-    ) == "something"
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        "",
-        "else",
-    ) == "else"
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        "something",
-        "else",
-    ) == ["something", "else"]
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        "",
-        ["something", "else"],
-    ) == ["something", "else"]
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        ["something", "else"],
-        "",
-    ) == ["something", "else"]
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        "something",
-        ["entirely", "else"],
-    ) == ["something", "entirely", "else"]
-
-    assert ssg.ansible.update_yaml_list_or_string(
-        ["something", "entirely"],
-        ["entirely", "else"],
-    ) == ["something", "entirely", "entirely", "else"]
-
-
-def test_ansible_class():
-    remediation = ssg.ansible.AnsibleRemediation.from_snippet_and_rule(
-        os.path.join(DATADIR, "ansible.yml"), os.path.join(DATADIR, "file_owner_grub2_cfg.yml")
-    )
-
-    assert remediation.config["reboot"] == 'false'
-    assert remediation.config["strategy"] == 'configure'
-    assert remediation.config["complexity"] == 'low'
-    assert remediation.config["disruption"] == 'low'
-
-
-def test_ansible_conformance():
-    remediation = ssg.ansible.AnsibleRemediation.from_snippet_and_rule(
-        os.path.join(DATADIR, "ansible.yml"), os.path.join(DATADIR, "file_owner_grub2_cfg.yml")
-    )
-    ref_remediation_dict = ordered_load(open(os.path.join(DATADIR, "ansible-resolved.yml")))
-
-    remediation.update("rhel7")
-
-    # The comparison has to be done this way due to possible order variations,
-    # which don't matter, but they make tests to fail.
-    assert set(remediation.parsed[0]["tags"]) == set(ref_remediation_dict[0]["tags"])
-    assert set(remediation.parsed[1]["tags"]) == set(ref_remediation_dict[1]["tags"])
-    assert set(remediation.parsed[0]["when"]) == set(ref_remediation_dict[0]["when"])
-    assert set(remediation.parsed[1]["when"]) == set(ref_remediation_dict[1]["when"])
-    assert set(remediation.parsed[0]["name"]) == set(ref_remediation_dict[0]["name"])

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -1,20 +1,12 @@
-import pytest
-
 import os
+
 import ssg.build_remediations as sbr
+import ssg.utils
+from ssg.yaml import ordered_load
 
-data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
-rule_dir = os.path.join(data_dir, "group_dir", "rule_dir")
+DATADIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
+rule_dir = os.path.join(DATADIR, "group_dir", "rule_dir")
 rhel_bash = os.path.join(rule_dir, "bash", "rhel.sh")
-
-
-def test_is_applicable_for_product():
-    assert sbr.is_applicable_for_product("multi_platform_all", "rhel7")
-    assert sbr.is_applicable_for_product("multi_platform_rhel", "rhel7")
-    assert sbr.is_applicable_for_product("multi_platform_rhel,multi_platform_ol", "rhel7")
-    assert sbr.is_applicable_for_product("Red Hat Enterprise Linux 7", "rhel7")
-    assert not sbr.is_applicable_for_product("Red Hat Enterprise Linux 7", "rhel6")
-    assert not sbr.is_applicable_for_product("multi_platform_ol", "rhel7")
 
 
 def test_is_supported_file_name():
@@ -32,10 +24,10 @@ def do_test_contents(remediation, config):
     assert 'strategy' in config
     assert 'disruption' in config
 
-    assert sbr.is_applicable_for_product(config['platform'], 'rhel7')
-    assert sbr.is_applicable_for_product(config['platform'], 'fedora')
-    assert not sbr.is_applicable_for_product(config['platform'], 'rhel6')
-    assert not sbr.is_applicable_for_product(config['platform'], 'ol7')
+    assert ssg.utils.is_applicable_for_product(config['platform'], 'rhel7')
+    assert ssg.utils.is_applicable_for_product(config['platform'], 'fedora')
+    assert not ssg.utils.is_applicable_for_product(config['platform'], 'rhel6')
+    assert not ssg.utils.is_applicable_for_product(config['platform'], 'ol7')
 
     assert 'false' == config['reboot']
     assert 'low' == config['complexity']
@@ -53,10 +45,62 @@ def test_process_fix():
 
     fixes = {}
 
-    remediation_obj = remediation_cls(
-        {}, "", "rhel7", rhel_bash, "rule_dir")
-    remediation_obj.process(fixes)
+    env_yaml = dict(product="rhel7")
+    remediation_obj = remediation_cls(rhel_bash)
+    sbr.process(remediation_obj, env_yaml, fixes, "rule_dir")
 
     assert 'rule_dir' in fixes
     assert len(fixes['rule_dir']) == 2
     do_test_contents(fixes['rule_dir'].contents, fixes['rule_dir'].config)
+
+
+def test_ansible_class():
+    remediation = sbr.AnsibleRemediation.from_snippet_and_rule(
+        os.path.join(DATADIR, "ansible.yml"), os.path.join(DATADIR, "file_owner_grub2_cfg.yml")
+    )
+
+    remediation.parse_from_file_with_jinja(dict())
+
+    assert remediation.metadata["reboot"] == 'false'
+    assert remediation.metadata["strategy"] == 'configure'
+    assert remediation.metadata["complexity"] == 'low'
+    assert remediation.metadata["disruption"] == 'low'
+
+
+def test_ansible_conformance():
+    remediation = sbr.AnsibleRemediation.from_snippet_and_rule(
+        os.path.join(DATADIR, "ansible.yml"), os.path.join(DATADIR, "file_owner_grub2_cfg.yml")
+    )
+    ref_remediation_dict = ordered_load(open(os.path.join(DATADIR, "ansible-resolved.yml")))
+
+    env_yaml = dict(product="rhel7")
+
+    remediation.parse_from_file_with_jinja(env_yaml)
+    # The comparison has to be done this way due to possible order variations,
+    # which don't matter, but they make tests to fail.
+    assert set(remediation.body[0]["tags"]) == set(ref_remediation_dict[0]["tags"])
+    assert set(remediation.body[1]["tags"]) == set(ref_remediation_dict[1]["tags"])
+    assert set(remediation.body[0]["when"]) == set(ref_remediation_dict[0]["when"])
+    assert set(remediation.body[1]["when"]) == set(ref_remediation_dict[1]["when"])
+    assert remediation.body[0]["name"] == ref_remediation_dict[0]["name"]
+    assert remediation.body[1]["name"] == ref_remediation_dict[1]["name"]
+
+
+def test_get_rule_dir_remediations():
+    bash = sbr.get_rule_dir_remediations(rule_dir, 'bash')
+    bash_files = list(map(os.path.basename, bash))
+
+    assert len(bash) == 2
+    assert 'something.sh' in bash_files
+    assert 'rhel.sh' in bash_files
+
+    rhel_bash = sbr.get_rule_dir_remediations(rule_dir, 'bash', 'rhel')
+    assert len(rhel_bash) == 1
+    assert rhel_bash[0].endswith('/rhel.sh')
+
+    ol_bash = sbr.get_rule_dir_remediations(rule_dir, 'bash', 'ol')
+    assert len(ol_bash) == 0
+
+    something_bash = sbr.get_rule_dir_remediations(rule_dir, 'bash', 'something')
+    assert len(something_bash) == 1
+    assert something_bash != rhel_bash

--- a/tests/unit/ssg-module/test_products.py
+++ b/tests/unit/ssg-module/test_products.py
@@ -5,22 +5,6 @@ import pytest
 import ssg.products
 
 
-def test_parse_name():
-    pn = ssg.products.parse_name
-
-    n, v = pn("rhel7")
-    assert n == "rhel"
-    assert v == "7"
-
-    n, v = pn("rhel")
-    assert n == "rhel"
-    assert not v
-
-    n, v = pn("rhosp13")
-    assert n == "rhosp"
-    assert v == "13"
-
-
 def test_get_all():
     ssg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
     products = ssg.products.get_all(ssg_root)
@@ -33,19 +17,3 @@ def test_get_all():
 
     assert "jre" in products.other
     assert "jre" not in products.linux
-
-
-def test_map_name():
-    mn = ssg.products.map_name
-
-    assert mn('multi_platform_rhel') == 'Red Hat Enterprise Linux'
-    assert mn('rhel') == 'Red Hat Enterprise Linux'
-    assert mn('rhel7') == 'Red Hat Enterprise Linux'
-    assert mn('rhosp') == 'Red Hat OpenStack Platform'
-    assert mn('rhosp13') == 'Red Hat OpenStack Platform'
-
-    with pytest.raises(RuntimeError):
-        mn('not-a-platform')
-
-    with pytest.raises(RuntimeError):
-        mn('multi_platform_all')

--- a/tests/unit/ssg-module/test_rules.py
+++ b/tests/unit/ssg-module/test_rules.py
@@ -1,29 +1,8 @@
-import pytest
-
 import os
 import ssg.rules
 
 data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 rule_dir = os.path.join(data_dir, "group_dir", "rule_dir")
-
-
-def test_is_applicable():
-    assert ssg.rules.is_applicable('all', 'rhel7')
-    assert ssg.rules.is_applicable('multi_platform_all', 'rhel7')
-    assert ssg.rules.is_applicable('rhel7', 'rhel7')
-    assert ssg.rules.is_applicable('multi_platform_rhel', 'rhel7')
-    assert ssg.rules.is_applicable('Red Hat Enterprise Linux 7', 'rhel7')
-
-    assert ssg.rules.is_applicable('all', 'rhosp13')
-    assert ssg.rules.is_applicable('multi_platform_rhosp', 'rhosp13')
-    assert ssg.rules.is_applicable('rhosp13', 'rhosp13')
-    assert ssg.rules.is_applicable('Red Hat OpenStack Platform 13', 'rhosp13')
-    assert not ssg.rules.is_applicable('rhel7', 'rhosp13')
-
-    assert not ssg.rules.is_applicable('rhosp13', 'rhel7')
-    assert not ssg.rules.is_applicable('fedora,multi_platform_ubuntu', 'rhel7')
-    assert not ssg.rules.is_applicable('ol7', 'rhel7')
-    assert not ssg.rules.is_applicable('fedora,debian8', 'rhel7')
 
 
 def test_get_rule_dir_id():
@@ -36,12 +15,12 @@ def test_is_rule_dir():
     assert ssg.rules.is_rule_dir(rule_dir)
 
 
-def test__applies_to_product():
-    assert ssg.rules._applies_to_product('shared', None)
-    assert ssg.rules._applies_to_product('rhel', None)
-    assert ssg.rules._applies_to_product('shared', 'rhel')
-    assert ssg.rules._applies_to_product('rhel', 'rhel')
-    assert not ssg.rules._applies_to_product('ol', 'rhel')
+def test_applies_to_product():
+    assert ssg.rules.applies_to_product('shared', None)
+    assert ssg.rules.applies_to_product('rhel', None)
+    assert ssg.rules.applies_to_product('shared', 'rhel')
+    assert ssg.rules.applies_to_product('rhel', 'rhel')
+    assert not ssg.rules.applies_to_product('ol', 'rhel')
 
 
 def test_find_rule_dirs():
@@ -69,23 +48,3 @@ def test_get_rule_dir_ovals():
     assert ol_ovals != ovals
     assert len(ol_ovals) == 1
     assert 'rhel.xml' not in ol_ovals
-
-
-def test_get_rule_dir_remediations():
-    bash = ssg.rules.get_rule_dir_remediations(rule_dir, 'bash')
-    bash_files = list(map(os.path.basename, bash))
-
-    assert len(bash) == 2
-    assert 'something.sh' in bash_files
-    assert 'rhel.sh' in bash_files
-
-    rhel_bash = ssg.rules.get_rule_dir_remediations(rule_dir, 'bash', 'rhel')
-    assert len(rhel_bash) == 1
-    assert rhel_bash[0].endswith('/rhel.sh')
-
-    ol_bash = ssg.rules.get_rule_dir_remediations(rule_dir, 'bash', 'ol')
-    assert len(ol_bash) == 0
-
-    something_bash = ssg.rules.get_rule_dir_remediations(rule_dir, 'bash', 'something')
-    assert len(something_bash) == 1
-    assert something_bash != rhel_bash

--- a/tests/unit/ssg-module/test_utils.py
+++ b/tests/unit/ssg-module/test_utils.py
@@ -3,6 +3,66 @@ import pytest
 import ssg.utils
 
 
+def test_is_applicable():
+    assert ssg.utils.is_applicable('all', 'rhel7')
+    assert ssg.utils.is_applicable('multi_platform_all', 'rhel7')
+    assert ssg.utils.is_applicable('rhel7', 'rhel7')
+    assert ssg.utils.is_applicable('multi_platform_rhel', 'rhel7')
+    assert ssg.utils.is_applicable('Red Hat Enterprise Linux 7', 'rhel7')
+
+    assert ssg.utils.is_applicable('all', 'rhosp13')
+    assert ssg.utils.is_applicable('multi_platform_rhosp', 'rhosp13')
+    assert ssg.utils.is_applicable('rhosp13', 'rhosp13')
+    assert ssg.utils.is_applicable('Red Hat OpenStack Platform 13', 'rhosp13')
+    assert not ssg.utils.is_applicable('rhel7', 'rhosp13')
+
+    assert not ssg.utils.is_applicable('rhosp13', 'rhel7')
+    assert not ssg.utils.is_applicable('fedora,multi_platform_ubuntu', 'rhel7')
+    assert not ssg.utils.is_applicable('ol7', 'rhel7')
+    assert not ssg.utils.is_applicable('fedora,debian8', 'rhel7')
+
+
+def test_is_applicable_for_product():
+    assert ssg.utils.is_applicable_for_product("multi_platform_all", "rhel7")
+    assert ssg.utils.is_applicable_for_product("multi_platform_rhel", "rhel7")
+    assert ssg.utils.is_applicable_for_product("multi_platform_rhel,multi_platform_ol", "rhel7")
+    assert ssg.utils.is_applicable_for_product("Red Hat Enterprise Linux 7", "rhel7")
+    assert not ssg.utils.is_applicable_for_product("Red Hat Enterprise Linux 7", "rhel6")
+    assert not ssg.utils.is_applicable_for_product("multi_platform_ol", "rhel7")
+
+
+def test_map_name():
+    mn = ssg.utils.map_name
+
+    assert mn('multi_platform_rhel') == 'Red Hat Enterprise Linux'
+    assert mn('rhel') == 'Red Hat Enterprise Linux'
+    assert mn('rhel7') == 'Red Hat Enterprise Linux'
+    assert mn('rhosp') == 'Red Hat OpenStack Platform'
+    assert mn('rhosp13') == 'Red Hat OpenStack Platform'
+
+    with pytest.raises(RuntimeError):
+        mn('not-a-platform')
+
+    with pytest.raises(RuntimeError):
+        mn('multi_platform_all')
+
+
+def test_parse_name():
+    pn = ssg.utils.parse_name
+
+    n, v = pn("rhel7")
+    assert n == "rhel"
+    assert v == "7"
+
+    n, v = pn("rhel")
+    assert n == "rhel"
+    assert not v
+
+    n, v = pn("rhosp13")
+    assert n == "rhosp"
+    assert v == "13"
+
+
 def test_merge_dicts():
     left = {1: 2}
     right = {"red fish": "blue fish"}

--- a/tests/unit/ssg-module/test_yaml.py
+++ b/tests/unit/ssg-module/test_yaml.py
@@ -1,0 +1,48 @@
+import ssg.yaml
+
+
+def test_list_or_string_update():
+    assert ssg.yaml.update_yaml_list_or_string(
+        "",
+        "",
+    ) == ""
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        "something",
+        "",
+    ) == "something"
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        ["something"],
+        "",
+    ) == "something"
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        "",
+        "else",
+    ) == "else"
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        "something",
+        "else",
+    ) == ["something", "else"]
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        "",
+        ["something", "else"],
+    ) == ["something", "else"]
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        ["something", "else"],
+        "",
+    ) == ["something", "else"]
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        "something",
+        ["entirely", "else"],
+    ) == ["something", "entirely", "else"]
+
+    assert ssg.yaml.update_yaml_list_or_string(
+        ["something", "entirely"],
+        ["entirely", "else"],
+    ) == ["something", "entirely", "entirely", "else"]

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -12,6 +12,7 @@ import json
 import ssg.build_yaml
 import ssg.oval
 import ssg.build_remediations
+import ssg.products
 import ssg.rules
 import ssg.yaml
 
@@ -76,7 +77,7 @@ def handle_rule_yaml(product_list, product_yamls, rule_id, rule_dir, guide_dir):
     rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, product_yaml)
     rule_products = set()
     for product in product_list:
-        if ssg.rules.is_applicable(rule_yaml.prodtype, product):
+        if ssg.utils.is_applicable(rule_yaml.prodtype, product):
             rule_products.add(product)
 
     rule_products = sorted(rule_products)
@@ -103,7 +104,7 @@ def handle_ovals(product_list, product_yamls, rule_obj):
         oval_obj['platforms'] = platforms
         oval_obj['products'] = set()
         for product in product_list:
-            if ssg.rules.is_applicable(cs_platforms, product):
+            if ssg.utils.is_applicable(cs_platforms, product):
                 oval_products[product].add(oval_name)
                 oval_obj['products'].add(product)
 
@@ -120,7 +121,7 @@ def handle_remediations(product_list, product_yamls, rule_obj):
     r_products = defaultdict(set)
     for r_type in ssg.build_remediations.REMEDIATION_TO_EXT_MAP:
         rule_remediations[r_type] = {}
-        r_paths = ssg.rules.get_rule_dir_remediations(rule_dir, r_type)
+        r_paths = ssg.build_remediations.get_rule_dir_remediations(rule_dir, r_type)
 
         for r_path in r_paths:
             r_name = os.path.basename(r_path)
@@ -142,7 +143,7 @@ def handle_remediations(product_list, product_yamls, rule_obj):
             r_obj['platforms'] = sorted(map(lambda x: x.strip(), platforms.split(',')))
             r_obj['products'] = set()
             for product in product_list:
-                if ssg.rules.is_applicable(platforms, product):
+                if ssg.utils.is_applicable(platforms, product):
                     r_products[product].add(r_name)
                     r_obj['products'].add(product)
 


### PR DESCRIPTION
This PR unifies the Ansible functionality used to

* generate general remediations output, and
* add rule-specific metadata to the Ansible output.

Moreover, it adds functionality for expanding templates the jinja way.

In order to accomplish this, the existing code (and it's respective tests) had to be moved around, so there are no circular dependencies.

Fixes: #3830, #3831