### PR TITLE
Revert "Expand documentation of xccdf rule severity"

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -710,28 +710,9 @@ A rule YAML file has one implied attribute:
 
 A rule itself contains these attributes:
 
-* `severity`: Is used for metrics and tracking. It can have one of the following values: `unknown`, `info`, `low`, `medium`, or `high`.
-+
-[cols="2", options="header"]
-|===
-|Level | Description
-|`unknown`
-|Severity not defined (default)
+* `severity`: Can be `unknown`, `low`, `medium`, or `high`.
 
-|`info`
-|Rule is informational only. Failing the rule doesn't imply failure to conform to the security guidance of the benchmark.
-
-|`low`
-|Not a serious problem
-
-|`medium`
-|Fairly serious problem
-
-|`high`
-|Grave or critical problem
-|===
-+
-The severity of the rule can be overridden by a profile with `refine-rule` selector.
+A rule must contain these attributes:
 
 * `title`: Human-readable title of the rule.
 * `rationale`: Human-readable HTML description of the reason why the rule exists and why it is important from the technical point of view. For example, rationale of the `partition_for_tmp` rule states that:


### PR DESCRIPTION
Reverts ComplianceAsCode/content#4609

NACK to original PR. These are not how the severity codes are currently defined. Should use the DISA language.

(and they should be a conversation about using something else, like NIST that Trevor mentioned awhile ago).