### PR TITLE
Print an error message when rule isn't found

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -194,6 +194,12 @@ class RuleChecker(oscap.Checker):
                 if not self._matches_target(rule.directory, target):
                     continue
                 self._matching_rule_found = True
+                if not xml_operations.find_rule_in_benchmark(
+                        self.datastream, self.benchmark_id, rule.id):
+                    logging.error(
+                        "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
+                        .format(rule.id, self.benchmark_id, self.datastream))
+                    return
                 self._check_rule(rule, remote_dir, state)
 
         if not self._matching_rule_found:

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -98,3 +98,12 @@ def benchmark_get_applicable_platforms(datastream, benchmark_id, logging=None):
     platform_elements = benchmark_node.findall('xccdf:platform', NAMESPACES)
     cpes = {platform_el.get("idref") for platform_el in platform_elements}
     return cpes
+
+
+def find_rule_in_benchmark(datastream, benchmark_id, rule_id, logging=None):
+    """
+    Returns rule node from the given benchmark.
+    """
+    benchmark_node = _get_benchmark_node(datastream, benchmark_id, logging)
+    rule = benchmark_node.find(".//xccdf:Rule[@id='{0}']".format(rule_id), NAMESPACES)
+    return rule


### PR DESCRIPTION
#### Description:
Displays an error message when you try to test a rule that has
a test scenario but isn't part of the supplied SCAP datastream.

#### Rationale:
From the existing output it was hard to figure out what exactly happened.

Fixes: #4448
