### PR TITLE
Add bash remediation, fix oval and add test scenarios for sssd_ssh_known_hosts_timeout

### DIFF
--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
@@ -1,0 +1,23 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+populate var_sssd_ssh_known_hosts_timeout
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+SSH_KNOWN_HOSTS_TIMEOUT_REGEX="[[:space:]]*\[ssh]([^\n\[]*\n+)+?[[:space:]]*ssh_known_hosts_timeout"
+SSH_REGEX="[[:space:]]*\[ssh]"
+
+# Try find [ssh] and ssh_known_hosts_timeout in sssd.conf, if it exists, set to
+# var_sssd_ssh_known_hosts_timeout, if it isn't here, add it, if [ssh] doesn't
+# exist, add it there
+if grep -qzosP $SSH_KNOWN_HOSTS_TIMEOUT_REGEX $SSSD_CONF; then
+        sed -i "s/ssh_known_hosts_timeout[^(\n)]*/ssh_known_hosts_timeout = $var_sssd_ssh_known_hosts_timeout/" $SSSD_CONF
+elif grep -qs $SSH_REGEX $SSSD_CONF; then
+        sed -i "/$SSH_REGEX/a ssh_known_hosts_timeout = $var_sssd_ssh_known_hosts_timeout" $SSSD_CONF
+else
+        mkdir -p /etc/sssd
+        touch $SSSD_CONF
+        echo -e "[ssh]\nssh_known_hosts_timeout = $var_sssd_ssh_known_hosts_timeout" >> $SSSD_CONF
+fi

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_ssh_known_hosts_timeout" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\[ssh]([^\n]*\n+)+?ssh_known_hosts_timeout[\s]+=[\s]+(\d+)$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[ssh](?:[^\n\[]*\n+)+?[\s]*ssh_known_hosts_timeout[\s]*=[\s]*(\d+)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4
 
 title: 'Configure SSSD to Expire SSH Known Hosts'
 

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -18,7 +18,6 @@ description: |-
 selections:
     - login_banner_text=dod_banners
     - inactivity_timeout_value=15_minutes
-    - var_sssd_ssh_known_hosts_timeout=5_minutes
     - var_screensaver_lock_delay=5_seconds
     - sshd_idle_timeout_value=10_minutes
     - var_accounts_fail_delay=4

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/comment.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/comment.fail.sh
@@ -3,7 +3,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
-TIMEOUT="86400"
+TIMEOUT="180"
 
 dnf -y install sssd
 systemctl enable sssd

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/comment.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/comment.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/correct_value.pass.sh
@@ -7,7 +7,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # this should pass for every product which contains ospp profile
 TIMEOUT="180"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/correct_value.pass.sh
@@ -3,7 +3,9 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
-TIMEOUT="86400"
+# The smallest variable value for sssd_memcache_timeout is 180 so
+# this should pass for every product which contains ospp profile
+TIMEOUT="180"
 
 dnf -y install sssd
 systemctl enable sssd

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
@@ -3,7 +3,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
-TIMEOUT="86400"
+TIMEOUT="180"
 
 dnf -y install sssd
 systemctl enable sssd

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_value.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_value.fail.sh
@@ -8,7 +8,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # Let's put there a higher value to fail
 TIMEOUT="99999"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_value.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_value.fail.sh
@@ -4,8 +4,8 @@
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 
-# The rule sssd_memcache_timeout requires memcache_timeout = 86400
-# Let's put there a different value to fail
+# The highest variable value for sssd_memcache_timeout is 86400 so
+# Let's put there a higher value to fail
 TIMEOUT="99999"
 
 dnf -y install sssd

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/comment.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/comment.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/comment.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/comment.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+TIMEOUT="180"
+
+dnf -y install sssd
+systemctl enable sssd
+mkdir -p /etc/sssd
+touch $SSSD_CONF
+echo -e "[ssh]\n#ssh_known_hosts_timeout = $TIMEOUT" >> $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+TIMEOUT="180"
+
+dnf -y install sssd
+systemctl enable sssd
+mkdir -p /etc/sssd
+touch $SSSD_CONF
+echo -e "[ssh]\nssh_known_hosts_timeout = $TIMEOUT" >> $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
@@ -7,7 +7,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # this should pass for every product which contains ospp profile
 TIMEOUT="180"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
@@ -3,6 +3,8 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
+# The smallest variable value for sssd_memcache_timeout is 180 so
+# this should pass for every product which contains ospp profile
 TIMEOUT="180"
 
 dnf -y install sssd

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_section.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_section.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+TIMEOUT="180"
+
+dnf -y install sssd
+systemctl enable sssd
+mkdir -p /etc/sssd
+touch $SSSD_CONF
+echo -e "[ssh]\nsomething = wrong\n[pam]\nssh_known_hosts_timeout = $TIMEOUT" >> $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_value.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_value.fail.sh
@@ -8,7 +8,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # Let's put there a different value to fail
 TIMEOUT="99999"
 
-dnf -y install sssd
+yum -y install sssd
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_value.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_value.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+SSSD_CONF="/etc/sssd/sssd.conf"
+
+# The rule sssd_memcache_timeout requires memcache_timeout = 86400
+# Let's put there a different value to fail
+TIMEOUT="99999"
+
+dnf -y install sssd
+systemctl enable sssd
+mkdir -p /etc/sssd
+touch $SSSD_CONF
+echo -e "[ssh]\nssh_known_hosts_timeout = $TIMEOUT" >> $SSSD_CONF


### PR DESCRIPTION
#### Description:

- Add bash remediation, fix oval and add test scenarios for sssd_ssh_known_hosts_timeout

#### Rationale:

- Scanning of rule was failing due to malformed regex in OVAL. Fixes use this rule as a basis https://github.com/ComplianceAsCode/content/tree/master/linux_os/guide/services/sssd/sssd_memcache_timeout
