### PR TITLE
Scap 1.3 content adjustments

### DIFF
--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -74,30 +74,3 @@ oval_external_content: "https://linux.oracle.com/security/oval/com.oracle.elsa-a
 {{# The rule will be "notchecked" #}}
 {{% endif %}}
 
-ocil_clause: 'updates are not installed'
-
-{{# TODO: What about non-rpm systems? #}}
-ocil: |-
-{{% if product in ["rhel6", "rhel7", "rhel8"] %}}
-    If the system is joined to the Red Hat Network, a Red Hat Satellite Server, or
-    a yum server which provides updates, invoking the following command will
-    indicate if updates are available:
-    <pre>$ sudo yum check-update</pre>
-{{% elif product == "ol7" %}}
-    If the system is joined to the ULN or a yum server which provides updates,
-    invoking the following command will indicate if updates are available:
-{{% endif %}}
-    <br /><br />
-    If the system is not configured to update from one of these sources,
-    run the following command to list when each package was last updated:
-    <pre>$ rpm -qa -last</pre>
-    <br /><br />
-{{% if product in ["rhel6", "rhel7", "rhel8"] %}}
-    Compare this to Red Hat Security Advisories (RHSA) listed at
-    https://access.redhat.com/security/updates/active/
-    to determine if the system is missing applicable updates.
-{{% elif product in ["ol7", "ol8"] %}}
-    Compare this to Oracle Linux Security Advisories (ELSA) listed at
-    https://linux.oracle.com/pls/apex/f?p=105:21:::NO:RP::
-    to determine if the system is missing applicable updates.
-{{% endif %}}

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -57,12 +57,13 @@ references:
 
 {{# Make sure all the external OVAL content links are secured via TLS! #}}
 
+# SCAP 1.3 content should reference flat non compressed xml files
 {{% if product == "rhel6" %}}
-oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL6.xml.bz2"
+oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL6.xml"
 {{% elif product == "rhel7" %}}
-oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2"
+oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml"
 {{% elif product == "rhel8" %}}
-oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2"
+oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml"
 {{% elif product == "ubuntu1404" %}}
 oval_external_content: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml"
 {{% elif product == "ubuntu1604" %}}


### PR DESCRIPTION
#### Description:

- Link to uncompressed external OVAL content
- Drop OCIL check for rule `security_patches_up_to_date`

#### Rationale:

- From Table 8 of SCAP 1.3 standard [1]:
  `A URI to the target component ... When referencing external content, the URI
SHALL be in the form of
scheme: ... and SHALL dereference to an XML stream that includes the SCAP
source data stream collection and the target component ....`
- From section 3.2.4.3 of [1]:
`An XCCDF benchmark MAY include a patches up-to-date rule that SHALL reference an OVAL source data stream component.`
  This should be read as only an OVAL check is allowed. Although there is no mention of OCIL check here.

[1] NIST.SP.800-126 revision 3

#### Notes:
Dropping whole OCIL check for this rule may be controversial, so I'm initially proposing this as Draft PR.
