### PR TITLE
Add Ansible macros for lineinfile remediations

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -20,7 +20,7 @@ Join the mailing list at https://fedorahosted.org/mailman/listinfo/scap-security
 ## Building ComplianceAsCode
 
 ### Installing build dependencies
- 
+
 On *Red Hat Enterprise Linux 6/7* make sure the packages `cmake`, `openscap-utils`,
 `PyYAML`, `python-jinja2` and their dependencies are installed:
 
@@ -672,7 +672,7 @@ The tool also can subtract rules between YAML profiles.
 
 For example, to subtract selected rules from a given profile based on rules selected by another profile, run this command:
 ----
-$ ./build-scripts/profile_tool.py sub --profile1 rhel7/profiles/ospp.profile --profile2 rhel7/profiles/pci-dss.profile 
+$ ./build-scripts/profile_tool.py sub --profile1 rhel7/profiles/ospp.profile --profile2 rhel7/profiles/pci-dss.profile
 ----
 
 This will result in a new YAML profile containing exclusive rules to the profile pointed by the --profile1 option.
@@ -997,11 +997,14 @@ IMPORTANT: The minimum version of Ansible must be at the latest supported versio
 Ansible remediations are either:
 - stored as `.yml` files in directory `ansible` in the rule directory
 - generated from templates
+- generated using jinja2 macros
 
 They are meant to be executed by Ansible itself when requested by openscap, so they are
 written using link:http://docs.ansible.com/ansible/latest/intro.html[Ansible's own language] with the following exceptions:
 
 - The remediation content must be only the _tasks_ section of what would be a playbook
+    - Tasks can include blocks for grouping related tasks.
+    - The `when` clause will get augmented in certain scenarios.
 - Notifications and handlers are not supported
 
 Here is an example of a Ansible remediation that ensures the SELinux is enabled in grub:
@@ -1030,6 +1033,25 @@ Due to undefined XCCDF Value selectors in this pseudo-profile, these Playbooks u
 
 We also build profile Playbook that contains tasks for all rules in the profile.
 The Playbook is generated in `/build/ansible/<product>-playbook-<profile_id>.yml`.
+
+Jinja macros for Ansible content are located in `/shared/macros-ansible.jinja`.
+
+These currently include the following high-level macros:
+ - `ansible_sshd_set` -- set a parameter in the sshd configuration
+ - `ansible_etc_profile_set` -- ensure a command gets execuded or a variable gets set in /etc/profile or /etc/profile.d
+
+They also include several low-level macros:
+ - `ansible_lineinfile` -- ensure a line is in a given file
+ - `ansible_stat` -- check the status of a path on the file system
+ - `ansible_find` -- find all files with matched content
+ - `ansible_only_lineinfile` -- ensure that no lines matching the regex are present and add the given line
+ - `ansible_set_config_file` -- for configuration files; set the given configuration value and ensure no conflicting values
+ - `ansible_set_config_file_dir` -- for configuration files and files in configuration directories; set the given configuration value and ensure no conflicting values
+
+When `msg` is absent from any of the above macros, rule title will be substituted instead.
+
+Whenever possible, please reuse the macros and form high-level simplifications.
+This ensures consistent, high quality remediations that we can edit in one place and reuse in many places.
 
 ==== Bash
 

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/ansible/shared.yml
@@ -3,9 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Disable Host-Based Authentication
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^HostbasedAuthentication
-    line: HostbasedAuthentication no
+{{{ ansible_sshd_set(parameter="HostbasedAuthentication", value="no") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
@@ -3,11 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-
-- name: "Allow Only SSH Protocol 2"
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: "^Protocol [0-9]"
-    line: "Protocol 2"
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: :reload ssh
+{{{ ansible_sshd_set(parameter="Protocol", value="2") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/ansible/shared.yml
@@ -3,11 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Disable Compression or Set Compression to delayed"
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: (?i)^#?compression
-    line: Compression delayed
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="Compression", value="delayed") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/ansible/shared.yml
@@ -3,10 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Disable SSH Access via Empty Passwords
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^PermitEmptyPasswords
-    line: PermitEmptyPasswords no
-    validate: /usr/sbin/sshd -t -f %s
+{{{ ansible_sshd_set(parameter="PermitEmptyPasswords", value="no") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/ansible/shared.yml
@@ -3,11 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Disable GSSAPI Authentication"
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: (?i)^#?gssapiauthentication
-    line: GSSAPIAuthentication no
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: sshd -t -f %s
+{{{ ansible_sshd_set(parameter="GSSAPIAuthentication", value="no") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/ansible/shared.yml
@@ -3,11 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Disable Kerberos Authentication"
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: (?i)^#?kerberosauthentication
-    line: KerberosAuthentication no
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="KerberosAuthentication", value="no") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/ansible/shared.yml
@@ -3,10 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Disable SSH Support for .rhosts Files
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^IgnoreRhosts
-    line: IgnoreRhosts yes
-    validate: /usr/sbin/sshd -t -f %s
+{{{ ansible_sshd_set(parameter="IgnoreRhosts", value="yes") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/ansible/shared.yml
@@ -3,10 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Disable SSH Support for Rhosts RSA Authentication
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^RhostsRSAAuthentication
-    line: RhostsRSAAuthentication no
-    validate: /usr/sbin/sshd -t -f %s
+{{{ ansible_sshd_set(parameter="RhostsRSAAuthentication", value="no") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/ansible/shared.yml
@@ -3,12 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Disable SSH Root Login"
-  lineinfile:
-    create: yes
-    dest: "/etc/ssh/sshd_config"
-    regexp: "^PermitRootLogin"
-    line: "PermitRootLogin no"
-    insertafter: '(?i)^#?authentication'
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="PermitRootLogin", value="no") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/ansible/shared.yml
@@ -3,13 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Disable SSH Support for User Known Hosts"
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^IgnoreUserKnownHosts
-    line: IgnoreUserKnownHosts yes
-    insertbefore: ^Match
-    firstmatch: yes 
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="IgnoreUserKnownHosts", value="yes") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/ansible/shared.yml
@@ -3,10 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Do Not Allow SSH Environment Options
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^PermitUserEnvironment
-    line: PermitUserEnvironment no
-    validate: /usr/sbin/sshd -t -f %s
+{{{ ansible_sshd_set(parameter="PermitUserEnvironment", value="no") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
@@ -3,11 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Enable Use of Strict Mode Checking"
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: (?i)^#?strictmodes
-    line: StrictModes yes
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="StrictMode", value="yes") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/ansible/shared.yml
@@ -3,10 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Enable SSH Warning Banner
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^Banner
-    line: Banner /etc/issue
-    validate: /usr/sbin/sshd -t -f %s
+{{{ ansible_sshd_set(parameter="Banner", value="/etc/issue") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/ansible/shared.yml
@@ -3,10 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Enable Encrypted X11 Forwarding
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^X11Forwarding
-    line: X11Forwarding yes
-    validate: /usr/sbin/sshd -t -f %s
+{{{ ansible_sshd_set(parameter="X11Forwarding", value="yes") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/ansible/shared.yml
@@ -1,9 +1,6 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv
-- name: Print last log
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^PrintLastLog
-    line: PrintLastLog yes
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{{ ansible_sshd_set(parameter="PrintLastLog", value="yes") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -5,11 +5,4 @@
 # disruption = low
 - (xccdf-var sshd_idle_timeout_value)
 
-- name: Set SSH Idle Timeout Interval
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^ClientAliveInterval
-    line: "ClientAliveInterval {{ sshd_idle_timeout_value }}"
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="ClientAliveInterval", value="{{ sshd_idle_timeout_value }}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/ansible/shared.yml
@@ -5,11 +5,4 @@
 # disruption = low
 - (xccdf-var var_sshd_set_keepalive)
 
-- name: Set SSH Client Alive Count
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^ClientAliveCountMax
-    line: 'ClientAliveCountMax {{ var_sshd_set_keepalive }}'
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="ClientAliveCountMax", value="{{ var_sshd_set_keepalive }}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -3,11 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Use Only Approved Ciphers
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^Ciphers
-    line: Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="Ciphers", value="aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/ansible/shared.yml
@@ -5,12 +5,4 @@
 # disruption = low
 - (xccdf-var sshd_approved_macs)
 
-- name: "Use Only Approved MACs"
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: ^MACs
-    line: "MACs {{ sshd_approved_macs }}"
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
-
+{{{ ansible_sshd_set(parameter="MACs", value="{{ sshd_approved_macs }}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
@@ -3,11 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Enable use of Privilege Separation"
-  lineinfile:
-    create: yes
-    dest: /etc/ssh/sshd_config
-    regexp: (?i)^#?useprivilegeseparation
-    line: UsePrivilegeSeparation sandbox
-    validate: /usr/sbin/sshd -t -f %s
-  #notify: restart sshd
+{{{ ansible_sshd_set(parameter="UsePrivilegeSeparation", value="sandbox") }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -5,9 +5,4 @@
 # disruption = low
 - (xccdf-var var_accounts_tmout)
 
-- name: Set Interactive Session Timeout
-  lineinfile:
-      create: yes
-      dest: /etc/profile
-      regexp: ^#?TMOUT
-      line: "TMOUT={{ var_accounts_tmout }}"
+{{{ ansible_etc_profile_set(parameter='TMOUT', value='{{ var_accounts_tmout }}') }}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -1,0 +1,152 @@
+{{#
+  A wrapper over the Ansible lineinfile module. This handles the most common
+  options for us. regex is optional and when blank, it won't be included in
+  the Ansible script; this allows arbitrary additions to files. new_line will
+  only be passed when state is present. with_items will be specified only if
+  non-empty, allowing for iterating through a variable of content (with the
+  appropriate macro-based path). register will be specified only if non-empty,
+  allowing for saving the output of this lineinfile module.
+
+  Note that all string-like parameters are single quoted in the YAML.
+#}}
+{{%- macro ansible_lineinfile(msg='', path='', regex='', new_line='', create='no', state='present', with_items='', register='', when='', validate='', insert_after='', insert_before='') -%}}
+- name: "{{{ msg or rule_title }}}"
+  lineinfile:
+    path: '{{{ path }}}'
+    create: {{{ create }}}
+    {{%- if regex %}}
+    regexp: '{{{ regex }}}'
+    {{%- endif %}}
+    {{%- if state == 'present' %}}
+    line: '{{{ new_line }}}'
+    state: present
+    {{%- if insert_after %}}
+    insertafter: '{{{ insert_after }}}'
+    {{%- elif insert_before %}}
+    insertbefore: '{{{ insert_before }}}'
+    {{%- endif %}}
+    {{% else %}}
+    state: '{{{ state }}}'
+    {{%- endif %}}
+    {{%- if validate %}}
+    validate: '{{{ validate }}}'
+    {{%- endif %}}
+  {{%- if with_items %}}
+  with_items: '{{{ with_items }}}'
+  {{%- endif %}}
+  {{%- if register %}}
+  register: '{{{ register }}}'
+  {{%- endif %}}
+  {{%- if when %}}
+  when: '{{{ when }}}'
+  {{%- endif %}}
+{{%- endmacro %}}
+
+{{#
+  Check the file system status of an object. Not a full implementation.
+#}}
+{{%- macro ansible_stat(msg='', path='', register='') %}}
+- name: '{{{ msg or rule_title }}}'
+  stat:
+    path: '{{{ path }}}'
+  {{%- if register %}}
+  register: '{{{ register }}}'
+  {{%- endif %}}
+{{%- endmacro %}}
+
+{{#
+  Find files matching a particular value. Not a full implementation.
+#}}
+{{%- macro ansible_find(msg='', paths='', recurse='yes', follow='no', contains='', register='', when='') %}}
+- name: '{{{ msg or rule_title }}}'
+  find:
+    paths: '{{{ paths }}}'
+    recurse: '{{{ recurse }}}'
+    follow: '{{{ follow }}}'
+    {{%- if contains %}}
+    contains: '{{{ contains }}}'
+    {{%- endif %}}
+  {{%- if register %}}
+  register: '{{{ register }}}'
+  {{%- endif %}}
+  {{%- if when %}}
+  when: '{{{ when }}}'
+  {{%- endif %}}
+{{%- endmacro %}}
+
+{{#
+  A wrapper for adding one, unique line to a file. A regex must be specified
+  to tell if the line is unique. This is helpful in configuration files where
+  a single configuration parameter might have multiple values, but only one
+  value is approved. All lines matching the regex are first removed and then
+  the new line is appended to the file.
+#}}
+{{%- macro ansible_only_lineinfile(msg, path, line_regex, new_line, create='no', block=False, validate='', insert_after='', insert_before='') -%}}
+{{%- if block %}}
+- name: "{{{ msg or rule_title }}}"
+  block:
+    {{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, new_line=None, create='no', state='absent')|indent }}}
+    {{{ ansible_lineinfile("Insert correct line to " + path, path, regex=None, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
+{{%- else %}}
+{{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, new_line=None, create='no', state='absent') }}}
+{{{ ansible_lineinfile("Insert correct line into " + path, path, regex=None, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
+{{%- endif %}}
+{{%- endmacro %}}
+
+{{#
+  Ensure the configuration is set in a file. Note this handles generic
+  key-seperator-value files with no sense of structure. In particular,
+  ini configuration files are best served with the ini Ansible module
+  instead of lineinfile-based solutions.
+#}}
+{{%- macro ansible_set_config_file(msg, file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='') %}}
+{{{ ansible_only_lineinfile(msg, file, prefix_regex + parameter + separator_regex, parameter + separator + value, create=create, block=True, validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
+{{%- endmacro %}}
+
+{{#
+  Ensure the configuration is set in a file and not conflicted by a
+  configuration in a directory. Note this handles generic key-separator-value
+  files with no sense of structure. In particular, ini configuration files are
+  best served with the ini Ansible module instead of lineinfile-based
+  solutions.
+#}}
+{{%- macro ansible_set_config_file_dir(msg, config_file, config_dir, set_file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='') %}}
+{{%- set var_dir = config_dir | replace("/", "_") | replace("-", "_") | replace(".", "_") -%}}
+{{%- set dir_exists = var_dir + "_exists" -%}}
+{{%- set dir_parameter = var_dir + "_has_parameter" -%}}
+{{%- set line_regex = prefix_regex + parameter + separator_regex -%}}
+{{%- set find_when = dir_exists + ".stat.isdir is defined and " + dir_exists + ".stat.isdir" -%}}
+{{%- set lineinfile_items = "{{ " + dir_parameter + ".files }}" -%}}
+{{%- set lineinfile_when = dir_parameter + ".matched" -%}}
+{{%- set new_line = parameter + separator + value -%}}
+- name: '{{{ msg or rule_title }}}'
+  block:
+    {{{ ansible_lineinfile("Deduplicate values from " + config_file, config_file, regex=line_regex, create='no', state='absent')|indent }}}
+    {{{ ansible_stat("Check if " + config_dir + " exists", path=config_dir, register=dir_exists)|indent }}}
+    {{{ ansible_find("Check if the parameter " + parameter + " is present in " + config_dir, paths=config_dir, contains=line_regex, register=dir_parameter, when=find_when)|indent }}}
+    {{{ ansible_lineinfile("Remove parameter from files in " + config_dir, path="{{ item.path }}", regex=line_regex, state="absent", with_items=lineinfile_items, when=lineinfile_when)|indent }}}
+    {{{ ansible_lineinfile("Insert correct line to " + set_file, set_file, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
+{{%- endmacro %}}
+
+{{#
+  High level macro to set a value in the ssh daemon configuration file. This
+  takes three values: msg (the name for the Ansible task), a parameter to set
+  in the configuration file, and the value to set it to. We specify a case
+  insensitive comparison in the prefix since this is used to deduplicate since
+  sshd_config has case-insensitive parameters (but case-sensitive values).
+  We also specify the validation program here; -t specifies test and -f allows
+  Ansible to pass a file at a different path.
+#}}
+{{%- macro ansible_sshd_set(msg='', parameter='', value='') %}}
+{{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^Match") }}}
+{{%- endmacro %}}
+
+{{#
+  High level macro to set a value in /etc/profile (and /etc/profile.d) bash
+  files. Note this is only suitable for calling a single command once with the
+  correct arguments and not for calling the same command multiple times with
+  different arguments. This includes setting an environment variable once.
+#}}
+{{%- macro ansible_etc_profile_set(msg='', parameter='', value='') %}}
+{{{ ansible_set_config_file_dir(msg, "/etc/profile", "/etc/profile.d", "/etc/profile", parameter, separator='=', separator_regex='=', value=value, create='yes', validate="bash -n %s") }}}
+{{%- endmacro %}}

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -14,6 +14,8 @@ JINJA_MACROS_BASE_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros.jinja")
 JINJA_MACROS_HIGHLEVEL_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-highlevel.jinja")
+JINJA_MACROS_ANSIBLE_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
+    __file__)), "shared", "macros-ansible.jinja")
 
 xml_version = """<?xml version="1.0" encoding="UTF-8"?>"""
 

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -5,7 +5,8 @@ import os.path
 import jinja2
 
 from .constants import (JINJA_MACROS_BASE_DEFINITIONS,
-                        JINJA_MACROS_HIGHLEVEL_DEFINITIONS)
+                        JINJA_MACROS_HIGHLEVEL_DEFINITIONS,
+                        JINJA_MACROS_ANSIBLE_DEFINITIONS)
 from .utils import required_key
 
 
@@ -109,6 +110,8 @@ def load_macros(substitutions_dict):
             JINJA_MACROS_BASE_DEFINITIONS, substitutions_dict)
         macro_definitions.update(extract_substitutions_dict_from_template(
             JINJA_MACROS_HIGHLEVEL_DEFINITIONS, substitutions_dict))
+        macro_definitions.update(extract_substitutions_dict_from_template(
+            JINJA_MACROS_ANSIBLE_DEFINITIONS, substitutions_dict))
     except Exception as exc:
         msg = ("Error extracting macro definitions: {0}"
                .format(str(exc)))
@@ -126,4 +129,5 @@ def process_file_with_macros(filepath, substitutions_dict):
     See also: process_file
     """
     substitutions_dict = load_macros(substitutions_dict)
+    assert 'indent' not in substitutions_dict
     return process_file(filepath, substitutions_dict)


### PR DESCRIPTION
#### Description:

Initial work-in-progress PR for `lineinfile`-style Ansible remediations. I'd appreciate feedback regarding initial design. I'll be updating this PR with additional Ansible macros to handle configuration directories (see the example [`in my testbed`](https://github.com/cipherboy/testbed/blob/master/ansible-lineinfile/roles/check-config-dir-duplicates/tasks/main.yml)). 

This PR adds `lineinfile` style ansible remediations as Jinja macros. In addition to the "simple" `lineinfile` remediation (a direct passthrough to turn a macro call into Ansible script), there are `one_line` and `config` based remediations. The former ensures there's only one of the specified line in the file, the latter handles building a regex from the parameter (with customizable prefix and separators regex parts). If absent, it will add the line `parameter + separator + value` to the file. 

One example is the rule `disable_host_auth` to set `HostbasedAuthentication no`  in `/etc/ssh/sshd_config`.

#### Goals:

- Add Ansible macros in this PR
- Add Bash macros to accomplish the same in a later PR.
- Add OVAL checks to check for these in a later PR.
- Extend the templating system to use these macros.

#### Rationale:

Hopefully this PR makes sense. By extending the use of macros everywhere (in #4415), we can hopefully make templating easier. This would also set us up to simplify templating later if we wanted to.

I think there's three common forms:
 - A basic config file,
 - A config file + a config directory,
 - A structured config file (ini, xml, etc).

Of these, this PR will hope to address 1 and 2 most thoroughly, though I'd like to add support for `ini` files in Ansible as well. Supporting `ini` and `xml` will be much harder in `bash` remediations. I haven't yet looked at OVAL support.