### PR TITLE
Fix deprecated IncludeConfig directive in rsyslog_files OVALs

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
@@ -22,36 +22,57 @@
 
   </definition>
 
-  <!-- First obtain rsyslog's $IncludeConfig directive and include() object (introduced in rsyslog v8.33.0) values.
-       To workaround empty include objects case, when FunctionGroup operations return "does not exist" result, added empty string match -->
+  <!-- First obtain rsyslog's $IncludeConfig directive and include() object (introduced in rsyslog v8.33.0) values.  -->
   <ind:textfilecontent54_object id="object_rfg_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive and include() object values" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+)|())$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+))$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Turn that glob value into Perl's regex so it can be used as filepath pattern below -->
   <local_variable id="var_rfg_include_config_regex" datatype="string" version="1" comment="$IncludeConfig value converted to regex">
-    <glob_to_regex>
-      <object_component item_field="subexpression" object_ref="object_rfg_rsyslog_include_config_value" />
-    </glob_to_regex>
+    <unique>
+      <glob_to_regex>
+        <object_component item_field="subexpression" object_ref="object_rfg_rsyslog_include_config_value" />
+      </glob_to_regex>
+    </unique>
   </local_variable>
 
-  <!-- Create collection of unique include_config regex values together with '/etc/rsyslog.conf'
-       path literal to obtain final list of all rsyslog's configuration files
-  -->
-  <local_variable id="var_rfg_all_log_files_as_collection" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
-    <unique>
-      <variable_component var_ref="var_rfg_include_config_regex" />
-      <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
-    </unique>
+  <!-- Create a variable_object from the regex variable
+       If the variable has no values, there won't be any objects -->
+  <ind:variable_object id="object_var_rfg_include_config_regex" comment="Make variable object from regex variable" version="1">
+    <ind:var_ref>var_rfg_include_config_regex</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable id="var_rfg_syslog_config" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
+    <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
+  </local_variable>
+
+  <ind:variable_object id="object_var_rfg_syslog_config" comment="Make variable object for use" version="1">
+    <ind:var_ref>var_rfg_syslog_config</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Combine the two variable_objects into one variable_object
+       We do it this way to avoid referencing an empty variable in a state comparison, which
+       will cause a test to evaluate to fail. Combining an empty set of objects is fine though -->
+  <ind:variable_object id="object_var_rfg_all_log_files" comment="Filter out empty string" version="1">
+    <set>
+      <object_reference>object_var_rfg_include_config_regex</object_reference>
+      <object_reference>object_var_rfg_syslog_config</object_reference>
+    </set>
+  </ind:variable_object>
+
+  <!-- In element filepath of object_rfg_log_files_paths we need to pass a list of values,
+       a list of objects won't do. So we make a local_variable from the variable_objects. -->
+  <local_variable id="var_rfg_all_log_files" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
+    <object_component object_ref="object_var_rfg_all_log_files" item_field="value"/>
   </local_variable>
 
   <!-- For each item from that collection (particular rsyslog's configuration file path) search
        that rsyslog's configuration file to select file paths for log files directives
   -->
   <ind:textfilecontent54_object id="object_rfg_log_files_paths" comment="All rsyslog configuration files" version="1">
-    <ind:filepath operation="pattern match" var_ref="var_rfg_all_log_files_as_collection" var_check="at least one" />
+    <ind:filepath operation="pattern match" var_ref="var_rfg_all_log_files" var_check="at least one" />
     <!-- Chunk of text retrieved from rsyslog's configuration file is considered
          to constitute a log file path if all of the following conditions are met:
          * the string represents a regular file on particular file system

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
@@ -22,11 +22,12 @@
 
   </definition>
 
-  <!-- First obtain rsyslog's $IncludeConfig directive value -->
-  <ind:textfilecontent54_object id="object_rfg_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive value" version="1">
+  <!-- First obtain rsyslog's $IncludeConfig directive and include() object (introduced in rsyslog v8.33.0) values.
+       To workaround empty include objects case, when FunctionGroup operations return "does not exist" result, added empty string match -->
+  <ind:textfilecontent54_object id="object_rfg_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive and include() object values" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\$IncludeConfig[\s]+([^\s;]+)</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+)|())$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Turn that glob value into Perl's regex so it can be used as filepath pattern below -->
@@ -36,24 +37,14 @@
     </glob_to_regex>
   </local_variable>
 
-  <!-- Concatenate that $IncludeConfig regex value together with '/etc/rsyslog.conf'
-       path literal to obtain final list of all rsyslog's configuration files in form
-       of a string. Use '%' character as delemiter to separate items
-  -->
-  <local_variable id="var_rfg_all_log_files_as_string_regex" datatype="string" version="1" comment="Locations of all rsyslog configuration files concatenated into string">
-    <concat>
-      <variable_component var_ref="var_rfg_include_config_regex" />
-      <literal_component datatype="string">%^/etc/rsyslog.conf$</literal_component>
-    </concat>
-  </local_variable>
-
-  <!-- Split the final string by '%' delimiter to obtain OVAL variable in the
-       form of collection of items
+  <!-- Create collection of unique include_config regex values together with '/etc/rsyslog.conf'
+       path literal to obtain final list of all rsyslog's configuration files
   -->
   <local_variable id="var_rfg_all_log_files_as_collection" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
-    <split delimiter='%'>
-      <variable_component var_ref="var_rfg_all_log_files_as_string_regex" />
-    </split>
+    <unique>
+      <variable_component var_ref="var_rfg_include_config_regex" />
+      <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
+    </unique>
   </local_variable>
 
   <!-- For each item from that collection (particular rsyslog's configuration file path) search

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
@@ -19,11 +19,12 @@
 
   </definition>
 
-  <!-- First obtain rsyslog's $IncludeConfig directive value -->
-  <ind:textfilecontent54_object id="object_rfo_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive value" version="1">
+  <!-- First obtain rsyslog's $IncludeConfig directive and include() object (introduced in rsyslog v8.33.0) values.
+       To workaround empty include objects case, when FunctionGroup operations return "does not exist" result, added empty string match -->
+  <ind:textfilecontent54_object id="object_rfo_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive and include() object values" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\$IncludeConfig[\s]+([^\s;]+)</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+)|())$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Turn that glob value into Perl's regex so it can be used as filepath pattern below -->
@@ -33,24 +34,14 @@
     </glob_to_regex>
   </local_variable>
 
-  <!-- Concatenate that $IncludeConfig regex value together with '/etc/rsyslog.conf'
-       path literal to obtain final list of all rsyslog's configuration files in form
-       of a string. Use '%' character as delemiter to separate items
-  -->
-  <local_variable id="var_rfo_all_log_files_as_string_regex" datatype="string" version="1" comment="Locations of all rsyslog configuration files concatenated into string">
-    <concat>
-      <variable_component var_ref="var_rfo_include_config_regex" />
-      <literal_component datatype="string">%^/etc/rsyslog.conf$</literal_component>
-    </concat>
-  </local_variable>
-
-  <!-- Split the final string by '%' delimiter to obtain OVAL variable in the
-       form of collection of items
+  <!-- Create collection of unique include_config regex values together with '/etc/rsyslog.conf'
+       path literal to obtain final list of all rsyslog's configuration files
   -->
   <local_variable id="var_rfo_all_log_files_as_collection" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
-    <split delimiter='%'>
-      <variable_component var_ref="var_rfo_all_log_files_as_string_regex" />
-    </split>
+    <unique>
+      <variable_component var_ref="var_rfo_include_config_regex" />
+      <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
+    </unique>
   </local_variable>
 
   <!-- For each item from that collection (particular rsyslog's configuration file path) search

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
@@ -19,36 +19,57 @@
 
   </definition>
 
-  <!-- First obtain rsyslog's $IncludeConfig directive and include() object (introduced in rsyslog v8.33.0) values.
-       To workaround empty include objects case, when FunctionGroup operations return "does not exist" result, added empty string match -->
+  <!-- First obtain rsyslog's $IncludeConfig directive and include() object (introduced in rsyslog v8.33.0) values.  -->
   <ind:textfilecontent54_object id="object_rfo_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive and include() object values" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+)|())$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+))$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Turn that glob value into Perl's regex so it can be used as filepath pattern below -->
   <local_variable id="var_rfo_include_config_regex" datatype="string" version="1" comment="$IncludeConfig value converted to regex">
-    <glob_to_regex>
-      <object_component item_field="subexpression" object_ref="object_rfo_rsyslog_include_config_value" />
-    </glob_to_regex>
+    <unique>
+      <glob_to_regex>
+        <object_component item_field="subexpression" object_ref="object_rfo_rsyslog_include_config_value" />
+      </glob_to_regex>
+    </unique>
   </local_variable>
 
-  <!-- Create collection of unique include_config regex values together with '/etc/rsyslog.conf'
-       path literal to obtain final list of all rsyslog's configuration files
-  -->
-  <local_variable id="var_rfo_all_log_files_as_collection" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
-    <unique>
-      <variable_component var_ref="var_rfo_include_config_regex" />
-      <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
-    </unique>
+  <!-- Create a variable_object from the regex variable
+       If the variable has no values, there won't be any objects -->
+  <ind:variable_object id="object_var_rfo_include_config_regex" comment="Make variable object from regex variable" version="1">
+    <ind:var_ref>var_rfo_include_config_regex</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable id="var_rfo_syslog_config" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
+    <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
+  </local_variable>
+
+  <ind:variable_object id="object_var_rfo_syslog_config" comment="Make variable object for use" version="1">
+    <ind:var_ref>var_rfo_syslog_config</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Combine the two variable_objects into one variable_object
+       We do it this way to avoid referencing an empty variable in a state comparison, which
+       will cause a test to evaluate to fail. Combining an empty set of objects is fine though -->
+  <ind:variable_object id="object_var_rfo_all_log_files" comment="Filter out empty string" version="1">
+    <set>
+      <object_reference>object_var_rfo_include_config_regex</object_reference>
+      <object_reference>object_var_rfo_syslog_config</object_reference>
+    </set>
+  </ind:variable_object>
+
+  <!-- In element filepath of object_rfg_log_files_paths we need to pass a list of values,
+       a list of objects won't do. So we make a local_variable from the variable_objects. -->
+  <local_variable id="var_rfo_all_log_files" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
+    <object_component object_ref="object_var_rfo_all_log_files" item_field="value"/>
   </local_variable>
 
   <!-- For each item from that collection (particular rsyslog's configuration file path) search
        that rsyslog's configuration file to select file paths for log files directives
   -->
   <ind:textfilecontent54_object id="object_rfo_log_files_paths" comment="All rsyslog configuration files" version="1">
-    <ind:filepath operation="pattern match" var_ref="var_rfo_all_log_files_as_collection" var_check="at least one" />
+    <ind:filepath operation="pattern match" var_ref="var_rfo_all_log_files" var_check="at least one" />
     <!-- Chunk of text retrieved from rsyslog's configuration file is considered
          to constitute a log file path if all of the following conditions are met:
          * the string represents a regular file on particular file system

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -26,32 +26,54 @@
        To workaround empty include objects case, when FunctionGroup operations return "does not exist" result, added empty string match -->
   <ind:textfilecontent54_object id="object_rfp_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive and include() object values" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+)|())$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+))$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Turn that glob value into Perl's regex so it can be used as filepath pattern below -->
   <local_variable id="var_rfp_include_config_regex" datatype="string" version="1" comment="$IncludeConfig value converted to regex">
-    <glob_to_regex>
-      <object_component item_field="subexpression" object_ref="object_rfp_rsyslog_include_config_value" />
-    </glob_to_regex>
+    <unique>
+      <glob_to_regex>
+        <object_component item_field="subexpression" object_ref="object_rfp_rsyslog_include_config_value" />
+      </glob_to_regex>
+    </unique>
   </local_variable>
 
-  <!-- Create collection of unique include_config regex values together with '/etc/rsyslog.conf'
-       path literal to obtain final list of all rsyslog's configuration files
-  -->
-  <local_variable id="var_rfp_all_log_files_as_collection" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
-    <unique>
-      <variable_component var_ref="var_rfp_include_config_regex" />
-      <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
-    </unique>
+  <!-- Create a variable_object from the regex variable
+       If the variable has no values, there won't be any objects -->
+  <ind:variable_object id="object_var_rfp_include_config_regex" comment="Make variable object from regex variable" version="1">
+    <ind:var_ref>var_rfp_include_config_regex</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable id="var_rfp_syslog_config" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
+    <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
+  </local_variable>
+
+  <ind:variable_object id="object_var_rfp_syslog_config" comment="Make variable object for use" version="1">
+    <ind:var_ref>var_rfp_syslog_config</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Combine the two variable_objects into one variable_object
+       We do it this way to avoid referencing an empty variable in a state comparison, which
+       will cause a test to evaluate to fail. Combining an empty set of objects is fine though -->
+  <ind:variable_object id="object_var_rfp_all_log_files" comment="Filter out empty string" version="1">
+    <set>
+      <object_reference>object_var_rfp_include_config_regex</object_reference>
+      <object_reference>object_var_rfp_syslog_config</object_reference>
+    </set>
+  </ind:variable_object>
+
+  <!-- In element filepath of object_rfg_log_files_paths we need to pass a list of values,
+       a list of objects won't do. So we make a local_variable from the variable_objects. -->
+  <local_variable id="var_rfp_all_log_files" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
+    <object_component object_ref="object_var_rfp_all_log_files" item_field="value"/>
   </local_variable>
 
   <!-- For each item from that collection (particular rsyslog's configuration file path) search
        that rsyslog's configuration file to select file paths for log files directives
   -->
   <ind:textfilecontent54_object id="object_rfp_log_files_paths" comment="All rsyslog configuration files" version="1">
-    <ind:filepath operation="pattern match" var_ref="var_rfp_all_log_files_as_collection" var_check="at least one" />
+    <ind:filepath operation="pattern match" var_ref="var_rfp_all_log_files" var_check="at least one" />
     <!-- Chunk of text retrieved from rsyslog's configuration file is considered
          to constitute a log file path if all of the following conditions are met:
          * the string represents a regular file on particular file system

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -22,11 +22,12 @@
 
   </definition>
 
-  <!-- First obtain rsyslog's $IncludeConfig directive value -->
-  <ind:textfilecontent54_object id="object_rfp_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive value" version="1">
+  <!-- First obtain rsyslog's $IncludeConfig directive and include() object (introduced in rsyslog v8.33.0) values.
+       To workaround empty include objects case, when FunctionGroup operations return "does not exist" result, added empty string match -->
+  <ind:textfilecontent54_object id="object_rfp_rsyslog_include_config_value" comment="rsyslog's $IncludeConfig directive and include() object values" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\$IncludeConfig[\s]+([^\s;]+)</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^(?:include\([\n\s]*file="([^\s;]+)".*|\$IncludeConfig[\s]+([^\s;]+)|())$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Turn that glob value into Perl's regex so it can be used as filepath pattern below -->
@@ -36,24 +37,14 @@
     </glob_to_regex>
   </local_variable>
 
-  <!-- Concatenate that $IncludeConfig regex value together with '/etc/rsyslog.conf'
-       path literal to obtain final list of all rsyslog's configuration files in form
-       of a string. Use '%' character as delemiter to separate items
-  -->
-  <local_variable id="var_rfp_all_log_files_as_string_regex" datatype="string" version="1" comment="Locations of all rsyslog configuration files concatenated into string">
-    <concat>
-      <variable_component var_ref="var_rfp_include_config_regex" />
-      <literal_component datatype="string">%^/etc/rsyslog.conf$</literal_component>
-    </concat>
-  </local_variable>
-
-  <!-- Split the final string by '%' delimiter to obtain OVAL variable in the
-       form of collection of items
+  <!-- Create collection of unique include_config regex values together with '/etc/rsyslog.conf'
+       path literal to obtain final list of all rsyslog's configuration files
   -->
   <local_variable id="var_rfp_all_log_files_as_collection" datatype="string" version="1" comment="Locations of all rsyslog configuration files as collection">
-    <split delimiter='%'>
-      <variable_component var_ref="var_rfp_all_log_files_as_string_regex" />
-    </split>
+    <unique>
+      <variable_component var_ref="var_rfp_include_config_regex" />
+      <literal_component datatype="string">^/etc/rsyslog.conf$</literal_component>
+    </unique>
   </local_variable>
 
   <!-- For each item from that collection (particular rsyslog's configuration file path) search


### PR DESCRIPTION
#### Description:
Fixes #4363 - $IncludeConfig directive is deprecated starting from rsyslog v8.33.0,
include() object should be used instead on RHEL8 and OL8.

Signed-off-by: Ilya Okomin <ilya.okomin@oracle.com>

#### Testing:
-Checked builds for ol7,ol8,rhel8
-Checked rules evaluation on ol8