### PR TITLE
Test suite: set bash and ansible remediation to verbose mode.

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -140,7 +140,7 @@ def run_stage_remediation_ansible(run_type, formatting, verbose_path):
                            '/' + formatting['output_file']):
         return False
     command = (
-        'ansible-playbook',  '-i', '{0},'.format(formatting['domain_ip']),
+        'ansible-playbook', '-v', '-i', '{0},'.format(formatting['domain_ip']),
         '-u' 'root', formatting['playbook'])
     command_string = ' '.join(command)
     returncode, output = common.run_cmd_local(command, verbose_path)
@@ -170,7 +170,7 @@ def run_stage_remediation_bash(run_type, formatting, verbose_path):
                            '/' + formatting['output_file']):
         return False
 
-    command_string = '/bin/bash /{output_file}'.format(** formatting)
+    command_string = '/bin/bash -x /{output_file}'.format(** formatting)
     returncode, output = common.run_cmd_remote(
         command_string, formatting['domain_ip'], verbose_path)
     # Appends output of script execution to the verbose_path file.


### PR DESCRIPTION
#### Description:

- SSG Test Suite: Set verbose mode when applying ansible or bash remediation.

#### Rationale:

- It is hard to debug Bash or Ansible remediation if they are not set to verbose mode.

Note: oscap already runs in `--verbose DEVEL`
