### PR TITLE
Remove double entry section in ansible remediation for sssd_ldap_start_tls.

### DIFF
--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/ansible/shared.yml
@@ -20,7 +20,6 @@
 - name: "Add default domain group and use STARTTLS (if no domain there)"
   ini_file:
     path: /etc/sssd/sssd.conf
-    section: domain/default
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"


### PR DESCRIPTION
#### Description:

- Remove duplicated section from ansible remediation for rule sssd_ldap_start_tls.

#### Rationale:

- Duplicated section entry caused warning when executing ansible-playbook using this ansible remediation. Since it has `section: "{{ item.section }}"` defined afterwards, the remediation would work anyway. But still it doesn't make sense to keep it there.

- Fixes  #4356
