### PR TITLE
Quietly handle documentation not complete errors

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -14,7 +14,7 @@ from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 from .rule_yaml import parse_prodtype
 
 from .checks import is_cce_format_valid, is_cce_value_valid
-from .yaml import open_and_expand, open_and_macro_expand
+from .yaml import DocumentationNotComplete, open_and_expand, open_and_macro_expand
 from .utils import required_key, mkdir_p
 
 from .xml import ElementTree as ET
@@ -385,7 +385,10 @@ class Benchmark(object):
                 )
                 continue
 
-            new_profile = Profile.from_yaml(dir_item_path, env_yaml)
+            try:
+                new_profile = Profile.from_yaml(dir_item_path, env_yaml)
+            except DocumentationNotComplete:
+                continue
             if new_profile is None:
                 continue
 

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -43,8 +43,12 @@ class PlaybookBuilder():
         if profile.extends:
             extended_profile_path = os.path.join(
                 self.profiles_dir, profile.extends + ".profile")
-            extended_profile = ssg.build_yaml.Profile.from_yaml(
-                extended_profile_path)
+            try:
+                extended_profile = ssg.build_yaml.Profile.from_yaml(
+                    extended_profile_path)
+            except ssg.yaml.DocumentationNotComplete:
+                sys.stderr.write("Skipping incomplete profile %s.\n" % extended_profile_path)
+                return None
             if not profile:
                 sys.stderr.write(
                     "Could not parse profile %s.\n" % extended_profile_path)
@@ -274,6 +278,11 @@ class PlaybookBuilder():
                 profile_path = os.path.join(self.profiles_dir, profile_file)
                 try:
                     profile = self.open_profile(profile_path)
+                except ssg.yaml.DocumentationNotComplete as e:
+                    msg = "Skipping incomplete profile {0}. To include incomplete " + \
+                          "profiles, build in debug mode.\n"
+                    sys.stderr.write(msg.format(profile_path))
+                    continue
                 except RuntimeError as e:
                     sys.stderr.write(str(e))
                     continue

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -27,6 +27,10 @@ def _bool_constructor(self, node):
 yaml_SafeLoader.add_constructor(u'tag:yaml.org,2002:bool', _bool_constructor)
 
 
+class DocumentationNotComplete(Exception):
+    pass
+
+
 def _save_rename(result, stem, prefix):
     result["{0}_{1}".format(prefix, stem)] = stem
 
@@ -45,9 +49,11 @@ def _open_yaml(stream, original_file=None, substitutions_dict={}):
 
         if yaml_contents.pop("documentation_complete", "true") == "false" and \
                 substitutions_dict.get("cmake_build_type") != "Debug":
-            return None
+            raise DocumentationNotComplete("documentation not complete and not a debug build")
 
         return yaml_contents
+    except DocumentationNotComplete as e:
+        raise e
     except Exception as e:
         count = 0
         _file = original_file


### PR DESCRIPTION
When the documentation isn't complete, `ssg.yaml` would silently return
None. This means that code would just detect if the result was `None`, not
knowing why (it could be an empty profile).

Instead, we raise a `DocumentationNotComplete` error: this will tell
callers why the result was `None` and what to do to fix it (run in debug
mode). In the most common output, this now shows:

    Skipping incomplete profile rhel7/profiles/anssi_nt28_minimal.profile. To include incomplete profiles, build in debug mode.

Instead of the former message:

    Could not parse profile `rhel7/profiles/anssi_nt28_intermediary.profile`.


Hopefully this message will be clearer for your forgetful former intern... :)


`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`