### PR TITLE
Simplify loading of Jinja macros

### DIFF
--- a/tests/unit/ssg-module/test_jinja.py
+++ b/tests/unit/ssg-module/test_jinja.py
@@ -10,8 +10,8 @@ def get_definitions_with_substitution(subs_dict=None):
         subs_dict = dict()
 
     definitions = os.path.join(os.path.dirname(__file__), "data", "definitions.jinja")
-    defs = ssg.jinja.extract_substitutions_dict_from_template(definitions, subs_dict)
-    return defs
+    ssg.jinja.update_substitutions_dict(definitions, subs_dict)
+    return subs_dict
 
 
 def test_macro_presence():


### PR DESCRIPTION
There's no real reason to return a new dictionary instead of extending
the existing dictionary when we're going to end up modifying the
existing dictionary at some point anyways.

At best this helped to not pollute `substitutions_dict` when an exception
occurred, however exceptions from this function are usually passed back
up to CMake and not otherwise handled.


### Rationale

We have a number of Jinja macros already. We also have some code in the `ssg` module which could be helpful. The next PR I'll open introduces select `ssg` functions into Jinja, allowing us to use them from the Jinja macros.

Note that we'll only ever be able to cal into Python from Jinja and not visa-versa.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`