### PR TITLE
postfix_client_configure_mail_alias for SLE12

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_sle
+. /usr/share/scap-security-guide/remediation_functions
+populate var_postfix_root_mail_alias
+
+replace_or_append '/etc/aliases' '^root' "$var_postfix_root_mail_alias" '@CCENUM@' '%s: %s'
+
+newaliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="postfix_client_configure_mail_alias" version="1">
+    <metadata>
+      <title>Ensure root has a mail alias</title>
+      <affected family="unix">
+          <platform>multi_platform_sle</platform>
+      </affected>
+      <description>Check if root has the correct mail alias.</description>
+    </metadata>
+    <criteria comment="Check if root has the correct mail alias.">
+      <criterion comment="Check if root has the correct mail alias." test_ref="test_postfix_client_configure_mail_alias"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="Check if root has the correct mail alias." id="test_postfix_client_configure_mail_alias" version="1" >
+    <ind:object object_ref="obj_root_mail_alias"/>
+    <ind:state state_ref="state_root_mail_alias"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_root_mail_alias" version="1">
+    <ind:filepath operation="equals">/etc/aliases</ind:filepath>
+    <ind:pattern operation="pattern match">^(?:[rR][oO][oO][tT]|"[rR][oO][oO][tT]")\s*:\s*(.+)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_root_mail_alias" version="1" comment="root email alias">
+    <ind:subexpression operation="equals" var_check="all" var_ref="var_postfix_root_mail_alias" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="expected email alias" datatype="string" id="var_postfix_root_mail_alias" version="1" />
+</def-group>

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/rule.yml
@@ -18,9 +18,11 @@ identifiers:
     cce@rhel6: 80508-5
 
 references:
-    disa@rhel6: "366"
+    disa: "366"
     srg@rhel6: SRG-OS-999999
     stigid@rhel6: RHEL-06-000521
+    nist: CM-6(b)
+    stigid@sle12: "020050"
 
 ocil_clause: 'it is not'
 


### PR DESCRIPTION
Adds the metadata for SLE12 to `postfix_client_configure_mail_alias` and an OVAL check and BASH remediation for SLE12.