### PR TITLE
install_vm.py: fix for osinfo-detect not working under sudo/su

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -25,7 +25,8 @@ def parse_args():
         "--distro",
         dest="distro",
         required=True,
-        help="What distribution to install (URL alias for fedora/rhel7/centos7/rhel8)"
+        choices=['fedora', 'rhel7', 'centos7', 'rhel8'],
+        help="What distribution to install."
     )
     parser.add_argument(
         "--domain",


### PR DESCRIPTION
#### Description:

The issue in osinfo-detect https://gitlab.com/libosinfo/libosinfo/issues/30
was preventing the script to install RHEL distros under sudo/su. This commit
fixes it and implements simpler logic for adding repositories into the
kickstart.