### PR TITLE
Options memcache_timeout and offline_credentials_expiration are performance-related, not security-related.

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -68,9 +68,6 @@ selections:
     - gnome_gdm_disable_automatic_login
     - gnome_gdm_disable_guest_login
     - sssd_run_as_sssd_user
-    - sssd_offline_cred_expiration
-    - sssd_memcache_timeout
-    - var_sssd_memcache_timeout=1_day
     - disable_host_auth
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
@@ -30,7 +30,6 @@ references:
     disa: "2007"
     nist: 'IA-5(10),IA-5(13)'
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FIA_AFL.1
     srg: SRG-OS-000383-GPOS-00166
     vmmsrg: SRG-OS-000383-VMM-001570
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
@@ -27,7 +27,6 @@ references:
     disa: "2007"
     nist: IA-5(13)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FIA_AFL.1
     srg: SRG-OS-000383-GPOS-00166
     vmmsrg: SRG-OS-000383-VMM-001570
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'

--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -67,9 +67,6 @@ selections:
     - gnome_gdm_disable_automatic_login
     - gnome_gdm_disable_guest_login
     - sssd_run_as_sssd_user
-    - sssd_offline_cred_expiration
-    - sssd_memcache_timeout
-    - var_sssd_memcache_timeout=1_day
     - disable_host_auth
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -390,8 +390,6 @@ selections:
     - package_pcsc-lite_installed
     - service_pcscd_enabled
     - sssd_enable_smartcards
-    - sssd_memcache_timeout
-    - sssd_offline_cred_expiration
     - sssd_ssh_known_hosts_timeout
     - encrypt_partitions
     - ensure_redhat_gpgkey_installed

--- a/rhel7/profiles/ospp42.profile
+++ b/rhel7/profiles/ospp42.profile
@@ -65,8 +65,6 @@ selections:
     - sshd_disable_root_login
     - gnome_gdm_disable_automatic_login
     - gnome_gdm_disable_guest_login
-    - sssd_offline_cred_expiration
-    - sssd_memcache_timeout
     - disable_host_auth
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -251,9 +251,6 @@ selections:
     - gnome_gdm_disable_automatic_login
     - gnome_gdm_disable_guest_login
     - sssd_run_as_sssd_user
-    - sssd_offline_cred_expiration
-    - sssd_memcache_timeout
-    - var_sssd_memcache_timeout=1_day
     - disable_host_auth
     - sshd_disable_gssapi_auth
     - sshd_disable_kerb_auth


### PR DESCRIPTION

#### Description:

- Stop setting SSSD options `memcache_timeout` and `offline_credentials_expiration` in OSPP profiles.

#### Rationale:

- They are performance related, not security related.
