### PR TITLE
Fix Debian8 and Fuse6 CPE dictionaries

### DIFF
--- a/debian8/cpe/debian8-cpe-dictionary.xml
+++ b/debian8/cpe/debian8-cpe-dictionary.xml
@@ -7,4 +7,49 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_debian8</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:shadow-utils">
+            <title xml:lang="en-us">Package shadow-utils is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -164,8 +164,6 @@ PRODUCT_TO_CPE_MAPPING = {
     ],
     "fuse6": [
         "cpe:/a:redhat:jboss_fuse:6.0",
-        "cpe:/a:redhat:jboss_fuse:6.1.0",
-        "cpe:/a:redhat:jboss_fuse_service_works:6.0",
     ],
     "jre": [
         "cpe:/a:oracle:jre:",


### PR DESCRIPTION
#### Description:

- Debian8 CPE dictionaries are missing CPE entries for `machine`, `container` and other Package CPEs
- Fuse6 Benchmark includes CPEs that are not listed in CPE Dictionary
  - The checks for the CPE aren't implemented too
