### PR TITLE
Remove mixed tabs with spaces in xccdf-create-ocil.xslt

### DIFF
--- a/shared/transforms/xccdf-create-ocil.xslt
+++ b/shared/transforms/xccdf-create-ocil.xslt
@@ -20,46 +20,46 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
      <timestamp><xsl:value-of as="xs:dateTime" select="date:date-time()"/></timestamp>
    </generator>
 
-	<questionnaires>
-	<xsl:for-each select=".//cdf:Rule">
-	<xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
-		<questionnaire id="{@id}_ocil">
-			<title><xsl:value-of select="cdf:title"/></title>
-			<actions>
-			<test_action_ref><xsl:value-of select="@id"/>_action</test_action_ref>
-			</actions>
-		</questionnaire>
-	</xsl:if>
-	</xsl:for-each>
-	</questionnaires>
+  <questionnaires>
+  <xsl:for-each select=".//cdf:Rule">
+  <xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <questionnaire id="{@id}_ocil">
+      <title><xsl:value-of select="cdf:title"/></title>
+      <actions>
+      <test_action_ref><xsl:value-of select="@id"/>_action</test_action_ref>
+      </actions>
+    </questionnaire>
+  </xsl:if>
+  </xsl:for-each>
+  </questionnaires>
 
-	<test_actions>
-	<xsl:for-each select=".//cdf:Rule">
-	<xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
-		<boolean_question_test_action id="{@id}_action" question_ref="{@id}_question">
-			<when_true>
-				<result>PASS</result>
-			</when_true>
-			<when_false>
-				<result>FAIL</result>
-			</when_false>
-		</boolean_question_test_action>
-	</xsl:if>
-	</xsl:for-each>
-	</test_actions>
+  <test_actions>
+  <xsl:for-each select=".//cdf:Rule">
+  <xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <boolean_question_test_action id="{@id}_action" question_ref="{@id}_question">
+      <when_true>
+        <result>PASS</result>
+      </when_true>
+      <when_false>
+        <result>FAIL</result>
+      </when_false>
+    </boolean_question_test_action>
+  </xsl:if>
+  </xsl:for-each>
+  </test_actions>
 
-	<questions>
-	<xsl:for-each select=".//cdf:Rule">
-	<xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
-		<boolean_question id="{@id}_question">
-			<question_text>
-			<xsl:apply-templates select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
-			Is it the case that <xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-export/@export-name"/>?
-			</question_text>
-		</boolean_question>
-	</xsl:if>
-	</xsl:for-each>
-	</questions>
+  <questions>
+  <xsl:for-each select=".//cdf:Rule">
+  <xsl:if test="cdf:check[@system='ocil-transitional']/cdf:check-content">
+    <boolean_question id="{@id}_question">
+      <question_text>
+      <xsl:apply-templates select="cdf:check[@system='ocil-transitional']/cdf:check-content"/>
+      Is it the case that <xsl:value-of select="cdf:check[@system='ocil-transitional']/cdf:check-export/@export-name"/>?
+      </question_text>
+    </boolean_question>
+  </xsl:if>
+  </xsl:for-each>
+  </questions>
 
   </ocil>
   </xsl:template>
@@ -69,7 +69,7 @@ xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date" 
     </xsl:template>
 
   <xsl:template match="cdf:check-content">
-	<xsl:apply-templates select="node()"/>
+  <xsl:apply-templates select="node()"/>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
- Causing mixed tabs and spaced in delivered OCIL content