### PR TITLE
Finish renaming STIG and CUI profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ ssg-rhel7-role-C2S.yml
 ssg-rhel7-role-cjis-rhel7-server.yml
 ssg-rhel7-role-common.yml
 ssg-rhel7-role-docker-host.yml
-ssg-rhel7-role-nist-800-171-cui.yml
+ssg-rhel7-role-cui.yml
 ...
 ```
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -192,8 +192,8 @@ Spreadsheet HTML tables - potentially useful as the basis for an
 ```bash
 $ ls -1 tables/table-rhel7-*.html
 ...
-tables/table-rhel7-nistrefs-ospp-rhel7.html
-tables/table-rhel7-nistrefs-stig-rhel7-disa.html
+tables/table-rhel7-nistrefs-ospp.html
+tables/table-rhel7-nistrefs-stig.html
 tables/table-rhel7-pcidssrefs.html
 tables/table-rhel7-srgmap-flat.html
 tables/table-rhel7-srgmap.html

--- a/rhel7/profiles/ipa-stig.profile
+++ b/rhel7/profiles/ipa-stig.profile
@@ -7,6 +7,6 @@ description: |-
     developed under the DoD consensus model to become a STIG in
     coordination with DISA FSO.
 
-extends: stig-http-disa
+extends: http-stig
 
 selections: []

--- a/rhel7/profiles/satellite-stig.profile
+++ b/rhel7/profiles/satellite-stig.profile
@@ -7,6 +7,6 @@ description: |-
     developed under the DoD consensus model to become a STIG in
     coordination with DISA FSO.
 
-extends: stig-http-disa
+extends: http-stig
 
 selections: []

--- a/rhel7/profiles/tower-stig.profile
+++ b/rhel7/profiles/tower-stig.profile
@@ -7,6 +7,6 @@ description: |-
     developed under the DoD consensus model to become a STIG in
     coordination with DISA FSO.
 
-extends: stig-http-disa
+extends: http-stig
 
 selections: []

--- a/tests/README.md
+++ b/tests/README.md
@@ -184,7 +184,7 @@ target domain and remediates it based on particular profile.
 
 To test RHEL7 STIG Profile on a VM:
 ```
-./test_suite.py profile --libvirt qemu:///session ssg-test-suite-rhel7 --datastream ../build/ssg-rhel7-ds.xml stig-rhel7-disa
+./test_suite.py profile --libvirt qemu:///session ssg-test-suite-rhel7 --datastream ../build/ssg-rhel7-ds.xml stig
 ```
 
 To test Fedora Standard Profile on a Podman container:

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/krb_sec_set.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/krb_sec_set.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_all_krb_sec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_all_krb_sec.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/
 sed -i 's/,sec=krb5:krb5i:krb5p//' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_krb_sec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/missing_krb_sec.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/
 # delete sec=.. only from nfs4

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/no_nfs.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_krb_sec_remote_filesystems/no_nfs.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/
 sed -i '/nfs/d' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_all_noexec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_all_noexec.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/
 sed -i 's/,noexec//' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_noexec.fail.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/missing_noexec.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/
 sed -i 's|\(.*nfs4.*\),noexec\(.*\)|\1\2|' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/no_nfs.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/no_nfs.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/
 sed -i '/nfs/d' /etc/fstab

--- a/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/noexec_set.pass.sh
+++ b/tests/data/group_services/group_nfs_and_rpc/group_nfs_configuring_clients/group_mounting_remote_filesystems/rule_mount_option_noexec_remote_filesystems/noexec_set.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp ../fstab /etc/

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony.pass.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y chrony
 yum remove -y ntp

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_nothing_done.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_nothing_done.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y chrony
 yum remove -y ntp

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/chrony_one_server_misconfigured.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y chrony
 yum remove -y ntp

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y ntp
 yum remove -y chrony

--- a/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
+++ b/tests/data/group_services/group_ntp/rule_chronyd_or_ntpd_set_maxpoll/ntp_wrong_maxpoll.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y ntp
 yum remove -y chrony

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_allow_only_protocol2/openssh-6.6-configured.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_allow_only_protocol2/openssh-6.6-configured.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # Test targeted to RHEL 7.4
 yum downgrade -y openssh-6.6.1p1 openssh-clients-6.6.1p1 openssh-server-6.6.1p1

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_allow_only_protocol2/openssh-6.6.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_allow_only_protocol2/openssh-6.6.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # Test targeted to RHEL 7.4
 yum downgrade -y openssh-6.6.1p1 openssh-clients-6.6.1p1 openssh-server-6.6.1p1

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_allow_only_protocol2/openssh-7.4.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_allow_only_protocol2/openssh-7.4.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 
 yum install -y openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/domain_not_there.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/domain_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_sssd_config

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir.pass.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_sssd_config

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir_bad_value.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir_bad_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_sssd_config

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir_not_absolute_path.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir_not_absolute_path.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_sssd_config

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir_not_there.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_configure_tls_ca_dir/ldap_tls_cacertdir_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_sssd_config

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/ldap_use_start_tls_false.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/ldap_use_start_tls_false.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_auth_and_sssd_configs

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/ldap_use_start_tls_not_there.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/ldap_use_start_tls_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_auth_and_sssd_configs

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/useldapauth_and_start_tls.pass.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/useldapauth_and_start_tls.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_auth_and_sssd_configs

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/useldapauth_no.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/useldapauth_no.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_auth_and_sssd_configs

--- a/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/useldapauth_not_there.fail.sh
+++ b/tests/data/group_services/group_sssd/group_sssd-ldap/rule_sssd_ldap_start_tls/useldapauth_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../setup_config_files.sh
 setup_correct_auth_and_sssd_configs

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_missing.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 SSSD_PAM_SERVICES_REGEX="^[\s]*\[sssd]([^\n]*\n+)+?[\s]*services.*pam.*$"
 SSSD_PAM_SERVICES="[sssd]

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/services_pam_wrong_section.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 cp wrong_sssd.conf $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/sssd_pam_services.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_enable_pam_services/sssd_pam_services.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 SSSD_PAM_SERVICES_REGEX="^[\s]*\[sssd]([^\n]*\n+)+?[\s]*services.*pam.*$"
 SSSD_PAM_SERVICES="[sssd]

--- a/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_dod_default_banner.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_dod_default_banner.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # dod_default banner
 echo "You are accessing a U.S. Government (USG) Information System (IS) that is 

--- a/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_dod_short.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_dod_short.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # dod_short banner
 echo "I've read & consent to terms in IS user agreem't." > /etc/issue

--- a/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_double_banner.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_double_banner.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # dod_default|dod_short banner
 echo "You are accessing a U.S. Government (USG) Information System (IS) that is 

--- a/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_usgcb_banner.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-banners/rule_banner_etc_issue/banner_etc_issue_disa_usgcb_banner.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # usgcb_default banner
 echo "-- WARNING -- This system is for the use of authorized users only. Individuals 

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/both-correct.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/both-correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set-up-pamd.sh
 
 set-up-pamd

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-default-die-pam_faillock.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-default-die-pam_faillock.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set-up-pamd.sh
 
 set-up-pamd

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-required-pam_faillock.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny_root/missing-required-pam_faillock.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set-up-pamd.sh
 
 set-up-pamd

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_set_password_hashing_algorithm/rule_set_password_hashing_algorithm_libuserconf/correct_crypt_style.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_set_password_hashing_algorithm/rule_set_password_hashing_algorithm_libuserconf/correct_crypt_style.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # example libuser.conf has set 'crypt_style = sha512'
 cp libuser.conf /etc/

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_set_password_hashing_algorithm/rule_set_password_hashing_algorithm_libuserconf/no_crypt_style.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_set_password_hashing_algorithm/rule_set_password_hashing_algorithm_libuserconf/no_crypt_style.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp libuser.conf /etc/
 sed -i "/crypt_style/d" /etc/libuser.conf

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_set_password_hashing_algorithm/rule_set_password_hashing_algorithm_libuserconf/weak_algorithm.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_set_password_hashing_algorithm/rule_set_password_hashing_algorithm_libuserconf/weak_algorithm.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp libuser.conf /etc/
 sed -i "s/crypt_style = sha512/crypt_style = md5/" /etc/libuser.conf

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/comment.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then
 	sed -i "s/^CREATE_HOME.*/CREATE_HOME yes/" /etc/login.defs

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/line_not_there.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/line_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 sed -i "/.*CREATE_HOME.*/d" /etc/login.defs

--- a/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_have_homedir_login_defs/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_activated.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_encrypt_sent_records/encrypt_sent_records_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../../auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_activated_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_not_activated.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_audispd_syslog_plugin_activated/audisp_syslog_plugin_not_activated.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_data.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_data.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental_async.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental_async.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_none.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_none.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_sync.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_sync.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_greater_than_minimum.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_greater_than_minimum.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_minimum_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_minimum_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_enough.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_enough.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_num_logs/num_logs_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_greater_than_minimum.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_greater_than_minimum.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_minimum_value.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_minimum_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_not_enough.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_not_enough.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left/space_left_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_email.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_email.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_exec.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_exec.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_halt.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_halt.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_ignore.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_ignore.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_single.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_single.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_suspend.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_suspend.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_syslog.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_space_left_action/space_left_action_syslog.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_bootloader-grub2/rule_grub2_password/missing.fail.sh
+++ b/tests/data/group_system/group_bootloader-grub2/rule_grub2_password/missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = none
 
 . grub-passwords.sh

--- a/tests/data/group_system/group_bootloader-grub2/rule_grub2_password/no-grub.pass.sh
+++ b/tests/data/group_system/group_bootloader-grub2/rule_grub2_password/no-grub.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . grub-passwords.sh
 

--- a/tests/data/group_system/group_bootloader-grub2/rule_grub2_password/password-set.pass.sh
+++ b/tests/data/group_system/group_bootloader-grub2/rule_grub2_password/password-set.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . grub-passwords.sh
 

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/cron_set_rsyslog_conf.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/cron_set_rsyslog_conf.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/cron_set_rsyslog_d.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/cron_set_rsyslog_d.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/no_cron_logging.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/no_cron_logging.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 
 RSYSLOG_CONF='/etc/rsyslog.conf'
 RSYSLOG_D_FILES='/etc/rsyslog.d/*'

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/no_rsyslog_file.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/no_rsyslog_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/rsyslog.conf
 rm -rf /etc/rsyslog.d

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/wrong_log_rsyslog_conf.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_cron_logging/wrong_log_rsyslog_conf.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_nist-800-171-cui, xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/comment.fail.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 if grep -q "^net.ipv4.conf.all.secure_redirects" /etc/sysctl.conf; then
 	sed -i "s/^net.ipv4.conf.all.secure_redirects.*/# net.ipv4.conf.all.secure_redirects = 0/" /etc/sysctl.conf

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/correct_value.pass.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 if grep -q "^net.ipv4.conf.all.secure_redirects" /etc/sysctl.conf; then
 	sed -i "s/^net.ipv4.conf.all.secure_redirects.*/net.ipv4.conf.all.secure_redirects = 0/" /etc/sysctl.conf

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/line_not_there.fail.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/line_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 sed -i "/^net.ipv4.conf.all.secure_redirects.*/d" /etc/sysctl.conf
 # setting correct runtime value to check it properly

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/wrong_value.fail.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_all_secure_redirects/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 if grep -q "^net.ipv4.conf.all.secure_redirects" /etc/sysctl.conf; then
 	sed -i "s/^net.ipv4.conf.all.secure_redirects.*/net.ipv4.conf.all.secure_redirects = 1/" /etc/sysctl.conf

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/comment.fail.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 if grep -q "^net.ipv4.conf.default.secure_redirects" /etc/sysctl.conf; then
 	sed -i "s/^net.ipv4.conf.default.secure_redirects.*/# net.ipv4.conf.default.secure_redirects = 0/" /etc/sysctl.conf

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/correct_value.pass.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 if grep -q "^net.ipv4.conf.default.secure_redirects" /etc/sysctl.conf; then
 	sed -i "s/^net.ipv4.conf.default.secure_redirects.*/net.ipv4.conf.default.secure_redirects = 0/" /etc/sysctl.conf

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/line_not_there.fail.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/line_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 sed -i "/^net.ipv4.conf.default.secure_redirects.*/d" /etc/sysctl.conf

--- a/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/wrong_value.fail.sh
+++ b/tests/data/group_system/group_network/group_network-kernel/group_network_host_and_router_parameters/rule_sysctl_net_ipv4_conf_default_secure_redirects/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_nist-800-171-cui
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_cui
 
 if grep -q "^net.ipv4.conf.default.secure_redirects" /etc/sysctl.conf; then
 	sed -i "s/^net.ipv4.conf.default.secure_redirects.*/net.ipv4.conf.default.secure_redirects = 1/" /etc/sysctl.conf

--- a/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_home_nosuid/fstab.fail.sh
+++ b/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_home_nosuid/fstab.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../partition.sh
 

--- a/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_home_nosuid/runtime.pass.sh
+++ b/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_home_nosuid/runtime.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../partition.sh
 

--- a/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_home_nosuid/separate.fail.sh
+++ b/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_home_nosuid/separate.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . ../partition.sh
 

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/cron_weekly_configured.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/cron_weekly_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_configured.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_just_periodic_checking.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/crontab_just_periodic_checking.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/default.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/default.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/var_cron_configured.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_aide/rule_aide_scan_notification/var_cron_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig-rhel7-disa
+# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -55,11 +55,11 @@ PROFILE_WHITELIST = set([
     "C2S",
     "cjis",
     "hipaa",
-    "nist-800-171-cui",
+    "cui",
     "ospp",
     "pci-dss",
     "rht-ccp",
-    "stig-rhel7-disa",
+    "stig",
 ])
 
 


### PR DESCRIPTION
In #4250 multiple STIG and CUI profiles have been renamed, but
there are still a lot of occurrences of the old names, mainly in the
test suite scenarios. This patch finishes the renaming everywhere.
