### PR TITLE
Add partition rules to mount_options.csv file for RHEL8 and update test scenarios.

### DIFF
--- a/rhel8/templates/csv/mount_options.csv
+++ b/rhel8/templates/csv/mount_options.csv
@@ -14,4 +14,9 @@
 /tmp,nodev
 /tmp,noexec
 /tmp,nosuid
+/home,nosuid
+/home,nodev
+/var/tmp,nodev
+/var/tmp,noexec
+/var/tmp,nosuid
 

--- a/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_var_tmp_noexec/fstab.fail.sh
+++ b/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_var_tmp_noexec/fstab.fail.sh
@@ -3,6 +3,8 @@
 
 . ../partition.sh
 
+clean_up_partition /var/tmp
+
 create_partition
 
 make_fstab_given_partition_line /var/tmp ext2 nodev

--- a/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_var_tmp_noexec/runtime.pass.sh
+++ b/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_var_tmp_noexec/runtime.pass.sh
@@ -3,6 +3,8 @@
 
 . ../partition.sh
 
+clean_up_partition /var/tmp
+
 create_partition
 
 make_fstab_correct_partition_line /var/tmp

--- a/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_var_tmp_noexec/separate.fail.sh
+++ b/tests/data/group_system/group_permissions/group_partitions/rule_mount_option_var_tmp_noexec/separate.fail.sh
@@ -3,6 +3,8 @@
 
 . ../partition.sh
 
+clean_up_partition /var/tmp
+
 create_partition
 
 make_fstab_correct_partition_line /var/tmp


### PR DESCRIPTION
Update mount_options.csv file in RHEL8 with required partitions as part of ccc rules.
Update test scenarios to unmount tested partition in rule_mount_option_var_tmp_noexec (otherwise it can be already mounted and the test scenario fails to setup).
