### PR TITLE
Fix accounts_passwords_pam_faillock_deny test scenarios and move to OSPP

### DIFF
--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/config_without_skip.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/config_without_skip.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp pam_config_without_skip /etc/pam.d/system-auth
 cp pam_config_without_skip /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/default_die_pam_unix.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/default_die_pam_unix.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 # Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario
 # The remediation would need to detect and remove default=die from pam_unix.so module

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/disablefaillock_authconfig.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/disablefaillock_authconfig.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 authconfig --disablefaillock --updateall

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_default_die_pam_unix
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_default_die_pam_unix
@@ -3,11 +3,11 @@
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
-auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        required      pam_faillock.so preauth silent deny=3 unlock_time=1200
 auth        [success=done ignore=ignore default=die]    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
-auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=1200
 auth        required      pam_deny.so
 
 account     required      pam_faillock.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly
@@ -3,11 +3,11 @@
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
-auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        required      pam_faillock.so preauth silent deny=3 unlock_time=1200
 auth        [success=done ignore=ignore default=2]    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
-auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=1200
 auth        required      pam_deny.so
 
 account     required      pam_faillock.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly_short
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_correctly_short
@@ -3,11 +3,11 @@
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
-auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        required      pam_faillock.so preauth silent deny=3 unlock_time=1200
 auth        [success=done ignore=ignore default=1]    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
-auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=1200
 auth        required      pam_deny.so
 
 account     required      pam_faillock.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer
@@ -3,11 +3,11 @@
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
-auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        required      pam_faillock.so preauth silent deny=3 unlock_time=1200
 auth        [success=done ignore=ignore default=3]    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
-auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=1200
 auth        required      pam_deny.so
 
 account     required      pam_faillock.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer_comment
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_skip_longer_comment
@@ -4,11 +4,11 @@
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
-auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        required      pam_faillock.so preauth silent deny=3 unlock_time=1200
 auth        [success=done ignore=ignore default=3]    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
-auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=1200
 auth        required      pam_deny.so
 
 account     required      pam_faillock.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_without_skip
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/pam_config_without_skip
@@ -3,10 +3,10 @@
 
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
-auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200
+auth        required      pam_faillock.so preauth silent deny=3 unlock_time=1200
 auth        sufficient    pam_unix.so nullok try_first_pass
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
-auth        [default=die] pam_faillock.so authfail deny=4 unlock_time=1200
+auth        [default=die] pam_faillock.so authfail deny=3 unlock_time=1200
 auth        required      pam_deny.so
 
 account     required      pam_faillock.so

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/remediable_sssd_authconfig.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/remediable_sssd_authconfig.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 authconfig --enablesssdauth --updateall

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp pam_config_skip_correctly /etc/pam.d/system-auth
 cp pam_config_skip_correctly /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly_short.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_correctly_short.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp pam_config_skip_correctly_short /etc/pam.d/system-auth
 cp pam_config_skip_correctly_short /etc/pam.d/password-auth

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 #
 # remediation = none
 # Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario

--- a/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer_comment.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-pam/group_locking_out_password_attempts/rule_accounts_passwords_pam_faillock_deny/skip_longer_comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 #
 # remediation = none
 # Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario


### PR DESCRIPTION
Change variable deny=3 and profile to OSPP in accounts_passwords_pam_faillock_deny test scenarios.

Test results RHEL8 Datastream
```
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/ggasparb/workspace/github/content/tests/logs/rule-custom-2019-06-24-1722/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_deny
ERROR - Script skip_longer_comment.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp found issue:
ERROR - Rule evaluation resulted in pass, instead of expected fail during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_deny'.
INFO - Script disablefaillock_authconfig.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script skip_correctly_short.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script skip_correctly.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script skip_longer.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script config_without_skip.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script default_die_pam_unix.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script remediable_sssd_authconfig.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_deny_root
INFO - Script missing-default-die-pam_faillock.fail.sh using profile xccdf_org.ssgproject.content_profile_cui OK
INFO - Script missing-default-die-pam_faillock.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script both-correct.pass.sh using profile xccdf_org.ssgproject.content_profile_cui OK
INFO - Script both-correct.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
INFO - Script missing-required-pam_faillock.fail.sh using profile xccdf_org.ssgproject.content_profile_cui OK
INFO - Script missing-required-pam_faillock.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
```

The ERROR is being caused by: https://bugzilla.redhat.com/show_bug.cgi?id=1549671 which is expected.