### PR TITLE
Remove ed25519 key generation from Dockerfiles as it is not supported when FIPS is enabled.

### DIFF
--- a/Dockerfiles/test_suite-centos
+++ b/Dockerfiles/test_suite-centos
@@ -6,7 +6,7 @@ ENV AUTH_KEYS=/root/.ssh/authorized_keys
 ARG CLIENT_PUBLIC_KEY
 ARG ADDITIONAL_PACKAGES
 
-# Insall Python so Ansible remediations can work
+# Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
@@ -15,7 +15,7 @@ RUN true \
         && true
 
 RUN true \
-        && for key_type in rsa ecdsa ed25519; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -6,7 +6,7 @@ ENV AUTH_KEYS=/root/.ssh/authorized_keys
 ARG CLIENT_PUBLIC_KEY
 ARG ADDITIONAL_PACKAGES
 
-# Insall Python so Ansible remediations can work
+# Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
@@ -15,7 +15,7 @@ RUN true \
         && true
 
 RUN true \
-        && for key_type in rsa ecdsa ed25519; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \

--- a/Dockerfiles/test_suite-rhel
+++ b/Dockerfiles/test_suite-rhel
@@ -6,7 +6,7 @@ ENV AUTH_KEYS=/root/.ssh/authorized_keys
 ARG CLIENT_PUBLIC_KEY
 ARG ADDITIONAL_PACKAGES
 
-# Insall Python so Ansible remediations can work
+# Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
@@ -15,7 +15,7 @@ RUN true \
         && true
 
 RUN true \
-        && for key_type in rsa ecdsa ed25519; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \


### PR DESCRIPTION
#### Description:

- Latest RHEL7 container image (FIPS enabled) doesn't build if it tries to generate this ssh ed25519 key. Remove also from other distributions (Fedora, CentOS)

https://access.redhat.com/solutions/3643252

Ansible playbooks from [Security Labs](https://github.com/RedHatDemos/SecurityDemos/blob/master/2019Labs/CustomSecurityContent/setup/) throw error when trying to build the RHEL container image.
