### PR TITLE
Fix issues in set_config_file

### DIFF
--- a/shared/bash_remediation_functions/include_lineinfile.sh
+++ b/shared/bash_remediation_functions/include_lineinfile.sh
@@ -21,9 +21,9 @@ function lineinfile_absent() {
     local insensitive="${8:-true}"
 
     if [ "$insensitive" == "true" ]; then
-        LC_ALL=C sed "/$regex/Id" "$path"
+        LC_ALL=C sed -i "/$regex/Id" "$path"
     else
-        LC_ALL=C sed "/$regex/d" "$path"
+        LC_ALL=C sed -i "/$regex/d" "$path"
     fi
 }
 
@@ -134,7 +134,7 @@ function set_config_file() {
     local separator_regex="${9:-\s\+}"
     local prefix_regex="${10:-^\s*}"
 
-    only_lineinfile "$path" "$prefix_regex$parameter$separator_regex" "$parameter$separator$value" "$create" "$insert_after" "$insert_before"
+    only_lineinfile "$path" "$prefix_regex$parameter$separator_regex" "$parameter$separator$value" "$create" "$insert_after" "$insert_before" "$insensitive"
 }
 
 function sshd_config_set() {


### PR DESCRIPTION
#### Description:
There were two issues:
- `sed` in `lineinfile_absent` function was missing `-i` (in-place) argument
- `set_config_file` accepted `insensitive` parameter, but didn't use it at all
