### PR TITLE
Add profile metadata override in rule mode

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -36,25 +36,10 @@ class CombinedChecker(rule.RuleChecker):
         self.results = list()
         self._current_result = None
 
-    def _parse_parameters(self, script):
-        """Parse parameters from script header"""
-        params = {'templates': [],
-                  'platform': ['multi_platform_all'],
-                  'remediation': ['all']}
-        with open(script, 'r') as script_file:
-            script_content = script_file.read()
-            for parameter in params:
-                found = re.search(r'^# {0} = ([ ,_\.\-\w]*)$'.format(parameter),
-                                  script_content,
-                                  re.MULTILINE)
-                if found is None:
-                    continue
-                splitted = found.group(1).split(',')
-                params[parameter] = [value.strip() for value in splitted]
-
-            # Override any metadata in test scenario, wrt to profile to test
-            # We already know that all target rules are part of the target profile
-            params['profiles'] = [self.profile]
+    def _modify_parameters(self, params):
+        # Override any metadata in test scenario, wrt to profile to test
+        # We already know that all target rules are part of the target profile
+        params['profiles'] = [self.profile]
         return params
 
     # Check if a rule matches any of the targets to be tested

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -205,6 +205,9 @@ class RuleChecker(oscap.Checker):
         if not self._matching_rule_found:
             logging.error("No matching rule ID found for '{0}'".format(target))
 
+    def _modify_parameters(self, params):
+        return params
+
     def _parse_parameters(self, script):
         """Parse parameters from script header"""
         params = {'profiles': [],
@@ -241,6 +244,7 @@ class RuleChecker(oscap.Checker):
             script_context = _get_script_context(script)
             if script_context is not None:
                 script_params = self._parse_parameters(os.path.join(rule_dir, script))
+                script_params = _modify_parameters(script_params)
                 if common.matches_platform(script_params["platform"], benchmark_cpes):
                     scenarios += [Scenario(script, script_context, script_params)]
                 else:

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -210,6 +210,11 @@ class RuleChecker(oscap.Checker):
         if self.scenarios_profile:
             params['profiles'] = [self.scenarios_profile]
 
+        if not params["profiles"]:
+            params["profiles"].append(ALL_PROFILE_ID)
+            logging.debug(
+                "Added the {0} profile to the list of available profiles for {1}"
+                .format(ALL_PROFILE_ID, script))
         return params
 
     def _parse_parameters(self, script):
@@ -254,11 +259,6 @@ class RuleChecker(oscap.Checker):
                 else:
                     logging.info("Script %s is not applicable on given platform" % script)
 
-                if not script_params["profiles"]:
-                    script_params["profiles"].append(ALL_PROFILE_ID)
-                    logging.debug(
-                        "Added the {0} profile to the list of available profiles for {1}"
-                        .format(ALL_PROFILE_ID, script))
         return scenarios
 
     def _check_rule(self, rule, remote_dir, state):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -137,6 +137,13 @@ def parse_args():
                              dest="scenarios_regex",
                              default=None,
                              help="Regular expression matching test scenarios to run")
+    parser_rule.add_argument("--profile",
+                             dest="scenarios_profile",
+                             default=None,
+                             help="Override the profile used for test scenarios."
+                                  " Variable selections will be done according "
+                                  "to this profile.")
+
 
     parser_combined = subparsers.add_parser("combined",
                                             help=("Tests all rules in a profile evaluating them "


### PR DESCRIPTION
#### Description:

- Reorganize where the changes to test scenario parameters should happen
  - It is unnecessary to have whole `_parse_parameters()` in `class CombinedChecker`

- Add  `--profile` option to Test Suite's `rule mode`
  - Allows tester to override `#profiles` metadata specified in the test scenario
  - Easier to test new profiles using existing test scenarios
  - When debugging a test scenario WRT to a profile, it is easier to just test it for this one profile


