### PR TITLE
initial PAM OVAL fixes

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -10,9 +10,12 @@
       </affected>
       <description>The passwords to remember should be set correctly.</description>
     </metadata>
-    <criteria comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly" operator="OR">
-      <criterion comment="remember parameter of pam_unix.so is set correctly" test_ref="test_accounts_password_pam_unix_remember" />
-      <criterion comment="remember parameter of pam_pwhistory.so is set correctly" test_ref="test_accounts_password_pam_pwhistory_remember" />
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
+      <criteria comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly" operator="OR">
+        <criterion comment="remember parameter of pam_unix.so is set correctly" test_ref="test_accounts_password_pam_unix_remember" />
+        <criterion comment="remember parameter of pam_pwhistory.so is set correctly" test_ref="test_accounts_password_pam_pwhistory_remember" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -2,12 +2,11 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Limit Password Reuse'
+title: 'Ensure PAM Enforces Password Reuse Limits'
 
 description: |-
-    Do not allow users to reuse recent passwords. This can be
-    accomplished by using the <tt>remember</tt> option for the <tt>pam_unix</tt>
-    or <tt>pam_pwhistory</tt> PAM modules.
+    If PAM is utilized on the system, the <tt>remember</tt> option for the <tt>pam_unix</tt>
+    or <tt>pam_pwhistory</tt> PAM modules can be used to ensure users do not reuse recent passwords.    
     <br /><br />
     In the file <tt>/etc/pam.d/system-auth</tt>, append <tt>remember=<sub idref="var_password_pam_unix_remember" /></tt>
     to the line which refers to the <tt>pam_unix.so</tt> or <tt>pam_pwhistory.so</tt>module, as shown below:
@@ -49,10 +48,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'the value of remember is not set equal to or greater than the expected setting'
+ocil_clause: 'PAM is installed and the value of remember is not set equal to or greater than the expected setting'
 
 ocil: |-
-    To verify the password reuse setting is compliant, run the following command:
+    If PAM is installed, to verify the password reuse setting is compliant, run the following command:
     <pre>$ grep remember /etc/pam.d/system-auth</pre>
     The output should show the following at the end of the line:
     <pre>remember=<sub idref="var_password_pam_unix_remember" /></pre>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
@@ -7,27 +7,22 @@
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
     </metadata>
-    <criteria operator="AND" comment="Checks common to both scenarios">
-      <criterion test_ref="test_accounts_passwords_pam_faillock_preauth_silent_system-auth"
-      comment="pam_faillock.so preauth silent set in system-auth" />
-      <criterion test_ref="test_accounts_passwords_pam_faillock_account_phase_system-auth"
-      comment="pam_faillock.so set in account phase of system-auth" />
-      <criterion test_ref="test_accounts_passwords_pam_faillock_preauth_silent_password-auth"
-      comment="pam_faillock.so preauth silent set in password-auth" />
-      <criterion test_ref="test_accounts_passwords_pam_faillock_account_phase_password-auth"
-      comment="pam_faillock.so set in account phase of password-auth" />
-      <criteria operator="AND">
-        <criteria operator="OR" comment="system-auth">
-          <criterion test_ref="test_accounts_passwords_pam_faillock_numeric_default_check_system-auth"
-            comment="Perform check if pam_faillock authfail follows pam_unix even with lines skipped" />
-          <criterion test_ref="test_accounts_passwords_pam_faillock_authfail_deny_system-auth"
-            comment="Perform check if pam_faillock authfail follows pam_unix with either sufficient or default=ignore" />
-        </criteria>
-        <criteria operator="OR" comment="password-auth">
-          <criterion test_ref="test_accounts_passwords_pam_faillock_numeric_default_check_password-auth"
-            comment="Perform check if pam_faillock authfail follows pam_unix even with lines skipped" />
-          <criterion test_ref="test_accounts_passwords_pam_faillock_authfail_deny_password-auth"
-          comment="pam_faillock.so authfail deny value set in password-auth" />
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
+      <criteria operator="AND" comment="Checks common to both scenarios">
+        <criterion test_ref="test_accounts_passwords_pam_faillock_preauth_silent_system-auth" comment="pam_faillock.so preauth silent set in system-auth" />
+        <criterion test_ref="test_accounts_passwords_pam_faillock_account_phase_system-auth" comment="pam_faillock.so set in account phase of system-auth" />
+        <criterion test_ref="test_accounts_passwords_pam_faillock_preauth_silent_password-auth" comment="pam_faillock.so preauth silent set in password-auth" />
+        <criterion test_ref="test_accounts_passwords_pam_faillock_account_phase_password-auth" comment="pam_faillock.so set in account phase of password-auth" />
+        <criteria operator="AND">
+          <criteria operator="OR" comment="system-auth">
+            <criterion test_ref="test_accounts_passwords_pam_faillock_numeric_default_check_system-auth" comment="Perform check if pam_faillock authfail follows pam_unix even with lines skipped" />
+            <criterion test_ref="test_accounts_passwords_pam_faillock_authfail_deny_system-auth" comment="Perform check if pam_faillock authfail follows pam_unix with either sufficient or default=ignore" />
+           </criteria>
+          <criteria operator="OR" comment="password-auth">
+            <criterion test_ref="test_accounts_passwords_pam_faillock_numeric_default_check_password-auth" comment="Perform check if pam_faillock authfail follows pam_unix even with lines skipped" />
+            <criterion test_ref="test_accounts_passwords_pam_faillock_authfail_deny_password-auth" comment="pam_faillock.so authfail deny value set in password-auth" />
+          </criteria>
         </criteria>
       </criteria>
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Deny For Failed Password Attempts'
+title: 'Ensure PAM Enforces Authentication Denial After Exceeding Failed Password Attempts'
 
 description: |-
-    To configure the system to lock out accounts after a number of incorrect login
+    If PAM is installed, to configure the system to lock out accounts after a number of incorrect login
     attempts using <tt>pam_faillock.so</tt>, modify the content of both
     <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt> as follows:
     <br /><br />
@@ -50,9 +50,9 @@ references:
     iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16
 
-ocil_clause: 'that is not the case'
+ocil_clause: 'PAM is installed and that is not the case'
 
 ocil: |-
-    To ensure the failed password attempt policy is configured correctly, run the following command:
+    If PAM is installed, to ensure the failed password attempt policy is configured correctly, run the following command:
     <pre>$ grep pam_faillock /etc/pam.d/system-auth</pre>
     The output should show <tt>deny=<sub idref="var_accounts_passwords_pam_faillock_deny" /></tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
@@ -12,15 +12,14 @@
       <description>The root account should be configured to deny access after the number of defined
       failed attempts has been reached.</description>
     </metadata>
-    <criteria>
-      <criterion test_ref="test_pam_faillock_preauth_silent_system-auth"
-      comment="pam_faillock.so preauth silent set in system-auth" />
-      <criterion test_ref="test_pam_faillock_authfail_deny_root_system-auth"
-      comment="pam_faillock.so authfail deny_root value set in system-auth" />
-      <criterion test_ref="test_pam_faillock_preauth_silent_password-auth"
-      comment="pam_faillock.so preauth silent set in password-auth" />
-      <criterion test_ref="test_pam_faillock_authfail_deny_root_password-auth"
-      comment="pam_faillock.so authfail deny_root value set in password-auth" />
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
+      <criteria>
+        <criterion test_ref="test_pam_faillock_preauth_silent_system-auth" comment="pam_faillock.so preauth silent set in system-auth" />
+        <criterion test_ref="test_pam_faillock_authfail_deny_root_system-auth" comment="pam_faillock.so authfail deny_root value set in system-auth" />
+        <criterion test_ref="test_pam_faillock_preauth_silent_password-auth" comment="pam_faillock.so preauth silent set in password-auth" />
+        <criterion test_ref="test_pam_faillock_authfail_deny_root_password-auth" comment="pam_faillock.so authfail deny_root value set in password-auth" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Configure the root Account for Failed Password Attempts'
+title: 'Ensure PAM Enforces Password Restrictions On root Account'
 
 description: |-
-    To configure the system to lock out the <tt>root</tt> account after a
+    If PAM is installed, to configure the system to lock out the <tt>root</tt> account after a
     number of incorrect login attempts using <tt>pam_faillock.so</tt>, modify
     the content of both <tt>/etc/pam.d/system-auth</tt> and
     <tt>/etc/pam.d/password-auth</tt> as follows:
@@ -43,10 +43,10 @@ references:
     iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16
 
-ocil_clause: 'that is not the case'
+ocil_clause: 'PAM is installed and that is not the case'
 
 ocil: |-
-    To ensure that even the <tt>root</tt> account is locked after a defined number of failed password
+    If PAM is installed, to ensure that even the <tt>root</tt> account is locked after a defined number of failed password
     attempts, run the following command:
     <pre>$ grep even_deny_root /etc/pam.d/system-auth</pre>
     The output should show <tt>even_deny_root</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
@@ -10,13 +10,16 @@
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
     </metadata>
-    <criteria>
-      <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_system-auth" />
-      <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_authfail_fail_interval_system-auth" />
-      <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_password-auth" />
-      <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" />
-      <criterion comment="account requires pam_faillock.so in /etc/pam.d/password-auth" test_ref="test_accounts_passwords_pam_faillock_account_requires_password-auth" />
-      <criterion comment="account requires pam_faillock.so in /etc/pam.d/system-auth" test_ref="test_accounts_passwords_pam_faillock_account_requires_system-auth" />
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
+      <criteria>
+        <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_system-auth" />
+        <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_authfail_fail_interval_system-auth" />
+        <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_password-auth" />
+        <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_preauth_fail_interval_password-auth" />
+        <criterion comment="account requires pam_faillock.so in /etc/pam.d/password-auth" test_ref="test_accounts_passwords_pam_faillock_account_requires_password-auth" />
+        <criterion comment="account requires pam_faillock.so in /etc/pam.d/system-auth" test_ref="test_accounts_passwords_pam_faillock_account_requires_system-auth" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Interval For Counting Failed Password Attempts'
+title: 'Ensure PAM Interval For Counting Failed Password Attempts is Configured'
 
 description: |-
-    Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive
+    If PAM is installed, then utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive
     configures the system to lock out an account after a number of incorrect
     login attempts within a specified time period. Modify the content of both
     <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt>
@@ -56,10 +56,10 @@ references:
     iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16
 
-ocil_clause: 'fail_interval is less than the required value'
+ocil_clause: 'PAM is installed and fail_interval is less than the required value'
 
 ocil: |-
-    To ensure the failed password attempt policy is configured correctly,
+    If PAM is installed, to ensure the failed password attempt policy is configured correctly,
     run the following command:
     <pre>$ grep pam_faillock /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>
     For each file, the output should show <tt>fail_interval=&lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is <tt><sub idref="var_accounts_passwords_pam_faillock_fail_interval" /></tt> or greater.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -10,11 +10,14 @@
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
     </metadata>
-    <criteria>
-      <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_system-auth" />
-      <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" />
-      <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_password-auth" />
-      <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" />
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
+      <criteria>
+        <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_system-auth" />
+        <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" />
+        <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_password-auth" />
+        <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Lockout Time for Failed Password Attempts'
+title: 'Ensure PAM Lockout Time for Failed Password Attempts is Configured'
 
 description: |-
-    To configure the system to lock out accounts after a number of incorrect login
+    If PAM is installed, to configure the system to lock out accounts after a number of incorrect login
     attempts and require an administrator to unlock the account using <tt>pam_faillock.so</tt>,
     modify the content of both <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt> as follows:
     <br /><br />
@@ -53,9 +53,9 @@ references:
     iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16
 
-ocil_clause: 'unlock_time is less than the expected value'
+ocil_clause: 'PAM is installed and unlock_time is less than the expected value'
 
 ocil: |-
-    To ensure the failed password attempt policy is configured correctly, run the following command:
+    If PAM is installed, to ensure the failed password attempt policy is configured correctly, run the following command:
     <pre>$ grep pam_faillock /etc/pam.d/system-auth</pre>
     The output should show <tt>unlock_time=&lt;some-large-number&gt;</tt> or <tt>never</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Password Strength Minimum Digit Characters'
+title: 'Ensure PAM Enforces Password Strength Requirements - Minimum Digit Characters'
 
 description: |-
-    The pam_pwquality module's <tt>dcredit</tt> parameter controls requirements for
+    If PAM is installed, the pam_pwquality module's <tt>dcredit</tt> parameter controls requirements for
     usage of digits in a password. When set to a negative number, any password will be required to
     contain that many digits. When set to a positive number, pam_pwquality will grant +1 additional
     length credit for each digit. Modify the <tt>dcredit</tt> setting in
@@ -45,10 +45,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'dcredit is not found or not equal to or less than the required value'
+ocil_clause: 'PAM is installed and dcredit is not found or not equal to or less than the required value'
 
 ocil: |-
-    To check how many digits are required in a password, run the following command:
+    If PAM is installed, to check how many digits are required in a password, run the following command:
     <pre>$ grep dcredit /etc/security/pwquality.conf</pre>
     The <tt>dcredit</tt> parameter (as a negative number) will indicate how many digits are required.
     The DoD requires at least one digit in a password. This would appear as <tt>dcredit = -1</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Password Strength Minimum Different Characters'
+title: 'Ensure PAM Enforces Password Strength Requirements - Minimum Different Characters'
 
 description: |-
-    The pam_pwquality module's <tt>difok</tt> parameter sets the number of characters
+    If PAM is installed, the pam_pwquality module's <tt>difok</tt> parameter sets the number of characters
     in a password that must not be present in and old password during a password change.
     <br /><br />
     Modify the <tt>difok</tt> setting in <tt>/etc/security/pwquality.conf</tt>
@@ -47,9 +47,9 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'difok is not found or not equal to or greater than the required value'
+ocil_clause: 'PAM is installed and difok is not found or not equal to or greater than the required value'
 
 ocil: |-
-    To check how many characters must differ during a password change, run the following command:
+    If PAM is installed, to check how many characters must differ during a password change, run the following command:
     <pre>$ grep difok /etc/security/pwquality.conf</pre>
     The <tt>difok</tt> parameter will indicate how many characters must differ.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Password Strength Minimum Lowercase Characters'
+title: 'Ensure PAM Enforces Password Strength Requirements - Minimum Lowercase Characters'
 
 description: |-
-    The pam_pwquality module's <tt>lcredit</tt> parameter controls requirements for
+    If PAM is installed, the pam_pwquality module's <tt>lcredit</tt> parameter controls requirements for
     usage of lowercase letters in a password. When set to a negative number, any password will be required to
     contain that many lowercase characters. When set to a positive number, pam_pwquality will grant +1 additional
     length credit for each lowercase character. Modify the <tt>lcredit</tt> setting in
@@ -44,10 +44,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'lcredit is not found or not less than or equal to the required value'
+ocil_clause: 'PAM is installed and lcredit is not found or not less than or equal to the required value'
 
 ocil: |-
-    To check how many lowercase characters are required in a password, run the following command:
+    If PAM is installed, to check how many lowercase characters are required in a password, run the following command:
     <pre>$ grep lcredit /etc/security/pwquality.conf</pre>
     The <tt>lcredit</tt> parameter (as a negative number) will indicate how many special characters are required.
     The DoD and FISMA require at least one lowercase character in a password. This would appear as <tt>lcredit = -1</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Password to Maximum of Consecutive Repeating Characters from Same Character Class'
+title: 'Ensure PAM Enforces Password Strength Requirements - Maximum of Consecutive Repeating Characters from Same Character Class'
 
 description: |-
-    The pam_pwquality module's <tt>maxclassrepeat</tt> parameter controls requirements for
+    If PAM is installed, the pam_pwquality module's <tt>maxclassrepeat</tt> parameter controls requirements for
     consecutive repeating characters from the same character class. When set to a positive number, it will reject passwords
     which contain more than that number of consecutive characters from the same character class. Modify the
     <tt>maxclassrepeat</tt> setting in <tt>/etc/security/pwquality.conf</tt> to equal <sub idref="var_password_pam_maxclassrepeat" />
@@ -37,9 +37,9 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'that is not the case'
+ocil_clause: 'PAM is installed and that is not the case'
 
 ocil: |-
-    To check the value for maximum consecutive repeating characters, run the following command:
+    If PAM is installed, to check the value for maximum consecutive repeating characters, run the following command:
     <pre>$ grep maxclassrepeat /etc/security/pwquality.conf</pre>
     For DoD systems, the output should show <tt>maxclassrepeat</tt>=4.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8
 
-title: 'Set Password Strength Minimum Different Categories'
+title: 'Ensure PAM Enforces Password Strength Requirements - Minimum Different Character Categories'
 
 description: |-
-    The pam_pwquality module's <tt>minclass</tt> parameter controls
+    If PAM is installed, the pam_pwquality module's <tt>minclass</tt> parameter controls
     requirements for usage of different character classes, or types, of character
     that must exist in a password before it is considered valid. For example,
     setting this value to three (3) requires that any password must have characters
@@ -51,10 +51,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'minclass is not found or not set equal to or greater than the required value'
+ocil_clause: 'PAM is installed and minclass is not found or not set equal to or greater than the required value'
 
 ocil: |-
-    To check how many categories of characters must be used in password during a password change,
+    If PAM is installed, to check how many categories of characters must be used in password during a password change,
     run the following command:
     <pre>$ grep minclass /etc/security/pwquality.conf</pre>
     The <tt>minclass</tt> parameter will indicate how many character classes must be used. If

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Password Minimum Length'
+title: 'Ensure PAM Enforces Password Strength Requirements - Minimum Length'
 
 description: |-
-    The pam_pwquality module's <tt>minlen</tt> parameter controls requirements for
+    If PAM is installed, the pam_pwquality module's <tt>minlen</tt> parameter controls requirements for
     minimum characters required in a password. Add <tt>minlen=<sub idref="var_password_pam_minlen" /></tt>
     after pam_pwquality to set minimum password length requirements.
 
@@ -43,9 +43,9 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'minlen is not found, or not equal to or greater than the required value'
+ocil_clause: 'PAM is installed and minlen is not found,tor not equal to or greater than the required value'
 
 ocil: |-
-    To check how many characters are required in a password, run the following command:
+    If PAM is installed, to check how many characters are required in a password, run the following command:
     <pre>$ grep minlen /etc/security/pwquality.conf</pre>
     Your output should contain <tt>minlen = <sub idref="var_password_pam_minlen" /></tt>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Password Strength Minimum Special Characters'
+title: 'Ensure PAM Enforces Password Strength Requirements - Minimum Special Characters'
 
 description: |-
-    The pam_pwquality module's <tt>ocredit=</tt> parameter controls requirements for
+    If PAM is installed, the pam_pwquality module's <tt>ocredit=</tt> parameter controls requirements for
     usage of special (or "other") characters in a password. When set to a negative number,
     any password will be required to contain that many special characters.
     When set to a positive number, pam_pwquality will grant +1
@@ -45,10 +45,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'ocredit is not found or not equal to or less than the required value'
+ocil_clause: 'PAM is installed and ocredit is not found or not equal to or less than the required value'
 
 ocil: |-
-    To check how many special characters are required in a password, run the following command:
+    If PAM is installed, to check how many special characters are required in a password, run the following command:
     <pre>$ grep ocredit /etc/security/pwquality.conf</pre>
     The <tt>ocredit</tt> parameter (as a negative number) will indicate how many special characters are required.
     The DoD and FISMA require at least one special character in a password.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -9,7 +9,8 @@
       </affected>
       <description>The password retry should meet minimum requirements</description>
     </metadata>
-    <criteria operator="AND" comment="Conditions for retry are satisfied">
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
       <criterion comment="pam_pwquality" test_ref="test_password_pam_pwquality_retry" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8
 
-title: 'Set Password Retry Prompts Permitted Per-Session'
+title: 'Ensure PAM Maximum Password Retry Prompts Permitted Per-Session is Configured'
 
 description: |-
-    To configure the number of retry prompts that are permitted per-session:
+    If PAM is installed, to configure the number of retry prompts that are permitted per-session:
     Edit the <tt>pam_pwquality.so</tt> statement in <tt>/etc/pam.d/system-auth</tt> to
     show <tt>retry=<sub idref="var_password_pam_retry" /></tt>, or a lower value if
     site policy is more restrictive.
@@ -38,10 +38,10 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4,A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,11,12,15,16,3,5,9
 
-ocil_clause: 'it is not the required value'
+ocil_clause: 'PAM is installed and it is not the required value'
 
 ocil: |-
-    To check how many retry attempts are permitted on a per-session basis, run the following command:
+    If PAM is installed, to check how many retry attempts are permitted on a per-session basis, run the following command:
     <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre>
     The <tt>retry</tt> parameter will indicate how many attempts are permitted.
     The DoD required value is less than or equal to 3.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: 'Set Password Strength Minimum Uppercase Characters'
+title: 'Ensure PAM Enforces Password Strength Requirements - Minimum Uppercase Characters'
 
 description: |-
-    The pam_pwquality module's <tt>ucredit=</tt> parameter controls requirements for
+    If PAM is installed, the pam_pwquality module's <tt>ucredit=</tt> parameter controls requirements for
     usage of uppercase letters in a password. When set to a negative number, any password will be required to
     contain that many uppercase characters. When set to a positive number, pam_pwquality will grant +1 additional
     length credit for each uppercase character. Modify the <tt>ucredit</tt> setting in
@@ -42,10 +42,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'ucredit is not found or not set less than or equal to the required value'
+ocil_clause: 'PAM is installed and ucredit is not found or not set less than or equal to the required value'
 
 ocil: |-
-    To check how many uppercase characters are required in a password, run the following command:
+    If PAM is installed, to check how many uppercase characters are required in a password, run the following command:
     <pre>$ grep ucredit /etc/security/pwquality.conf</pre>
     The <tt>ucredit</tt> parameter (as a negative number) will indicate how many uppercase characters are required.
     The DoD and FISMA require at least one uppercase character in a password.

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
@@ -10,7 +10,8 @@
       </affected>
       <description>The password hashing algorithm should be set correctly in /etc/pam.d/system-auth.</description>
     </metadata>
-    <criteria operator="AND">
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
       <criterion test_ref="test_pam_unix_sha512" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: "Ensure PAM Password Hashing Algorithm is Configured'
+title: "Ensure PAM Password Hashing Algorithm is Configured"
 
 description: |-
     If PAM is installed, the PAM system service can be configured to only store encrypted
@@ -61,7 +61,7 @@ references:
 ocil_clause: 'PAM is installed and it does not'
 
 ocil: |-
-    If PAM is isntalled, inspect the <tt>password</tt> section of <tt>/etc/pam.d/system-auth</tt> and
+    If PAM is installed, inspect the <tt>password</tt> section of <tt>/etc/pam.d/system-auth</tt> and
     ensure that the <tt>pam_unix.so</tt> module includes the argument
     <tt>sha512</tt>:
     <pre>$ grep sha512 /etc/pam.d/system-auth</pre>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
-title: "Set PAM's Password Hashing Algorithm"
+title: "Ensure PAM Password Hashing Algorithm is Configured'
 
 description: |-
-    The PAM system service can be configured to only store encrypted
+    If PAM is installed, the PAM system service can be configured to only store encrypted
     representations of passwords. In <tt>/etc/pam.d/system-auth</tt>, the
     <tt>password</tt> section of the file controls which PAM modules execute
     during a password change. Set the <tt>pam_unix.so</tt> module in the
@@ -58,10 +58,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'it does not'
+ocil_clause: 'PAM is installed and it does not'
 
 ocil: |-
-    Inspect the <tt>password</tt> section of <tt>/etc/pam.d/system-auth</tt> and
+    If PAM is isntalled, inspect the <tt>password</tt> section of <tt>/etc/pam.d/system-auth</tt> and
     ensure that the <tt>pam_unix.so</tt> module includes the argument
     <tt>sha512</tt>:
     <pre>$ grep sha512 /etc/pam.d/system-auth</pre>

--- a/shared/templates/csv/packages_removed.csv
+++ b/shared/templates/csv/packages_removed.csv
@@ -1,1 +1,2 @@
 nss-pam-ldapd
+pam

--- a/shared/templates/template_OVAL_accounts_password
+++ b/shared/templates/template_OVAL_accounts_password
@@ -11,13 +11,17 @@
       <description>The password {{{ VARIABLE }}} should meet minimum requirements</description>
     </metadata>
 {{% if product == "rhel6" %}}
-    <criteria>
-        <criterion comment="rhel6 pam_cracklib {{{ VARIABLE }}}" test_ref="test_password_pam_cracklib_{{{ VARIABLE }}}" />
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
+      <criterion comment="rhel6 pam_cracklib {{{ VARIABLE }}}" test_ref="test_password_pam_cracklib_{{{ VARIABLE }}}" />
     </criteria>
 {{% else %}}
-    <criteria operator="AND" comment="conditions for {{{ VARIABLE }}} are satisfied">
-      <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
-      <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
+    <criteria operator="OR">
+      <extend_definition comment="PAM not installed" definition_ref="package_pam_removed" />
+      <criteria operator="AND" comment="conditions for {{{ VARIABLE }}} are satisfied">
+        <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
+        <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
+      </criteria>
     </criteria>
 {{% endif %}}
   </definition>


### PR DESCRIPTION
- Updates multiple checks to evaluate if PAM is installed. Some distro/spins do not include a PAM stack which is resulting in false findings.
- Updates some rule titles to ``Ensure PAM Enforces <something>`` to align with how Audit rules are titled. Provides some visual clarity.

Resolves https://github.com/ComplianceAsCode/content/issues/4227