### PR TITLE
 Add Ansible remediation for configure_tmux_lock_command 

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1095,6 +1095,7 @@ Jinja macros for Ansible content are located in `/shared/macros-ansible.jinja`. 
 
 - `ansible_sshd_set` -- set a parameter in the sshd configuration
 - `ansible_etc_profile_set` -- ensure a command gets executed or a variable gets set in /etc/profile or /etc/profile.d
+- `ansible_tmux_set` -- set a command in tmux configuration
 
 They also include several low-level macros:
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/ansible/shared.yml
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{{ ansible_tmux_set(parameter="lock-command", value="vlock") }}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -142,6 +142,18 @@
 {{%- endmacro %}}
 
 {{#
+  High level macro to set a command in tmux configuration file /etc/tmux.conf.
+  Parameters:
+  - msg: the name for the Ansible task
+  - parameter: parameter to be set in the configuration file
+  - value: value of the parameter
+  Automatically adds "set -g " before the parameter.
+#}}
+{{%- macro ansible_tmux_set(msg='', parameter='', value='') %}}
+{{{ ansible_set_config_file(msg, "/etc/tmux.conf", "set -g " + parameter, value=value, create="yes") }}}
+{{%- endmacro %}}
+
+{{#
   High level macro to set a value in /etc/profile (and /etc/profile.d) bash
   files. Note this is only suitable for calling a single command once with the
   correct arguments and not for calling the same command multiple times with


### PR DESCRIPTION
#### Description:

First, it adds a Jinja macro to easily create Ansible remediation for `tmux` configuration. Then, it adds Ansible remediation for rule `configure_tmux_lock_command`.

#### Rationale:
This rule is a part of RHEL 8 CC configuration. The macro will make creating future Ansible tasks easier.