### PR TITLE
Test suite autodetect datastream.

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -7,6 +7,7 @@ import os
 import os.path
 import time
 import sys
+from glob import glob
 
 ssg_dir = os.path.join(os.path.dirname(__file__), "..")
 sys.path.append(ssg_dir)
@@ -43,7 +44,6 @@ def parse_args():
     common_parser.add_argument("--datastream",
                                dest="datastream",
                                metavar="DATASTREAM",
-                               required=True,
                                help=("Path to the Source DataStream on this "
                                      "machine which is going to be tested"))
     benchmarks = common_parser.add_mutually_exclusive_group()
@@ -216,9 +216,31 @@ def auto_select_xccdf_id(datastream, bench_number):
     return xccdf_ids[bench_number]
 
 
+def get_datastreams():
+    ds_glob = "ssg-*-ds.xml"
+    build_dir_path = [os.path.dirname(__file__), "..", "build"]
+    datastreams = glob(os.path.sep.join(build_dir_path + [ds_glob]))
+    return datastreams
+
+
+def get_unique_datastream():
+    datastreams = get_datastreams()
+    if len(datastreams) == 1:
+        return datastreams[0]
+    msg = ("Unable to auto-detect the datastream, "
+           "expected to find a single one in the build dir, but")
+    if not datastreams:
+        raise RuntimeError(msg + " found none.")
+    raise RuntimeError(
+        msg + " found multiple ones: {0}".format(datastreams))
+
+
 def normalize_passed_arguments(options):
     if 'ALL' in options.target:
         options.target = ['ALL']
+
+    if not options.datastream:
+        options.datastream = get_unique_datastream()
 
     if options.xccdf_id is None:
         options.xccdf_id = auto_select_xccdf_id(options.datastream,

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -218,8 +218,9 @@ def auto_select_xccdf_id(datastream, bench_number):
 
 def get_datastreams():
     ds_glob = "ssg-*-ds.xml"
-    build_dir_path = [os.path.dirname(__file__), "..", "build"]
-    datastreams = glob(os.path.sep.join(build_dir_path + [ds_glob]))
+    build_dir_path = [os.path.dirname(__file__) or ".", "..", "build"]
+    glob_pattern = os.path.sep.join(build_dir_path + [ds_glob])
+    datastreams = [os.path.normpath(p) for p in glob(glob_pattern)]
     return datastreams
 
 
@@ -227,12 +228,13 @@ def get_unique_datastream():
     datastreams = get_datastreams()
     if len(datastreams) == 1:
         return datastreams[0]
-    msg = ("Unable to auto-detect the datastream, "
-           "expected to find a single one in the build dir, but")
+    msg = ("Autodetection of the datastream file is possible only when there is "
+           "a single one in the build dir, but")
     if not datastreams:
-        raise RuntimeError(msg + " found none.")
+        raise RuntimeError(msg + " there is none.")
     raise RuntimeError(
-        msg + " found multiple ones: {0}".format(datastreams))
+        msg + " there are {0} of them. Use the --datastream option to select "
+        "e.g. {1}".format(len(datastreams), datastreams))
 
 
 def normalize_passed_arguments(options):


### PR DESCRIPTION
The frequent use case is that a single datastream is built in the build directory, and one wants it to be tested by the test suite.
This change add autodetection capabilities, so the --datastream option can be left out. If it is left out and there is not a single datastream in the build dir, an error is displayed instead.

As a side-effect, the `--datastream` option won't be required any longer, which is [generally recommended](https://docs.python.org/3/library/argparse.html#required).

> Required options are generally considered bad form because users expect options to be optional, and thus they should be avoided when possible.