### PR TITLE
[issue 4253] api_server_authorization_mode XCCDF and OVAL updates

### DIFF
--- a/applications/openshift/api-server/api_server_authorization_mode/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_authorization_mode/oval/shared.xml
@@ -5,7 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_ocp</platform>
       </affected>
-      <description>authorization-mode should be set to Webhook, or not set (default is Webhook).</description>
+      <description>If authorization-mode is configured, it should be set to Webhook.</description>
     </metadata>
     <criteria operator="OR">
       <criterion comment="authorization-mode not set, using default" test_ref="test_api_server_authorization_mode_default" />

--- a/applications/openshift/api-server/api_server_authorization_mode/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_authorization_mode/oval/shared.xml
@@ -1,25 +1,40 @@
 <def-group>
   <definition class="compliance" id="api_server_authorization_mode" version="1">
     <metadata>
-      <title>Disable use of AlwaysAllow for the API Server Authorization Mode</title>
+      <title>Ensure authorization-mode is set to Webhook</title>
       <affected family="unix">
         <platform>multi_platform_ocp</platform>
       </affected>
-      <description>AlwaysAllow should not be configured for authentication on the master node.</description>
+      <description>authorization-mode should be set to Webhook, or not set (default is Webhook).</description>
     </metadata>
-    <criteria operator="AND">
-      <criterion comment="AlwaysAllow does not exist" test_ref="test_api_server_authorization_mode" />
+    <criteria operator="OR">
+      <criterion comment="authorization-mode not set, using default" test_ref="test_api_server_authorization_mode_default" />
+      <criterion comment="authorization mode is set to Webhook" test_ref="test_api_server_authorization_mode_webhook" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="AlwaysAllow does not exist" id="test_api_server_authorization_mode" version="1">
-    <ind:object object_ref="object_api_server_authorization_mode" />
+  <!-- tests for default configuration value (e.g. authorization-mode not configured) -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="authorization-mode does not exist" id="test_api_server_authorization_mode_default" version="1">
+    <ind:object object_ref="object_api_server_authorization_mode_default" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_api_server_authorization_mode" version="1">
+  <ind:textfilecontent54_object id="object_api_server_authorization_mode_default" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*authorization-mode\:[\n]+[\s*]-[\s]+AlwaysAllow[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*authorization-mode\:*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  <!-- end test for default configuration value -->
+
+  <!-- tests for authorization-mode to be set to Webhook -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="authorization-mode does not exist" id="test_api_server_authorization_mode_webhook" version="1">
+    <ind:object object_ref="object_api_server_authorization_mode_webhook" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_api_server_authorization_mode_webhook" version="1">
+    <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*authorization-mode\:[\n]+[\s*]-[\s]+Webhook[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <!-- end test for default configuration value -->
 
 </def-group>

--- a/applications/openshift/api-server/api_server_authorization_mode/rule.yml
+++ b/applications/openshift/api-server/api_server_authorization_mode/rule.yml
@@ -8,15 +8,17 @@ description: |-
     By default, unauthenticated/unauthorized users have no access to OpenShift nodes
     and the API Server <tt>authorization-mode</tt> is set to <tt>Webhook</tt>.
     To ensure that the API server requires authorization for API requests,
-    validate that <tt>authorization-mode</tt> is is configured to <tt>Webhook</tt>
+    validate that <tt>authorization-mode</tt> is configured to <tt>Webhook</tt>
     in <tt>/etc/origin/master/master-config.yaml</tt>:
     <pre>kubernetesMasterConfig:
       apiServerArguments:
         authorization-mode:
         - Webhook</pre>
 
-    NOTE: If <tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>, the node
-    systemd service (<tt>atomic-openshift-node</tt>) will not start.
+warnings:
+  - functionality: |-
+      If <tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>, the node
+      systemd service (<tt>atomic-openshift-node</tt>) will not start.
 
 rationale: |-
     Ensuring <tt>authorization-mode</tt> is set to <tt>Webhook</tt> helps enforce that

--- a/applications/openshift/api-server/api_server_authorization_mode/rule.yml
+++ b/applications/openshift/api-server/api_server_authorization_mode/rule.yml
@@ -2,31 +2,32 @@ documentation_complete: true
 
 prodtype: ocp3
 
-title: 'Disable use of AlwaysAllow for the API Server Authorization Mode'
+title: 'Ensure API Server authorization-mode is set to Webhook'
 
 description: |-
-    The OpenShift API server should not allow anonymous API requests.
+    By default, unauthenticated/unauthorized users have no access to OpenShift nodes
+    and the API Server <tt>authorization-mode</tt> is set to <tt>Webhook</tt>.
     To ensure that the API server requires authorization for API requests,
-    validate that <tt>AlwaysAllow</tt> is not configured for <tt>authorization-mode</tt>
+    validate that <tt>authorization-mode</tt> is is configured to <tt>Webhook</tt>
     in <tt>/etc/origin/master/master-config.yaml</tt>:
     <pre>kubernetesMasterConfig:
       apiServerArguments:
         authorization-mode:
-        - AlwaysAllow</pre>
+        - Webhook</pre>
 
 rationale: |-
-    The <tt>AlwaysAllow</tt> authorization mode allows all requests including
-    anonymous requests. This would grant any authenticated entity full cluster
-    access.
+    If <tt>authorization-mode</tt> is configured ensure the value is set to <tt>Webhook</tt> The
+    node systemd service (<tt>atomic-openshift-node</tt>) will not start if the configuration
+    value is set to anything other than <tt>Webhook</tt>.
 
 severity: medium
 
 references:
     cis: 1.1.31
 
-ocil_clause: '<tt>authorization-mode</tt> is configured to use <tt>AlwaysAllow</tt>'
+ocil_clause: '<tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>'
 
 ocil: |-
     Run the following command on the master node(s):
     <pre>$ sudo grep -A1 authorization-mode /etc/origin/master/master-config.yaml</pre>
-    Verify that the output does not contain <tt>AlwaysAllow</tt>.
+    Verify that there is no output, or the output is set to <tt>Webhook</tt>.

--- a/applications/openshift/api-server/api_server_authorization_mode/rule.yml
+++ b/applications/openshift/api-server/api_server_authorization_mode/rule.yml
@@ -15,10 +15,12 @@ description: |-
         authorization-mode:
         - Webhook</pre>
 
+    NOTE: If <tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>, the node
+    systemd service (<tt>atomic-openshift-node</tt>) will not start.
+
 rationale: |-
-    If <tt>authorization-mode</tt> is configured ensure the value is set to <tt>Webhook</tt> The
-    node systemd service (<tt>atomic-openshift-node</tt>) will not start if the configuration
-    value is set to anything other than <tt>Webhook</tt>.
+    Ensuring <tt>authorization-mode</tt> is set to <tt>Webhook</tt> helps enforce that
+    unauthenticated/unauthorized users have no access to OpenShift nodes.
 
 severity: medium
 


### PR DESCRIPTION
resolves https://github.com/ComplianceAsCode/content/issues/4253

- update to look for default (no config) or authorization-mode to be set to Webhook
