### PR TITLE
Remove supported_platforms parameter from dnf-automatic_apply_updates rule

### DIFF
--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/oval/shared.xml
@@ -8,7 +8,6 @@ oval_check_config_file(
     missing_parameter_pass=false,
     application="dnf-automatic",
     multi_value=false,
-    missing_config_file_fail=true,
-    supported_platforms=["rhel8","ol8","fedora"]
+    missing_config_file_fail=true
 )
 }}}


### PR DESCRIPTION
#### Description:
Remove supported_platforms parameter from macro.

Parameter was removed in #4596 but this rule was merged shortly before that.