### PR TITLE
Use block style when a string contains a newline

### DIFF
--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -165,7 +165,15 @@ def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             data.items())
 
+    def _str_representer(dumper, data):
+        if '\n' in data:
+            return dumper.represent_scalar(u'tag:yaml.org,2002:str', data,
+                                           style='|')
+        else:
+            return dumper.represent_str(data)
+
     OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    OrderedDumper.add_representer(str, _str_representer)
 
     # Fix formatting by adding a space in between tasks
     unformatted_yaml = yaml.dump(data, None, OrderedDumper, **kwds)


### PR DESCRIPTION
By default, the yaml.Dumper dumps multiline strings surrounded by single quotes. If a newline character is a part of the string it is represented by an empty line in a single quoted string. The line breaks in a single quoted string are replaced by space. This assumes the user needs to know YAML specification to understand the behavior of the single quoted string. Also it looks ugly. Instead, we can use a literal
block style, represented by '|' character. In literal blocks, the line breaks are preserved and no extra empty lines are needed.