### PR TITLE
Add sssd entry in all CPE dictionaries

### DIFF
--- a/debian8/cpe/debian8-cpe-dictionary.xml
+++ b/debian8/cpe/debian8-cpe-dictionary.xml
@@ -42,6 +42,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/fedora/cpe/fedora-cpe-dictionary.xml
+++ b/fedora/cpe/fedora-cpe-dictionary.xml
@@ -67,6 +67,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ol7/cpe/ol7-cpe-dictionary.xml
+++ b/ol7/cpe/ol7-cpe-dictionary.xml
@@ -42,6 +42,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ol8/cpe/ol8-cpe-dictionary.xml
+++ b/ol8/cpe/ol8-cpe-dictionary.xml
@@ -42,6 +42,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/opensuse/cpe/opensuse-cpe-dictionary.xml
+++ b/opensuse/cpe/opensuse-cpe-dictionary.xml
@@ -57,6 +57,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/rhel6/cpe/rhel6-cpe-dictionary.xml
+++ b/rhel6/cpe/rhel6-cpe-dictionary.xml
@@ -62,6 +62,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/rhel7/cpe/rhel7-cpe-dictionary.xml
+++ b/rhel7/cpe/rhel7-cpe-dictionary.xml
@@ -72,6 +72,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/rhv4/cpe/rhv4-cpe-dictionary.xml
+++ b/rhv4/cpe/rhv4-cpe-dictionary.xml
@@ -47,6 +47,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/sle11/cpe/sle11-cpe-dictionary.xml
+++ b/sle11/cpe/sle11-cpe-dictionary.xml
@@ -47,6 +47,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/sle12/cpe/sle12-cpe-dictionary.xml
+++ b/sle12/cpe/sle12-cpe-dictionary.xml
@@ -47,6 +47,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
+++ b/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
@@ -42,6 +42,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
+++ b/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
@@ -42,6 +42,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
+++ b/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
@@ -42,6 +42,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
+++ b/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
@@ -41,6 +41,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
+++ b/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
@@ -41,6 +41,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_shadow-utils_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:systemd">
             <title xml:lang="en-us">Package systemd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->


### PR DESCRIPTION
#### Description:

- Adds `sssd` CPE platform entry in dictionaries of products that use `linux_os/` as the benchmark root.

#### Rationale:

- Fixes `scapval` validation
