### PR TITLE
Install just things needed for the sssd service to run.

### DIFF
--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/comment.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/comment.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/correct_value.pass.sh
@@ -7,7 +7,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # this should pass for every product which contains ospp profile
 TIMEOUT="180"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_section.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_value.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_memcache_timeout/wrong_value.fail.sh
@@ -8,7 +8,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # Let's put there a higher value to fail
 TIMEOUT="99999"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/common.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_offline_cred_expiration/common.sh
@@ -2,7 +2,7 @@
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/comment.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/comment.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/correct_value.pass.sh
@@ -7,7 +7,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # this should pass for every product which contains ospp profile
 TIMEOUT="180"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_section.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_section.fail.sh
@@ -5,7 +5,7 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_value.fail.sh
+++ b/tests/data/group_services/group_sssd/rule_sssd_ssh_known_hosts_timeout/wrong_value.fail.sh
@@ -8,7 +8,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # Let's put there a different value to fail
 TIMEOUT="99999"
 
-yum -y install sssd
+yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF


### PR DESCRIPTION
#### Description:

- Install just things needed for the sssd service to run.

#### Rationale:

- No need to pull in the whole sssd package and its dependencies.
- Namely, sssd-common (and its dependencies) are just fine.
