### PR TITLE
remove ensure_gpgcheck_repo_metadata from HIPAA profiles

### DIFF
--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -88,7 +88,6 @@ selections:
     - ensure_redhat_gpgkey_installed
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
-    - ensure_gpgcheck_repo_metadata
     - ensure_gpgcheck_local_packages
     - grub2_audit_argument
     - service_auditd_enabled

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -83,7 +83,6 @@ selections:
     - ensure_redhat_gpgkey_installed
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
-    - ensure_gpgcheck_repo_metadata
     - ensure_gpgcheck_local_packages
     - grub2_audit_argument
     - service_auditd_enabled

--- a/rhv4/profiles/rhvh-stig.profile
+++ b/rhv4/profiles/rhvh-stig.profile
@@ -371,7 +371,6 @@ selections:
     - ensure_redhat_gpgkey_installed
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
-    - ensure_gpgcheck_repo_metadata
     - ensure_gpgcheck_local_packages
     - network_sniffer_disabled
     - network_ipv6_disable_rpc


### PR DESCRIPTION
Double checked with Atif. ``ensure_gpgcheck_repo_metadata`` isn't needed for HIPAA profile either.