### PR TITLE
Fix-ups and remote host support for tests/install_vm.py

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -94,13 +94,13 @@ def main():
     print("Using SSH public key from file: {0}".format(data.ssh_pubkey))
     print("Using hypervisor: {0}".format(data.libvirt))
 
-    if not data.disk_dir:
-        if data.libvirt == "qemu:///system":
-            data.disk_dir = "/var/lib/libvirt/images/"
-        else:
-            data.disk_dir = home_dir + "/.local/share/libvirt/images/"
-    data.disk_path = os.path.join(data.disk_dir, data.domain) + ".qcow2"
-    print("Location of VM disk: {0}".format(data.disk_path))
+    if data.disk_dir:
+        disk_path = os.path.join(data.disk_dir, data.domain) + ".qcow2"
+        print("Location of VM disk: {0}".format(disk_path))
+        data.disk_spec = "path={0},format=qcow2,size=20".format(disk_path)
+    else:
+        data.disk_spec = "size=20,format=qcow2"
+
     data.ks_basename = os.path.basename(data.kickstart)
 
     if data.distro == "fedora":
@@ -131,7 +131,7 @@ def main():
         data.network = "default"
     else:
         data.network = "bridge=virbr0"
-    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --os-variant={variant} --hvm --accelerate --network {network} --disk path={disk_path},size=20,format=qcow2 --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} ksdevice=eth0 net.ifnames=0" --graphics=none --noautoconsole --wait=-1 --location={url}'.format(**data.__dict__)
+    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --os-variant={variant} --hvm --accelerate --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} ksdevice=eth0 net.ifnames=0" --graphics=none --noautoconsole --wait=-1 --location={url}'.format(**data.__dict__)
     if data.dry:
         print("\nThe following command would be used for the VM installation:")
         print(command)

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -143,12 +143,14 @@ def main():
 
     print("\nTo determine the IP address of the {0} VM use:".format(data.domain))
     if data.libvirt == "qemu:///system":
-        print("sudo virsh domifaddr {0}\n".format(data.domain))
+        print("  sudo virsh domifaddr {0}\n".format(data.domain))
     else:
-        print("arp -n | grep $(virsh -q domiflist {0} | awk '{{print $5}}')\n".format(data.domain))
-    print("To connect to the {0} VM use:\nssh {1} root@IP".format(data.domain, "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"))
-    print("If you have used the `--ssh-pubkey` also add '-o IdentityFile=PATH_TO_PRIVATE_KEY' option to your ssh command")
-    print("and export the SSH_ADDITIONAL_OPTIONS='-o IdentityFile=PATH_TO_PRIVATE_KEY' before running the SSG Test Suite.")
+        print("  arp -n | grep $(virsh -q domiflist {0} | awk '{{print $5}}')\n".format(data.domain))
+
+    print("To connect to the {0} VM use:\n  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@IP\n".format(data.domain))
+    print("To connect to the VM serial console, use:\n  virsh console {0}\n".format(data.domain))
+    print("If you have used the `--ssh-pubkey` also add '-o IdentityFile=PATH_TO_PRIVATE_KEY' option to your ssh command and export the SSH_ADDITIONAL_OPTIONS='-o IdentityFile=PATH_TO_PRIVATE_KEY' before running the SSG Test Suite.")
+
     if data.libvirt == "qemu:///system":
         print("\nIMPORTANT: When running SSG Test Suite use `sudo -E` to make sure that your SSH key is used.")
 

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python2
+
 import argparse
 import os
 import sys
-
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -10,7 +11,6 @@ def parse_args():
         "--libvirt",
         dest="libvirt",
         default="qemu:///session",
-        choices=("qemu:///session", "qemu:///system"),
         help="What hypervisor should be used when installing VM."
     )
     parser.add_argument(

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -52,6 +52,11 @@ def parse_args():
         help="Number of CPU cores configured for the VM."
     )
     parser.add_argument(
+        "--network",
+        dest="network",
+        help="Network type/spec, ie. bridge=br0 or network=name."
+    )
+    parser.add_argument(
         "--url",
         dest="url",
         default=None,
@@ -119,10 +124,11 @@ def main():
     data.kickstart = tmp_kickstart
     print("Using kickstart file: {0}".format(data.kickstart))
 
-    if data.libvirt == "qemu:///system":
-        data.network = "default"
-    else:
-        data.network = "bridge=virbr0"
+    if not data.network:
+        if data.libvirt == "qemu:///system":
+            data.network = "network=default"
+        else:
+            data.network = "bridge=virbr0"
 
     # The kernel option 'net.ifnames=0' is used to disable predictable network
     # interface names, for more details see:

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -127,7 +127,7 @@ def main():
     # The kernel option 'net.ifnames=0' is used to disable predictable network
     # interface names, for more details see:
     # https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} ksdevice=eth0 net.ifnames=0" --graphics=none --noautoconsole --wait=-1 --location={url}'.format(**data.__dict__)
+    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} ksdevice=eth0 net.ifnames=0 console=ttyS0,115200" --serial pty --graphics=none --noautoconsole --rng /dev/random --wait=-1 --location={url}'.format(**data.__dict__)
 
     if data.dry:
         print("\nThe following command would be used for the VM installation:")

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -57,6 +57,11 @@ def parse_args():
         help="Network type/spec, ie. bridge=br0 or network=name."
     )
     parser.add_argument(
+        "--disk",
+        dest="disk",
+        help="Disk type/spec, ie. pool=MyPool,bus=sata,cache=unsafe."
+    )
+    parser.add_argument(
         "--url",
         dest="url",
         default=None,
@@ -107,7 +112,9 @@ def main():
     print("Using SSH public key from file: {0}".format(data.ssh_pubkey))
     print("Using hypervisor: {0}".format(data.libvirt))
 
-    if data.disk_dir:
+    if data.disk:
+        data.disk_spec = data.disk
+    elif data.disk_dir:
         disk_path = os.path.join(data.disk_dir, data.domain) + ".qcow2"
         print("Location of VM disk: {0}".format(disk_path))
         data.disk_spec = "path={0},format=qcow2,size=20".format(disk_path)

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -127,7 +127,7 @@ def main():
     # The kernel option 'net.ifnames=0' is used to disable predictable network
     # interface names, for more details see:
     # https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --hvm --accelerate --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} ksdevice=eth0 net.ifnames=0" --graphics=none --noautoconsole --wait=-1 --location={url}'.format(**data.__dict__)
+    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} ksdevice=eth0 net.ifnames=0" --graphics=none --noautoconsole --wait=-1 --location={url}'.format(**data.__dict__)
 
     if data.dry:
         print("\nThe following command would be used for the VM installation:")


### PR DESCRIPTION
See the commit messages for each separate commit for more details.

The `install_vm.py` tool lacked support for remote libvirt hosts and also had a bunch of questionable options and hardcoded defaults - I've tried to clean it up to the best of my knowledge and it should now work for both local and remote installs.

If you use this tool in some non-default / non-standard way, please test these changes and let me know if something breaks!