### PR TITLE
Update no_direct_root_logins to evaluate if setup RPM is installed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
@@ -3,7 +3,7 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Test for existence /etc/cron.allow
+- name: Test for existence /etc/securetty
   stat:
     path: /etc/securetty
   register: securetty_empty

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
@@ -8,9 +8,12 @@
       <description>Preventing direct root logins help ensure accountability for actions
       taken on the system using the root account.</description>
     </metadata>
-    <criteria operator="AND">
-      <criterion comment="serial ports /etc/securetty" test_ref="test_no_direct_root_logins" />
-      <criterion comment="serial ports /etc/securetty" test_ref="test_etc_securetty_exists" />
+    <criteria operator="OR">
+      <extend_definition comment="setup RPM not installed" definition_ref="package_setup_removed" />
+      <criteria operator="AND">
+        <criterion comment="serial ports /etc/securetty" test_ref="test_no_direct_root_logins" />
+        <criterion comment="serial ports /etc/securetty" test_ref="test_etc_securetty_exists" />
+      </criteria>
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
@@ -3,7 +3,8 @@ documentation_complete: true
 title: 'Direct root Logins Not Allowed'
 
 description: |-
-    To further limit access to the <tt>root</tt> account, administrators
+    If the system supports TTY connections, e.g. if the <tt>setup</tt> package is installed,
+    to further limit access to the <tt>root</tt> account, administrators
     can disable root logins at the console by editing the <tt>/etc/securetty</tt> file.
     This file lists all devices the root user is allowed to login to. If the file does
     not exist at all, the root user can login through any communication device on the
@@ -43,10 +44,11 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'the /etc/securetty file is not empty'
+ocil_clause: 'the setup RPM is installed and the /etc/securetty file is not empty'
 
 ocil: |-
-    To ensure root may not directly login to the system over physical consoles,
+    If the system is capable of TTY, e.g. when the <tt>setup</tt> package is installed,
+    o ensure root may not directly login to the system over physical consoles,
     run the following command:
     <pre>cat /etc/securetty</pre>
     If any output is returned, this is a finding.

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
@@ -48,7 +48,7 @@ ocil_clause: 'the setup RPM is installed and the /etc/securetty file is not empt
 
 ocil: |-
     If the system is capable of TTY, e.g. when the <tt>setup</tt> package is installed,
-    o ensure root may not directly login to the system over physical consoles,
+    to ensure root may not directly login to the system over physical consoles,
     run the following command:
     <pre>cat /etc/securetty</pre>
     If any output is returned, this is a finding.

--- a/shared/templates/csv/packages_removed.csv
+++ b/shared/templates/csv/packages_removed.csv
@@ -1,1 +1,2 @@
 nss-pam-ldapd
+setup


### PR DESCRIPTION
- Updated OVAL to evaluate of setup RPM is installed
- Updated typo in Ansible
- Updated XCCDF OCIL to reflect condition of ``setup`` package being installed

The ``setup`` RPM provides the ``/etc/securetty`` file:
`````
$ rpm -qvf /etc/securetty
setup-2.8.71-10.el7.noarch
`````

Some distros/spins do not provide TTY. Suggest making this check dependent on ``setup`` being present.