### PR TITLE
Restrict rule_auditd_data_retention_flush test scenarios to RHEL7.

### DIFF
--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_data.pass.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_data.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental_async.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_incremental_async.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_none.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_none.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_not_there.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_not_there.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 . ../../auditd_utils.sh

--- a/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_sync.fail.sh
+++ b/tests/data/group_system/group_auditing/group_configure_auditd_data_retention/rule_auditd_data_retention_flush/flush_sync.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 . ../../auditd_utils.sh


### PR DESCRIPTION
Update test scenarios for rule_auditd_data_retention_flush and restrict to RHEL7.
Also change profile to be applicable.
