### PR TITLE
Set pipefail for pipe usage in Ansible shell tasks

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -5,7 +5,11 @@
 # disruption = low
 
 - name: Search for privileged commands
-  shell: "find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null | cat"
+  shell: |
+    set -o pipefail
+    find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null | cat
+  args:
+    executable: /bin/bash
   check_mode: no
   register: find_result
   changed_when: false

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -14,9 +14,12 @@
   when: (ansible_distribution == "RedHat" or ansible_distribution == "OracleLinux")
 
 - name: "Read files with incorrect hash"
-  shell: "rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/' | awk '{print $NF}'"
+  shell: |
+    set -o pipefail
+    rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/' | awk '{print $NF}'
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect hash using rpm module
+    executable: /bin/bash
   register: files_with_incorrect_hash
   changed_when: False
   when: (package_manager_reinstall_cmd is defined)

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -4,9 +4,12 @@
 # complexity = high
 # disruption = medium
 - name: "Read list of files with incorrect permissions"
-  shell: "rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)==\"M\") print $NF }'"
+  shell: |
+    set -o pipefail
+    rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }'
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect permissions using rpm module
+    executable: /bin/bash
   register: files_with_incorrect_permissions
   failed_when: False
   changed_when: False

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -14,10 +14,16 @@
 - name: Read signatures in GPG key
   # According to /usr/share/doc/gnupg2/DETAILS fingerprints are in "fpr" record in field 10
   {{% if product == "rhel8" -%}}
-  shell: gpg --show-key --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
+  shell: |
+    set -o pipefail
+    gpg --show-key --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
   {{%- else -%}}
-  shell: gpg --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
+  shell: |
+    set -o pipefail
+    gpg --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
   {{%- endif %}}
+  args:
+    executable: /bin/bash
   changed_when: False
   register: gpg_fingerprints
   check_mode: no


### PR DESCRIPTION
- Ansible lint: [306] Shells that use pipes should set the pipefail option