### PR TITLE
service_kdump_disabled for SLE12

### DIFF
--- a/linux_os/guide/services/base/service_kdump_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_kdump_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,ol7,ol8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8,sle12
 
 title: 'Disable KDump Kernel Crash Analyzer (kdump)'
 
@@ -31,6 +31,7 @@ references:
     nist-csf: PR.AC-3,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "021300"
+    stigid@sle12: "010840"
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 7.1,SR 7.6'
     isa-62443-2009: 4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.3.2,4.3.4.3.3
     cobit5: APO13.01,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.05,DSS06.06

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = enable
 # complexity = low


### PR DESCRIPTION
Adds the metadata for `service_kdump_disabled` to work with SLE12.