### PR TITLE
Add mask_service parameter to services disabled template.

### DIFF
--- a/debian8/templates/csv/services_disabled.csv
+++ b/debian8/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,ssh

--- a/debian8/templates/csv/services_disabled.csv
+++ b/debian8/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,ssh

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1199,7 +1199,6 @@ This is an example of a patch to add a new template into the templating system:
 @@ -43,6 +44,7 @@ def __init__(self):
              "sysctl_values.csv":       SysctlGenerator(),
              "services_disabled.csv":   ServiceDisabledGenerator(),
-             "services_disabled.csv":   ServiceDisabledGenerator(),
              "services_enabled.csv":    ServiceEnabledGenerator(),
 +            "packages_installed.csv":  PackageInstalledGenerator(),
          }

--- a/example/templates/csv/services_disabled.csv
+++ b/example/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,

--- a/example/templates/csv/services_disabled.csv
+++ b/example/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,

--- a/fedora/templates/csv/services_disabled.csv
+++ b/fedora/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,
 sssd,,
 debug-shell,systemd,

--- a/fedora/templates/csv/services_disabled.csv
+++ b/fedora/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,
 sssd,,
 debug-shell,systemd,

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
@@ -12,7 +12,7 @@ description: |-
     <tt>CTRL-ALT-F9</tt>. The <tt>debug-shell</tt> service should only be used
     for SystemD related issues and should otherwise be disabled.
     <br /><br />
-    By default, the <tt>debug-shell</tt> SystemD service is disabled.
+    By default, the <tt>debug-shell</tt> SystemD service is already disabled.
     {{{ describe_service_disable(service="debug-shell") }}}
 
 rationale: |-

--- a/ol7/templates/csv/services_disabled.csv
+++ b/ol7/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 abrtd,abrt,
 atd,at,
 autofs,autofs,

--- a/ol7/templates/csv/services_disabled.csv
+++ b/ol7/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 abrtd,abrt,
 atd,at,
 autofs,autofs,

--- a/ol8/templates/csv/services_disabled.csv
+++ b/ol8/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 abrtd,abrt,
 atd,at,
 autofs,autofs,

--- a/ol8/templates/csv/services_disabled.csv
+++ b/ol8/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 abrtd,abrt,
 atd,at,
 autofs,autofs,

--- a/opensuse/templates/csv/services_disabled.csv
+++ b/opensuse/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh,

--- a/opensuse/templates/csv/services_disabled.csv
+++ b/opensuse/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh,

--- a/rhel6/templates/csv/services_disabled.csv
+++ b/rhel6/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 abrtd,abrt,
 acpid,,
 autofs,autofs,

--- a/rhel6/templates/csv/services_disabled.csv
+++ b/rhel6/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 abrtd,abrt,
 acpid,,
 autofs,autofs,

--- a/rhel7/templates/csv/services_disabled.csv
+++ b/rhel7/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 abrtd,abrt,
 acpid,,
 atd,at,

--- a/rhel7/templates/csv/services_disabled.csv
+++ b/rhel7/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 abrtd,abrt,
 acpid,,
 atd,at,

--- a/rhel8/templates/csv/services_disabled.csv
+++ b/rhel8/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,
 sssd,,
 debug-shell,systemd,

--- a/rhel8/templates/csv/services_disabled.csv
+++ b/rhel8/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if mask_service is set the service will be masked, can be any string)
-sshd,openssh-server,,mask_service
-sssd,,,mask_service
-debug-shell,systemd,,mask_service
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+sshd,openssh-server,
+sssd,,
+debug-shell,systemd,

--- a/rhel8/templates/csv/services_disabled.csv
+++ b/rhel8/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
-sshd,openssh-server,
-sssd,,
-debug-shell,systemd,
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if mask_service is set the service will be masked, can be any string)
+sshd,openssh-server,,mask_service
+sssd,,,mask_service
+debug-shell,systemd,,mask_service

--- a/rhv4/templates/csv/services_disabled.csv
+++ b/rhv4/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 bluetooth,bluez,
 sshd,openssh-server,
 sssd,,

--- a/rhv4/templates/csv/services_disabled.csv
+++ b/rhv4/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 bluetooth,bluez,
 sshd,openssh-server,
 sssd,,

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -280,13 +280,23 @@ ocil_clause: "the package is installed"
     <pre>$ systemctl is-enabled <code>{{{ service }}}</code></pre>
     Output should indicate the <code>{{{ service }}}</code> service has either not been installed,
     or has been disabled at all runlevels, as shown in the example below:
-    <pre>$ systemctl is-enabled <code>{{{ service }}}</code><br/>disabled</pre>
+    <pre>$ systemctl is-enabled <code>{{{ service }}}</code><br/> disabled</pre>
 
     Run the following command to verify <code>{{{ service }}}</code> is not active (i.e. not running) through current runtime configuration:
     <pre>$ systemctl is-active {{{ service }}}</pre>
 
     If the service is not running the command will return the following output:
     <pre>inactive</pre>
+
+    By default the service will also be masked, to check that the <code>{{{ service }}}</code> is masked, run the following command:
+    <pre>$ systemctl show <code>{{{ service }}}</code> | grep "LoadState\|UnitFileState"</pre>
+
+    If the service is masked the command will return the following outputs:
+
+    <pre>LoadState=masked</pre>
+
+    <pre>UnitFileState=masked</pre>
+
 {{%- endmacro %}}
 
 
@@ -345,6 +355,8 @@ ocil_clause: "the package is installed"
 {{%- macro systemd_describe_service_disable(service) %}}
     The <code>{{{ service }}}</code> service can be disabled with the following command:
     <pre>$ sudo systemctl disable {{{ service }}}.service</pre>
+    The <code>{{{ service }}}</code> service can be masked with the following command:
+    <pre>$ sudo systemctl mask {{{ service }}}.service</pre>
 {{%- endmacro %}}
 
 

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -219,6 +219,15 @@ ocil_clause: "no line is returned"
 
     If the socket is not running the command will return the following output:
     <pre>inactive</pre>
+
+    By default the socket will also be masked, to check that the <code>{{{ socket }}}</code> is masked, run the following command:
+    <pre>$ systemctl show <code>{{{ socket }}}</code> | grep "LoadState\|UnitFileState"</pre>
+
+    If the socket is masked the command will return the following outputs:
+
+    <pre>LoadState=masked</pre>
+
+    <pre>UnitFileState=masked</pre>
 {{%- endmacro %}}
 
 
@@ -335,6 +344,8 @@ ocil_clause: "the package is installed"
 {{%- macro systemd_describe_socket_disable(socket) %}}
     The <code>{{{ socket }}}</code> socket can be disabled with the following command:
     <pre>$ sudo systemctl disable {{{ socket }}}.socket</pre>
+    The <code>{{{ socket }}}</code> socket can be masked with the following command:
+    <pre>$ sudo systemctl mask {{{ service }}}.socket</pre>
 {{%- endmacro %}}
 
 

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -37,7 +37,7 @@ class ServiceDisabledGenerator(FilesGenerator):
             print("\tError unpacking servicename, packagename, daemonname " +
                   "and mask_service: " + str(e))
             print("\tEntry: %s\n" % serviceinfo)
-            sys.exit(1)
+            raise CSVLineError()
 
         if not daemonname:
             daemonname = servicename

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -4,19 +4,31 @@
 
 import sys
 
-from template_common import FilesGenerator, UnknownTargetError
+from template_common import FilesGenerator, UnknownTargetError, CSVLineError
 
 
 class ServiceDisabledGenerator(FilesGenerator):
     def generate(self, target, serviceinfo):
         try:
-            # get the items out of the list
-            servicename, packagename, daemonname = serviceinfo
+
+        # get the items out of the list
+            # items can be in format
+            # <service_name, package_name, daemon_name> or
+            # <service_name, package_name, daemon_name, mask_service>
+            mask_service = False
+            if len(serviceinfo) == 3:
+                servicename, packagename, daemonname = serviceinfo
+            elif len(serviceinfo) == 4:
+                servicename, packagename, daemonname, mask_service = serviceinfo
+                # use boolean instead of any string that came from csv file
+                mask_service = True
+            else:
+                raise CSVLineError()
             if not packagename:
                 packagename = servicename
         except ValueError as e:
             print("\tEntry: %s\n" % serviceinfo)
-            print("\tError unpacking servicename, packagename, and daemonname: " + str(e))
+            print("\tError unpacking servicename, packagename, daemonname and mask_service: " + str(e))
             sys.exit(1)
 
         if not daemonname:
@@ -27,7 +39,8 @@ class ServiceDisabledGenerator(FilesGenerator):
                 "./template_BASH_service_disabled",
                 {
                     "SERVICENAME": servicename,
-                    "DAEMONNAME": daemonname
+                    "DAEMONNAME": daemonname,
+                    "MASK_SERVICE": mask_service
                 },
                 "./bash/service_{0}_disabled.sh", servicename
             )
@@ -37,7 +50,8 @@ class ServiceDisabledGenerator(FilesGenerator):
                 "./template_ANSIBLE_service_disabled",
                 {
                     "SERVICENAME": servicename,
-                    "DAEMONNAME": daemonname
+                    "DAEMONNAME": daemonname,
+                    "MASK_SERVICE": mask_service
                 },
                 "./ansible/service_{0}_disabled.yml", servicename
             )
@@ -47,7 +61,8 @@ class ServiceDisabledGenerator(FilesGenerator):
                 "./template_PUPPET_service_disabled",
                 {
                     "SERVICENAME": servicename,
-                    "DAEMONNAME": daemonname
+                    "DAEMONNAME": daemonname,
+                    "MASK_SERVICE": mask_service
                 },
                 "./puppet/service_{0}_disabled.yml", servicename
             )
@@ -58,7 +73,8 @@ class ServiceDisabledGenerator(FilesGenerator):
                 {
                     "SERVICENAME": servicename,
                     "DAEMONNAME":  daemonname,
-                    "PACKAGENAME": packagename
+                    "PACKAGENAME": packagename,
+                    "MASK_SERVICE": mask_service
                 },
                 "./oval/service_{0}_disabled.xml", servicename
             )
@@ -67,4 +83,4 @@ class ServiceDisabledGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: " +
-               "servicename,packagename")
+               "servicename,packagename,daemonname[,mask_service]")

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -16,21 +16,27 @@ class ServiceDisabledGenerator(FilesGenerator):
             # get the items out of the list
             # items can be in format
             # <service_name, package_name, daemon_name> or
-            # <service_name, package_name, daemon_name, dont_mask_service>
+            # <service_name, package_name, daemon_name, mask_service>
             if len(serviceinfo) == 3:
                 servicename, packagename, daemonname = serviceinfo
             elif len(serviceinfo) == 4:
-                servicename, packagename, daemonname, dont_mask_service = serviceinfo
+                servicename, packagename, daemonname, mask_service = serviceinfo
                 # use boolean instead of any string that came from csv file
-                mask_service = False if dont_mask_service != "" else True
+                if mask_service == "true":
+                    mask_service = True
+                elif mask_service == "false":
+                    mask_service = False
+                else:
+                    raise ValueError("Unrecognized option for mask_service parameter ({}). ".format(mask_service) +
+                                     "Possible values are: true or false.")
             else:
                 raise CSVLineError()
             if not packagename:
                 packagename = servicename
         except ValueError as e:
-            print("\tEntry: %s\n" % serviceinfo)
             print("\tError unpacking servicename, packagename, daemonname " +
-                  "and dont_mask_service: " + str(e))
+                  "and mask_service: " + str(e))
+            print("\tEntry: %s\n" % serviceinfo)
             sys.exit(1)
 
         if not daemonname:
@@ -85,4 +91,4 @@ class ServiceDisabledGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: " +
-               "servicename,packagename,daemonname[,dont_mask_service]")
+               "servicename,packagename,daemonname[,mask_service]")

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -10,25 +10,26 @@ from template_common import FilesGenerator, UnknownTargetError, CSVLineError
 class ServiceDisabledGenerator(FilesGenerator):
     def generate(self, target, serviceinfo):
         try:
+            # mask service by default
+            mask_service = True
 
-        # get the items out of the list
+            # get the items out of the list
             # items can be in format
             # <service_name, package_name, daemon_name> or
-            # <service_name, package_name, daemon_name, mask_service>
-            mask_service = False
+            # <service_name, package_name, daemon_name, dont_mask_service>
             if len(serviceinfo) == 3:
                 servicename, packagename, daemonname = serviceinfo
             elif len(serviceinfo) == 4:
-                servicename, packagename, daemonname, mask_service = serviceinfo
+                servicename, packagename, daemonname, dont_mask_service = serviceinfo
                 # use boolean instead of any string that came from csv file
-                mask_service = True
+                mask_service = False if dont_mask_service != "" else True
             else:
                 raise CSVLineError()
             if not packagename:
                 packagename = servicename
         except ValueError as e:
             print("\tEntry: %s\n" % serviceinfo)
-            print("\tError unpacking servicename, packagename, daemonname and mask_service: " + str(e))
+            print("\tError unpacking servicename, packagename, daemonname and dont_mask_service: " + str(e))
             sys.exit(1)
 
         if not daemonname:
@@ -83,4 +84,4 @@ class ServiceDisabledGenerator(FilesGenerator):
 
     def csv_format(self):
         return("CSV should contains lines of the format: " +
-               "servicename,packagename,daemonname[,mask_service]")
+               "servicename,packagename,daemonname[,dont_mask_service]")

--- a/shared/templates/create_services_disabled.py
+++ b/shared/templates/create_services_disabled.py
@@ -29,7 +29,8 @@ class ServiceDisabledGenerator(FilesGenerator):
                 packagename = servicename
         except ValueError as e:
             print("\tEntry: %s\n" % serviceinfo)
-            print("\tError unpacking servicename, packagename, daemonname and dont_mask_service: " + str(e))
+            print("\tError unpacking servicename, packagename, daemonname " +
+                  "and dont_mask_service: " + str(e))
             sys.exit(1)
 
         if not daemonname:

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -5,10 +5,11 @@
 # disruption = low
 {{%- if init_system == "systemd" %}}
 - name: "Unit Service Exists"
-  command: systemctl list-unit-files | grep -q '^{{{ DAEMONNAME }}}.service'
+  shell: systemctl list-unit-files | grep -q '^{{{ DAEMONNAME }}}.service'
   register: service_file_exists
+  ignore_errors: True
 
-- name: Disable {{{ SERVICENAME }}}
+- name: Disable service {{{ SERVICENAME }}}
   systemd:
     name: "{{{ DAEMONNAME }}}.service"
     enabled: "no"
@@ -16,12 +17,12 @@
 {{%- if MASK_SERVICE %}}
     masked: "yes"
 {{%- endif %}}
-  register: service_result
   when: service_file_exists.rc == 0
 
 - name: "Unit Socket Exists"
-  command: systemctl list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'
+  shell: systemctl list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'
   register: socket_file_exists
+  ignore_errors: True
 
 - name: Disable socket {{{ SERVICENAME }}}
   systemd:
@@ -31,7 +32,6 @@
 {{%- if MASK_SERVICE %}}
     masked: "yes"
 {{%- endif %}}
-  register: socket_result
   when: socket_file_exists.rc == 0
 
 {{% elif init_system == "upstart" %}}

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -3,19 +3,46 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-- name: Disable service {{{ SERVICENAME }}}
+{{%- if init_system == "systemd" %}}
+- name: "Unit Service Exists"
+  command: systemctl list-unit-files | grep -q '^{{{ DAEMONNAME }}}.service'
+  register: service_file_exists
+
+- name: Disable {{{ SERVICENAME }}}
   systemd:
-    name: "{{{ DAEMONNAME }}}.{{ item }}"
+    name: "{{{ DAEMONNAME }}}.service"
     enabled: "no"
     state: "stopped"
 {{%- if MASK_SERVICE %}}
     masked: "yes"
 {{%- endif %}}
   register: service_result
-  failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg) and ('Unit file {{{ DAEMONNAME }}}.{{ item }} does not exist' not in service_result.msg)"
-  with_items:
-    - service
-{{%- if init_system == "systemd" %}}
-    - socket
-{{%- endif %}}
+  when: service_file_exists.rc == 0
+  failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
 
+- name: "Unit Socket Exists"
+  command: systemctl list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'
+  register: socket_file_exists
+
+- name: Disable socket {{{ SERVICENAME }}}
+  systemd:
+    name: "{{{ DAEMONNAME }}}.socket"
+    enabled: "no"
+    state: "stopped"
+{{%- if MASK_SERVICE %}}
+    masked: "yes"
+{{%- endif %}}
+  register: socket_result
+  when: socket_file_exists.rc == 0
+  failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
+
+{{% elif init_system == "upstart" %}}
+- name: Stop {{{ SERVICENAME }}}
+  command: /sbin/service '{{{ DAEMONNAME }}}' stop
+- name: Switch off {{{ SERVICENAME }}}
+  command: /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
+
+{{%- else %}}
+
+JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
+{{%- endif %}}

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 - name: Disable service {{{ SERVICENAME }}}
-  service:
+  systemd:
     name: "{{{ DAEMONNAME }}}"
     enabled: "no"
     state: "stopped"
@@ -16,7 +16,7 @@
 
 {{% if init_system == "systemd" %}}
 - name: Disable socket of service {{{ SERVICENAME }}} if applicable
-  service:
+  systemd:
     name: "{{{ DAEMONNAME }}}.socket"
     enabled: "no"
     state: "stopped"

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -4,15 +4,21 @@
 # complexity = low
 # disruption = low
 - name: Disable service {{{ SERVICENAME }}}
-  systemd:
+  service:
     name: "{{{ DAEMONNAME }}}"
     enabled: "no"
     state: "stopped"
-    {{%- if MASK_SERVICE %}}
+  register: disable_service_result
+  failed_when: "disable_service_result is failed and ('Could not find the requested service' not in disable_service_result.msg)"
+
+{{%- if MASK_SERVICE %}}
+- name: Mask service {{{ SERVICENAME }}}
+  systemd:
+    name: "{{{ DAEMONNAME }}}"
     masked: "yes"
-    {{%- endif %}}
-  register: service_result
-  failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
+  register: mask_service_result
+  failed_when: "mask_service_result is failed and ('Could not find the requested service' not in mask_service_result.msg)"
+{{%- endif %}}
 
 {{% if init_system == "systemd" %}}
 - name: Disable socket of service {{{ SERVICENAME }}} if applicable

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -8,6 +8,9 @@
     name: "{{{ DAEMONNAME }}}"
     enabled: "no"
     state: "stopped"
+    {{%- if MASK_SERVICE %}}
+    masked: "yes"
+    {{%- endif %}}
   register: service_result
   failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
 
@@ -17,6 +20,9 @@
     name: "{{{ DAEMONNAME }}}.socket"
     enabled: "no"
     state: "stopped"
+    {{%- if MASK_SERVICE %}}
+    masked: "yes"
+    {{%- endif %}}
   register: socket_result
   failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
 {{% endif %}}

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -12,7 +12,7 @@
     masked: "yes"
 {{%- endif %}}
   register: service_result
-  failed_when: "service_result is failed and ('Could not find the requested service' not in result.msg)"
+  failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg) and ('Unit file {{{ DAEMONNAME }}}.{{ item }} does not exist' not in service_result.msg)"
   with_items:
     - service
 {{%- if init_system == "systemd" %}}

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -18,7 +18,6 @@
 {{%- endif %}}
   register: service_result
   when: service_file_exists.rc == 0
-  failed_when: "service_result is failed and ('Could not find the requested service' not in service_result.msg)"
 
 - name: "Unit Socket Exists"
   command: systemctl list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'
@@ -34,7 +33,6 @@
 {{%- endif %}}
   register: socket_result
   when: socket_file_exists.rc == 0
-  failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
 
 {{% elif init_system == "upstart" %}}
 - name: Stop {{{ SERVICENAME }}}

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -4,31 +4,18 @@
 # complexity = low
 # disruption = low
 - name: Disable service {{{ SERVICENAME }}}
-  service:
-    name: "{{{ DAEMONNAME }}}"
+  systemd:
+    name: "{{{ DAEMONNAME }}}.{{ item }}"
     enabled: "no"
     state: "stopped"
-  register: disable_service_result
-  failed_when: "disable_service_result is failed and ('Could not find the requested service' not in disable_service_result.msg)"
-
 {{%- if MASK_SERVICE %}}
-- name: Mask service {{{ SERVICENAME }}}
-  systemd:
-    name: "{{{ DAEMONNAME }}}"
     masked: "yes"
-  register: mask_service_result
-  failed_when: "mask_service_result is failed and ('Could not find the requested service' not in mask_service_result.msg)"
+{{%- endif %}}
+  register: service_result
+  failed_when: "service_result is failed and ('Could not find the requested service' not in result.msg)"
+  with_items:
+    - service
+{{%- if init_system == "systemd" %}}
+    - socket
 {{%- endif %}}
 
-{{% if init_system == "systemd" %}}
-- name: Disable socket of service {{{ SERVICENAME }}} if applicable
-  systemd:
-    name: "{{{ DAEMONNAME }}}.socket"
-    enabled: "no"
-    state: "stopped"
-    {{%- if MASK_SERVICE %}}
-    masked: "yes"
-    {{%- endif %}}
-  register: socket_result
-  failed_when: "socket_result is failed and ('Could not find the requested service' not in socket_result.msg)"
-{{% endif %}}

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -5,11 +5,15 @@
 # disruption = low
 {{%- if init_system == "systemd" %}}
 
+
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
+{{%- if MASK_SERVICE %}}
+"$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+{{%- endif %}}
 # Disable socket activation if we have a unit file for it
-"$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket\>' && "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.socket'
+"$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket' && "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.socket' {{%- if MASK_SERVICE %}} && "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket' {{%- endif %}}
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.
 # Service should be 'inactive', not 'failed' after reboot though.
@@ -17,6 +21,9 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 {{% elif init_system == "upstart" %}}
 
 /sbin/service '{{{ DAEMONNAME }}}' disable
+{{%- if MASK_SERVICE %}}
+/sbin/service '{{{ DAEMONNAME }}}' mask
+{{%- endif %}}
 /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
 {{% else %}}
 

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -13,11 +13,16 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
 {{%- endif %}}
 # Disable socket activation if we have a unit file for it
-"$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket' && "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.socket' {{%- if MASK_SERVICE %}} && "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket' {{%- endif %}}
+if "$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+    "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.socket'
+{{%- if MASK_SERVICE %}}
+    "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
+{{%- endif %}}
+fi
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.
 # Service should be 'inactive', not 'failed' after reboot though.
-"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true
 {{% elif init_system == "upstart" %}}
 
 /sbin/service '{{{ DAEMONNAME }}}' stop

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -1,6 +1,6 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
-# strategy = enable
+# strategy = disable
 # complexity = low
 # disruption = low
 {{%- if init_system == "systemd" %}}
@@ -28,7 +28,7 @@ fi
 
 /sbin/service '{{{ DAEMONNAME }}}' stop
 /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
-{{% else %}}
+{{%- else %}}
 
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -20,10 +20,7 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service'
 {{% elif init_system == "upstart" %}}
 
-/sbin/service '{{{ DAEMONNAME }}}' disable
-{{%- if MASK_SERVICE %}}
-/sbin/service '{{{ DAEMONNAME }}}' mask
-{{%- endif %}}
+/sbin/service '{{{ DAEMONNAME }}}' stop
 /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
 {{% else %}}
 

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -17,6 +17,7 @@
       <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
         <criterion comment="{{{ SERVICENAME }}} not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" />
         <criterion comment="{{{ SERVICENAME }}} socket not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" />
+        <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
         {{%- if MASK_SERVICE %}}
         <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" />
         <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" />

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -18,7 +18,8 @@
         <criterion comment="{{{ SERVICENAME }}} not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" />
         <criterion comment="{{{ SERVICENAME }}} socket not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" />
         {{%- if MASK_SERVICE %}}
-        <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_is_masked_{{{ SERVICENAME }}}" />
+        <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" />
+        <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" />
         {{%- endif %}}
       </criteria>
     </criteria>
@@ -58,15 +59,27 @@
       <linux:value>inactive</linux:value>
   </linux:systemdunitproperty_state>
 {{%- if MASK_SERVICE %}}
-  <linux:systemdunitproperty_test id="test_service_is_masked_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the {{{ SERVICENAME }}} service is masked" version="1">
-    <linux:object object_ref="obj_service_is_masked_{{{ SERVICENAME }}}"/>
-    <linux:state state_ref="state_service_is_masked_{{{ SERVICENAME }}}"/>
+  <linux:systemdunitproperty_test id="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the property LoadState from the service {{{ SERVICENAME }}} is masked" version="1">
+    <linux:object object_ref="obj_service_loadstate_is_masked_{{{ SERVICENAME }}}"/>
+    <linux:state state_ref="state_service_loadstate_is_masked_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
-  <linux:systemdunitproperty_object id="obj_service_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the LoadState property of {{{ SERVICENAME }}}" version="1">
+  <linux:systemdunitproperty_object id="obj_service_loadstate_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the LoadState property of {{{ SERVICENAME }}}" version="1">
     <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
     <linux:property>LoadState</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_is_masked_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is not running">
+  <linux:systemdunitproperty_state id="state_service_loadstate_is_masked_{{{ SERVICENAME }}}" version="1" comment="LoadState is set to masked">
+      <linux:value>masked</linux:value>
+  </linux:systemdunitproperty_state>
+
+  <linux:systemdunitproperty_test id="test_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the property UnitFileState from the service {{{ SERVICENAME }}} is masked" version="1">
+    <linux:object object_ref="obj_service_unitfilestate_is_masked_{{{ SERVICENAME }}}"/>
+    <linux:state state_ref="state_service_unitfilestate_is_masked_{{{ SERVICENAME }}}"/>
+  </linux:systemdunitproperty_test>
+  <linux:systemdunitproperty_object id="obj_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the UnitFileState property of {{{ SERVICENAME }}}" version="1">
+    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:property>UnitFileState</linux:property>
+  </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_state id="state_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" version="1" comment="UnitFileState is set to masked">
       <linux:value>masked</linux:value>
   </linux:systemdunitproperty_state>
 {{%- endif %}}

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -17,7 +17,9 @@
       <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
         <criterion comment="{{{ SERVICENAME }}} not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" />
         <criterion comment="{{{ SERVICENAME }}} socket not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" />
-        <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
+        {{%- if MASK_SERVICE %}}
+        <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_is_masked_{{{ SERVICENAME }}}" />
+        {{%- endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -55,6 +57,20 @@
   <linux:systemdunitproperty_state id="state_service_not_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is not running">
       <linux:value>inactive</linux:value>
   </linux:systemdunitproperty_state>
+{{%- if MASK_SERVICE %}}
+  <linux:systemdunitproperty_test id="test_service_is_masked_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the {{{ SERVICENAME }}} service is masked" version="1">
+    <linux:object object_ref="obj_service_is_masked_{{{ SERVICENAME }}}"/>
+    <linux:state state_ref="state_service_is_masked_{{{ SERVICENAME }}}"/>
+  </linux:systemdunitproperty_test>
+  <linux:systemdunitproperty_object id="obj_service_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the LoadState property of {{{ SERVICENAME }}}" version="1">
+    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:property>LoadState</linux:property>
+  </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_state id="state_service_is_masked_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is not running">
+      <linux:value>masked</linux:value>
+  </linux:systemdunitproperty_state>
+{{%- endif %}}
+
 
 {{% else %}}
 

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -18,7 +18,7 @@
         <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
         {{%- if MASK_SERVICE %}}
         <criterion comment="Property LoadState of service {{{ SERVICENAME }}} is masked" test_ref="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" />
-        <criterion comment="Property UnitFileState of service {{{ SERVICENAME }}} is masked" test_ref="test_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" />
+        <criterion comment="Property FragmentPath of service {{{ SERVICENAME }}} is set to /dev/null" test_ref="test_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" />
         {{%- else %}}
         <criterion comment="{{{ SERVICENAME }}} not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" />
         <criterion comment="{{{ SERVICENAME }}} socket not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" />
@@ -73,16 +73,16 @@
       <linux:value>masked</linux:value>
   </linux:systemdunitproperty_state>
 
-  <linux:systemdunitproperty_test id="test_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the property UnitFileState from the service {{{ SERVICENAME }}} is masked" version="1">
-    <linux:object object_ref="obj_service_unitfilestate_is_masked_{{{ SERVICENAME }}}"/>
-    <linux:state state_ref="state_service_unitfilestate_is_masked_{{{ SERVICENAME }}}"/>
+  <linux:systemdunitproperty_test id="test_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the property FragmentPath from the service {{{ SERVICENAME }}} is set to /dev/null" version="1">
+    <linux:object object_ref="obj_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}"/>
+    <linux:state state_ref="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
-  <linux:systemdunitproperty_object id="obj_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the UnitFileState property of {{{ SERVICENAME }}}" version="1">
+  <linux:systemdunitproperty_object id="obj_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" comment="Retrieve the FragmentPath property of {{{ SERVICENAME }}}" version="1">
     <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
-    <linux:property>UnitFileState</linux:property>
+    <linux:property>FragmentPath</linux:property>
   </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" version="1" comment="UnitFileState is set to masked">
-      <linux:value>masked</linux:value>
+  <linux:systemdunitproperty_state id="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" version="1" comment="FragmentPath is set to /dev/null">
+      <linux:value>/dev/null</linux:value>
   </linux:systemdunitproperty_state>
 {{%- endif %}}
 

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -19,8 +19,8 @@
         <criterion comment="{{{ SERVICENAME }}} socket not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" />
         <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
         {{%- if MASK_SERVICE %}}
-        <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" />
-        <criterion comment="{{{ SERVICENAME }}} is masked" test_ref="test_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" />
+        <criterion comment="Property LoadState of service {{{ SERVICENAME }}} is masked" test_ref="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" />
+        <criterion comment="Property UnitFileState of service {{{ SERVICENAME }}} is masked" test_ref="test_service_unitfilestate_is_masked_{{{ SERVICENAME }}}" />
         {{%- endif %}}
       </criteria>
     </criteria>

--- a/sle11/templates/csv/services_disabled.csv
+++ b/sle11/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh,

--- a/sle11/templates/csv/services_disabled.csv
+++ b/sle11/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh,

--- a/sle12/templates/csv/services_disabled.csv
+++ b/sle12/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 abrtd,abrt,
 acpid,,
 atd,at,

--- a/sle12/templates/csv/services_disabled.csv
+++ b/sle12/templates/csv/services_disabled.csv
@@ -1,4 +1,4 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 abrtd,abrt,
 acpid,,
 atd,at,

--- a/ssg/build_templates.py
+++ b/ssg/build_templates.py
@@ -73,7 +73,6 @@ class Builder(object):
             "audit_rules_login_events.csv":  AuditRulesLoginEventsGenerator(),
             "audit_rules_privileged_commands.csv":  AuditRulesPrivilegedCommandsGenerator(),
             "audit_rules_usergroup_modification.csv":  AuditRulesUserGroupModificationGenerator(),
-            "audit_rules_usergroup_modification.csv":  AuditRulesUserGroupModificationGenerator(),
             "audit_rules_execution.csv":        AuditRulesExecutionGenerator(),
             "audit_rules_path_syscall.csv":        AuditRulesPathSyscallGenerator(),
             "grub2_bootloader_argument.csv":        GRUB2BootloaderArgumentGenerator(),

--- a/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/service_disabled.pass.sh
+++ b/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/service_disabled.pass.sh
@@ -6,3 +6,4 @@ yum -y install avahi
 
 systemctl disable avahi-daemon.service
 systemctl disable avahi-daemon.socket
+systemctl mask avahi-daemon

--- a/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/socket_enabled.fail.sh
+++ b/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/socket_enabled.fail.sh
@@ -6,3 +6,4 @@ yum -y install avahi
 
 systemctl disable avahi-daemon.service
 systemctl enable avahi-daemon.socket
+systemctl unmask avahi-daemon

--- a/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/socket_enabled.fail.sh
+++ b/tests/data/group_services/group_avahi/group_disable_avahi_group/rule_service_avahi-daemon_disabled/socket_enabled.fail.sh
@@ -4,6 +4,6 @@
 
 yum -y install avahi
 
+systemctl unmask avahi-daemon
 systemctl disable avahi-daemon.service
 systemctl enable avahi-daemon.socket
-systemctl unmask avahi-daemon

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_disabled.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_disabled.pass.sh
@@ -2,4 +2,5 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 systemctl disable debug-shell.service
+systemctl stop debug-shell.service
 systemctl mask debug-shell.service

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_disabled.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_disabled.pass.sh
@@ -2,3 +2,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 systemctl disable debug-shell.service
+systemctl mask debug-shell.service

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_enabled.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_enabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-systemctl enable debug-shell.service
 systemctl unmask debug-shell.service
+systemctl enable debug-shell.service

--- a/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_enabled.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/rule_service_debug-shell_disabled/service_enabled.fail.sh
@@ -2,3 +2,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 systemctl enable debug-shell.service
+systemctl unmask debug-shell.service

--- a/ubuntu1404/templates/csv/services_disabled.csv
+++ b/ubuntu1404/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,ssh

--- a/ubuntu1404/templates/csv/services_disabled.csv
+++ b/ubuntu1404/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,ssh

--- a/ubuntu1604/templates/csv/services_disabled.csv
+++ b/ubuntu1604/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,ssh

--- a/ubuntu1604/templates/csv/services_disabled.csv
+++ b/ubuntu1604/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,ssh

--- a/ubuntu1804/templates/csv/services_disabled.csv
+++ b/ubuntu1804/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,ssh

--- a/ubuntu1804/templates/csv/services_disabled.csv
+++ b/ubuntu1804/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,ssh

--- a/wrlinux1019/templates/csv/services_disabled.csv
+++ b/wrlinux1019/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,

--- a/wrlinux1019/templates/csv/services_disabled.csv
+++ b/wrlinux1019/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,

--- a/wrlinux8/templates/csv/services_disabled.csv
+++ b/wrlinux8/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
+# <service_name, package_name, daemon_name[, mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (mask_service: mask the service. Acceptable values are: true or false. Default value is true.)
 sshd,openssh-server,

--- a/wrlinux8/templates/csv/services_disabled.csv
+++ b/wrlinux8/templates/csv/services_disabled.csv
@@ -1,2 +1,2 @@
-# service_name, package_name, daemon_name (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name)
+# <service_name, package_name, daemon_name[, dont_mask_service]> (as recognized by chkconfig / systemd. To be used when daemon_name differs from service_name) (if dont_mask_service is set the service will not be masked, can be any string)
 sshd,openssh-server,


### PR DESCRIPTION
#### Description:

- Introduces `mask_service` parameter to services disabled template allowing to build checks+remediations which consider the `masked` attribute of services (meaning that the service cannot be started at all)

#### Rationale:

- Only deactivating a service may be enough as it can be started as dependency of other services. Masking the service ensures it cannot be started at all, be it by manually starting or by dependency of another service.

- Fixes #4386 

Tasks:

- [x] OVAL check for version 5.11 - LoadState property is set to masked
- [x] Bash+Ansible mask the service is `mask_service` is set
- [x] ~~OVAL check for version 5.10 - symlink to /dev/null -~~ in this OVAL version does not support checking the symlink path, so it is not possible to implement.
- [x] Change service_disabled.csv from products other RHEL8? at least documentation
- [x] update rule text and jinja macros such as: `systemd_ocil_service_disabled`
- [x] Update all test scenarios for services disabled template
- [x] Fix ansible remediation