### PR TITLE
Profile/Product statistics in HTML - improvement for profile_stats.py and jenkins integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,9 @@ add_subdirectory("tests")
 add_custom_target(stats)
 add_custom_target(profile-stats)
 
+add_custom_target(html-stats)
+add_custom_target(html-profile-stats)
+
 ssg_build_bash_remediation_functions()
 
 ssg_build_man_page()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ find_python_module(yaml REQUIRED)
 find_python_module(jinja2 REQUIRED)
 find_python_module(pytest)
 find_python_module(pytest_cov)
+find_python_module(json2html)
 
 include(CMakeDependentOption)
 cmake_dependent_option(ENABLE_PYTHON_COVERAGE "Enable Python tests with coverage support" ON "PY_PYTEST_COV" OFF)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![CentOS CI Status](https://ci.centos.org/job/openscap-scap-security-guide/badge/icon)](https://ci.centos.org/job/openscap-scap-security-guide/)
 [![Travis CI Build Status](https://travis-ci.org/OpenSCAP/scap-security-guide.svg?branch=master)](https://travis-ci.org/OpenSCAP/scap-security-guide)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ComplianceAsCode/content/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ComplianceAsCode/content/?branch=master)
+[![Profile Statistics](https://jenkins.complianceascode.io/job/scap-security-guide-stats/badge/icon)](https://jenkins.complianceascode.io/job/scap-security-guide-stats/)
 
 <a href="docs/readme_images/report_sample.png"><img align="right" width="250" src="docs/readme_images/report_sample.png" alt="Evaluation report sample"></a>
 

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -67,7 +67,7 @@ def parse_args():
                         action="store_true", dest="all",
                         help="Show all available statistics.")
     parser_stats.add_argument("--format", default="plain",
-                        choices=["plain", "json", "csv"],
+                        choices=["plain", "json", "csv", "html"],
                         help="Which format to use for output.")
 
     subtracted_profile_desc = \
@@ -149,6 +149,9 @@ def main():
 
     if args.format == "json":
         print(json.dumps(ret, indent=4))
+    if args.format == "html":
+        from json2html import json2html
+        print(json2html.convert(json = json.dumps(ret)))
     elif args.format == "csv":
         # we can assume ret has at least one element
         # CSV header

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -633,14 +633,14 @@ endmacro()
 macro(ssg_make_stats_for_product PRODUCT)
     add_custom_target(${PRODUCT}-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Benchmark statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --profile all
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format json --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --profile all >stats
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMENT "[${PRODUCT}-stats] generating benchmark statistics"
     )
     add_custom_target(${PRODUCT}-profile-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Per profile statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format json --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" > profile-stats
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMENT "[${PRODUCT}-profile-stats] generating per profile statistics"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -633,17 +633,32 @@ endmacro()
 macro(ssg_make_stats_for_product PRODUCT)
     add_custom_target(${PRODUCT}-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Benchmark statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --profile all > stats.txt
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --profile all
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMENT "[${PRODUCT}-stats] generating benchmark statistics"
     )
     add_custom_target(${PRODUCT}-profile-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Per profile statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" > profile-stats.txt
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMENT "[${PRODUCT}-profile-stats] generating per profile statistics"
+    )
+endmacro()
+
+macro(ssg_make_html_stats_for_product PRODUCT)
+    add_custom_target(${PRODUCT}-html-stats
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format html --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --profile all > stats.html
+        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMENT "[${PRODUCT}-html-stats] generating benchmark html statistics"
+    )
+    add_custom_target(${PRODUCT}-html-profile-stats
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format html --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" > profile-stats.html
+        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMENT "[${PRODUCT}-html-profile-stats] generating per profile html statistics"
     )
 endmacro()
 
@@ -725,6 +740,10 @@ macro(ssg_build_product PRODUCT)
     ssg_make_stats_for_product(${PRODUCT})
     add_dependencies(stats ${PRODUCT}-stats)
     add_dependencies(profile-stats ${PRODUCT}-profile-stats)
+    ssg_make_html_stats_for_product(${PRODUCT})
+    add_dependencies(html-stats ${PRODUCT}-html-stats)
+    add_dependencies(html-profile-stats ${PRODUCT}-html-profile-stats)
+
     add_dependencies(man_page ${PRODUCT})
 
     if (SSG_SEPARATE_SCAP_FILES_ENABLED)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -633,14 +633,14 @@ endmacro()
 macro(ssg_make_stats_for_product PRODUCT)
     add_custom_target(${PRODUCT}-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Benchmark statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format json --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --profile all >stats
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --profile all > stats.txt
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMENT "[${PRODUCT}-stats] generating benchmark statistics"
     )
     add_custom_target(${PRODUCT}-profile-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Per profile statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format json --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" > profile-stats
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" > profile-stats.txt
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMENT "[${PRODUCT}-profile-stats] generating per profile statistics"

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -70,6 +70,16 @@ yum install yamllint ansible-lint
 yum install ninja-build
 ```
 
+(optional) Install the `json2html` package if you want to use generate HTML report statistics:
+
+```bash
+pip install json2html
+```
+if you are using python3:
+```bash
+pip3 install json2html
+```
+
 ### Downloading the source code
 
 Download and extract a tarball from the [list of releases](https://github.com/ComplianceAsCode/content/releases):
@@ -154,6 +164,20 @@ cd build/
 cmake -G Ninja ../
 ninja-build  # depending on the distribution just "ninja" may also work
 ```
+
+(optional) Generate statistics for products and profiles. Some of the statistics generated are: implemented OVAL, bash, ansible for rules, missing CCE, etc:
+
+```bash
+cd content/
+cd build/
+cmake ../
+make -j4 stats # create statistics for all products
+make -j4 profile-stats # create statistics for all profiles in all products
+```
+
+You can also create statistics per product, to do that just prepend the product name (e.g.: `rhel7-stats`) to the make target.
+
+If you want to go deeper into statistics, refer to <<Profile Statistics and Utilities>> section.
 
 ### Build outputs
 
@@ -597,6 +621,7 @@ For example, to check which rules in RHEL8 OSPP profile are missing remediations
 $ ./build_product rhel8
 $ ./build-scripts/profile_tool.py stats --missing-fixes --profile ospp --benchmark build/ssg-rhel8-xccdf.xml
 ----
+Note: There is an automated job which provides latest statistics from all products and all profiles, you can view it here: link:https://jenkins.complianceascode.io/job/scap-security-guide-stats/[Statistics]
 
 The tool also can subtract rules between YAML profiles.
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -177,6 +177,16 @@ make -j4 profile-stats # create statistics for all profiles in all products
 
 You can also create statistics per product, to do that just prepend the product name (e.g.: `rhel7-stats`) to the make target.
 
+It is possible to generate HTML output by triggering similar command:
+
+```bash
+cd content/
+cd build/
+cmake ../
+make -j4 html-stats # create statistics for all products, as a result <product>/stats.html file is created.
+make -j4 html-profile-stats # create statistics for all profiles in all products, as a result <product>/profile-stats.html file is created
+```
+
 If you want to go deeper into statistics, refer to <<Profile Statistics and Utilities>> section.
 
 ### Build outputs


### PR DESCRIPTION
#### Description:

- Introduces new HTML output format to profile_tool.py statistics tool. This is used by a newly created jenkins job to display information about products and profiles: https://jenkins.complianceascode.io/job/scap-security-guide-stats/Statistics/

#### Rationale:

- This will provide a better way to access the information about product/profile completeness regarding their selected rules. Completeness in a sense of which OVAL/bash/ansible are implemented, missing CCEs, etc. There is room for improvement on what data should be displayed and in which way.
