### PR TITLE
Fix example in csv_map

### DIFF
--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -143,7 +143,7 @@ class FilesGenerator(object):
 
         CSV lines can look like:
             col1, col2 # comment
-            col3, col4 # only-for: bash, oval
+            col3, col4 # except-for: bash, oval
         """
 
         with open(filename, "r") as csv_file:


### PR DESCRIPTION
#### Description:

 - Just a small comment fix to reflect reality. `except-for` instead of `only-for`. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`