### PR TITLE
Enable configure_crypto_policy set DEFAULT test scenario for RHEL8.

### DIFF
--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_default_set.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_default_set.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_standard
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
 
 update-crypto-policies --set "DEFAULT"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_default_set.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/policy_default_set.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
+# profiles = xccdf_org.ssgproject.content_profile_standard
 
 update-crypto-policies --set "DEFAULT"


### PR DESCRIPTION
Enable set DEFAULT configure_crypto_policy test scenario for RHEL8.