### PR TITLE
Improve OVAL for OpenSSH version check

### DIFF
--- a/shared/checks/oval/sshd_version_higher_than_74.xml
+++ b/shared/checks/oval/sshd_version_higher_than_74.xml
@@ -8,54 +8,33 @@
       <description>Check if version of OpenSSH Server is equal or higher than 7.4</description>
     </metadata>
     <criteria comment="OpenSSH Server version is equal or higher than 7.4" operator="OR">
-      <criteria comment="System uses RPM based packages" operator="AND">
-        <criteria comment="System uses RPM based packages" operator="OR">
-          <extend_definition comment="RHEL7 OS installed" definition_ref="installed_OS_is_rhel7" />
-          <extend_definition comment="RHEL6 OS installed" definition_ref="installed_OS_is_rhel6" />
-          <extend_definition comment="CentOS7 OS installed" definition_ref="installed_OS_is_centos7" />
-          <extend_definition comment="CentOS6 OS installed" definition_ref="installed_OS_is_centos6" />
-          <extend_definition comment="Fedora OS installed" definition_ref="installed_OS_is_fedora" />
-          <extend_definition comment="openSUSE OS installed" definition_ref="installed_OS_is_opensuse" />
-          <extend_definition comment="SLE11 OS installed" definition_ref="installed_OS_is_sle11" />
-          <extend_definition comment="SLE12 OS installed" definition_ref="installed_OS_is_sle12" />
-          <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7_family" />
-          <extend_definition comment="Installed OS is OL8" definition_ref="installed_OS_is_ol8_family" />
-        </criteria>
-        <criterion comment="Check RPM OpenSSH Server is equal or higher than 7.4"
-        test_ref="test_rpm_openssh-server_version" />
-      </criteria>
-      <criteria comment="System uses DEB based packages" operator="AND">
-        <criteria comment="System uses RPM based packages" operator="OR">
-          <extend_definition comment="Ubuntu 1404 OS installed" definition_ref="installed_OS_is_ubuntu1404" />
-          <extend_definition comment="Ubuntu 1604 OS installed" definition_ref="installed_OS_is_ubuntu1604" />
-          <extend_definition comment="Ubuntu 1804 OS installed" definition_ref="installed_OS_is_ubuntu1804" />
-          <extend_definition comment="Debian 8 OS installed" definition_ref="installed_OS_is_debian8" />
-        </criteria>
-        <criterion comment="Check DEB version of OpenSSH Server is equal or higher than 7.4"
-        test_ref="test_deb_openssh-server_version" />
-      </criteria>
+        <criterion comment="Check if OpenSSH Server is equal or higher than 7.4"
+            test_ref="test_openssh-server_version" />
     </criteria>
   </definition>
 
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="OpenSSH is version 7.4 or higher" id="test_rpm_openssh-server_version" version="1">
-    <linux:object object_ref="obj_rpm_openssh-server-version" />
-    <linux:state state_ref="state_rpm_openssh-server-version" />
+{{%- if pkg_system == "rpm" -%}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="OpenSSH is version 7.4 or higher" id="test_openssh-server_version" version="1">
+    <linux:object object_ref="obj_openssh-server_version" />
+    <linux:state state_ref="state_openssh-server_version" />
   </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_rpm_openssh-server-version" version="1">
+  <linux:rpminfo_object id="obj_openssh-server_version" version="1">
     <linux:name>openssh-server</linux:name>
   </linux:rpminfo_object>
-  <linux:rpminfo_state id="state_rpm_openssh-server-version" version="1">
+  <linux:rpminfo_state id="state_openssh-server_version" version="1">
     <linux:evr datatype="evr_string" operation="greater than or equal">0:7.4</linux:evr>
   </linux:rpminfo_state>
 
-  <linux:dpkginfo_test check="at least one" check_existence="any_exist" comment="OpenSSH is version 7.4 or higher" id="test_deb_openssh-server_version" version="1">
-    <linux:object object_ref="obj_deb_openssh-server-version" />
-    <linux:state state_ref="state_deb_openssh-server-version" />
+{{%- elif pkg_system == "dpkg" -%}}
+  <linux:dpkginfo_test check="at least one" check_existence="any_exist" comment="OpenSSH is version 7.4 or higher" id="test_openssh-server_version" version="1">
+    <linux:object object_ref="obj_openssh-server_version" />
+    <linux:state state_ref="state_openssh-server_version" />
   </linux:dpkginfo_test>
-  <linux:dpkginfo_object id="obj_deb_openssh-server-version" version="1">
+  <linux:dpkginfo_object id="obj_openssh-server_version" version="1">
     <linux:name>openssh-server</linux:name>
   </linux:dpkginfo_object>
-  <linux:dpkginfo_state id="state_deb_openssh-server-version" version="1">
+  <linux:dpkginfo_state id="state_openssh-server_version" version="1">
     <linux:evr datatype="evr_string" operation="greater than or equal">0:7.4</linux:evr>
   </linux:dpkginfo_state>
+{{%- endif -%}}
 </def-group>


### PR DESCRIPTION
#### Description:
The content for RPM-based distributions shouldn't contain dpkginfo test because on these systems OpenSCAP is typically shipped without dpkginfo probe and produces warning "OVAL object not supported". Using Jinja macros, we can include only the rpminfo test in SCAP content for RPM-based distros or include only dpkginfo test in SCAP content for DEB-based distros. This also simplifies the resulting OVAL definition.

#### Rationale:
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1640889

