### PR TITLE
Use right variable in sshd_set_keepalive OVAL check.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
@@ -44,7 +44,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_state id="state_sshd_clientalivecountmax" version="1">
     <ind:subexpression datatype="int" operation="less than or equal" var_check="all"
-    var_ref="sshd_max_auth_tries_value" />
+    var_ref="var_sshd_set_keepalive" />
   </ind:textfilecontent54_state>
   <ind:textfilecontent54_object id="obj_sshd_clientalivecountmax" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>


### PR DESCRIPTION
#### Description:

- Use right variable in the OVAL check for sshd_set_keepalive. See: https://github.com/ComplianceAsCode/content/compare/master...ggbecker:use-right-variable?expand=1#diff-1a6a5e8baa296218700838a3812a9b45R56
