### PR TITLE
Remove comments before performing sanity check for substituted bash remediations

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -724,6 +724,8 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
             if child is not None and child.text is not None:
                 modfix.append(child.text)
         modfixtext = "".join(modfix)
+        # Don't perform sanity check at bash comments because they are not substituted
+        modfixtext = re.sub(r'#.*', '', modfixtext)
         for func in remediation_functions:
             # Then efine expected XCCDF sub element form for this function
             funcxccdfsub = "<sub idref=\"function_%s\"" % func


### PR DESCRIPTION
#### Description:
When bash remediation contains comment with string, that is same as name of file from `shared/bash_remediations_functions` folder, then sanity check during build fails.

E.g. fail happened during build of #4597 because there was file with name `variables.sh` and one of bash remediations contains string with `# Set variables`.