### PR TITLE
tests/install_vm.py: fix python3 traceback in detect_url_os function

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -96,7 +96,7 @@ def detect_url_os(url):
         else:
             raise
 
-    contents = proc.stdout.read().rstrip()
+    contents = proc.stdout.read().rstrip().decode()
     if not contents:
         return None
     pairs = map(lambda x: x.split('='), contents.splitlines())


### PR DESCRIPTION
#### Description:

In python3 the `subprocess.Popen` returns byte string instead of normal
string, therefore it needs to be decoded.