### PR TITLE
Workaround SCAPVal 1.3.2 NullPointerException

### DIFF
--- a/tests/run_scapval.py
+++ b/tests/run_scapval.py
@@ -87,9 +87,19 @@ def test_datastream(datastream_path,  scapval_path, scap_version):
     try:
         subprocess.check_output(scapval_command, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        sys.stderr.write("Command '{0}' returned {1}:\n{2}\n".format(
-            " ".join(e.cmd), e.returncode, e.output.decode("utf-8")))
-        sys.exit(1)
+        scapval_output = e.output.decode("utf-8")
+        # Workaround: SCAPVal 1.3.2 can't generate HTML report because
+        # it throws a NullPointerException, but we don't need the HTML
+        # report for this test, so we can ignore this error.
+        # TODO: Remove this when this is fixed in SCAPVal
+        last_line = scapval_output.splitlines()[-1]
+        if not last_line.endswith(
+                "ERROR SCAPVal has encountered a problem and cannot continue "
+                "with this validation. - java.lang.NullPointerException: "
+                "XSLTemplateExtension cannot be null"):
+            sys.stderr.write("Command '{0}' returned {1}:\n{2}\n".format(
+                " ".join(e.cmd), e.returncode, scapval_output))
+            sys.exit(1)
     return process_results(result_path)
 
 


### PR DESCRIPTION
#### Description:
If run as a non-root user SCAPVal 1.3.2 can't generate HTML report because it throws a NullPointerException. This bug has been reproduced on Fedora 29 and RHEL 7.  We don't wish to run this test as root user. But, we don't need the HTML report for this test, because we parse the plain XML results. For the purpose of this test we can ignore this SCAPVal error until SCAPVal is fixed.

#### Rationale:
We originally thought that the problem with NullPointerException  demonstrates only on Fedora. Then we tried on a RHEL 7 VM. But we have discovered the real difference is that on Fedora we have run as a normal user, whereas on the VM we were logged in as root. Actually, the behavior is the same on both RHEL  7 and Fedora. Sorry for confusion.

I tried to find out if we can modify the JVM parameters, but with no success. Also the SCAPVal complains about `ERROR Problem trying to load file from - classpath:xsl/scapval-report.xsl`, which is weird, because `xsl/scapval-report.xsl` is from the `scapval-1.3.2.jar` as all the other files that were loaded successfully during the run. AFAIK Java loads JAR into memory, so it doesn't seem that there can be any permissions problem. I have a very little knowledge of Java, though.

See Jenkins runs, eg. https://jenkins.open-scap.org/job/scap-security-guide-scapval-scap-1.2/8/console
