### PR TITLE
Enable the (all) virtual profile in the rule-based test suite.

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -23,23 +23,25 @@ Scenario = collections.namedtuple(
     "Scenario", ["script", "context", "script_params"])
 
 
-
 def get_viable_profiles(selected_profiles, datastream, benchmark):
     """Read datastream, and return set intersection of profiles of given
     benchmark and those provided in `selected_profiles` parameter.
     """
 
     valid_profiles = []
-    all_profiles = xml_operations.get_all_profiles_in_benchmark(
+    all_profiles_elements = xml_operations.get_all_profiles_in_benchmark(
         datastream, benchmark, logging)
-    for ds_profile_element in all_profiles:
-        ds_profile = ds_profile_element.attrib['id']
+    all_profiles = [el.attrib["id"] for el in all_profiles_elements]
+    all_profiles.append("(all)")
+
+    for ds_profile in all_profiles:
         if 'ALL' in selected_profiles:
             valid_profiles += [ds_profile]
             continue
         for sel_profile in selected_profiles:
             if ds_profile.endswith(sel_profile):
                 valid_profiles += [ds_profile]
+
     if not valid_profiles:
         logging.error('No profile ends with "{0}"'
                       .format(", ".join(selected_profiles)))
@@ -71,7 +73,7 @@ def _apply_script(rule_dir, domain_ip, script):
 
 def _get_script_context(script):
     """Return context of the script."""
-    result = re.search('.*\.([^.]*)\.[^.]*$', script)
+    result = re.search(r'.*\.([^.]*)\.[^.]*$', script)
     if result is None:
         return None
     return result.group(1)
@@ -203,7 +205,7 @@ class RuleChecker(oscap.Checker):
         with open(script, 'r') as script_file:
             script_content = script_file.read()
             for parameter in params:
-                found = re.search(r'^# {0} = ([ ,_\.\-\w]*)$'.format(parameter),
+                found = re.search(r'^# {0} = ([ ,_\.\-\w\(\)]*)$'.format(parameter),
                                   script_content,
                                   re.MULTILINE)
                 if found is None:

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -16,6 +16,9 @@ from ssg_test_suite import common
 from ssg_test_suite.log import LogHelper
 import data
 
+
+ALL_PROFILE_ID = "(all)"
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
@@ -32,7 +35,7 @@ def get_viable_profiles(selected_profiles, datastream, benchmark):
     all_profiles_elements = xml_operations.get_all_profiles_in_benchmark(
         datastream, benchmark, logging)
     all_profiles = [el.attrib["id"] for el in all_profiles_elements]
-    all_profiles.append("(all)")
+    all_profiles.append(ALL_PROFILE_ID)
 
     for ds_profile in all_profiles:
         if 'ALL' in selected_profiles:
@@ -236,6 +239,12 @@ class RuleChecker(oscap.Checker):
                     scenarios += [Scenario(script, script_context, script_params)]
                 else:
                     logging.info("Script %s is not applicable on given platform" % script)
+
+                if not script_params["profiles"]:
+                    script_params["profiles"].append(ALL_PROFILE_ID)
+                    logging.debug(
+                        "Added the {0} profile to the list of available profiles for {1}"
+                        .format(ALL_PROFILE_ID, script))
         return scenarios
 
     def _check_rule(self, rule, remote_dir, state):


### PR DESCRIPTION
Following changes were needed:

1. The `(all)` profile is not visible in the datastream, it is a virtual profile that `oscap` creates.
1. Brackets were not allowed as value in test scenario headers.