### PR TITLE
Don't create blank prelink config if not installed

### DIFF
--- a/shared/bash_remediation_functions/disable_prelink.sh
+++ b/shared/bash_remediation_functions/disable_prelink.sh
@@ -1,6 +1,9 @@
 function disable_prelink {
-	# Disable prelinking and don't even check
-	# whether it is installed.
+	# prelink not installed
+	if test ! -e /etc/sysconfig/prelink -a ! -e /usr/sbin/prelink; then
+		return 0
+	fi
+
 	if grep -q ^PRELINKING /etc/sysconfig/prelink
 	then
 		sed -i 's/^PRELINKING[:blank:]*=[:blank:]*[:alpha:]*/PRELINKING=no/' /etc/sysconfig/prelink


### PR DESCRIPTION
RHEL-7 and later doesn't use prelink and the

   printf '\n' >> /etc/sysconfig/prelink

was creating an empty file.

Even though an argument could be made to disable it "just in case somebody installs it", keeping zombie files of a no-longer-used software on the system is a bad practice.