### PR TITLE
Add tests for kernel_module_firewire-core_disabled rule.

### DIFF
--- a/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/commented-install.fail.sh
+++ b/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/commented-install.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+source ./kernel_module_preparation.sh
+kernel_module_preparation "fire-wire"
+
+MODULES_FILE="/etc/modprobe.conf"
+echo "# install firewire-core /bin/false" >> "$MODULES_FILE"

--- a/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/different-module.fail.sh
+++ b/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/different-module.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+source ./kernel_module_preparation.sh
+kernel_module_preparation "fire-wire"
+
+MODULES_DIR="/etc/modules-load.d"
+mkdir -p "$MODULES_DIR"
+echo "install sctp /bin/false" >> "$MODULES_DIR/fire-wire.conf"

--- a/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/kernel_module_preparation.sh
+++ b/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/kernel_module_preparation.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Kernel module can be disabled in different files.
+# This function prepares environment for testing - it deletes all
+# occurrences of specified module.
+# Parameters: $1 - name of kernel module
+function kernel_module_preparation() {
+        if [ -z "$1" ]; then
+                echo "Please specify kernel module."
+                echo "Usage: prepare_kernel_module MODULE"
+                exit 1
+        fi
+
+        local MODULE=$1
+
+        # Paths to configuration files and directories for modprobe
+        kernel_mod_files=( "/etc/modprobe.d/*.conf" "/etc/modprobe.conf" "/etc/modules-load.d/*.conf" "/run/modules-load.d/.*conf" "/usr/lib/modules-load.d/*.conf" "/run/modprobe.d/*.conf" "/usr/lib/modprobe.d/*.conf" )
+
+        for filename in "${kernel_mod_files[@]}"; do
+                for file in $filename; do
+                        sed -i "/install[[:space:]]+$kern_module/d" $file
+                done
+        done
+}

--- a/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/lib-modprobed-file.pass.sh
+++ b/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/lib-modprobed-file.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+source ./kernel_module_preparation.sh
+kernel_module_preparation "fire-wire"
+
+MODULES_DIR="/usr/lib/modprobe.d"
+mkdir -p "$MODULES_DIR"
+echo "install firewire-core /bin/false" >> "$MODULES_DIR/firewire.conf"

--- a/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/modprobed-file.pass.sh
+++ b/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/modprobed-file.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+source ./kernel_module_preparation.sh
+kernel_module_preparation "fire-wire"
+
+MODULES_DIR="/etc/modprobe.d"
+mkdir -p "$MODULES_DIR"
+echo "install firewire-core /bin/true" >> "$MODULES_DIR/firewire.conf"

--- a/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/modules-loadd-file.pass.sh
+++ b/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/modules-loadd-file.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+source ./kernel_module_preparation.sh
+kernel_module_preparation "fire-wire"
+
+MODULES_DIR="/run/modules-load.d"
+mkdir -p "$MODULES_DIR"
+echo "install firewire-core /bin/true" >> "$MODULES_DIR/fire-wire.conf"

--- a/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/no-install-present.fail.sh
+++ b/tests/data/group_system/group_network/group_network-uncommon/rule_kernel_module_firewire-core_disabled/no-install-present.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+source ./kernel_module_preparation.sh
+kernel_module_preparation "fire-wire"


### PR DESCRIPTION
#### Description:
Add test scenarios for `kernel_module_firewire-core_disabled`.

This rule is templated in `shared/templates/template_OVAL_kernel_module_disabled` thus these tests should cover other rules from the template (`kernel_module_cramfs_disabled`, `kernel_module_atm_disabled`, `kernel_module_bluetooth_disabled` etc).
