### PR TITLE
Match the comment to the actual "less than or equal" operation.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -10,8 +10,8 @@
       <description>Checks interactive shell timeout</description>
     </metadata>
     <criteria operator="OR">
-      <criterion comment="TMOUT value in /etc/profile >= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
-      <criterion comment="TMOUT value in /etc/profile.d/*.sh >= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
+      <criterion comment="TMOUT value in /etc/profile &lt;= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
+      <criterion comment="TMOUT value in /etc/profile.d/*.sh &lt;= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
     </criteria>
   </definition>
 


### PR DESCRIPTION
#### Description:

- Match the comment to the actual "less than or equal" operation.

#### Rationale:

- Consistency.