### PR TITLE
Avoid matching suffixes by accident.

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
@@ -4,7 +4,7 @@
 . /usr/share/scap-security-guide/remediation_functions
 
 # Use LDAP for authentication
-replace_or_append '/etc/sysconfig/authconfig' 'USELDAPAUTH' 'yes' '@CCENUM@' '%s=%s'
+replace_or_append '/etc/sysconfig/authconfig' '^USELDAPAUTH' 'yes' '@CCENUM@' '%s=%s'
 
 # Configure client to use TLS for all authentications
-replace_or_append '/etc/nslcd.conf' 'ssl' 'start_tls' '@CCENUM@' '%s %s'
+replace_or_append '/etc/nslcd.conf' '^ssl' 'start_tls' '@CCENUM@' '%s %s'


### PR DESCRIPTION
#### Description:

- Avoid matching suffixes by accident.

#### Rationale:

- Without the carret character, the regular expressions can match suffixes of other options, or values in comments.
