### PR TITLE
Remove machine only from rules that are applicable to containers

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
@@ -11,5 +11,3 @@ description: |-
     In Red Hat Enterprise Linux servers and workstations, hardware token login
     {{% endif %}}
     is not enabled by default and must be enabled in the system settings.
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
@@ -34,3 +34,4 @@ ocil_clause: 'the pcscd service is not enabled'
 
 ocil: '{{{ ocil_service_enabled(service="pcscd") }}}'
 
+platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -44,5 +44,3 @@ ocil_clause: 'there is no database file'
 ocil: |-
     To find the location of the AIDE databse file, run the following command:
     <pre>$ sudo ls -l <i>DBDIR</i>/<i>database_file_name</i></pre>
-
-platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
@@ -49,5 +49,3 @@ ocil: |-
     <pre>$ grep aide /etc/crontab</pre>
     The output should return something similar to the following:
     <pre>05 4 * * * root /usr/sbin/aide --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost</pre>
-
-platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/rule.yml
@@ -41,5 +41,3 @@ ocil: |-
     To determine that AIDE is configured for FIPS 140-2 file hashing, run the following command:
     <pre>$ grep sha512 /etc/aide.conf</pre>
     Verify that the <tt>sha512</tt> option is added to the correct ruleset.
-
-platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
@@ -40,5 +40,3 @@ ocil: |-
     To determine that AIDE is verifying ACLs, run the following command:
     <pre>$ grep acl /etc/aide.conf</pre>
     Verify that the <tt>acl</tt> option is added to the correct ruleset.
-
-platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
@@ -40,5 +40,3 @@ ocil: |-
     To determine that AIDE is verifying extended file attributes, run the following command:
     <pre>$ grep xattrs /etc/aide.conf</pre>
     Verify that the <tt>xattrs</tt> option is added to the correct ruleset.
-
-platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -34,5 +34,3 @@ references:
 ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="aide") }}}'
-
-platform: machine


### PR DESCRIPTION
#### Description:

- Remove platform machine only from rules that are applicable to container.

#### Rationale:

- These rules are applicable to containers therefore can't be marked as machine only.

- Address raised issues on this PR: https://github.com/ComplianceAsCode/content/pull/4240
