### PR TITLE
Fix audit_rules_privileged_commands ansible remediation

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -39,7 +39,7 @@
     create: yes
   with_items:
     - "{{ files_result.results }}"
-  when: item.matched == 0
+  when: files_result.results is defined and item.matched == 0
 
 # Adds/overwrites the rule in /etc/audit/audit.rules
 


### PR DESCRIPTION
- Playbooks and roles where failing due to an undefined value when the audit_rules_privileged_commands ansible remediation was run in a container