### PR TITLE
Openssh RPM package product check in OVAL lineinfile macro

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -244,8 +244,13 @@
       <criteria comment="sshd is not installed" operator="AND">
         <extend_definition comment="sshd is not required or requirement is unset"
         definition_ref="sshd_not_required_or_unset" />
+        {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
+        <extend_definition comment="rpm package openssh removed"
+        definition_ref="package_openssh_removed" />
+        {{% else %}}
         <extend_definition comment="rpm package openssh-server removed"
         definition_ref="package_openssh-server_removed" />
+        {{% endif %}}
       </criteria>
 {{%- endmacro %}}
 


### PR DESCRIPTION
#### Description:
Add product check in OVAL lineinfile macro, because OpenSUSE, SLE11 and SLE12 products don't have `openssh-server` RPM package. 
(this check was missing [sshd_disable_root_login](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/oval/shared.xml#L16))

#### Rationale:
This could cause pass result for all ssh related rules replaced by lineinfile macro for OpenSUSE,SLE11 and SLE12 products, because the check wouldn't find `openssh-server` RPM package.
