### PR TITLE
More Ansible lint fixes

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -6,7 +6,7 @@
 - name: "Read list of files with incorrect ownership"
   shell: |
     set -o pipefail
-    rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)==\"U\" || substr($0,7,1)==\"G\") print $NF }'
+    rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect ownership using rpm module
     executable: /bin/bash
@@ -15,19 +15,17 @@
   changed_when: False
   check_mode: no
 
-- name: Create list of uniq packages
-  shell: |
-    set -o pipefail
-    rpm -qf {{ files_with_incorrect_ownership.stdout_lines }}|sort |uniq
+- name: Create list of packages
+  command: rpm -qf "{{ item }}"
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch packages with files with incorrect ownership using rpm module
-    executable: /bin/bash
-  register: uniq_list_of_packages
+  with_items: "{{ files_with_incorrect_ownership.stdout_lines | unique }}"
+  register: list_of_packages
   when: (files_with_incorrect_ownership.stdout_lines | length > 0)
 
 - name: "Correct file ownership with RPM"
-  shell: "rpm --quiet --setugids '{{ item }}'"
+  command: "rpm --quiet --setugids '{{ item }}'"
   args:
     warn: False # Ignore ANSIBLE0006, we can't correct ownership using rpm module
-  with_items: "{{ uniq_list_of_packages.stdout_lines }}"
+  with_items: "{{ list_of_packages.results | map(attribute='stdout_lines') | list | unique }}"
   when: (files_with_incorrect_ownership.stdout_lines | length > 0)

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -6,7 +6,7 @@
 - name: get back device associated to mountpoint
   shell: |
     set -o pipefail
-    mount | grep ' {{{ MOUNTPOINT }}} ' |cut -d ' ' -f 1
+    mount | grep ' {{{ MOUNTPOINT }}} ' | cut -d ' ' -f 1
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch device name with mount module
     executable: /bin/bash

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -4,26 +4,35 @@
 # complexity = low
 # disruption = high
 - name: get back device associated to mountpoint
-  shell: mount | grep ' {{{ MOUNTPOINT }}} ' |cut -d ' ' -f 1
+  shell: |
+    set -o pipefail
+    mount | grep ' {{{ MOUNTPOINT }}} ' |cut -d ' ' -f 1
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch device name with mount module
+    executable: /bin/bash
   register: device_name
   check_mode: no
   changed_when: False
 
 - block:
   - name: get back device previous mount option
-    shell: mount | grep ' {{{ MOUNTPOINT }}} ' | sed -re 's:.*\((.*)\):\1:'
+    shell: |
+      set -o pipefail
+      mount | grep ' {{{ MOUNTPOINT }}} ' | sed -re 's:.*\((.*)\):\1:'
     args:
       warn: False # Ignore ANSIBLE0006, we can't fetch current mount options with mount module
+    executable: /bin/bash
     register: device_cur_mountoption
     check_mode: no
     changed_when: False
 
   - name: get back device fstype
-    shell: mount | grep ' {{{ MOUNTPOINT }}} ' | cut -d ' ' -f 5
+    shell: |
+      set -o pipefail
+      mount | grep ' {{{ MOUNTPOINT }}} ' | cut -d ' ' -f 5
     args:
       warn: False # Ignore ANSIBLE0006, we can't fetch fstype with mount module
+    executable: /bin/bash
     register: device_fstype
     check_mode: no
     changed_when: False

--- a/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
+++ b/shared/templates/template_ANSIBLE_mount_option_remote_filesystems
@@ -5,13 +5,19 @@
 # disruption = medium
 
 - name: "Get nfs and nfs4 mount points, that don't have {{{ MOUNTOPTION }}}"
-  shell: grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "{{{ MOUNTOPTION }}}" | awk '{print $2}'
+  shell: |
+    set -o pipefail
+    grep -E "[[:space:]]nfs[4]?[[:space:]]" /etc/fstab | grep -v "{{{ MOUNTOPTION }}}" | awk '{print $2}'
+  args:
+    executable: /bin/bash
   register: points_register
   check_mode: no
   changed_when: False
 
 - name: "Add {{{ MOUNTOPTION }}} to mount points"
   shell: awk '$2=="{{ item }}"{$4=$4",{{{ MOUNTOPTION }}}"}1' /etc/fstab > fstab.tmp && mv fstab.tmp /etc/fstab
+  args:
+    executable: /bin/bash
   with_items:
     - "{{ points_register.stdout_lines }}"
   when: (points_register.stdout | length > 0)

--- a/shared/templates/template_ANSIBLE_mount_option_var
+++ b/shared/templates/template_ANSIBLE_mount_option_var
@@ -6,26 +6,35 @@
 - (xccdf-var {{{ MOUNTPOINT }}})
 
 - name: get back device associated to mountpoint
-  shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' |cut -d ' ' -f 1
+  shell: |
+    set -o pipefail
+    mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' |cut -d ' ' -f 1
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch device name with mount module
+    executable: /bin/bash
   register: device_name
   check_mode: no
   changed_when: False
 
 - block:
   - name: get back device previous mount option
-    shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | sed -re 's:.*\((.*)\):\1:'
+    shell: |
+      set -o pipefail
+      mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | sed -re 's:.*\((.*)\):\1:'
     args:
       warn: False # Ignore ANSIBLE0006, we can't fetch mount options with mount module
+      executable: /bin/bash
     register: device_cur_mountoption
     check_mode: no
     changed_when: False
 
   - name: get back device fstype
-    shell: mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | cut -d ' ' -f 5
+    shell: |
+      set -o pipefail
+      mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | cut -d ' ' -f 5
     args:
       warn: False # Ignore ANSIBLE0006, we can't fetch fstype with mount module
+      executable: /bin/bash
     register: device_fstype
     check_mode: no
     changed_when: False

--- a/shared/templates/template_ANSIBLE_mount_option_var
+++ b/shared/templates/template_ANSIBLE_mount_option_var
@@ -8,7 +8,7 @@
 - name: get back device associated to mountpoint
   shell: |
     set -o pipefail
-    mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' |cut -d ' ' -f 1
+    mount | grep ' {{ {{{ MOUNTPOINT }}} }} ' | cut -d ' ' -f 1
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch device name with mount module
     executable: /bin/bash


### PR DESCRIPTION
- Add pipefail to mount templates
- Fix rpm_verify_ownership ansible remediation script as it was failing during a run
