### PR TITLE
Quick fix for CombinedMode _modify_parameters()

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -39,7 +39,7 @@ class CombinedChecker(rule.RuleChecker):
         self.results = list()
         self._current_result = None
 
-    def _modify_parameters(self, params):
+    def _modify_parameters(self, script, params):
         # Override any metadata in test scenario, wrt to profile to test
         # We already know that all target rules are part of the target profile
         params['profiles'] = [self.profile]


### PR DESCRIPTION
#### Description:
- Update interface of `CombinedMode` method  `_modify_parameter()` to  match its parent's.

#### Rationale:
- `CombinedMode` inherits `_get_scenarios()` from RuleChecker but doesn't override it.
-  `RuleChecker`'s method  `_get_scenarios()` calls `_modify_parameters()` with two arguments.