### PR TITLE
Remove a message from stderr

### DIFF
--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -69,9 +69,11 @@ def main():
     for rule_id, fix_path in rule_id_to_remediation_map.items():
         remediation_obj = remediation_cls(fix_path)
         rule_path = os.path.join(args.resolved_rules_dir, rule_id + ".yml")
-        remediation_obj.load_rule_from(rule_path)
-        # Fixes gets updated with the contents of the fix, if it is applicable
-        remediation.process(remediation_obj, env_yaml, fixes, rule_id)
+        if os.path.isfile(rule_path):
+            remediation_obj.load_rule_from(rule_path)
+            # Fixes gets updated with the contents of the fix
+            # if it is applicable
+            remediation.process(remediation_obj, env_yaml, fixes, rule_id)
 
     remediation.write_fixes_to_dir(fixes, args.remediation_type,
                                    args.output_dir)

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -195,9 +195,8 @@ class Remediation(object):
         self.associated_rule = None
 
     def load_rule_from(self, rule_path):
-        if os.path.isfile(rule_path):
-            self.associated_rule = build_yaml.Rule.from_yaml(rule_path)
-            self.expand_env_yaml_from_rule()
+        self.associated_rule = build_yaml.Rule.from_yaml(rule_path)
+        self.expand_env_yaml_from_rule()
 
     def expand_env_yaml_from_rule(self):
         if not self.associated_rule:

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -372,9 +372,10 @@ class AnsibleRemediation(Remediation):
 
     @classmethod
     def from_snippet_and_rule(cls, snippet_fname, rule_fname):
-        result = cls(snippet_fname)
-        result.load_rule_from(rule_fname)
-        return result
+        if os.path.isfile(snippet_fname) and os.path.isfile(rule_fname):
+            result = cls(snippet_fname)
+            result.load_rule_from(rule_fname)
+            return result
 
 
 class AnacondaRemediation(Remediation):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -200,13 +200,7 @@ class Remediation(object):
         return self.load_rule_from(rule_path)
 
     def load_rule_from(self, rule_path):
-        if not os.path.isfile(rule_path):
-            msg = ("{lang} remediation snippet can't load the "
-                   "respective rule YML at {rule_fname}"
-                   .format(rule_fname=rule_path,
-                           lang=self.remediation_type))
-            print(msg, file=sys.stderr)
-        else:
+        if os.path.isfile(rule_path):
             self.associated_rule = build_yaml.Rule.from_yaml(rule_path)
             self.expand_env_yaml_from_rule()
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -194,11 +194,6 @@ class Remediation(object):
         self.remediation_type = remediation_type
         self.associated_rule = None
 
-    def load_associated_rule(self, resolved_rules_dir, rule_id):
-        rule_path = os.path.join(
-            resolved_rules_dir, rule_id + ".yml")
-        return self.load_rule_from(rule_path)
-
     def load_rule_from(self, rule_path):
         if os.path.isfile(rule_path):
             self.associated_rule = build_yaml.Rule.from_yaml(rule_path)
@@ -251,10 +246,6 @@ def process(remediation, env_yaml, fixes, rule_id):
 class BashRemediation(Remediation):
     def __init__(self, file_path):
         super(BashRemediation, self).__init__(file_path, "bash")
-
-    def load_associated_rule(self, resolved_rules_dir, rule_id):
-        # No point in loading rule for this remediation type as of now
-        pass
 
 
 class AnsibleRemediation(Remediation):
@@ -392,19 +383,11 @@ class AnacondaRemediation(Remediation):
         super(AnacondaRemediation, self).__init__(
             file_path, "anaconda")
 
-    def load_associated_rule(self, resolved_rules_dir):
-        # No point in loading rule for this remediation type as of now
-        pass
-
 
 class PuppetRemediation(Remediation):
     def __init__(self, file_path):
         super(PuppetRemediation, self).__init__(
             file_path, "puppet")
-
-    def load_associated_rule(self, resolved_rules_dir):
-        # No point in loading rule for this remediation type as of now
-        pass
 
 
 REMEDIATION_TO_CLASS = {


### PR DESCRIPTION
When a remediation can't find the respective rule YML, it produces
a message on stderr, which pollutes the build output. In fact, this
is a normal situation when the remediation exists but the rule
isn't a part of the given product.
