### PR TITLE
Double quote jinja variables

### DIFF
--- a/shared/templates/template_ANSIBLE_file_groupowner
+++ b/shared/templates/template_ANSIBLE_file_groupowner
@@ -5,11 +5,11 @@
 # disruption = low
 - name: Test for existence {{{ FILEPATH }}}
   stat:
-    path: {{{ FILEPATH }}}
+    path: "{{{ FILEPATH }}}"
   register: file_exists
 
 - name: Ensure group owner {{{ FILEGID }}} on {{{ FILEPATH }}}
   file:
-    path: {{{ FILEPATH }}}
-    group: {{{ FILEGID }}}
+    path: "{{{ FILEPATH }}}"
+    group: "{{{ FILEGID }}}"
   when: file_exists.stat is defined and file_exists.stat.exists

--- a/shared/templates/template_ANSIBLE_file_owner
+++ b/shared/templates/template_ANSIBLE_file_owner
@@ -5,11 +5,11 @@
 # disruption = low
 - name: Test for existence {{{ FILEPATH }}}
   stat:
-    path: {{{ FILEPATH }}}
+    path: "{{{ FILEPATH }}}"
   register: file_exists
 
 - name: Ensure owner {{{ FILEUID }}} on {{{ FILEPATH }}}
   file:
-    path: {{{ FILEPATH }}}
-    owner: {{{ FILEUID }}}
+    path: "{{{ FILEPATH }}}"
+    owner: "{{{ FILEUID }}}"
   when: file_exists.stat is defined and file_exists.stat.exists

--- a/shared/templates/template_ANSIBLE_file_permissions
+++ b/shared/templates/template_ANSIBLE_file_permissions
@@ -5,11 +5,11 @@
 # disruption = low
 - name: Test for existence {{{ FILEPATH }}}
   stat:
-    path: {{{ FILEPATH }}}
+    path: "{{{ FILEPATH }}}"
   register: file_exists
   
 - name: Ensure permission {{{ FILEMODE }}} on {{{ FILEPATH }}}
   file:
-    path: {{{ FILEPATH }}}
-    mode: {{{ FILEMODE }}}
+    path: "{{{ FILEPATH }}}"
+    mode: "{{{ FILEMODE }}}"
   when: file_exists.stat is defined and file_exists.stat.exists

--- a/shared/templates/template_ANSIBLE_file_regex_permissions
+++ b/shared/templates/template_ANSIBLE_file_regex_permissions
@@ -13,7 +13,7 @@
 - name: Set permissions for {{{ FILEPATH }}} file(s)
   file:
     path: "{{ item.path }}"
-    mode: {{{ FILEMODE }}}
+    mode: "{{{ FILEMODE }}}"
   with_items:
     - "{{ files_found.files }}"
 

--- a/shared/templates/template_ANSIBLE_package_installed
+++ b/shared/templates/template_ANSIBLE_package_installed
@@ -5,6 +5,6 @@
 # disruption = low
 - name: Ensure {{{ PKGNAME }}} is installed
   package:
-    name: {{{ PKGNAME }}}
+    name: "{{{ PKGNAME }}}"
     state: present
 

--- a/shared/templates/template_ANSIBLE_package_removed
+++ b/shared/templates/template_ANSIBLE_package_removed
@@ -5,6 +5,6 @@
 # disruption = low
 - name: Ensure {{{ PKGNAME }}} is removed
   package:
-    name: {{{ PKGNAME }}}
+    name: "{{{ PKGNAME }}}"
     state: absent
 

--- a/shared/templates/template_ANSIBLE_permissions
+++ b/shared/templates/template_ANSIBLE_permissions
@@ -5,13 +5,13 @@
 # disruption = low
 - name: Ensure permission {{{ FILEMODE }}}, owner {{{ FILEUID }}}, and group {{{ FILEGID }}} on {{{ FILEPATH }}}
   file:
-    path: {{{ FILEPATH }}}
+    path: "{{{ FILEPATH }}}"
     {{% if FILEMODE != "" %}}
-    mode: {{{ FILEMODE }}}
+    mode: "{{{ FILEMODE }}}"
     {{% endif %}}
     {{% if FILEUID != "" %}}
-    owner: {{{ FILEUID }}}
+    owner: "{{{ FILEUID }}}"
     {{% endif %}}
     {{% if FILEGID != "" %}}
-    group: {{{ FILEGID }}}
+    group: "{{{ FILEGID }}}"
     {{% endif %}}

--- a/shared/templates/template_ANSIBLE_sebool
+++ b/shared/templates/template_ANSIBLE_sebool
@@ -5,7 +5,7 @@
 # disruption = low
 - name: Set SELinux boolean {{{ SEBOOLID }}} to {{{ SEBOOL_BOOL }}}
   seboolean:
-    name: {{{ SEBOOLID }}}
-    state: {{{ SEBOOL_BOOL }}}
+    name: "{{{ SEBOOLID }}}"
+    state: "{{{ SEBOOL_BOOL }}}"
     persistent: yes
 

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -5,7 +5,7 @@
 # disruption = low
 - name: Disable service {{{ SERVICENAME }}}
   service:
-    name: {{{ DAEMONNAME }}}
+    name: "{{{ DAEMONNAME }}}"
     enabled: "no"
     state: "stopped"
   register: service_result
@@ -14,7 +14,7 @@
 {{% if init_system == "systemd" %}}
 - name: Disable socket of service {{{ SERVICENAME }}} if applicable
   service:
-    name: {{{ DAEMONNAME }}}.socket
+    name: "{{{ DAEMONNAME }}}.socket"
     enabled: "no"
     state: "stopped"
   register: socket_result

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -5,7 +5,7 @@
 # disruption = low
 - name: Enable service {{{ SERVICENAME }}}
   service:
-    name: {{{ DAEMONNAME }}}
+    name: "{{{ DAEMONNAME }}}"
     enabled: "yes"
     state: "started"
 

--- a/shared/templates/template_ANSIBLE_sysctl
+++ b/shared/templates/template_ANSIBLE_sysctl
@@ -5,8 +5,8 @@
 # disruption = medium
 - name: Ensure sysctl {{{ SYSCTLVAR }}} is set to {{{ SYSCTLVAL }}}
   sysctl:
-    name: {{{ SYSCTLVAR }}}
-    value: {{{ SYSCTLVAL }}}
+    name: "{{{ SYSCTLVAR }}}"
+    value: "{{{ SYSCTLVAL }}}"
     state: present
     reload: yes
 

--- a/shared/templates/template_ANSIBLE_sysctl_var
+++ b/shared/templates/template_ANSIBLE_sysctl_var
@@ -7,7 +7,7 @@
 
 - name: Ensure sysctl {{{ SYSCTLVAR }}} is set
   sysctl:
-    name: {{{ SYSCTLVAR }}}
+    name: "{{{ SYSCTLVAR }}}"
     value: "{{ sysctl_{{{ SYSCTLID }}}_value }}"
     state: present
     reload: yes


### PR DESCRIPTION
#### Description:

-Double quote Jinja variables 

#### Rationale:

- Helps to avoids problems with `yaml` syntax when a weird string should be part of the remediation.
  - e.g.: `|/bin/false`

```
Traceback (most recent call last):
  File "/home/wsato/git/content/build-scripts/combine_remediations.py", line 110, in <module>
    main()
  File "/home/wsato/git/content/build-scripts/combine_remediations.py", line 76, in main
    remediation.process(remediation_obj, env_yaml, fixes, rule_id)
  File "/home/wsato/git/content/ssg/build_remediations.py", line 222, in process
    result = remediation.parse_from_file_with_jinja(env_yaml)
  File "/home/wsato/git/content/ssg/build_remediations.py", line 264, in parse_from_file_with_jinja
    parsed = ssg.yaml.ordered_load(result.contents)
  File "/home/wsato/git/content/ssg/yaml.py", line 151, in ordered_load
    return yaml.load(stream, OrderedLoader)
  File "/usr/lib64/python3.7/site-packages/yaml/__init__.py", line 114, in load
    return loader.get_single_data()
...
  File "/usr/lib64/python3.7/site-packages/yaml/scanner.py", line 635, in fetch_literal
    self.fetch_block_scalar(style='|')
  File "/usr/lib64/python3.7/site-packages/yaml/scanner.py", line 649, in fetch_block_scalar
    self.tokens.append(self.scan_block_scalar(style))
  File "/usr/lib64/python3.7/site-packages/yaml/scanner.py", line 989, in scan_block_scalar
    chomping, increment = self.scan_block_scalar_indicators(start_mark)
  File "/usr/lib64/python3.7/site-packages/yaml/scanner.py", line 1089, in scan_block_scalar_indicators
    % ch, self.get_mark())
yaml.scanner.ScannerError: while scanning a block scalar
  in "<unicode string>", line 4, column 12:
        value: |/bin/false
               ^
expected chomping or indentation indicators, but found '/'
  in "<unicode string>", line 4, column 13:
        value: |/bin/false
                ^
ninja: build stopped: subcommand failed.

```