### PR TITLE
Profile subtraction: Sort selection of rules after subtraction

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -208,6 +208,7 @@ class Profile(object):
         profile.description = self.description
         profile.extends = self.extends
         profile.selected = list(set(self.selected) - set(other.selected))
+        profile.selected.sort()
         profile.unselected = list(set(self.unselected) - set(other.unselected))
         profile.variables = self.variables
         return profile


### PR DESCRIPTION

#### Description:

- Subtraction of profiles is used by `profile_tool.py` with `sub` command.

#### Rationale:

- If rule selection is sorted, it is easier to compare profiles.
