### PR TITLE
Add option for extra repository in install_vm.py script.

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -70,6 +70,12 @@ def parse_args():
         help="URL to an installation tree on a remote server."
     )
     parser.add_argument(
+        "--extra-repo",
+        dest="extra_repo",
+        default=None,
+        help="URL to an extra repository to be used during installation (e.g. AppStream)."
+    )
+    parser.add_argument(
         "--dry",
         dest="dry",
         action="store_true",
@@ -152,6 +158,13 @@ def main():
         if ostype:
             if any(filter(lambda x: x in ostype, ['centos.org', 'redhat.com'])):
                 content = content.replace("&&YUM_REPO_URL&&", data.url)
+                if data.extra_repo:
+                    # extra repository
+                    repo_cmd = "repo --name=extra-repository --baseurl={}".format(data.extra_repo)
+                    content = content.replace("&&YUM_EXTRA_REPO&&", repo_cmd)
+                    content = content.replace("&&YUM_EXTRA_REPO_URL&&", data.extra_repo)
+                else:
+                    content = content.replace("&&YUM_EXTRA_REPO&&", "")
         outfile.write(content)
     data.kickstart = tmp_kickstart
     print("Using kickstart file: {0}".format(data.kickstart))

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -1,6 +1,7 @@
 # SCAP Security Guide SCAP Test Suite node
 # This kickstart is known to apply for:
 # - Red Hat Enterprise Linux 7 Server
+# - Red Hat Enterprise Linux 8 - when using additional repository AppStream
 # - CentOS 7
 # - Fedora
 #
@@ -16,6 +17,7 @@ text
 
 # To enable custom repositories for the machine after installation use:
 #repo --name=myrepo --baseurl=http://...
+&&YUM_EXTRA_REPO&&
 
 # Set language to use during installation and the default language to use on the installed system (required)
 lang en_US.UTF-8
@@ -122,6 +124,16 @@ if ! [[ '&&YUM_REPO_URL&&' =~ YUM_REPO_URL ]]; then
 [inst-ks]
 name=Installation repo from kickstart
 baseurl=&&YUM_REPO_URL&&
+enabled=1
+gpgcheck=0
+EOF
+fi
+# create yum/dnf repository from URL if replaced by install_vm.py
+if ! [[ '&&YUM_EXTRA_REPO_URL&&' =~ YUM_EXTRA_REPO_URL ]]; then
+	cat >> /etc/yum.repos.d/inst-ks.repo <<EOF
+[inst-ks-2]
+name=Extra repo from kickstart
+baseurl=&&YUM_EXTRA_REPO_URL&&
 enabled=1
 gpgcheck=0
 EOF


### PR DESCRIPTION


#### Description:

- This allows to install RHEL8 machines providing the AppStream as
extra repository.

#### Rationale:

- Provide support for adding extra repository during OS installation, enabling RHEL8 installation.
