### PR TITLE
Update ensure_oracle_gpgkey_installed for OL8

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
@@ -1,7 +1,9 @@
 # platform = multi_platform_ol
 # OL fingerprints below retrieved from Oracle Linux Yum Server "Frequently Asked Questions"
 # https://yum.oracle.com/faq.html#a10
-readonly OL_FINGERPRINT="4214 4123 FECF C55B 9086 313D 72F9 7B74 EC55 1F03"
+readonly OL_FINGERPRINT="42144123FECFC55B9086313D72F97B74EC551F03"
+readonly OL8_FINGERPRINT="76FD3DB13AB67410B89DB10E82562EA9AD986DA3"
+
 # Location of the key we would like to import (once it's integrity verified)
 readonly OL_RELEASE_KEY="/etc/pki/rpm-gpg/RPM-GPG-KEY-oracle"
 
@@ -12,21 +14,16 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error)
-  IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint "${OL_RELEASE_KEY}"))
+  IFS=$'\n' GPG_OUT=($(gpg --with-fingerprint --with-colons "$OL_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10))
   GPG_RESULT=$?
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then
-    for ITEM in "${GPG_OUT[@]}"
-    do
-      # Filter just hexadecimal fingerprints from gpg's output from
-      # processing of a key file
-      RESULT=$(echo ${ITEM} | sed -n "s/[[:space:]]*Key fingerprint = \(.*\)/\1/p" | tr -s '[:space:]')
-      # If fingerprint matches Oracle Linux 6 and 7 key import the key
-      if [[ ${RESULT} ]] && [[ ${RESULT} = "${OL_FINGERPRINT}" ]] 
-      then
-        rpm --import "${OL_RELEASE_KEY}"
-      fi
-    done
+    # Filter just hexadecimal fingerprints from gpg's output from
+    # processing of a key file
+    echo "${GPG_OUT[*]}" | grep -vE "${OL_FINGERPRINT}|${OL8_FINGERPRINT}" || {
+      # If $ OL_RELEASE_KEY file doesn't contain any keys with unknown fingerprint, import it
+      rpm --import "${OL_RELEASE_KEY}"
+    }
   fi
 fi

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
@@ -8,13 +8,18 @@
       <description>The Oracle Linux key packages are required to be installed.</description>
     </metadata>
     <criteria comment="Vendor GPG keys" operator="OR">
-      <criteria comment="Oracle Vendor Keys" operator="AND">
-        <criteria comment="Oracle Installed" operator="OR">
+      <criteria comment="Oracle Vendor GPG Keys" operator="AND">
+        <criteria comment="Oracle Linux Release Installed" operator="OR">
           <extend_definition comment="Oracle Linux 6 installed" definition_ref="installed_OS_is_ol6_family" />
           <extend_definition comment="Oracle Linux 7 installed" definition_ref="installed_OS_is_ol7_family" />
+          <extend_definition comment="Oracle Linux 8 installed" definition_ref="installed_OS_is_ol8_family" />
         </criteria>
-        <criterion comment="package gpg-pubkey-ec551f03-53619141 is installed"
-        test_ref="test_package_gpgkey-ec551f03-53619141_installed" />
+        <criteria comment="Oracle GPG Key Installed" operator="OR">
+            <criterion comment="package gpg-pubkey-ec551f03-53619141 is installed"
+            test_ref="test_package_gpgkey-ec551f03-53619141_installed" />
+            <criterion comment="package gpg-pubkey-ad986da3-5cabf60d is installed"
+            test_ref="test_package_gpgkey-ad986da3-5cabf60d_installed" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>
@@ -24,6 +29,7 @@
     <linux:name>gpg-pubkey</linux:name>
   </linux:rpminfo_object>
 
+  <!-- Test for OL6 and OL7 key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
   id="test_package_gpgkey-ec551f03-53619141_installed" version="1"
   comment="Oracle Linux key package is installed">
@@ -34,6 +40,19 @@
   <linux:rpminfo_state id="state_package_gpg-pubkey-ec551f03-53619141" version="1">
     <linux:release>53619141</linux:release>
     <linux:version>ec551f03</linux:version>
+  </linux:rpminfo_state>
+
+  <!-- Test for OL8 key -->
+  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
+  id="test_package_gpgkey-ad986da3-5cabf60d_installed" version="1"
+  comment="Oracle Linux 8 key package is installed">
+    <linux:object object_ref="object_package_gpg-pubkey" />
+    <linux:state state_ref="state_package_gpg-pubkey-ad986da3-5cabf60d" />
+  </linux:rpminfo_test>
+
+  <linux:rpminfo_state id="state_package_gpg-pubkey-ad986da3-5cabf60d" version="1">
+    <linux:release>5cabf60d</linux:release>
+    <linux:version>ad986da3</linux:version>
   </linux:rpminfo_state>
 
 </def-group>


### PR DESCRIPTION
#### Description:
Update ensure_oracle_gpgkey_installed for OL8

- add new Oracle Linux 8 GPG key support
- fix gpg fingerprint handling for OL8 in bash script

Signed-off-by: Ilya Okomin <ilya.okomin@oracle.com>

#### Testing:
- Checked ol7,ol8 builds
- Checked ensure_oracle_gpgkey_installed evaluation and remediation on OL8