### PR TITLE
Enable rsyslog in packages_installed.csv for RHEL8.

### DIFF
--- a/rhel8/templates/csv/packages_installed.csv
+++ b/rhel8/templates/csv/packages_installed.csv
@@ -14,4 +14,5 @@ pcsc-lite
 vsftpd
 postfix
 tmux
+rsyslog
 sssd


### PR DESCRIPTION
#### Description:

- Enable `rsyslog` in packages_installed.csv template file.

#### Rationale:

- OSPP profile selects the rule and the template value was not there so the OVAL check was being removed from the datastream.

https://github.com/ComplianceAsCode/content/blob/076cb7a9d398ac54ce91360bd07dc41942a666ae/rhel8/profiles/ospp.profile#L246

From ssg test suite combined mode OSPP which found the issue:
```
INFO - xccdf_org.ssgproject.content_rule_package_rsyslog_installed
ERROR - Script installed.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp found issue:
ERROR - Rule evaluation resulted in WARNING: Skipping rule that requires an unregistered check system or incorrect content reference to evaluate. Please consider providing a valid SCAP/OVAL instead of http://scap.nist.gov/schema/ocil/2, instead of expected pass during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_package_rsyslog_installed'.
ERROR - Script notinstalled.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp found issue:
ERROR - Rule evaluation resulted in WARNING: Skipping rule that requires an unregistered check system or incorrect content reference to evaluate. Please consider providing a valid SCAP/OVAL instead of http://scap.nist.gov/schema/ocil/2, instead of expected fail during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_package_rsyslog_installed'.
```