### PR TITLE
Fix audit rules openat_o_trunc_write test scenarios.

### DIFF
--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write/o_creat.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write/o_creat.fail.sh
@@ -3,4 +3,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
-cp ../audit_open_o_creat.rules /etc/audit/rules.d/
+cp ../audit_openat_o_creat.rules /etc/audit/rules.d/

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write/o_trunc.pass.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write/o_trunc.pass.sh
@@ -3,4 +3,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
-cp ../audit_open_o_trunc_write.rules /etc/audit/rules.d/
+cp ../audit_openat_o_trunc_write.rules /etc/audit/rules.d/

--- a/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rules-amis.fail.sh
+++ b/tests/data/group_system/group_auditing/group_auditd_configure_rules/group_audit_unsuccessful_file_modification/rule_audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rules-amis.fail.sh
@@ -3,4 +3,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
-sed '3,4d' ../audit_open_o_trunc_write.rules > /etc/audit/rules.d/open-o_trunc_write.rules
+sed '3,4d' ../audit_openat_o_trunc_write.rules > /etc/audit/rules.d/openat-o_trunc_write.rules


### PR DESCRIPTION
Some test scenarios were using wrong file to setup the test.
