### PR TITLE
Smartcards auth in OL8 should be done via sssd 

### DIFF
--- a/linux_os/guide/services/sssd/package_sssd_installed/rule.yml
+++ b/linux_os/guide/services/sssd/package_sssd_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8
 
 title: 'Install the SSSD Package'
 

--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8
 
 title: 'Enable the SSSD Service'
 

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
@@ -7,6 +7,7 @@
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>SSSD should be configured to authenticate access to the system
     using smart cards.</description>

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4
+prodtype: rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Enable Smartcards in SSSD'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low
@@ -7,8 +7,8 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_smartcard_drivers
 
-grep -qs "card_drivers =" /etc/opensc*.conf && \
-	sed -i "s/card_drivers =.*/card_drivers = $var_smartcard_drivers;/g" /etc/opensc*.conf
-if ! [ $? -eq 0 ]; then
-	sed -i "s/.*card_drivers =.*/        card_drivers = $var_smartcard_drivers;/g" /etc/opensc*.conf
+OPENSC_TOOL="/usr/bin/opensc-tool"
+
+if [ -f "${OPENSC_TOOL}" ]; then
+    ${OPENSC_TOOL} -S app:default:card_drivers:$var_smartcard_drivers
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/oval/shared.xml
@@ -7,6 +7,7 @@
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Configure the organization's smart card driver so that only
       the smart card in use by the organization will be recognized by the system.</description>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4
+prodtype: rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Configure opensc Smart Card Drivers'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,Oracle Linux 7
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,Oracle Linux 7
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
@@ -7,6 +7,7 @@
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhv</platform>
+        <platform>Oracle Linux 7</platform>
       </affected>
       <description>The ability for users to perform interactive startups should
       be disabled.</description>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4
+prodtype: rhel7,rhel8,fedora,rhv4,ol7
 
 title: 'Configure NSS DB To Use opensc'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low
@@ -7,8 +7,8 @@
 . /usr/share/scap-security-guide/remediation_functions
 populate var_smartcard_drivers
 
-grep -qs "force_card_driver =" /etc/opensc*.conf && \
-	sed -i "s/force_card_driver =.*/force_card_driver = $var_smartcard_drivers;/g" /etc/opensc*.conf
-if ! [ $? -eq 0 ]; then
-	sed -i "s/.*force_card_driver =.*/        force_card_driver = $var_smartcard_drivers;/g" /etc/opensc*.conf
+OPENSC_TOOL="/usr/bin/opensc-tool"
+
+if [ -f "${OPENSC_TOOL}" ]; then
+    ${OPENSC_TOOL} -S app:default:force_card_driver:$var_smartcard_drivers
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/oval/shared.xml
@@ -7,6 +7,7 @@
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Force opensc to use the organization's smart card driver so that only
       the smart card in use by the organization will be recognized by the system.</description>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4
+prodtype: rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Force opensc To Use Defined Smart Card Driver'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
@@ -5,7 +5,7 @@ title: 'Hardware Tokens for Authentication'
 description: |-
     The use of hardware tokens such as smart cards for system login
     provides stronger, two-factor authentication than using a username and password.
-    {{% if product == "ol7" %}}
+    {{% if product in ['ol7', 'ol8'] %}}
     In {{{ full_name }}} servers, hardware token login
     {{% else %}}
     In Red Hat Enterprise Linux servers and workstations, hardware token login

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4
+prodtype: rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Install the opensc Package For Multifactor Authentication'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4
+prodtype: rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Install the pcsc-lite package'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4
+prodtype: rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Enable the pcscd Service'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/anaconda/shared.anaconda
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/anaconda/shared.anaconda
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,Oracle Linux 7
 
 package --add=pam_pkcs11 --add=esc

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 8,Oracle Linux 7
 . /usr/share/scap-security-guide/remediation_functions
 
 # Install required packages

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
@@ -6,7 +6,7 @@
         <platform>Red Hat Enterprise Linux 6</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_ol</platform>
+        <platform>Oracle Linux 7</platform>
       </affected>
       <description>Enable Smart Card logins</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
+prodtype: rhel6,rhel7,rhel8,fedora,ol7
 
 title: 'Enable Smart Card Login'
 
@@ -13,12 +13,12 @@ description: |-
     <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards") }}}</b></li>
     {{% elif product == "rhel8" %}}
     <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards") }}}</b></li>
-    {{% elif product in ["ol7", "ol8"] %}}
+    {{% elif product == "ol7" %}}
     <li><b>{{{ weblink(link="https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-s4-auth.html") }}}</b></li>
     {{% endif %}}
     </ul>
 
-    {{% if product not in ["ol7", "ol8"] %}}
+    {{% if product != "ol7" %}}
     For guidance on enabling SSH to authenticate against a Common Access Card (CAC), consult documentation at:
     <ul>
     <li><b>{{{ weblink(link="https://access.redhat.com/solutions/82273") }}}</b></li>

--- a/ol7/templates/csv/packages_installed.csv
+++ b/ol7/templates/csv/packages_installed.csv
@@ -9,6 +9,7 @@ gdm
 glibc,0:2.17-55.0.4.el7_0.3
 libreswan
 ntp
+opensc
 openssh-server
 pam_pkcs11
 pcsc-lite

--- a/ol8/profiles/pci-dss.profile
+++ b/ol8/profiles/pci-dss.profile
@@ -110,7 +110,13 @@ selections:
     - display_login_attempts
     - gid_passwd_group_same
     - grub2_audit_argument
-    - smartcard_auth
+    - package_opensc_installed
+    - var_smartcard_drivers=cac
+    - configure_opensc_card_drivers
+    - force_opensc_card_drivers
+    - service_pcscd_enabled
+    - sssd_enable_smartcards
+    - package_pcsc-lite_installed
     - var_multiple_time_servers=ol
     - chronyd_or_ntpd_specify_multiple_servers
     - chronyd_or_ntpd_specify_remote_server

--- a/ol8/templates/csv/packages_installed.csv
+++ b/ol8/templates/csv/packages_installed.csv
@@ -8,8 +8,9 @@ firewalld
 gdm
 libreswan
 ntp
+opensc
 openssh-server
-pam_pkcs11
 pcsc-lite
 rsyslog
+sssd
 tmux


### PR DESCRIPTION
#### Description:

Smartcards auth in OL8 should be done via sssd 
- Enable smartcard services and packages on OL
- Added OL support for force_opensc_card_drivers rule
- Add OL support for configure_opensc_card_drivers rule
- Fixed configure_opensc_card_drivers and force_opensc_card_drivers remediation to use opensc-tool
- Add OL support for sssd_enable_smartcards rule
- Add OL7 support for configure_opensc_nss_db rule
- Remove OL8 support from smartcard_auth rule
- Update OL8 profiles to do smartcards auth via sssd 

#### Testing:
- Checked ol7,ol8 builds to pass
- Checked rules and remediation to pass on OL8
