### PR TITLE
Fix regex which looks for line in file configuration.

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -150,7 +150,7 @@
 #}}
 {{%- set regex = prefix_regex+parameter+separator_regex -%}}
 {{%- else %}}
-{{%- set regex = prefix_regex+parameter+separator_regex+"(.*)[\s]*(?:|(?:#.*))?$" -%}}
+{{%- set regex = ".*(?:\\n\s*[^[\s].*)*\s*"+prefix_regex+parameter+separator_regex+"(.*)[\s]*(?:|(?:#.*))?$" -%}}
 {{%- endif %}}
 {{%- endif %}}
   <ind:textfilecontent54_object id="obj_{{{ rule_id }}}{{{ suffix_id }}}" version="1">

--- a/tests/data/group_system/group_auditing/rule_auditd_local_events/multiple_values.fail.sh
+++ b/tests/data/group_system/group_auditing/rule_auditd_local_events/multiple_values.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+echo "local_events = yes" > "/etc/audit/auditd.conf"
+echo "local_events = no" >> "/etc/audit/auditd.conf"


### PR DESCRIPTION
#### Description:

- The regex is now capable of finding multiple occurrences and only
considers the last occurrence.

Inspired by https://github.com/ComplianceAsCode/content/pull/4430/files#diff-693acc0bf8562e378862c734b05544a6R27 Thanks @adelton

#### Rationale:

- Only the last occurrence of a parameter should be taken into account when looking for line in file.

- Fixes #4645
