### PR TITLE
Build playbooks also for virtual '(all)' profile

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -257,6 +257,10 @@ macro(ssg_build_ansible_playbooks PRODUCT)
         generate-${PRODUCT}-ansible-playbooks
         DEPENDS "${ANSIBLE_PLAYBOOKS_DIR}"
     )
+    add_test(
+        NAME "${PRODUCT}-ansible-playbooks-generated-for-all-rules"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/ansible_playbooks_generated_for_all_rules.py" --build-dir "${CMAKE_BINARY_DIR}" --product "${PRODUCT}"
+    )
 endmacro()
 
 macro(ssg_build_remediations PRODUCT)

--- a/debian8/transforms/constants.xslt
+++ b/debian8/transforms/constants.xslt
@@ -6,7 +6,7 @@
 <xsl:variable name="product_short_name">Debian 8</xsl:variable>
 <xsl:variable name="product_stig_id_name">DEBIAN_8_STIG</xsl:variable>
 <xsl:variable name="product_guide_id_name">DEBIAN-8</xsl:variable>
-<xsl:variable name="prod_type">debian</xsl:variable>
+<xsl:variable name="prod_type">debian8</xsl:variable>
 
 <!-- Define URI of official Center for Internet Security Benchmark for Debian Linux v1.0 -->
 <xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf</xsl:variable>

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -974,6 +974,11 @@ The Ansible remediation will get included by our build system to the SCAP datast
 The build system generates an Ansible Playbook from the remediation for all profiles.
 The generated Playbook is located in `/build/<product>/playbooks/<profile_id>/<rule_id>.yml`.
 
+For each rule in the given product we also generate an Ansible Playbook regardless presence of the rule in any profile.
+The generated Playbook is located in `/build/<product>/playbooks/all/<rule_id>.yml`.
+The `/build/<product>/playbooks/all/` directory represents the virtual `(all)` profile which consists of all rules in the product.
+Due to undefined XCCDF Value selectors in this pseudo-profile, these Playbooks use default values of XCCDF Values when applicable.
+
 We also build profile Playbook that contains tasks for all rules in the profile.
 The Playbook is generated in `/build/roles/ssg-<product>-role-<profile_id>.yml`.
 

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,ubuntu1404,ubuntu1604,ol7,ol8,rhv4
+prodtype: rhel6,rhel7,rhel8,ubuntu1404,ubuntu1604,ubuntu1804,ol7,ol8,rhv4
 
 title: 'Ensure Software Patches Installed'
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -11,6 +11,7 @@ import yaml
 from .constants import XCCDF_PLATFORM_TO_CPE
 from .constants import PRODUCT_TO_CPE_MAPPING
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
+from .rule_yaml import parse_prodtype
 
 from .checks import is_cce_format_valid, is_cce_value_valid
 from .yaml import open_and_expand, open_and_macro_expand
@@ -787,6 +788,7 @@ class DirectoryLoader(object):
         self.profiles_dir = profiles_dir
         self.bash_remediation_fns = bash_remediation_fns
         self.env_yaml = env_yaml
+        self.product = env_yaml["product"]
 
         self.parent_group = None
 
@@ -897,6 +899,9 @@ class BuildLoader(DirectoryLoader):
     def _process_rules(self):
         for rule_yaml in self.rule_files:
             rule = Rule.from_yaml(rule_yaml, self.env_yaml)
+            prodtypes = parse_prodtype(rule.prodtype)
+            if "all" not in prodtypes and self.product not in prodtypes:
+                continue
             self.loaded_group.add_rule(rule)
             if self.resolved_rules_dir:
                 output_for_rule = os.path.join(

--- a/tests/ansible_playbooks_generated_for_all_rules.py
+++ b/tests/ansible_playbooks_generated_for_all_rules.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+
+import xml.etree.ElementTree as ET
+import os
+import os.path
+import argparse
+
+XCCDF_NS = "http://checklists.nist.gov/xccdf/1.2"
+
+
+def compare_ds_with_playbooks_dir(ds_path, playbooks_dir_path):
+    tree = ET.parse(ds_path)
+    root = tree.getroot()
+    rules_in_ds_with_ansible_fix = []
+    # uses the first benchmark if multiple benchmarks are present
+    benchmark = root.find(".//{%s}Benchmark" % XCCDF_NS)
+    for rule in benchmark.findall(".//{%s}Rule" % XCCDF_NS):
+        for fix in rule.findall("./{%s}fix" % XCCDF_NS):
+            system = fix.get("system")
+            if system == "urn:xccdf:fix:script:ansible":
+                id_ = rule.get("id")
+                id_ = id_.replace("xccdf_org.ssgproject.content_rule_", "")
+                rules_in_ds_with_ansible_fix.append(id_)
+    playbooks_in_dir = []
+    for filename in os.listdir(playbooks_dir_path):
+        id_, _ = os.path.splitext(filename)
+        playbooks_in_dir.append(id_)
+    assert set(rules_in_ds_with_ansible_fix) == set(playbooks_in_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Tests if Ansible Playbooks were generated for all rules"
+        "that have an Ansible remediation available in datastream."
+    )
+    parser.add_argument("--build-dir", required=True,
+                        help="Build directory containing built datastreams"
+                        "and playbooks subdirectory")
+    parser.add_argument("--product", required=True,
+                        help="Product ID")
+    args = parser.parse_args()
+    ds_path = os.path.join(args.build_dir, "ssg-" + args.product + "-ds.xml")
+    playbooks_dir_path = os.path.join(args.build_dir, args.product,
+                                      "playbooks", "all")
+    compare_ds_with_playbooks_dir(ds_path, playbooks_dir_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/ubuntu1404/transforms/constants.xslt
+++ b/ubuntu1404/transforms/constants.xslt
@@ -6,7 +6,7 @@
 <xsl:variable name="product_short_name">Ubuntu 1404</xsl:variable>
 <xsl:variable name="product_stig_id_name">UBUNTU_TRUSTY_STIG</xsl:variable>
 <xsl:variable name="product_guide_id_name">UBUNTU-TRUSTY</xsl:variable>
-<xsl:variable name="prod_type">ubuntu</xsl:variable>
+<xsl:variable name="prod_type">ubuntu1404</xsl:variable>
 
 <!-- Define URI of official Center for Internet Security Benchmark for Ubuntu Linux v1.0 -->
 <xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/ubuntu_linux/</xsl:variable>

--- a/ubuntu1604/transforms/constants.xslt
+++ b/ubuntu1604/transforms/constants.xslt
@@ -6,7 +6,7 @@
 <xsl:variable name="product_short_name">Ubuntu 1604</xsl:variable>
 <xsl:variable name="product_stig_id_name">UBUNTU_XENIAL_STIG</xsl:variable>
 <xsl:variable name="product_guide_id_name">UBUNTU-XENIAL</xsl:variable>
-<xsl:variable name="prod_type">ubuntu</xsl:variable>
+<xsl:variable name="prod_type">ubuntu1604</xsl:variable>
 
 <!-- Define URI of official Center for Internet Security Benchmark for Ubuntu Linux v1.0 -->
 <xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/ubuntu_linux/</xsl:variable>

--- a/ubuntu1804/transforms/constants.xslt
+++ b/ubuntu1804/transforms/constants.xslt
@@ -6,7 +6,7 @@
 <xsl:variable name="product_short_name">Ubuntu 1804</xsl:variable>
 <xsl:variable name="product_stig_id_name">UBUNTU_BIONIC_BEAVER</xsl:variable>
 <xsl:variable name="product_guide_id_name">UBUNTU-BIONIC</xsl:variable>
-<xsl:variable name="prod_type">ubuntu</xsl:variable>
+<xsl:variable name="prod_type">ubuntu1804</xsl:variable>
 
 <!-- Define URI of official Center for Internet Security Benchmark for Ubuntu Linux v1.0 -->
 <xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/ubuntu_linux/</xsl:variable>


### PR DESCRIPTION
#### Description:
Generates playbooks for all product rules without profile context to a directory.

The playbooks will be generated into `/build/${product}/playbooks/all` directory.

To do the build easily, we fixed a problem that `/build/${product}/rules` directory contained also rules that weren't applicable to given product, now the directory will contain only relevant rules.

The PR also adds a small test that compares the built datastream and `/build/${product}/playbooks/all` to check if Ansible Playbooks were generated for all rules that have an Ansible remediation available in datastream.

#### Rationale:


A product typically contains lots of rules, not all of them are part of any profile. As it may happen that a rule falls out of a profile, it is a good idea to be able to generate playbooks for all rules that are not part of any profile using the build_rule_playbooks.py script.

