### PR TITLE
update STIG antivirus language

### DIFF
--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/rule.yml
@@ -5,14 +5,15 @@ prodtype: rhel6,rhel7,rhel8,fedora,rhv4
 title: 'Install Virus Scanning Software'
 
 description: |-
-    Install virus scanning software, which uses signatures to search for the
-    presence of viruses on the filesystem.
-    Ensure virus definition files are no older than 7 days, or their last release.
+    Virus scanning software can be used to protect a system from penetration from
+    computer viruses and to limit their spread through intermediate systems.
 
-    Configure the virus scanning software to perform scans dynamically on all
-    accessed files.  If this is not possible, configure the
-    system to scan all altered files on the system on a daily
-    basis. If the system processes inbound SMTP mail, configure the virus scanner
+    The virus scanning software should be configured to perform scans dynamically
+    on accessed files. If this capability is not available, the system must be
+    configured to scan, at a minimum, all altered files on the system on a daily
+    basis.
+
+    If the system processes inbound SMTP mail, the virus scanner must be configured
     to scan all received mail.
 
 rationale: |-
@@ -26,30 +27,23 @@ identifiers:
     cce@rhel7: 27140-3
 
 references:
-    disa: 1239,1668
-    nist: 'SC-28,SI-3'
+    disa: 366,1239,1668
+    nist: SC-28,SI-3,SI-3(1)(ii)
     nist-csf: DE.CM-4,DE.DP-3,PR.DS-1
     srg@rhel6: SRG-OS-00270
     stigid@rhel6: RHEL-06-000284
+    srg: SRG-OS-000480-GPOS-00227
+    stigid@rhel7: "032000"
     isa-62443-2013: 'SR 3.2,SR 3.3,SR 3.4,SR 4.1'
     isa-62443-2009: 4.3.4.3.8,4.4.3.2
     cobit5: APO01.06,APO13.02,BAI02.01,BAI06.01,DSS04.07,DSS05.01,DSS05.02,DSS05.03,DSS06.06
     iso27001-2013: A.12.2.1,A.14.2.8,A.8.2.3
     cis-csc: 12,13,14,4,7,8
 
-ocil_clause: 'virus scanning software does not run continuously, or at least daily, or has signatures that are out of date'
+ocil_clause: 'there is no anti-virus solution installed on the system'
 
 ocil: |-
-    Inspect the system for a cron job or system service which executes
-    a virus scanning tool regularly.
-    <br />
-
-    To verify the McAfee VSEL system service is operational,
-    run the following command:
-    <pre>$ sudo /sbin/service nails status</pre>
-    <br />
-    To check on the age of uvscan virus definition files, run the following command:
-    <pre>$ sudo cd /opt/NAI/LinuxShield/engine/dat
-    $ sudo ls -la avvscan.dat avvnames.dat avvclean.dat</pre>
+    Verify an anti-virus solution is installed on the system. The anti-virus solution may be
+    bundled with an approved host-based security solution.
 
 platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -46,9 +46,11 @@ ocil: |-
 
 warnings:
     - general: |-
-        Note in DoD environments, supplemental intrusion
-        detection tools, such as the McAfee Host-based Security System, are available
-        to integrate with existing infrastructure. When these supplemental tools
-        interfere with proper functioning of SELinux, SELinux takes precedence.
+        In DoD environments, supplemental intrusion detection and antivirus tools,
+        such as the McAfee Host-based Security System, are available to integrate with
+        existing infrastructure. Per DISA guidance, when these supplemental tools interfere
+        with proper functioning of SELinux, SELinux takes precedence. Should further
+        clarification be required, DISA contact information is published publicly at
+        https://iase.disa.mil/stigs/Pages/contact.aspx.
 
 platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
@@ -2,12 +2,19 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8,rhv4
 
-title: 'Install McAfee Virus Scanning Software'
+title: 'Install Virus Scanning Software'
 
 description: |-
-    Install McAfee VirusScan Enterprise for Linux antivirus software
-    which is provided for DoD systems and uses signatures to search for the
-    presence of viruses on the filesystem.
+    Virus scanning software can be used to protect a system from penetration from
+    computer viruses and to limit their spread through intermediate systems.
+
+    The virus scanning software should be configured to perform scans dynamically
+    on accessed files. If this capability is not available, the system must be
+    configured to scan, at a minimum, all altered files on the system on a daily
+    basis.
+
+    If the system processes inbound SMTP mail, the virus scanner must be configured
+    to scan all received mail.
 
 rationale: |-
     Virus scanning software can be used to detect if a system has been compromised by
@@ -30,17 +37,19 @@ references:
     iso27001-2013: A.12.2.1,A.14.2.8,A.8.2.3
     cis-csc: 12,13,14,4,7,8
 
-ocil_clause: 'virus scanning software is not installed or running'
+ocil_clause: 'there is no anti-virus solution installed on the system'
 
 ocil: |-
-    To verify that McAfee VirusScan Enterprise for Linux is installed
-    and running, run the following command(s):
-    <pre>$ sudo systemctl status nails</pre>
-    <pre>$ rpm -q McAfeeVSEForLinux</pre>
+    Verify an anti-virus solution is installed on the system. The anti-virus solution may be
+    bundled with an approved host-based security solution.
 
 warnings:
     - general: |-
-        Due to McAfee HIPS being 3rd party software, automated
-        remediation is not available for this configuration check.
+        In DoD environments, supplemental intrusion detection and antivirus tools,
+        such as the McAfee Host-based Security System, are available to integrate with
+        existing infrastructure. Per DISA guidance, when these supplemental tools interfere
+        with proper functioning of SELinux, SELinux takes precedence. Should further
+        clarification be required, DISA contact information is published publicly at
+        https://iase.disa.mil/stigs/Pages/contact.aspx.
 
 platform: machine

--- a/rhel7/profiles/rhelh-stig.profile
+++ b/rhel7/profiles/rhelh-stig.profile
@@ -425,7 +425,6 @@ selections:
     - audit_rules_execution_setfiles
     - audit_rules_kernel_module_loading_create
     - audit_rules_kernel_module_loading_finit
-    - install_mcafee_antivirus
     - configure_firewalld_ports
     - package_openssh-server_installed
     - sshd_print_last_log

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -228,7 +228,7 @@ selections:
     - audit_rules_file_deletion_events_unlinkat
     - rsyslog_remote_loghost
     - rsyslog_nolisten
-    - install_mcafee_antivirus
+    - install_antivirus
     - accounts_max_concurrent_login_sessions
     - configure_firewalld_ports
     - sshd_use_approved_ciphers

--- a/rhv4/profiles/rhvh-stig.profile
+++ b/rhv4/profiles/rhvh-stig.profile
@@ -425,7 +425,6 @@ selections:
     - audit_rules_execution_setfiles
     - audit_rules_kernel_module_loading_create
     - audit_rules_kernel_module_loading_finit
-    - install_mcafee_antivirus
     - configure_firewalld_ports
     - package_openssh-server_installed
     - sshd_print_last_log


### PR DESCRIPTION
DISA STIG updated its language to be less specific about antivirus. Updating our language to match.

- Updates XCCDF for generic language to match DISA;
- Removes OVAL, since we can't match for all possible A/V conditions;
- Removes rule from OSPP and other Red Hat controlled profiles

--- edit ---
Thanks to Bruce Benson for raising awareness of this!
