### PR TITLE
Update OCIL in grub2 backlog limit rule.

### DIFF
--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -26,13 +26,13 @@ ocil_clause: 'audit backlog limit is not configured'
 
 ocil: |-
     Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. If they include <tt>audit_backlog_limit=1</tt>, then auditing
+    in <tt>/etc/default/grub</tt>. If they include <tt>audit=1</tt>, then auditing
     is enabled at boot time.
     <br /><br />
-    To ensure <tt>audit_backlog_limit=1</tt> is configured on all installed kernels, the
+    To ensure <tt>audit_backlog_limit=8192</tt> is configured on all installed kernels, the
     following command may be used:
     <br />
-    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="audit_backlog_limit=1"</pre>
+    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="audit_backlog_limit=8192"</pre>
     <br />
 
 warnings:


### PR DESCRIPTION
#### Description:

- Update OCIL in grub2 backlog limit rule.

#### Rationale:

- OCIL from grub2_audit_backlog_limit_argument rule was referring wrong setting when talking about audit enabling.
- Fixes #4274 
