### PR TITLE
accounts_tmout - Fixed OVALs and tests.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_tmout" version="2">
+  <definition class="compliance" id="accounts_tmout" version="3">
     <metadata>
       <title>Set Interactive Session Timeout</title>
       <affected family="unix">
@@ -15,31 +15,37 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="TMOUT in /etc/profile" id="test_etc_profile_tmout" version="1">
-    <ind:object object_ref="object_etc_profile_tmout" />
+  {{% macro test_tmout(test_stem, files) %}}
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="TMOUT in {{{ files }}}" id="test_{{{ test_stem }}}" version="2">
+    <ind:object object_ref="object_{{{ test_stem }}}" />
     <ind:state state_ref="state_etc_profile_tmout" />
   </ind:textfilecontent54_test>
+  {{% endmacro %}}
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="TMOUT in /etc/profile.d/*.sh" id="test_etc_profiled_tmout" version="1">
-    <ind:object object_ref="object_etc_profiled_tmout" />
-    <ind:state state_ref="state_etc_profile_tmout" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="object_etc_profile_tmout" version="1">
-    <ind:filepath>/etc/profile</ind:filepath>
+  {{% macro object_tmout(test_stem, path, filename, filepath) %}}
+  <ind:textfilecontent54_object id="object_{{{ test_stem }}}" version="2">
+    {{% if path %}}
+    <ind:path>{{{ path }}}</ind:path>
+    {{% endif %}}
+    {{% if filename %}}
+    <ind:filename operation="pattern match">{{{ filename }}}</ind:filename>
+    {{% endif %}}
+    {{% if filepath %}}
+    <ind:filepath>{{{ filepath }}}</ind:filepath>
+    {{% endif %}}
     <ind:pattern operation="pattern match">^[\s]*TMOUT[\s]*=[\s]*(.*)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endmacro %}}
 
-  <ind:textfilecontent54_object id="object_etc_profiled_tmout" version="1">
-    <ind:path>/etc/profile.d</ind:path>
-    <ind:filename operation="pattern match">^.*\.sh$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*TMOUT[\s]*=[\s]*(.*)[\s]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
+  {{{ test_tmout(  test_stem="etc_profile_tmout", files="/etc/profile") }}}
+  {{{ object_tmout(test_stem="etc_profile_tmout", filepath="/etc/profile") }}}
 
-  <ind:textfilecontent54_state id="state_etc_profile_tmout" version="1">
-    <ind:subexpression datatype="int" operation="greater than or equal" var_check="all" var_ref="var_accounts_tmout" />
+  {{{ test_tmout(  test_stem="etc_profiled_tmout", files="/etc/profile.d/*.sh") }}}
+  {{{ object_tmout(test_stem="etc_profiled_tmout", path="/etc/profile.d", filename="^.*\.sh$") }}}
+
+  <ind:textfilecontent54_state id="state_etc_profile_tmout" version="2">
+    <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="var_accounts_tmout" />
   </ind:textfilecontent54_state>
 
   <external_variable comment="external variable for TMOUT" datatype="int" id="var_accounts_tmout" version="1" />

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_tmout/supercompliance.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_tmout/supercompliance.pass.sh
@@ -3,7 +3,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=600/" /etc/profile
+	sed -i "s/.*TMOUT.*/TMOUT=60/" /etc/profile
 else
-	echo "TMOUT=600" >> /etc/profile
+	echo "TMOUT=60" >> /etc/profile
 fi

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_tmout/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_tmout/wrong_value.fail.sh
@@ -3,7 +3,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^TMOUT" /etc/profile; then
-	sed -i "s/^TMOUT.*/TMOUT=100/" /etc/profile
+	sed -i "s/^TMOUT.*/TMOUT=3600/" /etc/profile
 else
-	echo "TMOUT=100" >> /etc/profile
+	echo "TMOUT=3600" >> /etc/profile
 fi


### PR DESCRIPTION
The OVAL check has been enriched by jinja, so it is deduplicated.

The check now treats shorter timeouts are more secure and vice versa.