### PR TITLE
Improve template sysctl to support other types of values

### DIFF
--- a/debian8/templates/csv/sysctl_values.csv
+++ b/debian8/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 # xccdf value based (depend on the profile)

--- a/fedora/templates/csv/sysctl_values.csv
+++ b/fedora/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 kernel.dmesg_restrict,1

--- a/ol7/templates/csv/sysctl_values.csv
+++ b/ol7/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0

--- a/ol8/templates/csv/sysctl_values.csv
+++ b/ol8/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0

--- a/opensuse/templates/csv/sysctl_values.csv
+++ b/opensuse/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 net.ipv6.conf.all.disable_ipv6,1

--- a/rhel6/templates/csv/sysctl_values.csv
+++ b/rhel6/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0

--- a/rhel7/templates/csv/sysctl_values.csv
+++ b/rhel7/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0

--- a/rhel8/templates/csv/sysctl_values.csv
+++ b/rhel8/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 kernel.dmesg_restrict,1

--- a/rhv4/templates/csv/sysctl_values.csv
+++ b/rhv4/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0

--- a/shared/templates/create_sysctl.py
+++ b/shared/templates/create_sysctl.py
@@ -1,6 +1,6 @@
 import re
 
-from template_common import FilesGenerator, UnknownTargetError
+from template_common import FilesGenerator, UnknownTargetError, CSVLineError
 
 
 class SysctlGenerator(FilesGenerator):
@@ -44,6 +44,8 @@ class SysctlGenerator(FilesGenerator):
             data_type = "int"
         elif len(serviceinfo) == 3:
             sysctl_var, sysctl_val, data_type = serviceinfo
+        else:
+            raise CSVLineError()
 
         # convert variable name to a format suitable for 'id' tags
         sysctl_var_id = re.sub('[-\.]', '_', sysctl_var)

--- a/shared/templates/create_sysctl.py
+++ b/shared/templates/create_sysctl.py
@@ -33,8 +33,18 @@ class SysctlGenerator(FilesGenerator):
         }
 
     def generate(self, target, serviceinfo):
+
         # get the items out of the list
-        sysctl_var, sysctl_val = serviceinfo
+        # items can be in format
+        # <sysctl_parameter_name, value> or
+        # <sysctl_parameter_name, value, type>
+        if len(serviceinfo) == 2:
+            sysctl_var, sysctl_val = serviceinfo
+            # Default data type for sysctl is int
+            data_type = "int"
+        elif len(serviceinfo) == 3:
+            sysctl_var, sysctl_val, data_type = serviceinfo
+
         # convert variable name to a format suitable for 'id' tags
         sysctl_var_id = re.sub('[-\.]', '_', sysctl_var)
 
@@ -95,6 +105,7 @@ class SysctlGenerator(FilesGenerator):
                         {
                             "SYSCTLID":  sysctl_var_id,
                             "SYSCTLVAR": sysctl_var,
+                            "DATATYPE": data_type,
                         },
                         "./oval/{0}.xml", prefix + sysctl_var_id
                     )
@@ -107,7 +118,8 @@ class SysctlGenerator(FilesGenerator):
                         {
                             "SYSCTLID":  sysctl_var_id,
                             "SYSCTLVAR": sysctl_var,
-                            "SYSCTLVAL": sysctl_val
+                            "SYSCTLVAL": sysctl_val,
+                            "DATATYPE": data_type,
                         },
                         "./oval/{0}.xml", prefix + sysctl_var_id
                     )
@@ -117,4 +129,4 @@ class SysctlGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: " +
-               "sysctlvariable,sysctlvalue")
+               "sysctlvariable,sysctlvalue[,<datatype>]")

--- a/shared/templates/csv/sysctl_values.csv
+++ b/shared/templates/csv/sysctl_values.csv
@@ -1,0 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
+# Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
+# Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
+

--- a/shared/templates/template_OVAL_sysctl_runtime
+++ b/shared/templates/template_OVAL_sysctl_runtime
@@ -22,6 +22,6 @@
   </unix:sysctl_object>
 
   <unix:sysctl_state id="state_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
-    <unix:value datatype="int" operation="equals">{{{ SYSCTLVAL }}}</unix:value>
+    <unix:value datatype="{{{ DATATYPE }}}" operation="equals">{{{ SYSCTLVAL }}}</unix:value>
   </unix:sysctl_state>
 </def-group>

--- a/shared/templates/template_OVAL_sysctl_runtime_var
+++ b/shared/templates/template_OVAL_sysctl_runtime_var
@@ -22,8 +22,8 @@
   </unix:sysctl_object>
 
   <unix:sysctl_state id="state_sysctl_runtime_{{{ SYSCTLID }}}" version="1">
-    <unix:value datatype="int" operation="equals" var_ref="sysctl_{{{ SYSCTLID }}}_value" />
+    <unix:value datatype="{{{ DATATYPE }}}" operation="equals" var_ref="sysctl_{{{ SYSCTLID }}}_value" />
   </unix:sysctl_state>
 
-  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="int" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
+  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="{{{ DATATYPE }}}" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
 </def-group>

--- a/shared/templates/template_OVAL_sysctl_static
+++ b/shared/templates/template_OVAL_sysctl_static
@@ -71,7 +71,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_static_sysctld_{{{ SYSCTLID }}}" version="1">
-    <ind:subexpression operation="equals" datatype="int">{{{ SYSCTLVAL }}}</ind:subexpression>
+    <ind:subexpression operation="equals" datatype="{{{ DATATYPE }}}">{{{ SYSCTLVAL }}}</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <!-- Check the /etc/sysctl.conf configuration -->

--- a/shared/templates/template_OVAL_sysctl_static_var
+++ b/shared/templates/template_OVAL_sysctl_static_var
@@ -71,7 +71,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_static_sysctld_{{{ SYSCTLID }}}" version="1">
-    <ind:subexpression operation="equals"  var_ref="sysctl_{{{ SYSCTLID }}}_value" datatype="int" />
+    <ind:subexpression operation="equals"  var_ref="sysctl_{{{ SYSCTLID }}}_value" datatype="{{{ DATATYPE }}}" />
   </ind:textfilecontent54_state>
 
   <!-- Check the /etc/sysctl.conf configuration -->
@@ -100,7 +100,7 @@
     <ind:object object_ref="object_static_sysctld_{{{ SYSCTLID }}}" />
   </ind:textfilecontent54_test>
 
-  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="int" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
+  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="{{{ DATATYPE }}}" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
 {{% else %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="{{{ SYSCTLVAR }}} static configuration" id="test_static_sysctl_{{{ SYSCTLID }}}" version="1">
     <ind:object object_ref="object_static_sysctl_{{{ SYSCTLID }}}" />
@@ -150,9 +150,9 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_static_sysctld_{{{ SYSCTLID }}}" version="1">
-    <ind:subexpression operation="equals"  var_ref="sysctl_{{{ SYSCTLID }}}_value" datatype="int" />
+    <ind:subexpression operation="equals"  var_ref="sysctl_{{{ SYSCTLID }}}_value" datatype="{{{ DATATYPE }}}" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="int" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
+  <external_variable comment="External variable for {{{ SYSCTLVAR }}}" datatype="{{{ DATATYPE }}}" id="sysctl_{{{ SYSCTLID }}}_value" version="1" />
 {{% endif %}}
 </def-group>

--- a/shared/templates/template_common.py
+++ b/shared/templates/template_common.py
@@ -19,6 +19,10 @@ class ActionType:
     BUILD = 3
 
 
+class CSVLineError(Exception):
+    pass
+
+
 class UnknownTargetError(ValueError):
     def __init__(self, lang):
         super(UnknownTargetError, self).__init__(
@@ -163,6 +167,11 @@ class FilesGenerator(object):
                     # target is invalid.
                     if e.lang not in TEMPLATED_LANGUAGES:
                         sys.stderr.write(str(e) + "\n")
+            except CSVLineError as e:
+                sys.stderr.write("Unexpected CSV line format in "
+                                 "file {}: \"{}\"\n".format(filename, ",".join(csv_line)))
+
+
 
     @abstractmethod
     def csv_format(self):

--- a/sle11/templates/csv/sysctl_values.csv
+++ b/sle11/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 net.ipv6.conf.all.disable_ipv6,1

--- a/sle12/templates/csv/sysctl_values.csv
+++ b/sle12/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 fs.suid_dumpable,0

--- a/ubuntu1404/templates/csv/sysctl_values.csv
+++ b/ubuntu1404/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 # xccdf value based (depend on the profile)

--- a/ubuntu1604/templates/csv/sysctl_values.csv
+++ b/ubuntu1604/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 # xccdf value based (depend on the profile)

--- a/ubuntu1804/templates/csv/sysctl_values.csv
+++ b/ubuntu1804/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 # xccdf value based (depend on the profile)

--- a/wrlinux/templates/csv/sysctl_values.csv
+++ b/wrlinux/templates/csv/sysctl_values.csv
@@ -1,3 +1,5 @@
+# The value_type is 'int' by default
+# Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
 net.ipv6.conf.all.disable_ipv6,1


### PR DESCRIPTION
#### Description:

- Extend sysctl templates to support other data types
- Update docs in sysctl_value CSV files 

#### Rationale:
- Most of the sysctl values are integers, but some can be strings.
