### PR TITLE
Do not test empty OVAL 5.10 definition rendered by Jinja

### DIFF
--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -56,11 +56,17 @@ def main():
                 xml_content = ssg.jinja.process_file_with_macros(oval, env_yaml)
                 oval_contents = ssg.utils.split_string_content(xml_content)
 
-                results = ssg.oval.parse_affected(oval_contents)
+                try:
+                    results = ssg.oval.parse_affected(oval_contents)
 
-                assert len(results) == 3
-                assert isinstance(results[0], int)
-                assert isinstance(results[1], int)
+                    assert len(results) == 3
+                    assert isinstance(results[0], int)
+                    assert isinstance(results[1], int)
+
+                except ValueError as e:
+                    print("No <affected> element found in file {}".format(oval))
+                    raise e
+
 
         guide_dirs.add(guide_dir)
 

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -54,6 +54,11 @@ def main():
 
             for oval in ssg.rules.get_rule_dir_ovals(rule_dir):
                 xml_content = ssg.jinja.process_file_with_macros(oval, env_yaml)
+                # Some OVAL definitions may render to an empty definition
+                # when building OVAL 5.10 only content
+                if not xml_content:
+                    continue
+
                 oval_contents = ssg.utils.split_string_content(xml_content)
 
                 try:


### PR DESCRIPTION
#### Description:

- Skip testing empty rendered OVAL definition.
- Improve error message to indicate which OVAL definition failed `validate-parse-affected` test.

#### Rationale:

- When building only OVAL 5.10 content only, `validate-parse-affected` test fails because it tries to test a definition that was rendered empty by Jinja.
- Some definitions can be empty when building OVAL 5.10 only content.
  - For example: https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_setting/oval/shared.xml
- Fixes Jenkins job [scap-security-guide-nightly-oval510-zip](https://jenkins.complianceascode.io/view/Maintenance%20Jobs/job/scap-security-guide-nightly-oval510-zip/)
