### PR TITLE
Refactor fix-rules.py tool

### DIFF
--- a/shared/macros-highlevel.jinja
+++ b/shared/macros-highlevel.jinja
@@ -4,7 +4,7 @@
     {{%- elif pkg_system == "dpkg" -%}}
         {{{ dpkg_ocil_package(package) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown package system '{{{ pkg_system }}}'.
+        JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -15,7 +15,8 @@
     {{%- elif pkg_system == "dpkg" %}}
         {{{ dpkg_complete_ocil_entry_package(package) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown package system '{{{ pkg_system }}}'.
+ocil: |-
+    JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -34,7 +35,7 @@
     {{%- elif pkg_manager == "dnf" -%}}
         {{{ dnf_package_install(package) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown package manager '{{{ pkg_manager }}}'.
+        JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -53,7 +54,7 @@
     {{%- elif pkg_manager == "dnf" -%}}
         {{{ dnf_package_remove(package) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown package manager '{{{ pkg_manager }}}'.
+        JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -64,7 +65,7 @@
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_service_enable(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -75,7 +76,7 @@
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_service_disable(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -86,7 +87,7 @@
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_ocil_service_enabled(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -97,7 +98,7 @@
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_ocil_service_disabled(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -108,7 +109,7 @@
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_socket_enable(socket) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -119,7 +120,7 @@
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_socket_disable(socket) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -130,7 +131,7 @@
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_complete_ocil_entry_socket_and_service_disabled(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR: Unknown init system '{{{ init_system }}}'.
+        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 

--- a/shared/macros-highlevel.jinja
+++ b/shared/macros-highlevel.jinja
@@ -131,7 +131,8 @@ ocil: |-
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_complete_ocil_entry_socket_and_service_disabled(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+ocil: |-
+    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 

--- a/shared/macros-highlevel.jinja
+++ b/shared/macros-highlevel.jinja
@@ -3,8 +3,8 @@
         {{{ rpm_ocil_package(package) }}}
     {{%- elif pkg_system == "dpkg" -%}}
         {{{ dpkg_ocil_package(package) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -14,7 +14,7 @@
         {{{ rpm_complete_ocil_entry_package(package) }}}
     {{%- elif pkg_system == "dpkg" %}}
         {{{ dpkg_complete_ocil_entry_package(package) }}}
-    {{%- else %}}
+    {{%- else -%}}
 ocil: |-
     JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
     {{%- endif -%}}
@@ -34,8 +34,8 @@ ocil: |-
         {{{ yum_package_install(package) }}}
     {{%- elif pkg_manager == "dnf" -%}}
         {{{ dnf_package_install(package) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -53,8 +53,8 @@ ocil: |-
         {{{ yum_package_remove(package) }}}
     {{%- elif pkg_manager == "dnf" -%}}
         {{{ dnf_package_remove(package) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -64,8 +64,8 @@ ocil: |-
         {{{ systemd_describe_service_enable(service) }}}
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_service_enable(service) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -75,8 +75,8 @@ ocil: |-
         {{{ systemd_describe_service_disable(service) }}}
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_service_disable(service) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -86,8 +86,8 @@ ocil: |-
         {{{ systemd_ocil_service_enabled(service) }}}
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_ocil_service_enabled(service) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -97,8 +97,8 @@ ocil: |-
         {{{ systemd_ocil_service_disabled(service) }}}
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_ocil_service_disabled(service) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -108,8 +108,8 @@ ocil: |-
         {{{ systemd_describe_socket_enable(socket) }}}
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_socket_enable(socket) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -119,8 +119,8 @@ ocil: |-
         {{{ systemd_describe_socket_disable(socket) }}}
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_socket_disable(socket) }}}
-    {{%- else %}}
-    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -130,7 +130,7 @@ ocil: |-
         {{{ systemd_complete_ocil_entry_socket_and_service_disabled(service) }}}
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_complete_ocil_entry_socket_and_service_disabled(service) }}}
-    {{%- else %}}
+    {{%- else -%}}
 ocil: |-
     JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}

--- a/shared/macros-highlevel.jinja
+++ b/shared/macros-highlevel.jinja
@@ -4,7 +4,7 @@
     {{%- elif pkg_system == "dpkg" -%}}
         {{{ dpkg_ocil_package(package) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
+    JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -35,7 +35,7 @@ ocil: |-
     {{%- elif pkg_manager == "dnf" -%}}
         {{{ dnf_package_install(package) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
+    JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -54,7 +54,7 @@ ocil: |-
     {{%- elif pkg_manager == "dnf" -%}}
         {{{ dnf_package_remove(package) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
+    JINJA MACRO ERROR - Unknown package manager '{{{ pkg_manager }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -65,7 +65,7 @@ ocil: |-
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_service_enable(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -76,7 +76,7 @@ ocil: |-
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_service_disable(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -87,7 +87,7 @@ ocil: |-
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_ocil_service_enabled(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -98,7 +98,7 @@ ocil: |-
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_ocil_service_disabled(service) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -109,7 +109,7 @@ ocil: |-
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_socket_enable(socket) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 
@@ -120,7 +120,7 @@ ocil: |-
     {{%- elif init_system == "upstart" -%}}
         {{{ upstart_describe_socket_disable(socket) }}}
     {{%- else %}}
-        JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
+    JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
 {{%- endmacro %}}
 

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -122,7 +122,6 @@ def find_rules(directory, func):
                 or "tests/" in path:
                 continue
             try:
-                print(path)
                 if func(path, product_yaml):
                     results.append((path, product_yaml_path))
             except jinja2.exceptions.UndefinedError:

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -50,7 +50,7 @@ def has_invalid_cce(yaml_file, product_yaml=None):
     if 'identifiers' in rule and rule['identifiers'] is not None:
         for i_type, i_value in rule['identifiers'].items():
             if i_type[0:3] == 'cce':
-                if not checks.is_cce_value_valid("CCE-" + i_value):
+                if not checks.is_cce_value_valid("CCE-" + str(i_value)):
                     return True
     return False
 
@@ -115,9 +115,14 @@ def find_rules(directory, func):
 
         for filename in files:
             path = os.path.join(root, filename)
-            if len(path) < 8 or path[-8:] != 'rule.yml' or "tests/" in path:
+            rule_filename_id = 'rule.yml'
+            rule_filename_id_len = len(rule_filename_id)
+            if len(path) < rule_filename_id_len \
+                or path[-(rule_filename_id_len):] != rule_filename_id \
+                or "tests/" in path:
                 continue
             try:
+                print(path)
                 if func(path, product_yaml):
                     results.append((path, product_yaml_path))
             except jinja2.exceptions.UndefinedError:
@@ -307,8 +312,8 @@ def fix_prefix_cce(file_contents, yaml_contents):
         for i_type, i_value in yaml_contents[section].items():
             if i_type[0:3] == 'cce':
                 has_prefix = i_value[0:3].upper() == 'CCE'
-                remainder_valid = checks.is_cce_format_valid("CCE-" + i_value[3:])
-                remainder_valid |= checks.is_cce_format_valid("CCE-" + i_value[4:])
+                remainder_valid = checks.is_cce_format_valid("CCE-" + str(i_value[3:]))
+                remainder_valid |= checks.is_cce_format_valid("CCE-" + str(i_value[4:]))
                 if has_prefix and remainder_valid:
                     prefixed_identifiers.append(i_type)
 
@@ -324,7 +329,7 @@ def fix_invalid_cce(file_contents, yaml_contents):
     if yaml_contents[section] is not None:
         for i_type, i_value in yaml_contents[section].items():
             if i_type[0:3] == 'cce':
-                if not checks.is_cce_value_valid("CCE-" + i_value):
+                if not checks.is_cce_value_valid("CCE-" + str(i_value)):
                     invalid_identifiers.append(i_type)
 
     return remove_section_keys(file_contents, yaml_contents, section, invalid_identifiers)
@@ -415,7 +420,6 @@ def find_prefix_cce(directory):
 
     for result in results:
         rule_path = result[0]
-        rule_path = result[0]
         product_yaml_path = result[1]
 
         product_yaml = None
@@ -430,7 +434,6 @@ def find_invalid_cce(directory):
     print("Number of rules with invalid CCEs: %d" % len(results))
 
     for result in results:
-        rule_path = result[0]
         rule_path = result[0]
         product_yaml_path = result[1]
 

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -6,6 +6,7 @@ import jinja2
 import argparse
 
 from ssg import yaml, checks
+from ssg.shims import input_func
 import ssg
 
 
@@ -372,8 +373,7 @@ def fix_file(path, product_yaml, func):
     print("====BEGIN AFTER====")
     print_file(file_contents)
     print("====END AFTER====")
-
-    response = raw_input("Confirm writing output to %s: (y/n): " % path)
+    response = input_func("Confirm writing output to %s: (y/n): " % path)
     if response.strip() == 'y':
         f = open(path, 'w')
         for line in file_contents:

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -83,7 +83,7 @@ def find_rules(directory, func):
     # a/b/c/something.rule
     #
     # The corresponding rule and contents of the product.yml are then passed
-    # into func(/path/to/rule, product_yaml_contents); if the result evalutes
+    # into func(/path/to/rule, product_yaml_contents); if the result evaluates
     # to true, the tuple (/path/to/rule, /path/to/product.yml) is saved as a
     # result.
     #
@@ -481,7 +481,7 @@ Commands:
 \tinvalid_identifiers - check and fix rules with invalid identifiers
 \tint_identifiers - check and fix rules with pseudo-integer identifiers
 \tempty_references - check and fix rules with empty references
-\tint_references - check and fix rules with pseduo-integer references
+\tint_references - check and fix rules with pseudo-integer references
                                      """)
     parser.add_argument("command", help="Which fix to perform.",
                         choices=['empty_identifiers', 'prefixed_identifiers',


### PR DESCRIPTION
#### Description:

- This PR aims to refactor fix-rules.py so it works with the new directory structure. Additionally it fixes some faulty JINJA macros when an error occurs.

#### Rationale:
This
Utility for fixing mistakes in .rule files
Commands:
	- empty_identifiers - check and fix rules with empty identifiers
	- prefixed_identifiers - check and fix rules with prefixed (CCE-) identifiers
	- invalid_identifiers - check and fix rules with invalid identifiers
	- int_identifiers - check and fix rules with pseudo-integer identifiers
	- empty_references - check and fix rules with empty references
	- int_references - check and fix rules with pseudo-integer references
