### PR TITLE
Remove duplicated CCE suffix from replace_or_append bash remediation.

### DIFF
--- a/shared/bash_remediation_functions/replace_or_append.sh
+++ b/shared/bash_remediation_functions/replace_or_append.sh
@@ -52,7 +52,7 @@ function replace_or_append {
   # Test that the cce arg is not empty or does not equal @CCENUM@.
   # If @CCENUM@ exists, it means that there is no CCE assigned.
   if [ -n "$cce" ] && [ "$cce" != '@CCENUM@' ]; then
-    cce="CCE-${cce}"
+    cce="${cce}"
   else
     cce="CCE"
   fi


### PR DESCRIPTION
#### Description:

- Remove duplicated `CCE-` suffix from documentation added by bash remediation.

#### Rationale:

- @CCENUM@ when expanded already contains the suffix `CCE-`.
