### PR TITLE
Fixes of Jinja macro `oval_check_config_file`

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -203,7 +203,7 @@
   sshd_config has case-insensitive parameters (but case-sensitive values).
 #}}
 {{%- macro oval_sshd_config(parameter='', value='', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false, supported_platforms=['all']) %}}
-{{{ oval_check_config_file("/etc/ssh/sshd_config", prefix_regex="(?i)^[\s]*", parameter=parameter, separator_regex='(?-i)[\s]+', value=value, missing_parameter_pass=missing_parameter_pass, application="sshd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail) }}}
+{{{ oval_check_config_file("/etc/ssh/sshd_config", prefix_regex="^[\s]*(?i)", parameter=parameter, separator_regex='(?-i)[\s]+', value=value, missing_parameter_pass=missing_parameter_pass, application="sshd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail) }}}
 {{%- endmacro %}}
 
 {{#

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -17,7 +17,7 @@
     - multi_value (boolean): If set, it means that the parameter can accept multiple values and the expected value must be present in the current list of values.
     - missing_config_file_fail (boolean): If set, the check will fail if the configuration is not existent in the system.
 #}}
-{{%- macro oval_check_config_file(path='', prefix_regex='^\s*', parameter='', separator_regex='(?-i)[\s]+', value='', missing_parameter_pass=false, application='', multi_value='', missing_config_file_fail=false) -%}}
+{{%- macro oval_check_config_file(path='', prefix_regex='^\s*', parameter='', separator_regex='(?-i)[\s]+', value='', missing_parameter_pass=false, application='', multi_value=false, missing_config_file_fail=false) -%}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     <metadata>

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -17,7 +17,7 @@
     - multi_value (boolean): If set, it means that the parameter can accept multiple values and the expected value must be present in the current list of values.
     - missing_config_file_fail (boolean): If set, the check will fail if the configuration is not existent in the system.
 #}}
-{{%- macro oval_check_config_file(path='', prefix_regex='^\s*', parameter='', separator_regex='(?-i)[\s]+', value='', missing_parameter_pass=false, application='', multi_value=false, missing_config_file_fail=false) -%}}
+{{%- macro oval_check_config_file(path='', prefix_regex='^\s*', parameter='', separator_regex='\s+', value='', missing_parameter_pass=false, application='', multi_value=false, missing_config_file_fail=false) -%}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     <metadata>


### PR DESCRIPTION
#### Description:

This pull request proposes 2 changes in Jinja macro `oval_check_config_file` that generates OVAL to check config files:

1. Set multi_value to false instead of an empy string
The variable is used as boolean and is also documented as boolean.


2. Change default separator regex
The former default separator regex `(?-i)[\s]+` was wrong, because `(?-i)` means "stop being case-insensitive". It needs a pair `(?i)` before in the regular expression and is ineffective but confusing alone.
It should be harmless to change the default value now because all of the occurrences are calling the macro with the `separator_regex` parameter set.


#### Rationale:
Makes the default values more sensible and therefore it makes the macro generally usable.