### PR TITLE
Add GDM CPE and mark GNOME group

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/group.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/group.yml
@@ -9,3 +9,5 @@ description: |-
     displayed in this graphical environment for these users.
     The following sections describe how to configure the GDM login
     banner.
+
+platform: gdm

--- a/linux_os/guide/system/software/gnome/group.yml
+++ b/linux_os/guide/system/software/gnome/group.yml
@@ -12,3 +12,5 @@ description: |-
     Red Hat Graphical environment.
     <br /><br />
     For more information on GNOME and the GNOME Project, see <b>{{{ weblink(link="https://www.gnome.org") }}}</b>.
+
+platform: gdm

--- a/rhel7/cpe/rhel7-cpe-dictionary.xml
+++ b/rhel7/cpe/rhel7-cpe-dictionary.xml
@@ -47,6 +47,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/shared/checks/oval/installed_env_has_gdm_package.xml
+++ b/shared/checks/oval/installed_env_has_gdm_package.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_gdm_package" version="1">
+    <metadata>
+      <title>Package gdm is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package gdm is installed.</description>
+      <reference ref_id="cpe:/a:gdm" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package gdm is installed" test_ref="test_env_has_gdm_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_gdm_installed" version="1"
+  comment="system has package gdm installed">
+    <linux:object object_ref="obj_env_has_gdm_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_gdm_installed" version="1">
+    <linux:name>gdm</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_gdm_installed" version="1"
+  comment="system has package gdm installed">
+    <linux:object object_ref="obj_env_has_gdm_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_gdm_installed" version="1">
+    <linux:name>gdm</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -376,6 +376,7 @@ OCILREFATTR_TO_TAG = {
 XCCDF_PLATFORM_TO_CPE = {
     "machine": "cpe:/a:machine",
     "container": "cpe:/a:container",
+    "gdm": "cpe:/a:gdm",
     "libuser": "cpe:/a:libuser",
     "nss-pam-ldapd": "cpe:/a:nss-pam-ldapd",
     "pam": "cpe:/a:pam",


### PR DESCRIPTION
#### Description:

- Adds CPE Name for package GDM installed.

#### Rationale:

- Followup from #4248
- Rules regarding GNOME should be not applicable if GDM is not installed.
- Fixes #2445

#### Notes:
- I have decided to go the less granular way, to just check for `gdm`. If necessary, the rules can be more specific and check for `gnome-desktop3`, `gnome-shell`
- The way we handle the CPE dictionaries is not great, and will need improvements to scale.