### PR TITLE
[wip] remove extended def from ./kubelet/kubelet_configure_client_ca/oval/s…

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_client_ca/oval/shared.xml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/oval/shared.xml
@@ -8,7 +8,6 @@
       <description>Ensure the OpenShift node kubelet is using certificates</description>
     </metadata>
     <criteria operator="AND">
-      <extend_definition comment="Runtime configuration is correct" definition_ref="ocp_service_runtime_config_client_ca_file" />
       <criterion comment="clientCA is configured" test_ref="test_kubelet_configure_client_ca" />
     </criteria>
   </definition>


### PR DESCRIPTION

the extended check doesn't exist, causing this rule to always fail
