### PR TITLE
Use systemd-sulogin-shell to set single-user mode password in RHEL8

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -4,7 +4,7 @@
 
 service_file="/usr/lib/systemd/system/rescue.service"
 
-{{% if product == "fedora" -%}}
+{{% if product in ["fedora", "rhel8"] -%}}
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"
 {{%- else -%}}
 sulogin="/sbin/sulogin"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -29,7 +29,7 @@
   {{%- if init_system == "systemd" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product == "fedora" -%}}
+    {{% if product in ["fedora", "rhel8"] -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -41,7 +41,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
-    {{%- if product == "fedora" -%}}
+    {{%- if product in ["fedora", "rhel8"] -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-.*/sbin/sulogin</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -64,7 +64,7 @@ ocil: |-
 {{% else %}}
     <pre>$ grep sulogin /usr/lib/systemd/system/rescue.service</pre>
     The output should be similar to the following, and the line must begin with
-    {{% if product == "fedora" -%}}
+    {{% if product in ["fedora", "rhel8"] -%}}
         ExecStart and /usr/lib/systemd/systemd-sulogin-shell.
         <pre>ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue</pre>
     {{%- else -%}}

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/correct_value.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 service_file="/usr/lib/systemd/system/rescue.service"

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/wrong_value.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_require_singleuser_auth/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 service_file="/usr/lib/systemd/system/rescue.service"


### PR DESCRIPTION
#### Description:

- Update description, oval and bash fix of rule `require_singleuser_auth` with regards to service's `ExecStart` configuration.

#### Rationale:

- In RHEL8, single-user mode password should be set using `/usr/lib/systemd/systemd-sulogin-shell`
