### PR TITLE
Use separate partition for /var/tmp in tests/kickstart

### DIFF
--- a/rhel7/templates/csv/mount_options.csv
+++ b/rhel7/templates/csv/mount_options.csv
@@ -13,11 +13,12 @@
 /dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+# /tmp is mounted as tmpfs by default by systemd (and thus not in fstab)
+/tmp,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/tmp,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/tmp,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /home,nosuid
 /home,nodev
-/tmp,nodev
-/tmp,noexec
-/tmp,nosuid
 /var/tmp,nodev
 /var/tmp,noexec
 /var/tmp,nosuid

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -86,16 +86,16 @@ volgroup VolGroup --pesize=4096 pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=root --vgname=VolGroup --size=12288 --grow
 # CCE-26557-9: Ensure /home Located On Separate Partition
-logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
-# CCE-26435-8: Ensure /tmp Located On Separate Partition
-logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
 # CCE-26639-5: Ensure /var Located On Separate Partition
 logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048 --fsoptions="nodev"
 # CCE-26215-4: Ensure /var/log Located On Separate Partition
 logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
 logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
-logvol swap --name=swap --vgname=VolGroup --size=2016
+# CCE-: Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 
 # Packages selection (%packages section is required)
 %packages


### PR DESCRIPTION
/tmp is mounted as tmpfs by systemd (and will be explicitly remediated
anyway), /var/tmp is supposed to be persistent according to FHS and is
needed for mount_option_var_tmp_nodev.

There is another rule, mount_option_var_tmp_bind, which is in conflict
with this, but its remediation script already accounts with /var/tmp
being on a separate partition, taking appropriate steps.