### PR TITLE
additional UBI prep

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
@@ -10,9 +10,9 @@
       <description>Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf
       to none to prevent a reboot if Ctrl-Alt-Delete is pressed more than 7 times in 2 seconds.</description>
     </metadata>
-    <criteria>
-      <criterion comment="check CtrlAltDelBurstAction is set to none"
-      test_ref="test_disable_ctrlaltdel_burstaction" />
+    <criteria operator="OR">
+      <extend_definition comment="systemd RPM is not installed" definition_ref="package_systemd_removed" />
+      <criterion comment="check CtrlAltDelBurstAction is set to none" test_ref="test_disable_ctrlaltdel_burstaction" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
@@ -5,7 +5,7 @@ prodtype: rhel7,rhel8,ol7,ol8
 title: 'Disable Ctrl-Alt-Del Burst Action'
 
 description: |-
-    By default, <tt>SystemD</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>
+    If the <tt>systemd</tt> package is insatlled, by default, <tt>SystemD</tt> will reboot the system if the <tt>Ctrl-Alt-Del</tt>
     key sequence is pressed Ctrl-Alt-Delete more than 7 times in 2 seconds.
     <br /><br />
     To configure the system to ignore the <tt>CtrlAltDelBurstAction</tt>
@@ -37,10 +37,10 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 12,13,14,15,16,18,3,5
 
-ocil_clause: 'the system is configured to reboot when Ctrl-Alt-Del is pressed more than 7 times in 2 seconds.'
+ocil_clause: 'systemd is installed and the system is configured to reboot when Ctrl-Alt-Del is pressed more than 7 times in 2 seconds.'
 
 ocil: |-
-    To ensure the system is configured to ignore the Ctrl-Alt-Del setting,
+    If the <tt>systemd</tt> package is installed, to ensure the system is configured to ignore the Ctrl-Alt-Del setting,
     enter the following command:
     <pre>$ sudo grep -i ctrlaltdelburstaction /etc/systemd/system.conf</pre>
     The output should return:

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/oval/shared.xml
@@ -9,9 +9,10 @@
         <platform>multi_platform_ol</platform>
       </affected>
       <description>The accounts should be configured to expire automatically following password expiration.</description>
-    </metadata>
-    <criteria comment="the value INACTIVE parameter should be set appropriately in /etc/default/useradd">
-      <criterion test_ref="test_etc_default_useradd_inactive" />
+    </metadata> 
+    <criteria operator="OR" >
+      <extend_definition comment="shadow-utils not installed" definition_ref="package_shadow-utils_removed" />
+      <criterion test_ref="test_etc_default_useradd_inactive" comment="the value INACTIVE parameter should be set appropriately in /etc/default/useradd" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
@@ -5,7 +5,8 @@ prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 title: 'Set Account Expiration Following Inactivity'
 
 description: |-
-    To specify the number of days after a password expires (which
+    If the <tt>shadow-utils</tt> package is installed and the system supports password-based user logins,
+    to specify the number of days after a password expires (which
     signifies inactivity) until an account is permanently disabled, add or correct
     the following lines in <tt>/etc/default/useradd</tt>, substituting
     <tt><i>NUM_DAYS</i></tt> appropriately:
@@ -53,10 +54,11 @@ references:
     iso27001-2013: A.12.4.1,A.12.4.3,A.18.1.4,A.6.1.2,A.7.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
 
-ocil_clause: 'the value of INACTIVE is greater than the expected value'
+ocil_clause: 'shadow-utils package is installed and the value of INACTIVE is greater than the expected value'
 
 ocil: |-
-    To verify the <tt>INACTIVE</tt> setting, run the following command:
+    If the <tt>shadow-utils</tt> package is installed,
+    to verify the <tt>INACTIVE</tt> setting, run the following command:
     <pre>$ grep "INACTIVE" /etc/default/useradd</pre>
     The output should indicate the <tt>INACTIVE</tt> configuration option is set
     to an appropriate integer as shown in the example below:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/oval/shared.xml
@@ -7,8 +7,9 @@
       </affected>
       <description>The maximum password age policy should meet minimum requirements.</description>
     </metadata>
-    <criteria comment="The value PASS_MAX_DAYS should be set appropriately in /etc/login.defs">
-      <criterion test_ref="test_pass_max_days" />
+    <criteria operator="OR">
+      <extend_definition comment="shadow-utils RPM not installed" definition_ref="package_shadow-utils_removed" />
+      <criterion test_ref="test_pass_max_days" comment="The value PASS_MAX_DAYS should be set appropriately in /etc/login.defs" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Set Password Maximum Age'
 
 description: |-
-    To specify password maximum age for new accounts,
+    If <tt>shadow-utils</tt> is installed, to specify password maximum age for new accounts,
     edit the file <tt>/etc/login.defs</tt>
     and add or correct the following line:
     <pre>PASS_MAX_DAYS <sub idref="var_accounts_maximum_age_login_defs" /></pre>
@@ -48,10 +48,10 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'PASS_MAX_DAYS is not set equal to or greater than the required value'
+ocil_clause: 'shadow-utils package is installed and PASS_MAX_DAYS is not set equal to or greater than the required value'
 
 ocil: |-
-    To check the maximum password age, run the command:
+    If <tt>shadow-utils</tt> package is installed, to check the maximum password age, run the command:
     <pre>$ grep PASS_MAX_DAYS /etc/login.defs</pre>
     The DoD and FISMA requirement is 60.
     A value of 180 days is sufficient for many environments.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/oval/shared.xml
@@ -7,8 +7,9 @@
       </affected>
       <description>The minimum password age policy should be set appropriately.</description>
     </metadata>
-    <criteria comment="The value of PASS_MIN_DAYS should be set appropriately in /etc/login.defs">
-      <criterion test_ref="test_pass_min_days" />
+    <criteria operator="OR">
+      <extend_definition comment="shadow-utils RPM is not installed" definition_ref="package_shadow-utils_removed" />
+      <criterion test_ref="test_pass_min_days" comment="The value of PASS_MIN_DAYS should be set appropriately in /etc/login.defs" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Set Password Minimum Age'
 
 description: |-
-    To specify password minimum age for new accounts,
+    If the <tt>shadow-utils</tt> package is installed, to specify password minimum age for new accounts,
     edit the file <tt>/etc/login.defs</tt>
     and add or correct the following line:
     <pre>PASS_MIN_DAYS <sub idref="var_accounts_minimum_age_login_defs" /></pre>
@@ -44,8 +44,8 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'it is not equal to or greater than the required value'
+ocil_clause: 'the shadow-utils package is installed and PASS_MIN_DAYS in /etc/login.defs is not equal to or greater than the required value'
 
 ocil: |-
-    To check the minimum password age, run the command:
+    If <tt>shadow-utils</tt> package is installed, to check the minimum password age, run the command:
     <pre>$ grep PASS_MIN_DAYS /etc/login.defs</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/oval/shared.xml
@@ -8,7 +8,8 @@
       </affected>
       <description>The password minimum length should be set appropriately.</description>
     </metadata>
-    <criteria operator="AND">
+    <criteria operator="OR">
+      <extend_definition comment="shadow-utils RPM is not installed" definition_ref="package_shadow-utils_removed" />
       <criterion test_ref="test_pass_min_len" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
@@ -3,7 +3,8 @@ documentation_complete: true
 title: 'Set Password Minimum Length in login.defs'
 
 description: |-
-    To specify password length requirements for new accounts, edit the file
+    If the system supports password-based authentication and <tt>shadow-utils</tt> is installed,
+    to specify password length requirements for new accounts, edit the file
     <tt>/etc/login.defs</tt> and add or correct the following line:
     <pre>PASS_MIN_LEN <sub idref="var_accounts_password_minlen_login_defs" /></pre>
     <br /><br />
@@ -45,9 +46,9 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
 
-ocil_clause: 'it is not set to the required value'
+ocil_clause: 'shadow-utils is isntalled and PASS_MIN_LEN is not set to the required value in /etc/login.defs'
 
 ocil: |-
-    To check the minimum password length, run the command:
+    If <tt>shadow-utils</tt> is installed, to check the minimum password length, run the command:
     <pre>$ grep PASS_MIN_LEN /etc/login.defs</pre>
     The DoD requirement is <tt>15</tt>.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/oval/shared.xml
@@ -7,7 +7,8 @@
       </affected>
       <description>The password expiration warning age should be set appropriately.</description>
     </metadata>
-    <criteria>
+    <criteria operator="OR">
+      <extend_definition comment="shadow-utils RPM is not installed" definition_ref="package_shadow-utils_removed" />
       <criterion test_ref="test_pass_warn_age" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
@@ -3,8 +3,8 @@ documentation_complete: true
 title: 'Set Password Warning Age'
 
 description: |-
-    To specify how many days prior to password
-    expiration that a warning will be issued to users,
+    If the system supports password-based logins, such as when the <tt>shadow-utils</tt> package is installed,
+    to specify how many days prior to password expiration that a warning will be issued to users,
     edit the file <tt>/etc/login.defs</tt> and add or correct
      the following line:
     <pre>PASS_WARN_AGE <sub idref="var_accounts_password_warn_age_login_defs" /></pre>
@@ -34,9 +34,10 @@ references:
     iso27001-2013: A.12.4.1,A.12.4.3,A.18.1.4,A.6.1.2,A.7.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
 
-ocil_clause: 'it is not set to the required value'
+ocil_clause: 'shadow-utils is installed and PASS_WARN_AGE is not set to the required value in /etc/login.defs'
 
 ocil: |-
-    To check the password warning age, run the command:
+    If the system supports password-based authentication and <tt>shadow-utils</tt> is installed,
+    to check the password warning age, run the command:
     <pre>$ grep PASS_WARN_AGE /etc/login.defs</pre>
     The DoD requirement is 7.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/oval/rhel7.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/oval/rhel7.xml
@@ -8,7 +8,8 @@
       <description>The delay between failed authentication attempts should be
       set for all users specified in /etc/login.defs</description>
     </metadata>
-    <criteria>
+    <criteria operator="OR">
+      <extend_definition comment="shadow-utils RPM is not installed" definition_ref="package_shadow-utils_removed" />
       <criterion test_ref="test_accounts_logon_fail_delay" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
@@ -3,7 +3,8 @@ documentation_complete: true
 title: 'Ensure the Logon Failure Delay is Set Correctly in login.defs'
 
 description: |-
-    To ensure the logon failure delay controlled by <tt>/etc/login.defs</tt> is set properly,
+    If <tt>shadow-utils</tt> is installed and the system is configured to accept password-based logins,
+    to ensure the logon failure delay controlled by <tt>/etc/login.defs</tt> is set properly,
     add or correct the <tt>FAIL_DELAY</tt> setting in <tt>/etc/login.defs</tt> to read as follows:
     <pre>FAIL_DELAY <sub idref="var_accounts_fail_delay" /></pre>
 
@@ -28,10 +29,11 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
     cis-csc: 11,3,9
 
-ocil_clause: 'the above command returns no output, or FAIL_DELAY is configured less than the expected value'
+ocil_clause: 'shadow-utils is installed and the above command returns no output, or FAIL_DELAY is configured less than the expected value'
 
 ocil: |-
-    Verify the <tt>FAIL_DELAY</tt> setting is configured correctly in the <tt>/etc/login.defs</tt> file by
+    If <tt>shadow-utils</tt> is installed,
+    verify the <tt>FAIL_DELAY</tt> setting is configured correctly in the <tt>/etc/login.defs</tt> file by
     running the following command:
     <pre>$ sudo grep -i "FAIL_DELAY" /etc/login.defs</pre>
     All output must show the value of <tt>FAIL_DELAY</tt> set as shown in the below:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/oval/shared.xml
@@ -11,10 +11,13 @@
       minimum requirements.</description>
     </metadata>
     <criteria operator="OR">
-      <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" test_ref="test_limitsd_maxlogins" />
-      <criteria operator="AND">
-	  <criterion comment="the value maxlogins should not be set at all in /etc/security/limits.d/*.conf" test_ref="test_limitsd_maxlogins_exists" negate="true" />
-	  <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.conf" test_ref="test_maxlogins" />
+      <extend_definition comment="pam RPM is not installed" definition_ref="package_pam_removed" />
+      <criteria operator="OR">
+        <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" test_ref="test_limitsd_maxlogins" />
+        <criteria operator="AND">
+          <criterion comment="the value maxlogins should not be set at all in /etc/security/limits.d/*.conf" test_ref="test_limitsd_maxlogins_exists" negate="true" />
+          <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.conf" test_ref="test_maxlogins" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
@@ -1,12 +1,15 @@
 documentation_complete: true
 
-title: 'Limit the Number of Concurrent Login Sessions Allowed Per User'
+title: 'Ensure PAM Limits the Number of Concurrent Login Sessions Allowed Per User'
 
 description: |-
     Limiting the number of allowed users and sessions per user can limit risks related to Denial of
     Service attacks. This addresses concurrent sessions for a single account and does not address
-    concurrent sessions by a single user via multiple accounts. To set the number of concurrent
-    sessions per user add the following line in <tt>/etc/security/limits.conf</tt>:
+    concurrent sessions by a single user via multiple accounts. 
+
+    If <tt>pam</tt> is installed and the system is configured to support password-based authentication,
+    to set the number of concurrent sessions per user add the following line in 
+    <tt>/etc/security/limits.conf</tt>:
     <pre>* hard maxlogins <sub idref="var_accounts_max_concurrent_login_sessions" /></pre>
 
 rationale: |-
@@ -37,10 +40,10 @@ references:
     iso27001-2013: A.13.1.1,A.13.1.3,A.13.2.1,A.14.1.2,A.14.1.3
     cis-csc: 14,15,18,9
 
-ocil_clause: 'maxlogins is not equal to or less than the expected value'
+ocil_clause: 'PAM is installed and maxlogins is not equal to or less than the expected value'
 
 ocil: |-
-    Run the following command to ensure the <tt>maxlogins</tt> value is
+    If <tt>pam</tt> is installed, run the following command to ensure the <tt>maxlogins</tt> value is
     configured for all users on the system:
     <pre># grep "maxlogins" /etc/security/limits.conf</pre>
     You should receive output similar to the following:

--- a/shared/templates/csv/packages_removed.csv
+++ b/shared/templates/csv/packages_removed.csv
@@ -1,2 +1,3 @@
 nss-pam-ldapd
 shadow-utils
+pam

--- a/shared/templates/csv/packages_removed.csv
+++ b/shared/templates/csv/packages_removed.csv
@@ -1,3 +1,4 @@
 nss-pam-ldapd
 shadow-utils
 pam
+systemd

--- a/shared/templates/csv/packages_removed.csv
+++ b/shared/templates/csv/packages_removed.csv
@@ -1,1 +1,2 @@
 nss-pam-ldapd
+shadow-utils


### PR DESCRIPTION
Updates multiple rules to evaluate if associated RPM is installed before evaluating.

Needed because some distros/spins may not have shadow-utils.