### PR TITLE
Documentation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,21 @@ is a snippet of the instructions:
 ...
 ```
 
+### Bash
+To see a list of available Bash scripts, run:
+
+```bash
+# ls /usr/share/scap-security-guide/bash/
+...
+rhel7-script-hipaa.sh
+rhel7-script-ospp.sh
+rhel7-script-pci-dss.sh
+...
+```
+
+These Bash scripts are generated from *SCAP* profiles available for the products.
+Similar to Ansible Playbooks, each of the Bash scripts contain instructions on how to deploy them.
+
 ## Support
 
 The SSG mailing list can be found at [https://lists.fedorahosted.org/mailman/listinfo/scap-security-guide](https://lists.fedorahosted.org/mailman/listinfo/scap-security-guide).

--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -102,7 +102,11 @@ If you wish to build the content yourself, please, refer to link:https://github.
 == Running a Scan
 
 === Command Line Interface (CLI)
-This document outlines the usage of OpenSCAP, a command-line utility packaged within Fedora and Red Hat Enterprise Linux which allows users to load, scan, validate, edit, and export SCAP documents. Additional details regarding OpenSCAP can be found on the project homepage located at http://open-scap.org/.
+This document outlines the usage of OpenSCAP, a command-line utility packaged within Fedora and Red Hat Enterprise Linux which allows users to load, scan, validate, edit, and export SCAP documents.
+
+See also https://static.open-scap.org/openscap-1.3/oscap_user_manual.html[OpenSCAP User Manual] for instructions how to use OpenSCAP.
+Additional details regarding OpenSCAP can be found on the project homepage located at http://open-scap.org/.
+
 Five arguments to OpenSCAP are needed to perform a system scan against the upstream DISA STIG profile:
 
     * --profile +
@@ -114,20 +118,16 @@ Five arguments to OpenSCAP are needed to perform a system scan against the upstr
     * --report +
     Optional, indicates location to place HTML formatted results
 
-    * --cpe +
-    Mandatory, identifies location of CPE dictionary
-
-    * xccdf location +
-    Mandatory, identifies location of XCCDF file
+    * datastream location +
+    Mandatory, identifies location of SCAP Source Datastream file
 
 Putting these arguments together, a properly formatted command would be:
 
 ----
-$ sudo oscap xccdf eval --profile stig-rhel6-server \
+$ sudo oscap xccdf eval --profile stig \
 --results /tmp/results.xml \
 --report /tmp/report.html \
---cpe /usr/share/xml/scap/ssg/content/ssg-rhel6-cpe-dictionary.xml \
-/usr/share/xml/scap/ssg/content/ssg-rhel6-xccdf.xml
+/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
 ----
 
 While the scan is running, you will see output similar to the following on your screen:
@@ -200,7 +200,11 @@ Looking at the `/tmp/results.xml` file, you will notice lines similar to those b
 === Remediation
 
 ==== Bash Scripts
+
 ComplianceAsCode embeds bash remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations.
+
+A pregenerated Bash remediation script for each profile can be found in `/usr/share/scap-security-guide/bash/` or if you build the project from source in `./build/bash`.
+
 OpenSCAP, the CLI delivered with Fedora and Red Hat Enterprise Linux systems, contains the ability to transform XML results into an executable script. The syntax to generate a remediation script is:
 
 ----

--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -201,9 +201,10 @@ Looking at the `/tmp/results.xml` file, you will notice lines similar to those b
 
 ==== Bash Scripts
 
-ComplianceAsCode embeds bash remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations.
+A Bash remediation script for each profile is shipped in `scap-security-guide` package.
+The scripts can be found in `/usr/share/scap-security-guide/bash/` or if you build the project from source in `./build/bash`.
 
-A pregenerated Bash remediation script for each profile can be found in `/usr/share/scap-security-guide/bash/` or if you build the project from source in `./build/bash`.
+Moreover, ComplianceAsCode embeds bash remediation scripts into the SCAP content. This allows for SCAP compatible tools to extract these remediation scripts to aide in potential remediation of system misconfigurations.
 
 OpenSCAP, the CLI delivered with Fedora and Red Hat Enterprise Linux systems, contains the ability to transform XML results into an executable script. The syntax to generate a remediation script is:
 


### PR DESCRIPTION
#### Description:

As a part of the documentation session I have done these changes:
- recommend using datastream instead of plain XCCDF
- mention where Bash scripts for profiles can be found

#### Rationale:

