### PR TITLE
Change test scenarios for rule rpm_verify_permissions

### DIFF
--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_rpm_verification/rule_rpm_verify_permissions/all_permissions_ok.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_rpm_verification/rule_rpm_verify_permissions/all_permissions_ok.pass.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+
+# Declare array to hold list of RPM packages we need to correct permissions for
+declare -a SETPERMS_RPM_LIST
+
+# Create a list of files on the system having permissions different from what
+# is expected by the RPM database
+FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }'))
+
+# For each file path from that list:
+# * Determine the RPM package the file path is shipped by,
+# * Include it into SETPERMS_RPM_LIST array
+
+for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
+do
+	RPM_PACKAGE=$(rpm -qf "$FILE_PATH")
+	SETPERMS_RPM_LIST=("${SETPERMS_RPM_LIST[@]}" "$RPM_PACKAGE")
+done
+
+# Remove duplicate mention of same RPM in $SETPERMS_RPM_LIST (if any)
+SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ') )
+
+# For each of the RPM packages left in the list -- reset its permissions to the
+# correct values
+for RPM_PACKAGE in "${SETPERMS_RPM_LIST[@]}"
+do
+	rpm --setperms "${RPM_PACKAGE}"
+done
+

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_rpm_verification/rule_rpm_verify_permissions/all_permissions_ok.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_rpm_verification/rule_rpm_verify_permissions/all_permissions_ok.pass.sh
@@ -2,9 +2,8 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
-
-# Declare array to hold list of RPM packages we need to correct permissions for
-declare -a SETPERMS_RPM_LIST
+# Declare an associative array to hold list of RPM packages we need to correct permissions for
+declare -A SETPERMS_RPM_LIST
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
@@ -17,15 +16,12 @@ FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)
 for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
 do
 	RPM_PACKAGE=$(rpm -qf "$FILE_PATH")
-	SETPERMS_RPM_LIST=("${SETPERMS_RPM_LIST[@]}" "$RPM_PACKAGE")
+	SETPERMS_RPM_LIST["$RPM_PACKAGE"]=1
 done
-
-# Remove duplicate mention of same RPM in $SETPERMS_RPM_LIST (if any)
-SETPERMS_RPM_LIST=( $(echo "${SETPERMS_RPM_LIST[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ') )
 
 # For each of the RPM packages left in the list -- reset its permissions to the
 # correct values
-for RPM_PACKAGE in "${SETPERMS_RPM_LIST[@]}"
+for RPM_PACKAGE in "${!SETPERMS_RPM_LIST[@]}"
 do
 	rpm --setperms "${RPM_PACKAGE}"
 done

--- a/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_rpm_verification/rule_rpm_verify_permissions/fresh_system.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_software-integrity/group_rpm_verification/rule_rpm_verify_permissions/fresh_system.pass.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
-
-# verify (-V) all installed (-a) packages permissions,
-# if permissions differs from package metadata, then attribute 'M' is printed
-result=$(rpm -Va | grep '^.M')
-
-[ -z "$result" ]


### PR DESCRIPTION
Test scenario fresh_system.pass.sh is removed, because it's wrong,
because it doesn't set up the system in any way, it only checks if all
the files have correct permissions according to RPM. However, on test
machines, there are usually some files which have incorrect permissions.
Also, on a default RHEL 7 installation, there are files which have
incorrect permissions.  Instead of fresh_system.pass.sh we add a
different test scenario that ensures every file has correct permissions
according to RPM after the set up phase. The scenario basically contains
the remediation for this rule.

