### PR TITLE
Rebranded scap-security-guide to ComplianceAsCode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ apt install ssg-applications  # for application-oriented guides (Firefox, JBoss,
 ### From release ZIP files
 
 Download pre-built SSG zip archive from
-[the release page](https://github.com/OpenSCAP/scap-security-guide/releases/latest).
+[the release page](https://github.com/ComplianceAsCode/content/releases/latest).
 Each zip file is an archive with ready-made SCAP source datastreams.
 
 ### From COPR
@@ -134,7 +134,7 @@ detailed instructions.
 
 ### From source
 
-If SCAP Security Guide is not packaged in your distribution or if the
+If ComplianceAsCode is not packaged in your distribution (it may be present there as `scap-security-guide` package), or if the
 version that is packaged is too old, you need to build the content yourself
 and install it via `make install`. Please see the [Developer Guide](docs/manual/developer_guide.adoc)
 document for more info. We also recommend opening an issue on that distributions
@@ -142,10 +142,10 @@ bug tracker to voice interest.
 
 ## Usage
 
-We assume you have installed SCAP Security Guide system-wide into a
+We assume you have installed ComplianceAsCode system-wide into a
 standard location from current upstream sources as instructed in the previous section.
 
-There are several ways to consume SCAP Security Guide content, we will only
+There are several ways to consume ComplianceAsCode content, we will only
 go through a few of them here.
 
 ### `oscap` tool
@@ -252,7 +252,7 @@ You can also join the `#openscap` IRC channel on `chat.freenode.net`.
 This project started in 2011 as a collaboration between government agencies and
 commercial operating system vendors. The original name was SCAP Security Guide.
 The original scope was to create SCAP datastreams. Over time, it grew into the
-biggest open-source SCAP content project.
+biggest open-source beyond-SCAP content project.
 
 The next few years saw the introduction of not just government-specific security
 profiles but also commercial, such as PCI-DSS.

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1,4 +1,4 @@
-# SCAP Security Guide Developer Guide
+# ComplianceAsCode Developer Guide
 :imagesdir: ./images
 :templatesdir: ../../shared/templates
 :rhel7dir: ../../rhel7/templates/csv
@@ -17,7 +17,7 @@ We will explain the directory layout, used formats and the build system.
 ## Mailing List
 Join the mailing list at https://fedorahosted.org/mailman/listinfo/scap-security-guide.
 
-## Building SCAP Security Guide
+## Building ComplianceAsCode
 
 ### Installing build dependencies
 
@@ -327,7 +327,7 @@ This will take care of the build environment and all necessary setup.
 docker build --no-cache --file Dockerfile --tag oscap:$(date -u +%Y%m%d%H%M) --tag oscap:latest .
 ```
 
-### Build SSG using the container image
+### Build the content using the container image
 
 To build all the content, run a container without any flags.
 
@@ -564,8 +564,8 @@ always be generated using `create-stig-overlay.py`.**
 
 To create `stig_overlay.xml`, there are two things that are required: an
 official non-draft STIG release from DISA containing a XCCDF file
-(e.g. `U_Red_Hat_Enterprise_Linux_7_STIG_V1R1_Manual-xccdf.xml` and a SSG
-generated XCCDF file (e.g. `ssg-rhel7-xccdf.xml`)
+(e.g. `U_Red_Hat_Enterprise_Linux_7_STIG_V1R1_Manual-xccdf.xml` and an XCCDF file built
+by the project (e.g. `ssg-rhel7-xccdf.xml`)
 
 Example using `create-stig-overlay.py`:
 ----
@@ -644,10 +644,10 @@ This will result in a new YAML profile containing exclusive rules to the profile
 
 == Contributing with XCCDFs, OVALs and remediations
 
-There are three main types of content in SSG, they are rules, defined using the XCCDF standard, checks, usually written in link:https://oval.mitre.org/language/about/[OVAL] format, and remediations, that can be executed on ansible, bash, anaconda installer and puppet.
-SSG also has its own templating mechanism, allowing content writers to create models and use it to generate a number of checks and remediations.
+There are three main types of content in the project, they are rules, defined using the XCCDF standard, checks, usually written in link:https://oval.mitre.org/language/about/[OVAL] format, and remediations, that can be executed on ansible, bash, anaconda installer and puppet.
+ComplianceAsCode also has its own templating mechanism, allowing content writers to create models and use it to generate a number of checks and remediations.
 
-The SSG content is primarily divided by platform and it can be seen on its directory structure:
+The ComplianceAsCode content is primarily divided by platform and it can be seen on its directory structure:
 
 
 ----
@@ -901,7 +901,7 @@ This utility requires an up to date JSON tree created by `rule_dir_json.py`.
 ==== Checks
 
 Checks are used to evaluate a Rule. They are written using a custom OVAL syntax and are stored as xml files inside the _checks/oval_ directory for the desired platform.
-During the building process, SSG will transform the checks in OVAL compliant checks.
+During the building process, the system will transform the checks in OVAL compliant checks.
 
 In order to create a new check, you must create a file in the appropriate directory, and name it the same as the Rule _id_. This _id_ will also be used as the OVAL _id_ attribute.
 The content of the file should follow the OVAL specification with these exceptions:
@@ -964,8 +964,8 @@ Remediations also carry metadata that should be present at the beginning of the 
 | Field | Description | Accepted values
 
 | platform
-| CPE name, CPE applicability language expression or even SSG wildcards declaring which platforms the fix can be applied
-| link:https://github.com/OpenSCAP/openscap/blob/maint-1.2/cpe/openscap-cpe-dict.xml[Default CPE dictionary is packaged along with openscap]. Custom CPE dictionaries can be used. SSG wildcards are multi_platform_[all, oval, fedora, debian, ubuntu, linux, rhel, openstack, opensuse, rhev, sle].
+| CPE name, CPE applicability language expression or even wildcards declaring which platforms the fix can be applied
+| link:https://github.com/OpenSCAP/openscap/blob/maint-1.2/cpe/openscap-cpe-dict.xml[Default CPE dictionary is packaged along with openscap]. Custom CPE dictionaries can be used. Wildcards are multi_platform_[all, oval, fedora, debian, ubuntu, linux, rhel, openstack, opensuse, rhev, sle].
 
 | reboot
 | Whether or not a reboot is necessary after the fix
@@ -1059,7 +1059,8 @@ When writing new bash remediations content, please follow the following guidelin
 
 ==== Templating
 
-Often, a set of very related checks and/or remediations needs to be created. Instead of creating them individually, you can use the templating mechanism provided by the SSG. It supports OVAL checks and Ansible, Bash, Anaconda and Puppet remediations.
+Often, a set of very related checks and/or remediations needs to be created. Instead of creating them individually, you can use the templating mechanism provided by the ComplianceAsCode project.
+It supports OVAL checks and Ansible, Bash, Anaconda and Puppet remediations.
 In order to use this mechanism, you have to:
 
 1) Create the template files, one for each type of file. Each one should be named `template_<TYPE>_<NAME>.jinja`. Where `<TYPE>` should be OVAL, ANSIBLE, BASH, ANACONDA or PUPPET and `<NAME>` is the what we will call hereafter the template name.
@@ -1099,7 +1100,7 @@ This is the file with the generator class for the installed package template, it
 include::{templatesdir}/create_package_installed.py
 ----
 
-4) Finally, you have to ensure the SSG knows your template. To do that, you have to edit the file _ssg/build_templates.py_ and include the generator class you've just created and declare which csv file to use along with it.
+4) Finally, you have to ensure the build system knows your template. To do that, you have to edit the file _ssg/build_templates.py_ and include the generator class you've just created and declare which csv file to use along with it.
 
 This is an example of a patch to add a new template into the templating system:
 
@@ -1124,7 +1125,7 @@ This is an example of a patch to add a new template into the templating system:
 
 === Tests (ctest)
 
-SCAP Security Guide uses ctest to orchestrate testing upstream. To run the test suite go to the build folder and execute `ctest`:
+ComplianceAsCode uses ctest to orchestrate testing upstream. To run the test suite go to the build folder and execute `ctest`:
 
 ----
 cd build/
@@ -1139,7 +1140,7 @@ See some of the existing testing code in `cmake/SSGCommon.cmake`.
 
 === Contribution to infrastructure code
 
-The SSG build and templating system is mostly written in Python.
+The ComplianceAsCode build and templating system is mostly written in Python.
 
 ==== Python
 
@@ -1158,8 +1159,7 @@ describes the goal of the project.
 This git repository was created by simply renaming and moving the SCAP Security Guide (SSG)
 repository to a different GitHub organization.
 
-Due to this history, the repository contains many mentions of SCAP Security Guide.
-These legacy mentions are continuously cleaned up as the project develops.
+Due to this history, the repository contains mentions of SCAP Security Guide or `ssg`.
 Some of them are kept due to backwards compatibility.
 
 For example, the output files produced by our build system still start by `ssg-` prefix.

--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -1,4 +1,4 @@
-= SCAP Security Guide User Guide
+= ComplianceAsCode User Guide
 :imagesdir: ./images
 :toc:
 :toc-placement: preamble
@@ -8,7 +8,7 @@ toc::[]
 
 == Introduction
 
-The SCAP Security Guide (SSG) project delivers security guidance, baselines and
+The ComplianceAsCode (SSG) project delivers security guidance, baselines and
 associated validation mechanisms utilizing the Security Content Automation
 Protocol (SCAP). SSG provides content for Red Hat Enterprise Linux and JBoss
 Enterprise Application Server (JBoss EAP).
@@ -35,7 +35,7 @@ information that could reasonably be expected to cause damage to U.S. National
 Security. As part of this mission, NSA develops and distributes configuration
 guidance for operating systems. These guides are currently being used
 throughout the U.S. government and by numerous entities as a security baseline
-for their systems. The SCAP Security Guide project serves as NSA's upstream
+for their systems. The ComplianceAsCode project serves as NSA's upstream
 source for https://www.nsa.gov/ia/mitigation_guidance/security_configuration_guides/operating_systems.shtml#linux2[Red Hat Enterprise Linux operating system guidance].
 
 image::logos-400x400-disa-300x300.jpg[align="left"]
@@ -44,7 +44,7 @@ The http://www.disa.mil/About/Our-Organization-Structure/OD-Field-Office/Field-S
 (DISA FSO) authors hardening guidance known as Security Technical
 Implementation Guides (http://iase.disa.mil/stigs/index.html[STIGs]). These
 documents, used throughout the U.S. military to harden systems, establish
-formal security compliance baselines. The SCAP Security Guide project serves as
+formal security compliance baselines. The ComplianceAsCode project serves as
 the usptream development source for http://iase.disa.mil/stigs/os/unix-linux/Pages/red-hat.aspx[Red Hat STIG content]
 and helps DISA FSO move towards their business objective of utilizing
 SCAP-based formats to automate security compliance across U.S. military
@@ -61,7 +61,7 @@ configuration of operating systems and applications. NCP is migrating its
 repository of checklists to conform to the Security Content Automation Protocol
 (SCAP).”
 
-The SCAP Security Guide project serves as the upstream repository for
+The ComplianceAsCode project serves as the upstream repository for
 https://nvd.nist.gov/ncp/checklist/811[Red Hat Enterprise Linux related checklists].
 
 == Installing
@@ -205,7 +205,7 @@ XML Results
 === Remediation
 
 ==== Bash Scripts
-SCAP Security Guide embeds bash remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations.
+ComplianceAsCode embeds bash remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations.
 OpenSCAP, the CLI delivered with Fedora and Red Hat Enterprise Linux systems, contains the ability to transform XML results into an executable script. The syntax to generate a remediation script is:
 
 ----
@@ -269,8 +269,8 @@ This output could be redirected to a bash script, or built into your RHEL6 provi
 
 #### Ansible Playbooks
 
-SCAP Security Guide embeds ansible remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations. When using OpenSCAP with
-Ansible, it is advisable to use the playbooks from https://github.com/RedHatOfficial. These playbooks are generated from the SCAP Security Guide project and are also available on Ansible Galaxy.
+ComplianceAsCode embeds ansible remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations. When using OpenSCAP with
+Ansible, it is advisable to use the playbooks from https://github.com/RedHatOfficial. These playbooks are generated from the ComplianceAsCode project and are also available on Ansible Galaxy.
 
 IMPORTANT: The minimum version of Ansible must be at the latest supported version. See https://access.redhat.com/support/policy/updates/ansible-engine for information on the supported Ansible versions.
 
@@ -301,7 +301,7 @@ employee or contractor; it is not available to the general public.
 The SPAWAR SCC website is http://www.public.navy.mil/spawar/Atlantic/ProductsServices/Pages/SCAP.aspx.
 
 
-To utilize SCC with SCAP Security Guide content:
+To utilize SCC with ComplianceAsCode content:
 
 1. Import SSG content into SCC through the cscc -is command
 +


### PR DESCRIPTION
This PR removes the old SSG reference whenever it is safe to do in the ComplianceAsCode documentation.