### PR TITLE
Check if all rules in profile exist

### DIFF
--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -71,7 +71,7 @@ def main():
         profiles = loader.loaded_group.profiles
         for p in profiles:
             p.validate_variables(loader.all_values)
-            p.validate_rules(loader.all_rules)
+            p.validate_rules(loader.all_rules, loader.all_groups)
 
         loader.export_group_to_file(args.output)
     elif args.action == "list-inputs":

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -71,6 +71,7 @@ def main():
         profiles = loader.loaded_group.profiles
         for p in profiles:
             p.validate_variables(loader.all_values)
+            p.validate_rules(loader.all_rules)
 
         loader.export_group_to_file(args.output)
     elif args.action == "list-inputs":

--- a/rhel6/profiles/C2S.profile
+++ b/rhel6/profiles/C2S.profile
@@ -149,7 +149,6 @@ selections:
     - audit_rules_mac_modification
     - audit_rules_login_events
     - audit_rules_session_events
-    - audit_dac_actions
     - audit_rules_unsuccessful_file_modification
     - audit_rules_privileged_commands
     - audit_rules_media_export
@@ -169,8 +168,6 @@ selections:
     - sshd_set_idle_timeout
     - sshd_limit_user_access
     - sshd_enable_warning_banner
-    - set_password_hashing_algorithm
-    - password_quality_pamcracklib
     - accounts_passwords_pam_faillock_deny
     - accounts_password_pam_unix_remember
     - no_direct_root_logins

--- a/rhel6/profiles/CS2.profile
+++ b/rhel6/profiles/CS2.profile
@@ -73,7 +73,6 @@ selections:
     - set_password_hashing_algorithm_systemauth
     - set_password_hashing_algorithm_logindefs
     - set_password_hashing_algorithm_libuserconf
-    - root_paths
     - accounts_root_path_dirs_no_write
     - accounts_umask_etc_bashrc
     - accounts_umask_etc_login_defs
@@ -195,7 +194,6 @@ selections:
     - network_ipv6_static_address
     - network_ipv6_privacy_extensions
     - network_ipv6_default_gateway
-    - network_ipv6_limit_requests
     - sysctl_net_ipv6_conf_default_accept_ra
     - sysctl_net_ipv6_conf_default_accept_redirects
     - network_sniffer_disabled

--- a/rhel6/profiles/nist-CL-IL-AL.profile
+++ b/rhel6/profiles/nist-CL-IL-AL.profile
@@ -233,5 +233,4 @@ selections:
     - service_sysstat_disabled
     - service_httpd_disabled
     - package_httpd_removed
-    - disabling_vsftpd
     - package_vsftpd_removed


### PR DESCRIPTION
#### Description:
Prints an error message and aborts the build if profile selects a rule that doesn't exist or isn't present in the built product. The check is done early in the build process which means users won't have to validate the built content to find mistakes such as typo in rule ID in the profile file.

To enable this I had to remove groups selected in profile. This is OK because selecting a group in a profile doesn't have any effect. All rules are unselected by default and if you don't select the rules explicitly in the profile they aren't evaluated regardless the parent group. In other words, selecting groups doesn't affect selecting rules.

#### Rationale:
We want to catch a wrong rule in profile during the build.

Fixes: #4541
