### PR TITLE
readarray fixes

### DIFF
--- a/linux_os/guide/system/entropy/kernel_disable_entropy_contribution_for_solid_state_drives/bash/rhel6.sh
+++ b/linux_os/guide/system/entropy/kernel_disable_entropy_contribution_for_solid_state_drives/bash/rhel6.sh
@@ -7,7 +7,7 @@
 # -a		Display all devices (including empty ones) in the list
 # -d		Don't print device holders or slaves information
 # -n		Suppress printing of introductory heading line in the list
-readarray SYSTEM_BLOCK_DEVICES < <(/bin/lsblk -o NAME -a -d -n)
+readarray -t SYSTEM_BLOCK_DEVICES < <(/bin/lsblk -o NAME -a -d -n)
 
 # For each SSD block device from that list
 # (device where /sys/block/DEVICE/queue/rotation == 0)

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -5,7 +5,7 @@
 RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
-readarray RSYSLOG_INCLUDE_CONFIG < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
+readarray -t RSYSLOG_INCLUDE_CONFIG < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
@@ -7,12 +7,9 @@
 # Shortened ID for frequently used character class
 SP="[:space:]"
 
-# Backup IFS value
-IFS_BKP="$IFS"
-
 # Load /etc/fstab's content with LABEL= and UUID= tags expanded to real
 # device names into FSTAB_REAL_DEVICES array splitting items by newline
-readarray FSTAB_REAL_DEVICES < <(findmnt --fstab --evaluate --noheadings)
+readarray -t FSTAB_REAL_DEVICES < <(findmnt --fstab --evaluate --noheadings)
 
 for line in "${FSTAB_REAL_DEVICES[@]}"
 do
@@ -58,13 +55,12 @@ do
             # Split the retrieved value by the hash '#' delimiter to get the
             # row's head & tail (i.e. columns other than mount options) which won't
             # get modified
-            IFS=$'#'
-            read TARGET_HEAD TARGET_OPTS TARGET_TAIL <<< "$FSTAB_TARGET_ROW"
+            TARGET_HEAD=$(cut -f 1 -d '#' <<< "$FSTAB_TARGET_ROW")
+            TARGET_OPTS=$(cut -f 2 -d '#' <<< "$FSTAB_TARGET_ROW")
+            TARGET_TAIL=$(cut -f 3 -d '#' <<< "$FSTAB_TARGET_ROW")
             # Replace old mount options for particular /etc/fstab's row (for this target
             # and fstype) with new mount options
             sed -i "s#${TARGET_HEAD}\(.*\)${TARGET_TAIL}#${TARGET_HEAD}${MOUNT_OPTIONS}${TARGET_TAIL}#" /etc/fstab
-            # Reset IFS back to default
-            IFS="$IFS_BKP"
         fi
     fi
 done

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/bash/shared.sh
@@ -9,7 +9,7 @@ declare -A SETPERMS_RPM_DICT
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-readarray FILES_WITH_INCORRECT_PERMS < <(rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }')
+readarray -t FILES_WITH_INCORRECT_PERMS < <(rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }')
 
 for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
@@ -9,7 +9,7 @@ declare -A SETPERMS_RPM_DICT
 
 # Create a list of files on the system having permissions different from what
 # is expected by the RPM database
-readarray FILES_WITH_INCORRECT_PERMS < <(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }')
+readarray -t FILES_WITH_INCORRECT_PERMS < <(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }')
 
 for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
 do

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -25,7 +25,7 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
-  readarray GPG_OUT < <(gpg --show-keys --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '^fpr' | cut -d ":" -f 10)
+  readarray -t GPG_OUT < <(gpg --show-keys --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '^fpr' | cut -d ":" -f 10)
   GPG_RESULT=$?
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
@@ -14,7 +14,7 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error)
-  readarray GPG_OUT < <(gpg --with-fingerprint --with-colons "$OL_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
+  readarray -t GPG_OUT < <(gpg --with-fingerprint --with-colons "$OL_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
   GPG_RESULT=$?
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -12,16 +12,12 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
-  # Backup IFS value
-  IFS_BKP=$IFS
 {{% if product == "rhel8" %}}
-  readarray GPG_OUT < <(gpg --show-keys --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
+  readarray -t GPG_OUT < <(gpg --show-keys --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
 {{% else %}}
-  readarray GPG_OUT < <(gpg --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
+  readarray -t GPG_OUT < <(gpg --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
 {{% endif %}}
   GPG_RESULT=$?
-  # Reset IFS back to default
-  IFS=$IFS_BKP
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -109,8 +109,6 @@ local append_expected_rule=0
 
 for audit_file in "${files_to_inspect[@]}"
 do
-
-	IFS_BKP="$IFS"
 	# Filter existing $audit_file rules' definitions to select those that:
 	# * follow the rule pattern, and
 	# * meet the hardware architecture requirement, and
@@ -162,13 +160,16 @@ do
 				then
 					retval=1
 				fi
-				IFS_BKP="$IFS"
+
 				# 2) Delete syscalls for this group, but keep those from other groups
 				# Convert current rule syscall's string into array splitting by '-S' delimiter
+				IFS_BKP="$IFS"
 				IFS=$'-S'
 				read -a rule_syscalls_as_array <<< "$rule_syscalls"
 				# Reset IFS back to default
 				IFS="$IFS_BKP"
+				# Splitting by "-S" can't be replaced by the readarray functionality easily
+
 				# Declare new empty string to hold '-S syscall' arguments from other groups
 				new_syscalls_for_rule=''
 				# Walk through existing '-S syscall' arguments

--- a/shared/bash_remediation_functions/fix_audit_watch_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_watch_rule.sh
@@ -60,7 +60,7 @@ then
 # If rule isn't defined, add '/etc/audit/rules.d/$key.rules' to list of files for inspection.
 elif [ "$tool" == 'augenrules' ]
 then
-	readarray matches < <(grep -P "[\s]*-w[\s]+$path" /etc/audit/rules.d/*.rules)
+	readarray -t matches < <(grep -P "[\s]*-w[\s]+$path" /etc/audit/rules.d/*.rules)
 
 	# For each of the matched entries
 	for match in "${matches[@]}"

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -19,9 +19,6 @@ function perform_audit_rules_privileged_commands_remediation {
 local tool="$1"
 local min_auid="$2"
 
-# Backup IFS value
-IFS_BKP="$IFS"
-
 # Check sanity of the input
 if [ $# -ne "2" ]
 then
@@ -54,15 +51,13 @@ then
 #   missing rules should be inserted
 elif [ "$tool" == 'augenrules' ]
 then
-	IFS=$'\n'
-	files_to_inspect=($(find /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -print))
+	readarray -t files_to_inspect < <(find /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -print)
 	output_audit_file="/etc/audit/rules.d/privileged.rules"
 fi
 
 # Obtain the list of SUID/SGID binaries on the particular system (split by newline)
 # into privileged_binaries array
-IFS=$'\n'
-privileged_binaries=($(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null))
+readarray -t privileged_binaries < <(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null)
 
 # Keep list of SUID/SGID binaries that have been already handled within some previous iteration
 declare -a sbinaries_to_skip=()
@@ -126,20 +121,22 @@ do
 
 			# Select all other SUID/SGID binaries possibly also present in the found rule
 
-			readarray handled_sbinaries < <(grep -o -e "-F path=[^[:space:]]\+" <<< "$concrete_rule")
+			readarray -t handled_sbinaries < <(grep -o -e "-F path=[^[:space:]]\+" <<< "$concrete_rule")
 
 			handled_sbinaries=(${handled_sbinaries[@]//-F path=/})
 
 			# Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
-			readarray sbinaries_to_skip < <(for i in "${sbinaries_to_skip[@]}" "${handled_sbinaries[@]}"; do echo "$i"; done | sort -du)
+			readarray -t sbinaries_to_skip < <(for i in "${sbinaries_to_skip[@]}" "${handled_sbinaries[@]}"; do echo "$i"; done | sort -du)
 
 			# Separate concrete_rule into three sections using hash '#'
 			# sign as a delimiter around rule's permission section borders
 			concrete_rule="$(echo "$concrete_rule" | sed -n "s/\(.*\)\+\(-F perm=[rwax]\+\)\+/\1#\2#/p")"
 
 			# Split concrete_rule into head, perm, and tail sections using hash '#' delimiter
-			IFS=$'#'
-			read -r rule_head rule_perm rule_tail <<<  "$concrete_rule"
+
+			rule_head=$(cut -d '#' -f 1 <<< "$concrete_rule")
+			rule_perm=$(cut -d '#' -f 2 <<< "$concrete_rule")
+			rule_tail=$(cut -d '#' -f 3 <<< "$concrete_rule")
 
 			# Extract already present exact access type [r|w|x|a] from rule's permission section
 			access_type=${rule_perm//-F perm=/}
@@ -184,7 +181,4 @@ do
 	done
 
 done
-
-# Reset IFS back to default
-IFS="$IFS_BKP"
 }


### PR DESCRIPTION
* Remove `IFS`-based decomposition in favor of plain `cut`.
* Added -t to `readarray` call: The -t option removes separators from individual array items. Without `-t`, individual array items contain the trailing newline.