### PR TITLE
Remove unused parameter in OVAL macros and fix service enable upstart Bash remediation

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -220,7 +220,7 @@
   We specify a case insensitive comparison in the prefix because
   sshd_config has case-insensitive parameters (but case-sensitive values).
 #}}
-{{%- macro oval_sshd_config(parameter='', value='', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false, supported_platforms=['all']) %}}
+{{%- macro oval_sshd_config(parameter='', value='', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false) %}}
 {{{ oval_check_config_file("/etc/ssh/sshd_config", prefix_regex="^[\s]*(?i)", parameter=parameter, separator_regex='(?-i)[\s]+', value=value, missing_parameter_pass=missing_parameter_pass, application="sshd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail) }}}
 {{%- endmacro %}}
 
@@ -247,7 +247,7 @@
     - multi_value (boolean): If set, it means that the parameter can accept multiple values and the expected value must be present in the current list of values.
     - missing_config_file_fail (boolean): If set, the check will fail if the configuration is not existent in the system.
 #}}
-{{%- macro oval_grub_config(parameter='', value='', missing_parameter_pass=false, multi_value=true, missing_config_file_fail=false, supported_platforms=['all']) %}}
+{{%- macro oval_grub_config(parameter='', value='', missing_parameter_pass=false, multi_value=true, missing_config_file_fail=false) %}}
 {{{ oval_check_config_file("/etc/default/grub", prefix_regex="^[\s]*", parameter=parameter, separator_regex='=', value=value, missing_parameter_pass=missing_parameter_pass, application="grub", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail) }}}
 {{%- endmacro %}}
 

--- a/shared/templates/template_BASH_service_enabled
+++ b/shared/templates/template_BASH_service_enabled
@@ -10,7 +10,7 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
 {{% elif init_system == "upstart" %}}
 
-/sbin/service '{{{ DAEMONNAME }}}' enable
+/sbin/service '{{{ DAEMONNAME }}}' start
 /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' on
 {{% else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'

--- a/shared/templates/template_BASH_service_enabled
+++ b/shared/templates/template_BASH_service_enabled
@@ -10,8 +10,8 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
 {{% elif init_system == "upstart" %}}
 
-/sbin/service '{{{ DAEMONNAME }}}' disable
-/sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
+/sbin/service '{{{ DAEMONNAME }}}' enable
+/sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' on
 {{% else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}


### PR DESCRIPTION
#### Description:

Fix a couple of things in the project:
- unused parameter in OVAL macros
- fix enabling service upstart in bash template.