### PR TITLE
Correct SSH StrictModes

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/ansible/shared.yml
@@ -3,4 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-{{{ ansible_sshd_set(parameter="StrictMode", value="yes") }}}
+{{{ ansible_sshd_set(parameter="StrictModes", value="yes") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/oval/shared.xml
@@ -8,7 +8,7 @@
         <platform>multi_platform_rhv</platform>
         <platform>multi_platform_ol</platform>
       </affected>
-      <description>Enable StrictMode to check users home directory permissions
+      <description>Enable StrictModes to check users home directory permissions
 and configurations.</description>
     </metadata>
     <criteria comment="SSH is configured correctly or is not installed"


### PR DESCRIPTION
#### Description:
Fixes a missing 's' in StrictModes option from /etc/ssh/sshd_config.


#### Rationale:
See man sshd_config that it's StrictModes.