### PR TITLE
Macro OVAL lineinfile to collect all objects, and make sure only one exists.

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -156,7 +156,7 @@
   <ind:textfilecontent54_object id="obj_{{{ rule_id }}}{{{ suffix_id }}}" version="1">
     <ind:filepath>{{{ path }}}</ind:filepath>
     <ind:pattern operation="pattern match">{{{ regex }}}</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{%- endmacro %}}
 

--- a/tests/data/group_system/group_auditing/rule_auditd_local_events/double_assignment.fail.sh
+++ b/tests/data/group_system/group_auditing/rule_auditd_local_events/double_assignment.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+echo "local_events = yes" >> "/etc/audit/auditd.conf"
+echo "local_events = no" >> "/etc/audit/auditd.conf"


### PR DESCRIPTION
#### Description:

- Update test to look for only one object
- Update object to return all objects found

#### Rationale:

- The test, as it was, was passing if all objects existed. And the object defined that only one object would be returned. Thus, with multiple `parameter = value` assignments, only one of them was considered, probably the first.

- Fixes #4645

