### PR TITLE
no_empty_passwords rule - add test scenarios and fix OVAL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -16,7 +16,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_empty_passwords" version="1">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">\s*nullok\s*</ind:pattern>
+    <ind:pattern operation="pattern match">^[^#]*nullok.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -16,7 +16,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_empty_passwords" version="1">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^[^#]*nullok.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[^#]*\bnullok\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/no_nullok.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/no_nullok.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+sed -i '/nullok/d' /etc/pam.d/system-auth

--- a/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_commented.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_commented.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
+
+sed -i '/nullok/d' $SYSTEM_AUTH_FILE
+echo "# auth  sufficient  pam_unix.so try_first_pass nullok" >> $SYSTEM_AUTH_FILE

--- a/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_multiple_times.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_multiple_times.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
+
+echo "auth  sufficient  pam_unix.so try_first_pass nullok" >> $SYSTEM_AUTH_FILE
+echo "auth  required    pam_unix.so nullok" >> $SYSTEM_AUTH_FILE

--- a/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_present.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_present.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "auth  sufficient  pam_unix.so try_first_pass nullok" >> /etc/pam.d/system-auth

--- a/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_secure.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-restrictions/group_password_storage/rule_no_empty_passwords/nullok_secure.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
+
+sed -i '/nullok/d' $SYSTEM_AUTH_FILE
+echo "auth  sufficient  pam_unix.so nullok_secure" >> $SYSTEM_AUTH_FILE


### PR DESCRIPTION
#### Description:
Adds test scenarios for no_empty_passwords rule.

After creating test scenarios I found out that oval check fails when `/etc/pam.d/system-auth` file contains commented `nullok`, but it should pass.