### PR TITLE
FTP service-related rules for SLE12

### DIFF
--- a/fedora/templates/csv/packages_removed.csv
+++ b/fedora/templates/csv/packages_removed.csv
@@ -8,3 +8,4 @@ xorg-x11-server-common
 sendmail
 sssd
 systemd
+vsftpd

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/bash/shared.sh
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux
+# platform = multi_platform_wrlinux,multi_platform_sle
 
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/oval/shared.xml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_sle</platform>
       </affected>
       <description>This setting will cause the system greeting banner to be 
       used for FTP connections as well.</description>
@@ -19,7 +20,11 @@
     <ind:object object_ref="object_test_ftp_present_banner" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="Banner for FTP Users" id="object_test_ftp_present_banner" version="1">
+    {{% if product == "sle12" %}}
+    <ind:filepath>/etc/vsftpd.conf</ind:filepath>
+    {{% else %}}
     <ind:filepath>/etc/vsftpd/vsftpd.conf</ind:filepath>
+    {{% endif %}}
     <ind:pattern operation="pattern match">^[\s]*banner_file=/etc/issue[\s]*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/oval/shared.xml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/oval/shared.xml
@@ -10,7 +10,7 @@
       used for FTP connections as well.</description>
     </metadata>
     <criteria operator="OR">
-      <extend_definition comment="vsftpd package is not installed" negate="true" definition_ref="package_vsftpd_installed" />
+      <extend_definition comment="vsftpd package is not installed" definition_ref="package_vsftpd_removed" />
       <criterion comment="Banner for FTP Users" test_ref="test_ftp_present_banner" />
     </criteria>
   </definition>

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/rule.yml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/rule.yml
@@ -1,11 +1,15 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,sle12
 
 title: 'Create Warning Banners for All FTP Users'
 
 description: |-
+    {{% if product == "sle12" %}}
+    Edit the vsftpd configuration file, which resides at <tt>/etc/vsftpd.conf</tt>
+    {{% else %}}
     Edit the vsftpd configuration file, which resides at <tt>/etc/vsftpd/vsftpd.conf</tt>
+    {{% endif %}}
     by default. Add or correct the following configuration options:
     <pre>banner_file=/etc/issue</pre>
 
@@ -20,6 +24,7 @@ identifiers:
 references:
     stigid@rhel6: RHEL-06-000348
     srg@rhel6: SRG-OS-000023
+    stigid@sle12: "030010"
     disa: "48"
 
 ocil_clause: 'it does not'
@@ -28,8 +33,16 @@ ocil: |-
     If FTP services are not installed, this is not applicable.
     <br /><br />
     To verify this configuration, run the following command:
+    {{% if product == "sle12" %}}
+    <pre>grep "banner_file" /etc/vsftpd.conf</pre>
+    {{% else %}}
     <pre>grep "banner_file" /etc/vsftpd/vsftpd.conf</pre>
+    {{% endif %}}
 
     The output should show the value of <tt>banner_file</tt> is set to <tt>/etc/issue</tt>, an example of which is shown below:
+    {{% if product == "sle12" %}}
+    <pre>$ sudo grep "banner_file" /etc/vsftpd.conf
+    {{% else %}}
     <pre>$ sudo grep "banner_file" /etc/vsftpd/vsftpd.conf
+    {{% endif %}}
     banner_file=/etc/issue</pre>


### PR DESCRIPTION
This changes `ftp_present_banner` for SLE12.

I believe the switch from a negated `package_vsftpd_installed` to `package_vsftpd_removed` was just an aesthetic choice, but I'm not quite sure anymore.