### PR TITLE
User guide build link to develper guide

### DIFF
--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -86,25 +86,11 @@ $ sudo dnf -y install scap-security-guide
 ------------
 
 
-=== Building
+=== Installing content from upstream
 
-If you need to build the upstream content rather than getting it from the distribution, you can build it yourself.
-Either of the steps below will conclude with datastreams and other content built in the `build` directory.
+If you need to use upstream content rather than what is shipped in the distribution, you can build it yourself.
+Please, refer to link:https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer_guide.adoc#3-building-scap-security-guide[Building SCAP Security Guide] section, in the link:https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer_guide.adoc[Developer Guide].
 
-* Use the `build_product` script to build a single product of your choice:
-+
-------------
-$ ./build_product fedora
-$ cd build
-------------
-
-* Manual build process:
-+
-------------
-$ cd build
-$ cmake ..
-$ make fedora
-------------
 
 == Running a Scan
 

--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -88,8 +88,14 @@ $ sudo dnf -y install scap-security-guide
 
 === Installing content from upstream
 
-If you need to use upstream content rather than what is shipped in the distribution, you can build it yourself.
-Please, refer to link:https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer_guide.adoc#3-building-scap-security-guide[Building SCAP Security Guide] section, in the link:https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer_guide.adoc[Developer Guide].
+If you need to use upstream content rather than what is shipped in the distribution, you can download the nightly build, or build it yourself.
+
+The nightly builds are performed by our link:https://jenkins.complianceascode.io/view/Maintenance%20Jobs/[Jenkins instance], in the nightly jobs. Below are direct links to the latest builds:
+
+* link:https://jenkins.complianceascode.io/view/SCAP%20Security%20Guide/job/scap-security-guide-nightly-zip/lastSuccessfulBuild/artifact/scap-security-guide-nightly.zip[nightly build with OVAL 5.11]
+* link:https://jenkins.complianceascode.io/view/SCAP%20Security%20Guide/job/scap-security-guide-nightly-oval510-zip/lastSuccessfulBuild/artifact/scap-security-guide-nightly-oval-510.zip[nightly build with OVAL 5.10]
+
+If you wish to build the content yourself, please, refer to link:https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer_guide.adoc#3-building-scap-security-guide[Building SCAP Security Guide] section, in the link:https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer_guide.adoc[Developer Guide].
 
 
 == Running a Scan


### PR DESCRIPTION
#### Description:

- Remove steps to build content from User Guide
- Refer to Developer Guide on how to build the content
- Also suggest possibility to use nightly zip from upstream

#### Rationale:

- Lets keep the build instructions in the Developer Guide, and reference it when needed.
