### PR TITLE
Update product CPE Dictionaries

### DIFF
--- a/ol7/cpe/ol7-cpe-dictionary.xml
+++ b/ol7/cpe/ol7-cpe-dictionary.xml
@@ -17,4 +17,39 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ol8/cpe/ol8-cpe-dictionary.xml
+++ b/ol8/cpe/ol8-cpe-dictionary.xml
@@ -17,4 +17,39 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/opensuse/cpe/opensuse-cpe-dictionary.xml
+++ b/opensuse/cpe/opensuse-cpe-dictionary.xml
@@ -22,4 +22,49 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_opensuse_leap15</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhel6/cpe/rhel6-cpe-dictionary.xml
+++ b/rhel6/cpe/rhel6-cpe-dictionary.xml
@@ -37,4 +37,39 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhel8/cpe/rhel8-cpe-dictionary.xml
+++ b/rhel8/cpe/rhel8-cpe-dictionary.xml
@@ -27,4 +27,39 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhv4/cpe/rhv4-cpe-dictionary.xml
+++ b/rhv4/cpe/rhv4-cpe-dictionary.xml
@@ -22,4 +22,39 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/sle11/cpe/sle11-cpe-dictionary.xml
+++ b/sle11/cpe/sle11-cpe-dictionary.xml
@@ -12,4 +12,49 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sle11</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/sle12/cpe/sle12-cpe-dictionary.xml
+++ b/sle12/cpe/sle12-cpe-dictionary.xml
@@ -12,4 +12,49 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sle12</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
+++ b/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
@@ -7,4 +7,49 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_ubuntu1404</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
+++ b/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
@@ -7,4 +7,49 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_ubuntu1604</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
+++ b/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
@@ -7,4 +7,49 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_ubuntu1804</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/wrlinux/cpe/wrlinux-cpe-dictionary.xml
+++ b/wrlinux/cpe/wrlinux-cpe-dictionary.xml
@@ -10,5 +10,49 @@
             <title xml:lang="en-us">Wind River Linux 9</title>        
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_wrlinux</check>
       </cpe-item>        
-
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>


### PR DESCRIPTION
#### Description:

- Update CPE Dictionaries

#### Rationale:

- Every CPE Name should be defined in the CPE dictionary
  - This could be the reason for some `notapplicable` results.
- Some products didn't had entries for `machine` and `container` CPE Names

#### Note:
- I'm aware is terrible copy-paste solution, but currently there is no clever solution in the build system for this.
