### PR TITLE
Use VM install repo URL on the installed system

### DIFF
--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -116,6 +116,17 @@ printf "%s\n" "&&HOST_PUBLIC_KEY&&" >> /root/.ssh/authorized_keys
 chmod og-rw /root/.ssh /root/.ssh/authorized_keys
 systemctl enable sshd
 
+# create yum/dnf repository from URL if replaced by install_vm.py
+if ! [[ '&&YUM_REPO_URL&&' =~ YUM_REPO_URL ]]; then
+	cat > /etc/yum.repos.d/inst-ks.repo <<EOF
+[inst-ks]
+name=Installation repo from kickstart
+baseurl=&&YUM_REPO_URL&&
+enabled=1
+gpgcheck=0
+EOF
+fi
+
 %end
 
 # Reboot after the installation is complete (optional)


### PR DESCRIPTION
Fedora doesn't need this (installs mirrors implicitly) and the list can be extended if this logic is checked to work with ie. SLES or openSUSE.

I don't like the `gpgcheck=0`, but the VM is supposed to be transient and this works with internal or otherwise temporary unsigned repositories.