### PR TITLE
Fix macro expansion in OVAL by using available process_file_with_macros.

### DIFF
--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -11,7 +11,7 @@ from .constants import oval_namespace as oval_ns
 from .constants import oval_footer
 from .constants import oval_header
 from .constants import MULTI_PLATFORM_LIST
-from .jinja import process_file
+from .jinja import process_file_with_macros
 from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs
 from . import utils
 from .xml import ElementTree
@@ -273,7 +273,7 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
             # this OVAL was in a rule directory.
             filename = "%s.xml" % rule_id
 
-            xml_content = process_file(_path, env_yaml)
+            xml_content = process_file_with_macros(_path, env_yaml)
 
             if not _check_is_applicable_for_product(xml_content, product):
                 continue
@@ -291,7 +291,7 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
             # sort the files to make output deterministic
             for filename in sorted(os.listdir(oval_dir)):
                 if filename.endswith(".xml"):
-                    xml_content = process_file(
+                    xml_content = process_file_with_macros(
                         os.path.join(oval_dir, filename), env_yaml
                     )
 


### PR DESCRIPTION
#### Description:

- Use process_file_with_macros in OVAL expansion so jinja macros can work with OVAL.

#### Rationale:

- Jinja macros can be expanded within OVAL checks.
