### PR TITLE
tests/install_vm.py: Do not abort if ostype detection fails

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -149,8 +149,9 @@ def main():
         content = infile.read()
         content = content.replace("&&HOST_PUBLIC_KEY&&", pub_key)
         ostype = detect_url_os(data.url)
-        if any(filter(lambda x: x in ostype, ['centos.org', 'redhat.com'])):
-            content = content.replace("&&YUM_REPO_URL&&", data.url)
+        if ostype:
+            if any(filter(lambda x: x in ostype, ['centos.org', 'redhat.com'])):
+                content = content.replace("&&YUM_REPO_URL&&", data.url)
         outfile.write(content)
     data.kickstart = tmp_kickstart
     print("Using kickstart file: {0}".format(data.kickstart))


### PR DESCRIPTION
#### Description:

- Fixes `tests/install_vm.py` abort in case `osinfo-detect` doesn't magage to detect OS type.