### PR TITLE
Test shadow-utils presence with CPE applicability

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
@@ -62,3 +62,5 @@ ocil: |-
     to an appropriate integer as shown in the example below:
     <pre>$ grep "INACTIVE" /etc/default/useradd
     INACTIVE=<sub idref="var_account_disable_post_pw_expiration" /></pre>
+
+platform: shadow-utils

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
@@ -55,3 +55,5 @@ ocil: |-
     <pre>$ grep PASS_MAX_DAYS /etc/login.defs</pre>
     The DoD and FISMA requirement is 60.
     A value of 180 days is sufficient for many environments.
+
+platform: shadow-utils

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
@@ -49,3 +49,5 @@ ocil_clause: 'it is not equal to or greater than the required value'
 ocil: |-
     To check the minimum password age, run the command:
     <pre>$ grep PASS_MIN_DAYS /etc/login.defs</pre>
+
+platform: shadow-utils

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
@@ -51,3 +51,5 @@ ocil: |-
     To check the minimum password length, run the command:
     <pre>$ grep PASS_MIN_LEN /etc/login.defs</pre>
     The DoD requirement is <tt>15</tt>.
+
+platform: shadow-utils

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
     To check the password warning age, run the command:
     <pre>$ grep PASS_WARN_AGE /etc/login.defs</pre>
     The DoD requirement is 7.
+
+platform: shadow-utils

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     All output must show the value of <tt>FAIL_DELAY</tt> set as shown in the below:
     <pre>$ sudo grep -i "FAIL_DELAY" /etc/login.defs
     fail_delay <sub idref="var_accounts_fail_delay" /></pre>
+
+platform: shadow-utils

--- a/rhel7/cpe/rhel7-cpe-dictionary.xml
+++ b/rhel7/cpe/rhel7-cpe-dictionary.xml
@@ -47,4 +47,9 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
 </cpe-list>

--- a/shared/checks/oval/installed_env_has_shadow-utils_package.xml
+++ b/shared/checks/oval/installed_env_has_shadow-utils_package.xml
@@ -1,0 +1,24 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_shadow-utils_package" version="1">
+    <metadata>
+      <title>Package shadow-utils is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package shadow-utils is installed.</description>
+      <reference ref_id="cpe:/a:shadow-utils" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package shadow-utils is installed" test_ref="test_env_has_shadow-utils_installed" />
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="system has package shadow-utils installed" id="test_env_has_shadow-utils_installed" version="1">
+    <linux:object object_ref="obj_env_has_shadow-utils_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_shadow-utils_installed" version="1">
+    <linux:name>shadow-utils</linux:name>
+  </linux:rpminfo_object>
+
+</def-group>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -375,7 +375,8 @@ OCILREFATTR_TO_TAG = {
 
 XCCDF_PLATFORM_TO_CPE = {
     "machine": "cpe:/a:machine",
-    "container": "cpe:/a:container"
+    "container": "cpe:/a:container",
+    "shadow-utils": "cpe:/a:shadow-utils",
 }
 
 # _version_name_map = {


### PR DESCRIPTION
#### Description:

- Introduce shadow-utils CPE
- Set relevant rules with `platform: shadow-utils`

#### Rationale:

- Some environments may not have package `shadow-utils` installed

#### Notes:
- The way we handle the CPE dictionaries is not great, and will need improvements to scale.