### PR TITLE
Macros everywhere

### DIFF
--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -98,8 +98,8 @@ class FilesGenerator(object):
 
         try:
             jinja_dict = ssg.utils.merge_dicts(self.env_yaml, constants)
-            filled_template = ssg.jinja.process_file(template_filepath,
-                                                     jinja_dict)
+            filled_template = ssg.jinja.process_file_with_macros(template_filepath,
+                                                                 jinja_dict)
 
             with open(output_filepath, "w") as f:
                 f.write(filled_template)

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -13,7 +13,7 @@ import ssg.yaml
 from . import build_yaml
 from . import rules
 from . import utils
-from .jinja import process_file as jinja_process_file
+from .jinja import process_file_with_macros as jinja_process_file
 from .xml import ElementTree
 
 REMEDIATION_TO_EXT_MAP = {

--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -13,7 +13,7 @@ from .constants import oval_namespace as ovalns
 from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs
 from .xml import ElementTree as ET
 from .xml import oval_generated_header
-from .yaml import process_file
+from .jinja import process_file_with_macros
 from .id_translate import IDTranslator
 
 SHARED_OVAL = re.sub(r'ssg/.*', 'shared', __file__) + '/checks/oval/'
@@ -98,7 +98,7 @@ def applicable_platforms(oval_file):
 
     platforms = []
     header = oval_generated_header("applicable_platforms", "5.11", "0.0.1")
-    body = process_file(oval_file, {})
+    body = process_file_with_macros(oval_file, {})
     oval_tree = ET.fromstring(header + body + footer)
 
     element_path = "./{%s}def-group/{%s}definition/{%s}metadata/{%s}affected/{%s}platform"


### PR DESCRIPTION
#### Description

Depends on #4413; will be rebased once that is merged. 
    
Templates, remediations, and OVAL checks have been enabled for Jinja
macro use. This should let us cut down reuse of common code snippets by
moving them to Jinja macros. We can also augment our templating system
by using Jinja macros.

#### Rationale

I opted to split out these changes from #4413 because they might be more controversial. I recall discussions about them in the past but don't remember specifics or their outcomes. My goal with these are to introduce new macros that we can use in the `lineinfile`-type templating. 

This gives us a few options for the future:

 - Use macros to augment templating. This is probably the least work option and is what I'm working towards now.
 - Replace templating entirely with macros. This means the current templating logic could write out a remediation/check/etc. which uses a Jinja macro and check that into the source tree. All changes to the content would go through the Jinja macro. Users/developers could see that the rule has a check/remediation and also be able to edit it only one place (i.e., the Jinja macro definition file).