### PR TITLE
WIP: Preserve correct configurations

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1093,8 +1093,8 @@ The Playbook is generated in `/build/ansible/<product>-playbook-<profile_id>.yml
 
 Jinja macros for Ansible content are located in `/shared/macros-ansible.jinja`. These currently include the following high-level macros:
 
+- `ansible_etc_profile_set_variable` -- ensure a variable gets set in /etc/profile or /etc/profile.d
 - `ansible_sshd_set` -- set a parameter in the sshd configuration
-- `ansible_etc_profile_set` -- ensure a command gets executed or a variable gets set in /etc/profile or /etc/profile.d
 - `ansible_tmux_set` -- set a command in tmux configuration
 
 They also include several low-level macros:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -5,4 +5,4 @@
 # disruption = low
 - (xccdf-var var_accounts_tmout)
 
-{{{ ansible_etc_profile_set(parameter='TMOUT', value='{{ var_accounts_tmout }}') }}}
+{{{ ansible_etc_profile_set_variable(parameter='TMOUT', value='{{ var_accounts_tmout }}') }}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -99,8 +99,8 @@
   ini configuration files are best served with the ini Ansible module
   instead of lineinfile-based solutions.
 #}}
-{{%- macro ansible_set_config_file(msg, file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='') %}}
-{{{ ansible_only_lineinfile(msg, file, prefix_regex + parameter + separator_regex, parameter + separator + value, create=create, block=True, validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
+{{%- macro ansible_set_config_file(msg, file, parameter, separator=' ', separator_regex='\s+', value='', value_regex='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='') %}}
+{{{ ansible_only_lineinfile(msg, file, prefix_regex + parameter + separator_regex + value_regex, parameter + separator + value, create=create, block=True, validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
 {{%- endmacro %}}
 
 {{#
@@ -110,11 +110,11 @@
   best served with the ini Ansible module instead of lineinfile-based
   solutions.
 #}}
-{{%- macro ansible_set_config_file_dir(msg, config_file, config_dir, set_file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='') %}}
+{{%- macro ansible_set_config_file_dir(msg, config_file, config_dir, set_file, parameter, separator=' ', separator_regex='\s+', value='', value_regex='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='') %}}
 {{%- set var_dir = config_dir | replace("/", "_") | replace("-", "_") | replace(".", "_") -%}}
 {{%- set dir_exists = var_dir + "_exists" -%}}
 {{%- set dir_parameter = var_dir + "_has_parameter" -%}}
-{{%- set line_regex = prefix_regex + parameter + separator_regex -%}}
+{{%- set line_regex = prefix_regex + parameter + separator_regex + value_regex -%}}
 {{%- set find_when = dir_exists + ".stat.isdir is defined and " + dir_exists + ".stat.isdir" -%}}
 {{%- set lineinfile_items = "{{ " + dir_parameter + ".files }}" -%}}
 {{%- set lineinfile_when = dir_parameter + ".matched" -%}}
@@ -138,7 +138,7 @@
   Ansible to pass a file at a different path.
 #}}
 {{%- macro ansible_sshd_set(msg='', parameter='', value='') %}}
-{{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^Match") }}}
+{{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, value_regex='(?!' + value + '$).*', create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^Match") }}}
 {{%- endmacro %}}
 
 {{#
@@ -159,6 +159,6 @@
   correct arguments and not for calling the same command multiple times with
   different arguments. This includes setting an environment variable once.
 #}}
-{{%- macro ansible_etc_profile_set(msg='', parameter='', value='') %}}
+{{%- macro ansible_etc_profile_set_variable(msg='', parameter='', value='') %}}
 {{{ ansible_set_config_file_dir(msg, "/etc/profile", "/etc/profile.d", "/etc/profile", parameter, separator='=', separator_regex='=', value=value, create='yes', validate="bash -n %s") }}}
 {{%- endmacro %}}


### PR DESCRIPTION
#### Problem Statement

Our bash and ansible remediations currently match in effect. First they strip all lines with the configuration parameter. Then they add the line with the correct value, regardless of whether or not they stripped a line with the correct value already.

One could envision a capable admin who already has a compliant configuration getting annoyed at this behavior, since SCAP remediations could be continually rewriting his config. We have the capabilities to only remove non-compliant lines and add the compliant line only if it is missing, so we probably should.

It is definitely possible with a three-line check (remove-incorrect, check, add-if-missing), but I'm wondering if anyone has ideas about how to make it a two-line check (remove-incorrect, add-if-missing). Thoughts?

#### Help wanted:

This does the easy part: update it to not remove a configuration line with the correct value.

What remains is checking if the file has the correct line, and only add it if it doesn't. 

Also, renames `ansible_etc_profile_set` to `ansible_etc_profile_set_variable` and updates its description -- it really can't be used with a command with `=` as the separator and no way to change the separator. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`