### PR TITLE
Document where test scenarios are located

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -287,7 +287,7 @@ scenarios for this rule are located in
 In reality, only ID of the rule needs to be correct, group structure is not
 currently used.
 
-To quickly open the tests for a rule with ID, add a similar function to your `.bashrc`:
+To quickly find the tests for a rule with ID, add a similar function to your `.bashrc`:
 
 ```
 function find_tests() {
@@ -306,7 +306,7 @@ function find_tests() {
 The directory with the tests for a rule with given ID can be opened this way:
 
 ```
-open_tests <rule_ID>
+find_tests <rule_ID>
 ```
 
 Scenarios are currently supported only in `bash`. And type of scenario is

--- a/tests/README.md
+++ b/tests/README.md
@@ -293,17 +293,17 @@ To quickly find the tests for a rule with ID, add a similar function to your `.b
 function find_tests() {
     rule_id="$1"
     ssg_root="/path/to/your/content/git/repository"
-    test_dir=$(find $ssg_root/tests/data/ -type d -name *$rule_id*)
+    test_dir=$(find $ssg_root/tests/data/ -type d -name "*$rule_id*")
 
     if [ ! -z "$test_dir" ]; then
-        printf "Test scenarios for rules their name contains \"$rule_id\" can be found at:\n$test_dir\n"
+        printf "Test scenarios for \"$rule_id\" rules can be found at:\n$test_dir\n"
     else
         printf "No test scenarios for rules containing \"$rule_id\".\n"
     fi
 }
 ```
 
-The directory with the tests for a rule with given ID can be opened this way:
+The directory with the tests for a rule with given ID can be found this way:
 
 ```
 find_tests <rule_ID>

--- a/tests/README.md
+++ b/tests/README.md
@@ -272,8 +272,8 @@ The Test Suite will pause its execution, and you will be able to SSH into the en
 
 #### How rule validation scenarios work
 
-In directory `/tests/data` there are directories mirroring tree structure of
-Benchmark.
+In directory `tests/data` there are directories mirroring tree structure of
+Benchmark. This readme is already in `tests` directory.
 
 The difference between Benchmark tree structure (eg. `/linux_os/guide/`) and
 the test scenario tree is that the group directories have added `group_` prefix
@@ -284,18 +284,24 @@ For example, the rule `accounts_tmout` is located in
 scenarios for this rule are located in
 `/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_tmout`.
 
-In reality, only name of the rule directory needs to be correct, group
-structure is not currently used.
+In reality, only ID of the rule needs to be correct, group structure is not
+currently used.
 
-To quickly find the tests, add a similar function to your `.bashrc`:
+To quickly open the tests for a rule with ID, add a similar function to your `.bashrc`:
 
 ```
-function find_tests() {
+function open_tests() {
     rule_id="$1"
     ssg_root="/path/to/your/content/git/repository"
     tests_dir=$(find $ssg_root/tests/data/ -name rule_$rule_id)
     [ -n "$tests_dir" ] && cd $tests_dir
 }
+```
+
+The directory with the tests for a rule with given ID can be opened this way:
+
+```
+open_tests <rule_ID>
 ```
 
 Scenarios are currently supported only in `bash`. And type of scenario is

--- a/tests/README.md
+++ b/tests/README.md
@@ -290,11 +290,16 @@ currently used.
 To quickly open the tests for a rule with ID, add a similar function to your `.bashrc`:
 
 ```
-function open_tests() {
+function find_tests() {
     rule_id="$1"
     ssg_root="/path/to/your/content/git/repository"
-    tests_dir=$(find $ssg_root/tests/data/ -name *$rule_id*)
-    [ -n "$tests_dir" ] && cd $tests_dir
+    test_dir=$(find $ssg_root/tests/data/ -type d -name *$rule_id*)
+
+    if [ ! -z "$test_dir" ]; then
+        printf "Test scenarios for rules their name contains \"$rule_id\" can be found at:\n$test_dir\n"
+    else
+        printf "No test scenarios for rules containing \"$rule_id\".\n"
+    fi
 }
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -272,9 +272,31 @@ The Test Suite will pause its execution, and you will be able to SSH into the en
 
 #### How rule validation scenarios work
 
-In directory `data` are directories mirroring `group/group/.../rule`
-structure of datastream. In reality, only name of the rule directory needs to be
-correct, group structure is currently not used.
+In directory `/tests/data` there are directories mirroring tree structure of
+Benchmark.
+
+The difference between Benchmark tree structure (eg. `/linux_os/guide/`) and
+the test scenario tree is that the group directories have added `group_` prefix
+in their name and rule directories have added `rule_` prefix in their name.
+
+For example, the rule `accounts_tmout` is located in
+`linux_os/guide/system/accounts/accounts-session/accounts_tmout`, and test
+scenarios for this rule are located in
+`/tests/data/group_system/group_accounts/group_accounts-session/rule_accounts_tmout`.
+
+In reality, only name of the rule directory needs to be correct, group
+structure is not currently used.
+
+To quickly find the tests, add a similar function to your `.bashrc`:
+
+```
+function find_tests() {
+    rule_id="$1"
+    ssg_root="/path/to/your/content/git/repository"
+    tests_dir=$(find $ssg_root/tests/data/ -name rule_$rule_id)
+    [ -n "$tests_dir" ] && cd $tests_dir
+}
+```
 
 Scenarios are currently supported only in `bash`. And type of scenario is
 defined by its file name.

--- a/tests/README.md
+++ b/tests/README.md
@@ -272,8 +272,8 @@ The Test Suite will pause its execution, and you will be able to SSH into the en
 
 #### How rule validation scenarios work
 
-In directory `tests/data` there are directories mirroring tree structure of
-Benchmark. This readme is already in `tests` directory.
+In directory `data/` there are directories mirroring tree structure of
+Benchmark.
 
 The difference between Benchmark tree structure (eg. `/linux_os/guide/`) and
 the test scenario tree is that the group directories have added `group_` prefix
@@ -293,7 +293,7 @@ To quickly open the tests for a rule with ID, add a similar function to your `.b
 function open_tests() {
     rule_id="$1"
     ssg_root="/path/to/your/content/git/repository"
-    tests_dir=$(find $ssg_root/tests/data/ -name rule_$rule_id)
+    tests_dir=$(find $ssg_root/tests/data/ -name *$rule_id*)
     [ -n "$tests_dir" ] && cd $tests_dir
 }
 ```


### PR DESCRIPTION
#### Description:
Improve the tests/README.md to document where test scenarios are located and suggests the users to use a bash function to quickly find the test scenarios for a given rule.

#### Rationale:
Improves the SSGTS documentation.
