### PR TITLE
Make the Bash lineinfile functions callable from remediations

### DIFF
--- a/shared/bash_remediation_functions/include_lineinfile.sh
+++ b/shared/bash_remediation_functions/include_lineinfile.sh
@@ -1,6 +1,19 @@
 # Functions which minic Ansible's lineinfile module.
 # dependencies: die.sh
 
+function include_lineinfile() {
+    :
+}
+
+# Print a message to stderr and exit the shell
+# $1: The message to print.
+# $2: The error code (optional, default is 1)
+function die {
+	local _message="$1" _rc="${2:-1}"
+	printf '%s\n' "$_message" >&2
+	exit "$_rc"
+}
+
 # Internal helper function to remove a line, if it is present.
 function lineinfile_absent() {
     local path="$1"


### PR DESCRIPTION
#### Description:
The functions called in Bash remediation need to have a corresponding
.sh file with the same name as the name of the function located
in bash_remediation_functions directory. Otherwise they will not be
expanded. To be able to use the high-level functions such as
set_config_file, we will add an including mechanism.  Users will call
include_lineinfile and the build system will include the whole file
include_lineinfile.sh. This patch also copies the die function because
the build system does not support dependent functions in other files.

#### Rationale:

Enables using  Bash functions introduced in #4597 in our remediations.
