### PR TITLE
Add YUM installation checks to various rules

### DIFF
--- a/linux_os/guide/system/software/updating/clean_components_post_updating/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/oval/shared.xml
@@ -11,7 +11,8 @@
       <description>The clean_requirements_on_remove option should be used to ensure that old 
       versions of software components are removed after updating.</description>
     </metadata>
-    <criteria>
+    <criteria operator="OR">
+      <extend_definition comment="YUM not installed" definition_ref="package_yum_removed" />
       <criterion comment="check value of clean_requirements_on_remove in /etc/yum.conf" test_ref="test_yum_clean_components_post_updating" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -5,9 +5,10 @@ prodtype: rhel7,rhel8,ol7,ol8,rhv4
 title: 'Ensure {{{ pkg_manager }}} Removes Previous Package Versions'
 
 description: |-
-    <tt>{{{ pkg_manager }}}</tt> should be configured to remove previous software components after
-    new versions have been installed. To configure <tt>{{{ pkg_manager }}}</tt> to remove the
-    previous software components after updating, set the <tt>clean_requirements_on_remove</tt>
+    If <tt>{{{ pkg_manager }}}</tt> is installed, <tt>{{{ pkg_manager }}}</tt> should be
+    configured to remove previous software components after new versions have been 
+    installed. To configure <tt>{{{ pkg_manager }}}</tt> to remove the previous software
+    components after updating, set the <tt>clean_requirements_on_remove</tt>
     to <tt>1</tt> in <tt>{{{ pkg_manager_config_file }}}</tt>.
 
 rationale: |-
@@ -32,11 +33,11 @@ references:
     iso27001-2013: A.12.6.1,A.14.2.3,A.16.1.3,A.18.2.2,A.18.2.3
     cis-csc: 18,20,4
 
-ocil_clause: 'clean_requirements_on_remove is not enabled or configured correctly'
+ocil_clause: '{{{ pkg_manager }}} is installed and clean_requirements_on_remove is not enabled or configured correctly'
 
 ocil: |-
-    To verify that <tt>clean_requirements_on_remove</tt> is configured properly, run the
-    following command:
+    If {{{ pkg_manager }}} is installed, to verify that <tt>clean_requirements_on_remove</tt>
+    is configured properly, run the following command:
     <pre>$ grep clean_requirements_on_remove {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:
     <pre>clean_requirements_on_remove=1</pre>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
@@ -9,7 +9,8 @@
       of an RPM package's signature always occurs prior to its
       installation.</description>
     </metadata>
-    <criteria operator="AND">
+    <criteria operator="OR">
+     <extend_definition comment="YUM not installed" definition_ref="package_yum_removed" />
      <criterion comment="check value of gpgcheck in {{{ pkg_manager_config_file }}}" test_ref="test_ensure_gpgcheck_globally_activated" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 title: 'Ensure gpgcheck Enabled In Main {{{ pkg_manager }}} Configuration'
 
 description: |-
-    The <tt>gpgcheck</tt> option controls whether
+    If {{{ pkg_manager }}} is installed, the <tt>gpgcheck</tt> option controls whether
     RPM packages' signatures are always checked prior to installation.
     To configure {{{ pkg_manager }}} to check package signatures before installing
     them, ensure the following line appears in <tt>{{{ pkg_manager_config_file }}}</tt> in
@@ -57,12 +57,12 @@ references:
     iso27001-2013: A.11.2.4,A.12.1.2,A.12.2.1,A.12.5.1,A.12.6.2,A.14.1.2,A.14.1.3,A.14.2.2,A.14.2.3,A.14.2.4
     cis-csc: 11,2,3,9
 
-ocil_clause: 'GPG checking is not enabled'
+ocil_clause: '{{{ pkg_manager }}} is installed and GPG checking is not enabled'
 
 ocil: |-
-    To determine whether <tt>{{{ pkg_manager }}}</tt> is configured to use <tt>gpgcheck</tt>,
-    inspect <tt>{{{ pkg_manager_config_file }}}</tt> and ensure the following appears in the
-    <tt>[main]</tt> section:
+    If {{{ pkg_manager }}} is installed, to determine whether <tt>{{{ pkg_manager }}}</tt>
+    is configured to use <tt>gpgcheck</tt>, inspect <tt>{{{ pkg_manager_config_file }}}</tt>
+    and ensure the following appears in the <tt>[main]</tt> section:
     <pre>gpgcheck=1</pre>
     A value of <tt>1</tt> indicates that <tt>gpgcheck</tt> is enabled. Absence of a
     <tt>gpgcheck</tt> line or a setting of <tt>0</tt> indicates that it is

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 title: 'Ensure gpgcheck Enabled In Main {{{ pkg_manager }}} Configuration'
 
 description: |-
-    If {{{ pkg_manager }}} is installed, the <tt>gpgcheck</tt> option controls whether
+    If <tt>{{{ pkg_manager }}}</tt> is installed, the <tt>gpgcheck</tt> option controls whether
     RPM packages' signatures are always checked prior to installation.
     To configure {{{ pkg_manager }}} to check package signatures before installing
     them, ensure the following line appears in <tt>{{{ pkg_manager_config_file }}}</tt> in
@@ -60,7 +60,7 @@ references:
 ocil_clause: '{{{ pkg_manager }}} is installed and GPG checking is not enabled'
 
 ocil: |-
-    If {{{ pkg_manager }}} is installed, to determine whether <tt>{{{ pkg_manager }}}</tt>
+    If <tt>{{{ pkg_manager }}}</tt> is installed, to determine whether <tt>{{{ pkg_manager }}}</tt>
     is configured to use <tt>gpgcheck</tt>, inspect <tt>{{{ pkg_manager_config_file }}}</tt>
     and ensure the following appears in the <tt>[main]</tt> section:
     <pre>gpgcheck=1</pre>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/oval/shared.xml
@@ -13,7 +13,8 @@
       of an RPM package's signature always occurs prior to its
       installation.</description>
     </metadata>
-    <criteria>
+    <criteria operator="OR">
+      <extend_definition comment="YUM not installed" definition_ref="package_yum_removed" />
       <criterion comment="check value of localpkg_gpgcheck in {{{ pkg_manager_config_file }}}" test_ref="test_yum_ensure_gpgcheck_local_packages" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 title: 'Ensure gpgcheck Enabled for Local Packages'
 
 description: |-
-    <tt>{{{ pkg_manager }}}</tt> should be configured to verify the signature(s) of local packages
+    If {{{ pkg_manager }}} is installed, <tt>{{{ pkg_manager }}}</tt> should be configured to verify the signature(s) of local packages
     prior to installation. To configure <tt>{{{ pkg_manager }}}</tt> to verify signatures of local
     packages, set the <tt>localpkg_gpgcheck</tt> to <tt>1</tt> in <tt>{{{ pkg_manager_config_file }}}</tt>.
 
@@ -39,11 +39,11 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
     cis-csc: 11,3,9
 
-ocil_clause: 'gpgcheck is not enabled or configured correctly to verify local packages'
+ocil_clause: '{{{ pkg_manager }}} is installed and gpgcheck is not enabled or configured correctly to verify local packages'
 
 ocil: |-
-    To verify that <tt>localpkg_gpgcheck</tt> is configured properly, run the following
-    command:
+    If {{{ pkg_manager }}} is installed, to verify that <tt>localpkg_gpgcheck</tt>
+    is configured properly, run the following command:
     <pre>$ grep localpkg_gpgcheck {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:
     <pre>localpkg_gpgcheck=1</pre>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 title: 'Ensure gpgcheck Enabled for Local Packages'
 
 description: |-
-    If {{{ pkg_manager }}} is installed, <tt>{{{ pkg_manager }}}</tt> should be configured to verify the signature(s) of local packages
+    If <tt>{{{ pkg_manager }}}</tt> is installed, <tt>{{{ pkg_manager }}}</tt> should be configured to verify the signature(s) of local packages
     prior to installation. To configure <tt>{{{ pkg_manager }}}</tt> to verify signatures of local
     packages, set the <tt>localpkg_gpgcheck</tt> to <tt>1</tt> in <tt>{{{ pkg_manager_config_file }}}</tt>.
 
@@ -42,7 +42,7 @@ references:
 ocil_clause: '{{{ pkg_manager }}} is installed and gpgcheck is not enabled or configured correctly to verify local packages'
 
 ocil: |-
-    If {{{ pkg_manager }}} is installed, to verify that <tt>localpkg_gpgcheck</tt>
+    If <tt>{{{ pkg_manager }}}</tt> is installed, to verify that <tt>localpkg_gpgcheck</tt>
     is configured properly, run the following command:
     <pre>$ grep localpkg_gpgcheck {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
@@ -11,7 +11,7 @@
       of repository metadata always occurs.</description>
     </metadata>
     <criteria operator="OR">
-      <extend_definition comment="YUM not installed" definition_ref="package_yum_installed" />
+      <extend_definition comment="YUM not installed" definition_ref="package_yum_removed" />
       <criterion comment="check value of repo_gpgcheck in /etc/yum.conf" test_ref="test_yum_ensure_gpgcheck_repo_metadata" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
@@ -10,8 +10,8 @@
       <description>The repo_gpgcheck option should be used to ensure that checking
       of repository metadata always occurs.</description>
     </metadata>
-    <criteria operator="AND">
-      <extend_definition comment="YUM installed" definition_ref="package_yum_installed" />
+    <criteria operator="OR">
+      <extend_definition comment="YUM not installed" definition_ref="package_yum_installed" />
       <criterion comment="check value of repo_gpgcheck in /etc/yum.conf" test_ref="test_yum_ensure_gpgcheck_repo_metadata" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
@@ -10,7 +10,8 @@
       <description>The repo_gpgcheck option should be used to ensure that checking
       of repository metadata always occurs.</description>
     </metadata>
-    <criteria>
+    <criteria operator="AND">
+      <extend_definition comment="YUM installed" definition_ref="package_yum_installed" />
       <criterion comment="check value of repo_gpgcheck in /etc/yum.conf" test_ref="test_yum_ensure_gpgcheck_repo_metadata" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8,ol7,ol8
 title: 'Ensure gpgcheck Enabled for Repository Metadata'
 
 description: |-
-    If {{{ pkg_manager }}} is installed, verify the operating system prevents 
+    If <tt>{{{ pkg_manager }}}</tt> is installed, verify the operating system prevents 
     the installation of patches, service packs, device drivers, or 
     operating system components of local packages without verification 
     of the repository metadata. 
@@ -52,7 +52,7 @@ references:
 ocil_clause: '{{{ pkg_manager }}} is installed and gpgcheck is not enabled or configured correctly to verify repository metadata'
 
 ocil: |-
-    If {{{ pkg_manager }}} is installed, to verify that <tt>repo_gpgcheck</tt> is
+    If <tt>{{{ pkg_manager }}}</tt> is installed, to verify that <tt>repo_gpgcheck</tt> is
     configured properly, run the following command:
     <pre>$ grep repo_gpgcheck {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8,ol7,ol8
 title: 'Ensure gpgcheck Enabled for Repository Metadata'
 
 description: |-
-    If {{{ pkg_system }}} is installed, verify the operating system prevents 
+    If {{{ pkg_manager }}} is installed, verify the operating system prevents 
     the installation of patches, service packs, device drivers, or 
     operating system components of local packages without verification 
     of the repository metadata. 
@@ -49,11 +49,11 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
     cis-csc: 11,3,9
 
-ocil_clause: 'YUM is installed and gpgcheck is not enabled or configured correctly to verify repository metadata'
+ocil_clause: '{{{ pkg_manager }}} is installed and gpgcheck is not enabled or configured correctly to verify repository metadata'
 
 ocil: |-
-    If YUM is installed, to verify that <tt>repo_gpgcheck</tt> is configured properly, run the following
-    command:
+    If {{{ pkg_manager }}} is installed, to verify that <tt>repo_gpgcheck</tt> is
+    configured properly, run the following command:
     <pre>$ grep repo_gpgcheck {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:
     <pre>repo_gpgcheck=1</pre>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
@@ -5,9 +5,11 @@ prodtype: rhel7,rhel8,ol7,ol8
 title: 'Ensure gpgcheck Enabled for Repository Metadata'
 
 description: |-
-    Verify the operating system prevents the installation of patches,
-    service packs, device drivers, or operating system components of
-    local packages without verification of the repository metadata.
+    If {{{ pkg_system }}} is installed, verify the operating system prevents 
+    the installation of patches, service packs, device drivers, or 
+    operating system components of local packages without verification 
+    of the repository metadata. 
+
     Check that <tt>{{{ pkg_manager }}}</tt> verifies the repository
     metadata prior to install with the following command.
     This should be configured by setting <tt>repo_gpgcheck</tt> to <tt>1</tt>
@@ -47,10 +49,10 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
     cis-csc: 11,3,9
 
-ocil_clause: 'gpgcheck is not enabled or configured correctly to verify repository metadata'
+ocil_clause: 'YUM is installed and gpgcheck is not enabled or configured correctly to verify repository metadata'
 
 ocil: |-
-    To verify that <tt>repo_gpgcheck</tt> is configured properly, run the following
+    If YUM is installed, to verify that <tt>repo_gpgcheck</tt> is configured properly, run the following
     command:
     <pre>$ grep repo_gpgcheck {{{ pkg_manager_config_file }}}</pre>
     The output should return something similar to:

--- a/shared/templates/csv/packages_installed.csv
+++ b/shared/templates/csv/packages_installed.csv
@@ -1,3 +1,1 @@
 samba-common
-yum
-pam

--- a/shared/templates/csv/packages_installed.csv
+++ b/shared/templates/csv/packages_installed.csv
@@ -1,1 +1,3 @@
 samba-common
+yum
+pam

--- a/shared/templates/csv/packages_removed.csv
+++ b/shared/templates/csv/packages_removed.csv
@@ -1,1 +1,3 @@
 nss-pam-ldapd
+pam
+yum


### PR DESCRIPTION
Update checks to evaluate if YUM is installed before failing as some systems are readonly and may not have a package manager.