### PR TITLE
Update Fedora CPE Dictionary

### DIFF
--- a/fedora/cpe/fedora-cpe-dictionary.xml
+++ b/fedora/cpe/fedora-cpe-dictionary.xml
@@ -42,4 +42,39 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>


### PR DESCRIPTION
#### Description:

- Fedora CPE Dictionary was not updated to include package CPEs

#### Rationale:

- Rules applicable for, `pam` will evaluate to `notapplicable` if the dictionary doesn't know how to evaluate `pam` CPE.
