### PR TITLE
Enable Kernel page-table isolation.

### DIFF
--- a/fedora/profiles/ospp.profile
+++ b/fedora/profiles/ospp.profile
@@ -63,6 +63,7 @@ selections:
     - grub2_slub_debug_argument
     - grub2_page_poison_argument
     - grub2_vsyscall_argument
+    - grub2_pti_argument
     - no_empty_passwords
     - require_singleuser_auth
     - service_debug-shell_disabled

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -1,0 +1,56 @@
+documentation_complete: true
+
+prodtype: rhel8,fedora,ol8
+
+title: 'Enable Kernel Page-Table Isolation (KPTI)'
+
+description: |-
+    To enable Kernel page-table isolation,
+    add the argument <tt>pti=on</tt> to the default
+    GRUB 2 command line for the Linux operating system in
+    <tt>/etc/default/grub</tt>, in the manner below:
+    <pre>GRUB_CMDLINE_LINUX="pti=on"</pre>
+
+rationale: |-
+    Kernel page-table isolation is a kernel feature that mitigates
+    the Meltdown security vulnerability and hardens the kernel
+    against attempts to bypass kernel address space layout
+    randomization (KASLR).
+
+severity: high
+
+identifiers:
+    cce@rhel8: 81037-4
+
+ocil_clause: 'Kernel page-table isolation is not enabled'
+
+ocil: |-
+    Inspect the form of default GRUB 2 command line for the Linux operating system
+    in <tt>/etc/default/grub</tt>. If they include <tt>pti=on</tt>,
+    then Kernel page-table isolation is enabled at boot time.
+    <br /><br />
+    To ensure <tt>pti=on</tt> is configured on all installed kernels, the
+    following command may be used:
+    <br />
+    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="pti=on</pre>
+    <br />
+
+warnings:
+    - management: |-
+        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
+        is automatically updated each time a new kernel is installed. Note that any
+        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
+        file. To update the GRUB 2 configuration file manually, use the
+        <pre>grub2-mkconfig -o</pre> command as follows:
+        <ul>
+        <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
+        <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
+{{% if product in ["rhel8", "ol8"] %}}
+        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
+{{% else %}}
+        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
+{{% endif %}}
+        </ul>
+
+platform: machine

--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -62,6 +62,7 @@ selections:
     - grub2_slub_debug_argument
     - grub2_page_poison_argument
     - grub2_vsyscall_argument
+    - grub2_pti_argument
     - no_empty_passwords
     - require_singleuser_auth
     - service_debug-shell_disabled

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -45,8 +45,8 @@ selections:
     ## RHEL 8 CCE-80944-2: Enable page allocator poisoning
     - grub2_page_poison_argument
 
-    ## TO DO: New rule for "pti=on"
-    ##  https://github.com/ComplianceAsCode/content/issues/4588
+    ## Enable Kernel Page-Table Isolation (KPTI)
+    - grub2_pti_argument
 
     ## RHEL 8 CCE-80946-7: Disable vsyscalls
     - grub2_vsyscall_argument

--- a/shared/templates/csv/grub2_bootloader_argument.csv
+++ b/shared/templates/csv/grub2_bootloader_argument.csv
@@ -8,3 +8,4 @@ audit_backlog_limit,8192
 slub_debug,P
 page_poison,1
 vsyscall,none
+pti,on


### PR DESCRIPTION
#### Description:

- Enable Kernel page-table isolation.

#### Rationale:

- Kernel page-table isolation is a kernel feature that mitigates the Meltdown security vulnerability and hardens the kernel ~hardening~ against attempts to bypass kernel address space layout randomization (KASLR).
