### PR TITLE
obsolete service (rhosts/shosts/telnet) rules for SLE12

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_sle
 
 # Identify local mounts
 MOUNT_LIST=$(df | grep "^/dev" | awk '{ print $6 }') 

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_rhel,multi_platform_sle
 
 # Identify local mounts
-MOUNT_LIST=$(df | grep "^/dev" | awk '{ print $6 }') 
+MOUNT_LIST=$(df --local | awk '{ print $6 }')
 
 # Find file on each listed mount point
 for cur_mount in ${MOUNT_LIST}

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>No shosts.equiv file deployed on the system</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_sle</platform>
       </affected>
       <description>There should not be any shosts.equiv files on the system.</description>
     </metadata>

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,sle12
 
 title: 'Remove Host-Based Authentication Files'
 
@@ -26,7 +26,8 @@ identifiers:
 references:
     disa: "366"
     srg: SRG-OS-000480-GPOS-00227
-    stigid: "040550"
+    stigid@rhel7: "040550"
+    stigid@sle12: "010410"
 
 ocil_clause: 'these files exist'
 

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_sle
 
 # Identify local mounts
 MOUNT_LIST=$(df | grep "^/dev" | awk '{ print $6 }') 

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_rhel,multi_platform_sle
 
 # Identify local mounts
-MOUNT_LIST=$(df | grep "^/dev" | awk '{ print $6 }') 
+MOUNT_LIST=$(df --local | awk '{ print $6 }')
 
 # Find file on each listed mount point
 for cur_mount in ${MOUNT_LIST}

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>No .shosts file deployed on the system</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_sle</platform>
       </affected>
       <description>There should not be any .shosts files on the system.</description>
     </metadata>

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
@@ -9,14 +9,14 @@ description: |-
     list remote hosts and users that are trusted by the
     local system. To remove these files, run the following command
     to delete them from any location:
-    <pre>$ sudo rm ~/.shosts</pre>
+    <pre>$ sudo find / -name '.shosts' -type f -delete</pre>
 
 rationale: |-
     The .shosts files are used to configure host-based authentication for
     individual users or the system via SSH. Host-based authentication is not
     sufficient for preventing unauthorized access to the system, as it does not
     require interactive identification and authentication of a connection request,
-    or for the use of two-factor authentication.false
+    or for the use of two-factor authentication.
 
 severity: high
 
@@ -32,7 +32,7 @@ references:
 ocil_clause: 'these files exist'
 
 ocil: |-
-    To verify that there are no <tt>/etc/shosts.equiv</tt> files
+    To verify that there are no <tt>.shosts</tt> files
     on the system, run the following command:
-    <pre>$ sudo find / -name '*.shosts'</pre>
+    <pre>$ sudo find / -name '.shosts'</pre>
     No output should be returned.

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,sle12
 
 title: 'Remove User Host-Based Authentication Files'
 
@@ -26,7 +26,8 @@ identifiers:
 references:
     disa: "366"
     srg: SRG-OS-000480-GPOS-00227
-    stigid: "040540"
+    stigid@rhel7: "040540"
+    stigid@sle12: "010400"
 
 ocil_clause: 'these files exist'
 

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,ol7,ol8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8,sle12
 
 title: 'Uninstall telnet-server Package'
 
@@ -42,6 +42,7 @@ references:
     nist-csf: PR.AC-3,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000095-GPOS-00049
     stigid@rhel7: "021710"
+    stigid@sle12: "030000"
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 7.1,SR 7.6'
     isa-62443-2009: 4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.3.2,4.3.4.3.3
     cobit5: APO13.01,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.05,DSS06.06


### PR DESCRIPTION
Metadata changes to enable checks for obsolete services in SLE12, and some minor wording and remediation improvements.