### PR TITLE
Various Ansible fixes

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
@@ -10,14 +10,13 @@
     grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "sec=krb5:krb5i:krb5p" | awk '{print $2}'
   args:
     warn: False
+    executable: /bin/bash
   register: points_register
   check_mode: no
   changed_when: False
 
 - name: "Add Kerberos security to mount points"
-  shell: |
-    set -o pipefail
-    awk '$2=="{{ item }}"{$4=$4",sec=krb5:krb5i:krb5p"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
+  shell: awk '$2=="{{ item }}"{$4=$4",sec=krb5:krb5i:krb5p"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
   args:
     warn: False
   with_items:

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/ansible/shared.yml
@@ -5,13 +5,21 @@
 # disruption = medium
 
 - name: "Get nfs and nfs4 mount points, that don't have Kerberos security option"
-  shell: grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "sec=krb5:krb5i:krb5p" | awk '{print $2}'
+  shell: |
+    set -o pipefail
+    grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "sec=krb5:krb5i:krb5p" | awk '{print $2}'
+  args:
+    warn: False
   register: points_register
   check_mode: no
   changed_when: False
 
 - name: "Add Kerberos security to mount points"
-  shell: awk '$2=="{{ item }}"{$4=$4",sec=krb5:krb5i:krb5p"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
+  shell: |
+    set -o pipefail
+    awk '$2=="{{ item }}"{$4=$4",sec=krb5:krb5i:krb5p"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
+  args:
+    warn: False
   with_items:
     - "{{ points_register.stdout_lines }}"
   when: (points_register.stdout | length > 0)

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/ansible/shared.yml
@@ -6,7 +6,7 @@
 - (xccdf-var var_sssd_ldap_tls_ca_dir)
 
 - name: "Test for domain group"
-  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
   changed_when: False
@@ -23,7 +23,7 @@
     - { section: sssd, option: domains, value: default}
     - { section: domain/default, option: id_provider, value: files }
     - { section: domain/default, option: ldap_tls_cacertdir, value: "{{ var_sssd_ldap_tls_ca_dir }}" }
-  when: test_grep_domain.stdout == ""
+  when: test_grep_domain.stdout | length < 1
 
 - name: "Configure LDAPs path to CA directory"
   ini_file:
@@ -33,4 +33,4 @@
     value: "{{ var_sssd_ldap_tls_ca_dir }}"
     create: yes
     mode: 0600
-  when: test_grep_domain.stdout != ""
+  when: test_grep_domain.stdout | length > 0

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -12,7 +12,7 @@
     create: yes
 
 - name: "Test for domain group"
-  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
   changed_when: False
@@ -30,7 +30,7 @@
     - { section: sssd, option: domains, value: default}
     - { section: domain/default, option: id_provider, value: files }
     - { section: domain/default, option: ldap_id_use_start_tls, value: true}
-  when: test_grep_domain.stdout == ""
+  when: test_grep_domain.stdout | length < 1
 
 - name: "Configure LDAP to use STARTTLS"
   ini_file:
@@ -40,5 +40,5 @@
     value: true
     create: yes
     mode: 0600
-  when: test_grep_domain.stdout != ""
+  when: test_grep_domain.stdout | length > 0
 

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 - name: "Test for domain group"
-  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
   changed_when: False
@@ -20,7 +20,7 @@
   with_items:
     - { section: sssd, option: domains, value: default}
     - { section: domain/default, option: id_provider, value: files }
-  when: test_grep_domain.stdout == ""
+  when: test_grep_domain.stdout | length < 1
 - name: "Enable Smartcards in SSSD"
   ini_file:
     dest: /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -6,7 +6,7 @@
 - (xccdf-var var_sssd_memcache_timeout)
 
 - name: "Test for domain group"
-  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
   changed_when: False
@@ -22,7 +22,7 @@
   with_items:
     - { section: sssd, option: domains, value: default}
     - { section: domain/default, option: id_provider, value: files }
-  when: test_grep_domain.stdout == ""
+  when: test_grep_domain.stdout | length < 1
 
 - name: "Configure SSSD's Memory Cache to Expire"
   ini_file:

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 - name: "Test for domain group"
-  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
   changed_when: False
@@ -20,7 +20,7 @@
   with_items:
     - { section: sssd, option: domains, value: default}
     - { section: domain/default, option: id_provider, value: files }
-  when: test_grep_domain.stdout == ""
+  when: test_grep_domain.stdout | length < 1
 
 - name: "Configure SSD to Expire Offline Credentials"
   ini_file:

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -6,7 +6,7 @@
 - (xccdf-var sshd_idle_timeout_value)
 
 - name: "Test for domain group"
-  shell: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
   changed_when: False
@@ -22,7 +22,7 @@
   with_items:
     - { section: sssd, option: domains, value: default}
     - { section: domain/default, option: id_provider, value: files }
-  when: test_grep_domain.stdout == ""
+  when: test_grep_domain.stdout | length < 1
 
 - name: "Configure SSSD to Expire SSH Known Hosts"
   ini_file:

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
@@ -10,4 +10,6 @@
 
 - name: "Direct root Logins Not Allowed"
   shell: echo > /etc/securetty
+  args:
+    warn: False
   changed_when: securetty_empty.stat.size > 1

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
@@ -14,6 +14,7 @@
     tr ":" "\n" <<< "$PATH" | xargs -I% find % -maxdepth 0 -type d
   args:
     warn: False
+    executable: /bin/bash
   changed_when: False
   failed_when: False
   register: root_paths

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
@@ -9,7 +9,11 @@
   when: ansible_user != "root"
 
 - name: "Get root paths which are not symbolic links"
-  shell: 'tr ":" "\n" <<< "$PATH" | xargs -I% find % -maxdepth 0 -type d'
+  shell: |
+    set -o pipefail
+    tr ":" "\n" <<< "$PATH" | xargs -I% find % -maxdepth 0 -type d
+  args:
+    warn: False
   changed_when: False
   failed_when: False
   register: root_paths

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -9,6 +9,7 @@
     set -o pipefail
     find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null | cat
   args:
+    warn: False
     executable: /bin/bash
   check_mode: no
   register: find_result

--- a/linux_os/guide/system/auditing/grub_legacy_audit_argument/ansible/rhel6.yml
+++ b/linux_os/guide/system/auditing/grub_legacy_audit_argument/ansible/rhel6.yml
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 - name: "Enable Auditing for Processes Which Start Prior to the Audit Daemon"
-  shell: /sbin/grubby --update-kernel=ALL --args="audit=1"
+  command: /sbin/grubby --update-kernel=ALL --args="audit=1"

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = medium
 # disruption = medium
 - name: "Read list of system executables without root ownership"
-  shell: "find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \\! -user root"
+  command: "find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \\! -user root"
   register: no_root_system_executables
   changed_when: False
   failed_when: False

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = medium
 # disruption = medium
 - name: "Read list libraries without root ownership"
-  shell: "find -L /usr/lib /usr/lib64 /lib /lib64 \\! -user root"
+  command: "find -L /usr/lib /usr/lib64 /lib /lib64 \\! -user root"
   register: libraries_not_owned_by_root
   changed_when: False
   failed_when: False

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = medium
 # disruption = medium
 - name: "Read list of world and group writable system executables"
-  shell: "find /bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec -perm /022 -type f"
+  command: "find /bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec -perm /022 -type f"
   register: world_writable_library_files
   changed_when: False
   failed_when: False

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = high
 # disruption = medium
 - name: "Read list of world and group writable files in libraries directories"
-  shell: "find /lib /lib64 /usr/lib /usr/lib64 -perm /022 -type f"
+  command: "find /lib /lib64 /usr/lib /usr/lib64 -perm /022 -type f"
   register: world_writable_library_files
   changed_when: False
   failed_when: False

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
@@ -13,4 +13,4 @@
     create: yes
 
 - name: Verify that Crypto Policy is Set (runtime)
-  shell: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
+  command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -21,6 +21,7 @@
     rpm -qf {{ files_with_incorrect_ownership.stdout_lines }}|sort |uniq
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch packages with files with incorrect ownership using rpm module
+    executable: /bin/bash
   register: uniq_list_of_packages
   when: (files_with_incorrect_ownership.stdout_lines | length > 0)
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -4,16 +4,21 @@
 # complexity = high
 # disruption = medium
 - name: "Read list of files with incorrect ownership"
-  shell: "rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)==\"U\" || substr($0,7,1)==\"G\") print $NF }'"
+  shell: |
+    set -o pipefail
+    rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)==\"U\" || substr($0,7,1)==\"G\") print $NF }'
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect ownership using rpm module
+    executable: /bin/bash
   register: files_with_incorrect_ownership
   failed_when: False
   changed_when: False
   check_mode: no
 
 - name: Create list of uniq packages
-  shell: "rpm -qf {{ files_with_incorrect_ownership.stdout_lines }}|sort |uniq"
+  shell: |
+    set -o pipefail
+    rpm -qf {{ files_with_incorrect_ownership.stdout_lines }}|sort |uniq
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch packages with files with incorrect ownership using rpm module
   register: uniq_list_of_packages

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -23,6 +23,7 @@
     gpg --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
   {{%- endif %}}
   args:
+    warn: False
     executable: /bin/bash
   changed_when: False
   register: gpg_fingerprints

--- a/shared/templates/template_ANSIBLE_sebool_var
+++ b/shared/templates/template_ANSIBLE_sebool_var
@@ -8,7 +8,7 @@
 - name: Ensure libsemanage-python installed
   package:
     name: libsemanage-python
-    state: latest
+    state: present
 
 - name: Set SELinux boolean {{{ SEBOOLID }}} accordingly
   seboolean:


### PR DESCRIPTION
- Use 'command' instead of 'shell' whenever feasible
- Don't warn for using shell when shell is needed
- Don't use 'latest' for installing libsemanage packages
- Add pipefail to tasks that have to be shell
- Don't evaluate conditions to empty strings