### PR TITLE
Remove firewalld DefaultZone=drop check from rhel7/ccc profile

### DIFF
--- a/rhel7/profiles/ccc.profile
+++ b/rhel7/profiles/ccc.profile
@@ -189,7 +189,6 @@ selections:
 
     # Firewalld
     - service_firewalld_enabled
-    - set_firewalld_default_zone
 
     # abrt
     - package_abrt_removed


### PR DESCRIPTION
There is no specific requirement in OSPPv4.2 for this, the system
should therefore default to reasonably secure defaults, which means
public zone with only dhcp+ssh allowed.

No need for "drop all network traffic".