### PR TITLE
Mark service rules as machine only.

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="avahi-daemon") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
@@ -37,3 +37,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="abrtd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_acpid_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_acpid_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="acpid") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_certmonger_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_certmonger_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="certmonger") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_cgconfig_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cgconfig_disabled/rule.yml
@@ -30,3 +30,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="cgconfig") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_cgred_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cgred_disabled/rule.yml
@@ -29,3 +29,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="cgred") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_cpupower_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cpupower_disabled/rule.yml
@@ -30,3 +30,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="cpupower") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_cpuspeed_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cpuspeed_disabled/rule.yml
@@ -30,3 +30,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="cpuspeed") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_haldaemon_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_haldaemon_disabled/rule.yml
@@ -31,3 +31,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="haldaemon") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_kdump_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_kdump_disabled/rule.yml
@@ -38,3 +38,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="kdump") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_mdmonitor_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_mdmonitor_disabled/rule.yml
@@ -29,3 +29,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="mdmonitor") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_messagebus_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_messagebus_disabled/rule.yml
@@ -33,3 +33,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="messagebus") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_netconsole_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_netconsole_disabled/rule.yml
@@ -34,3 +34,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="netconsole") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_ntpdate_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_ntpdate_disabled/rule.yml
@@ -38,3 +38,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="ntpdate") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_oddjobd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_oddjobd_disabled/rule.yml
@@ -37,3 +37,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="oddjobd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_portreserve_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_portreserve_disabled/rule.yml
@@ -31,3 +31,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="portreserve") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_psacct_enabled/rule.yml
+++ b/linux_os/guide/services/base/service_psacct_enabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 1,11,12,13,14,15,16,2,3,5,6,7,8,9
 
 ocil: '{{{ ocil_service_disabled(service="psacct") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_qpidd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_qpidd_disabled/rule.yml
@@ -38,3 +38,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="qpidd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_quota_nld_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_quota_nld_disabled/rule.yml
@@ -35,3 +35,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="quota_nld") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_rdisc_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rdisc_disabled/rule.yml
@@ -37,3 +37,5 @@ references:
     cis-csc: 1,11,12,13,14,15,16,18,3,4,6,8,9
 
 ocil: '{{{ ocil_service_disabled(service="rdisc") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_rhnsd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rhnsd_disabled/rule.yml
@@ -37,3 +37,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="rhnsd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_rhsmcertd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rhsmcertd_disabled/rule.yml
@@ -33,3 +33,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="rhsmcertd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_saslauthd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_saslauthd_disabled/rule.yml
@@ -34,3 +34,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="saslauthd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_smartd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_smartd_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="smartd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/base/service_sysstat_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_sysstat_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="sysstat") }}}'
+
+platform: machine

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/rule.yml
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/rule.yml
@@ -38,3 +38,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="atd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="dhcpd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
@@ -28,3 +28,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="named") }}}'
+
+platform: machine

--- a/linux_os/guide/services/ftp/disabling_vsftpd/service_vsftpd_disabled/rule.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/service_vsftpd_disabled/rule.yml
@@ -30,3 +30,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="vsftpd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
@@ -27,3 +27,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="httpd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
@@ -20,3 +20,5 @@ references:
     cis: 2.2.11
 
 ocil: '{{{ ocil_service_disabled(service="dovecot") }}}'
+
+platform: machine

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
@@ -23,3 +23,5 @@ identifiers:
 
 references:
     cis: 2.2.7
+
+platform: machine

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -31,3 +31,5 @@ references:
 ocil_clause: 'it does not'
 
 ocil: '{{{ ocil_service_disabled(service="nfs") }}}'
+
+platform: machine

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_rpcsvcgssd_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_rpcsvcgssd_disabled/rule.yml
@@ -20,3 +20,5 @@ identifiers:
     cce@rhel7: 80238-9
 
 ocil: '{{{ ocil_service_disabled(service="rpcsvcgssd") }}}'
+
+platform: machine

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/service_xinetd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/service_xinetd_disabled/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
     If network services are using the xinetd service, this is not applicable.
     <br /><br />
     {{{ ocil_service_disabled(service="xinetd") }}}
+
+platform: machine

--- a/linux_os/guide/services/obsolete/nis/service_ypbind_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/service_ypbind_disabled/rule.yml
@@ -34,3 +34,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="ypbind") }}}'
+
+platform: machine

--- a/linux_os/guide/services/obsolete/r_services/service_rexec_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rexec_disabled/rule.yml
@@ -39,3 +39,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 {{{ complete_ocil_entry_socket_and_service_disabled("rexec") }}}
+
+platform: machine

--- a/linux_os/guide/services/obsolete/r_services/service_rlogin_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rlogin_disabled/rule.yml
@@ -40,3 +40,5 @@ references:
     cis-csc: 1,11,12,14,15,16,3,5,8,9
 
 {{{ complete_ocil_entry_socket_and_service_disabled("rlogin") }}}
+
+platform: machine

--- a/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
@@ -39,3 +39,5 @@ references:
     cis-csc: 1,11,12,14,15,16,3,5,8,9
 
 {{{ complete_ocil_entry_socket_and_service_disabled("rsh") }}}
+
+platform: machine

--- a/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
@@ -59,3 +59,5 @@ references:
     cis-csc: 1,11,12,14,15,16,3,5,8,9
 
 {{{ complete_ocil_entry_socket_and_service_disabled("telnet") }}}
+
+platform: machine

--- a/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
@@ -32,3 +32,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="tftp") }}}'
+
+platform: machine

--- a/linux_os/guide/services/printing/service_cups_disabled/rule.yml
+++ b/linux_os/guide/services/printing/service_cups_disabled/rule.yml
@@ -25,3 +25,5 @@ references:
     cis-csc: 11,14,3,9
 
 ocil: '{{{ ocil_service_disabled(service="cups") }}}'
+
+platform: machine

--- a/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
+++ b/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
@@ -20,3 +20,5 @@ references:
     cis: 2.2.13
 
 ocil: '{{{ ocil_service_disabled(service="squid") }}}'
+
+platform: machine

--- a/linux_os/guide/services/routing/disabling_quagga/service_zebra_disabled/rule.yml
+++ b/linux_os/guide/services/routing/disabling_quagga/service_zebra_disabled/rule.yml
@@ -30,3 +30,5 @@ references:
     cis-csc: 12,15,8
 
 ocil: '{{{ ocil_service_disabled(service="zebra") }}}'
+
+platform: machine

--- a/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
@@ -21,3 +21,5 @@ references:
     disa: "1436"
 
 ocil: '{{{ ocil_service_disabled(service="smb") }}}'
+
+platform: machine

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -21,3 +21,5 @@ references:
     cis: 2.2.14
 
 ocil: '{{{ ocil_service_disabled(service="snmpd") }}}'
+
+platform: machine

--- a/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
@@ -34,3 +34,5 @@ references:
     cis-csc: 11,12,14,15,3,8,9
 
 ocil: '{{{ ocil_service_disabled(service="bluetooth") }}}'
+
+platform: machine

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
@@ -47,3 +47,5 @@ references:
     cis-csc: 1,12,15,16,5
 
 ocil: '{{{ ocil_service_disabled(service="autofs") }}}'
+
+platform: machine


### PR DESCRIPTION
#### Description:

- These rules pass when scanning container but we want them as notapplicable.

#### Rationale:

- Rules who have ocil as ocil_service_disabled or complete_ocil_entry_socket_and_service_disabled were marked as machine only.
