### PR TITLE
Remove the sshd_disable_rhosts_rsa rule from OL8 profiles

### DIFF
--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -72,7 +72,6 @@ selections:
     - disable_host_auth
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth
-    - sshd_disable_rhosts_rsa
     - sshd_disable_rhosts
     - sshd_disable_user_known_hosts
     - var_accounts_passwords_pam_faillock_deny=3


### PR DESCRIPTION
Remove the sshd_disable_rhosts_rsa rule from OL8 profiles

Signed-off-by: Ilya Okomin <ilya.okomin@oracle.com>