### PR TITLE
Build multiple products

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,29 +48,39 @@ option(SSG_SEPARATE_SCAP_FILES_ENABLED "If enabled, separate SCAP files (OVAL, X
 option(SSG_JINJA2_CACHE_ENABLED "If enabled, the jinja2 templating files will be cached into bytecode. Also see SSG_JINJA2_CACHE_DIR." TRUE)
 set(SSG_JINJA2_CACHE_DIR "${CMAKE_BINARY_DIR}/jinja2_cache" CACHE PATH "Where the jinja2 cached bytecode should be stored. This speeds up builds at the expense of disk space. You can use one location for multiple SSG builds for performance improvements.")
 
-option(SSG_PRODUCT_CHROMIUM "If enabled, the Chromium SCAP content will be built" TRUE)
-option(SSG_PRODUCT_DEBIAN8 "If enabled, the Debian 8 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_EAP6 "If enabled, the JBoss EAP6 SCAP content will be built" TRUE)
+# SSG_PRODUCT_DEFAULT modifies the behavior of all other options. Products
+# which should be built by default should use the value ${SSG_PRODUCT_DEFAULT}
+# instead of the boolean True. This allows us disable all default products by
+# passing `-DSSG_PRODUCT_DEFAULT=OFF` and then manually specifying a list of
+# products to build.
+option(SSG_PRODUCT_DEFAULT "If enabled, all default release products will be built; otherwise only explicitly enabled products will be" TRUE)
+
+# Products to build content for. These generally correspond to directories in
+# the root of this project. Note that the example product is always disabled
+# unless explicitly asked for.
+option(SSG_PRODUCT_CHROMIUM "If enabled, the Chromium SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_DEBIAN8 "If enabled, the Debian 8 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_EAP6 "If enabled, the JBoss EAP6 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_EXAMPLE "If enabled, the Example SCAP content will be built" FALSE)
-option(SSG_PRODUCT_FEDORA "If enabled, the Fedora SCAP content will be built" TRUE)
-option(SSG_PRODUCT_FIREFOX "If enabled, the Firefox SCAP content will be built" TRUE)
-option(SSG_PRODUCT_FUSE6 "If enabled, the JBoss Fuse6 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_JRE "If enabled, the JRE SCAP content will be built" TRUE)
-option(SSG_PRODUCT_OCP3 "If enabled, the OCP3 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_OL7 "If enabled, the Oracle Linux 7 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_OL8 "If enabled, the Oracle Linux 8 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_OPENSUSE "If enabled, the openSUSE SCAP content will be built" TRUE)
-option(SSG_PRODUCT_RHEL6 "If enabled, the RHEL6 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_RHEL7 "If enabled, the RHEL7 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_RHEL8 "If enabled, the RHEL8 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_RHOSP13 "If enabled, the RHOSP13 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_RHV4 "If enabled, the RHV4 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_SLE11 "If enabled, the SLE11 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_SLE12 "If enabled, the SLE12 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_UBUNTU1404 "If enabled, the Ubuntu 14.04 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_UBUNTU1604 "If enabled, the Ubuntu 16.04 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_UBUNTU1804 "If enabled, the Ubuntu 18.04 SCAP content will be built" TRUE)
-option(SSG_PRODUCT_WRLINUX "If enabled, the WRLinux SCAP content will be built" TRUE)
+option(SSG_PRODUCT_FEDORA "If enabled, the Fedora SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_FIREFOX "If enabled, the Firefox SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_FUSE6 "If enabled, the JBoss Fuse6 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_JRE "If enabled, the JRE SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_OCP3 "If enabled, the OCP3 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_OL7 "If enabled, the Oracle Linux 7 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_OL8 "If enabled, the Oracle Linux 8 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_OPENSUSE "If enabled, the openSUSE SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_RHEL6 "If enabled, the RHEL6 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_RHEL7 "If enabled, the RHEL7 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_RHEL8 "If enabled, the RHEL8 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_RHOSP13 "If enabled, the RHOSP13 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_RHV4 "If enabled, the RHV4 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_SLE11 "If enabled, the SLE11 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_SLE12 "If enabled, the SLE12 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_UBUNTU1404 "If enabled, the Ubuntu 14.04 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_UBUNTU1604 "If enabled, the Ubuntu 16.04 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_UBUNTU1804 "If enabled, the Ubuntu 18.04 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_WRLINUX "If enabled, the WRLinux SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 
 option(SSG_CENTOS_DERIVATIVES_ENABLED "If enabled, CentOS derivative content will be built from the RHEL content" TRUE)
 option(SSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED "If enabled, Scientific Linux derivative content will be built from the RHEL content" TRUE)

--- a/build_product
+++ b/build_product
@@ -10,7 +10,18 @@ to_lowercase() {
 
 opt_product_in() {
 	switch="-DSSG_PRODUCT_$(to_uppercase "$1")=ON"
-	printf "%s" "$switch"
+	echo "$switch"
+}
+
+is_product() {
+	local candidate="$1"
+	for cmake_product in "${all_cmake_products[@]}"; do
+		if test "$(to_uppercase "$candidate")" = "$cmake_product"; then
+			return 0
+		fi
+	done
+
+	return 1
 }
 
 handle_wrong_argument() {
@@ -19,18 +30,18 @@ handle_wrong_argument() {
 		all_cmake_lowercase+=("$(to_lowercase "$p")")
 	done
 	possible_products=$'\n'"$(printf ' * %s\n' "${all_cmake_lowercase[@]}")"
-	printf "Wipes out contents of the 'build' directory and builds only and only the given product."
+	printf "Wipes out contents of the 'build' directory and builds only and only the given products."
 	echo
 	echo
 	printf 'Usage:\n'
-	printf '\tbuild-product <product name>\n'
+	printf '\tbuild-product <product-name> [<product-name> ...]\n'
 	echo
 	if test -n "$1"; then
 		printf "The argument '%s' is not supported.\\n" "$1"
 	else
-		printf 'Supply product name as first argument to the script.\n'
+		printf 'Supply product names as arguments to this script.\n'
 	fi
-	printf 'Choose one of product names from the list: %s' "$possible_products"
+	printf 'Choose one or more product names from the list: %s' "$possible_products"
 	echo
 	exit 1
 }
@@ -61,17 +72,18 @@ all_cmake_products=(
 	WRLINUX
 )
 
-chosen_product=$1
+if (( $# == 0 )); then
+	handle_wrong_argument
+fi
 
-chosen_product_encountered_among_cmake=off
-cmake_disable_all_args=()
-for p in "${all_cmake_products[@]}"; do
-	cmake_disable_all_args+=(-DSSG_PRODUCT_$p=OFF)
-	if test "$(to_uppercase "$chosen_product")" = "$p"; then
-		chosen_product_encountered_among_cmake=on
+cmake_enable_args=()
+for chosen_product in "$@"; do
+	if is_product "$chosen_product"; then
+		cmake_enable_args+=("$(opt_product_in "$chosen_product")")
+	else
+		handle_wrong_argument "$chosen_product"
 	fi
 done
-test "$chosen_product_encountered_among_cmake" = on || handle_wrong_argument "$chosen_product"
 
 cores=$(nproc 2>/dev/null) || cores=1
 
@@ -86,5 +98,5 @@ fi
 set -e
 rm -rf build/*
 cd build
-cmake .. "${cmake_disable_all_args[@]}" "$(opt_product_in $chosen_product)" -G "$cmake_generator"
-$build_command "-j${cores}" "$chosen_product"
+cmake .. -DSSG_PRODUCT_DEFAULT=OFF "${cmake_enable_args[@]}" -G "$cmake_generator"
+$build_command "-j${cores}"


### PR DESCRIPTION
#### Description:

After @jan-cerny's #4416 I felt this was the next obvious improvement (also, I wanted to build multiple profiles at once for some of my testing but I didn't want to maintain a separate list of products in my own [`build`](https://github.com/cipherboy/dotfiles/blob/master/bashrc.d/build.sh) scripts).

This adds two things:

 - `SSG_PRODUCT_DEFAULT` -- a flag which controls the behavior of all default products. This defaults to `TRUE`, and is substituted into all products which default to `TRUE`, namely all but the example one. When you disable `SSG_PRODUCT_DEFAULT`, the default value of all otherwise-default-enable products becomes `FALSE`; however you can enable any profile explicitly and it will behave as expected.
 - Updates `build_product` to support multiple products on the command line. I also simplified some of the casing logic / etc. 