### PR TITLE
Add new rhel8 aux gpg pubkey

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -19,8 +19,12 @@
         </criteria>
         <criterion comment="package gpg-pubkey-fd431d51-4ae0493b is installed"
         test_ref="test_package_gpgkey-fd431d51-4ae0493b_installed" />
-        <criterion comment="package gpg-pubkey-2fa658e0-45700c69 is installed"
-        test_ref="test_package_gpgkey-2fa658e0-45700c69_installed" />
+        <criteria comment="Auxiliary Red Hat Key Installed" operator="OR">
+          <criterion comment="package gpg-pubkey-2fa658e0-45700c69 is installed"
+          test_ref="test_package_gpgkey-2fa658e0-45700c69_installed" />
+          <criterion comment="package gpg-pubkey-d4082792-5b32db75 is installed"
+          test_ref="test_package_gpgkey-d4082792-5b32db75_installed" />
+        </criteria>
       </criteria>
       <criteria comment="CentOS Vendor Keys" operator="OR">
         <criteria comment="CentOS Installed" operator="OR">
@@ -65,6 +69,19 @@
   <linux:rpminfo_state id="state_package_gpg-pubkey-2fa658e0-45700c69" version="1">
     <linux:release>45700c69</linux:release>
     <linux:version>2fa658e0</linux:version>
+  </linux:rpminfo_state>
+
+  <!-- Test for Red Hat auxiliary key -->
+  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
+  id="test_package_gpgkey-d4082792-5b32db75_installed" version="1"
+  comment="Red Hat auxiliary key package is installed">
+    <linux:object object_ref="object_package_gpg-pubkey" />
+    <linux:state state_ref="state_package_gpg-pubkey-d4082792-5b32db75" />
+  </linux:rpminfo_test>
+
+  <linux:rpminfo_state id="state_package_gpg-pubkey-d4082792-5b32db75" version="1">
+    <linux:release>5b32db75</linux:release>
+    <linux:version>d4082792</linux:version>
   </linux:rpminfo_state>
 
   <!-- Test for CentOS7 key -->

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/rule.yml
@@ -20,7 +20,7 @@ description: |-
 
     Alternatively, the key may be pre-loaded during the RHEL installation. In
     such cases, the key can be installed by running the following command:
-    <pre>sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-key-redhat-release</pre>
+    <pre>sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release</pre>
 
 
 rationale: |-

--- a/tests/data/group_system/group_software/group_updating/rule_ensure_redhat_gpgkey_installed/key_installed.pass.sh
+++ b/tests/data/group_system/group_software/group_updating/rule_ensure_redhat_gpgkey_installed/key_installed.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/tests/data/group_system/group_software/group_updating/rule_ensure_redhat_gpgkey_installed/missing_key.fail.sh
+++ b/tests/data/group_system/group_software/group_updating/rule_ensure_redhat_gpgkey_installed/missing_key.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# remove all available keys
+
+KEYS=$(rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\n')
+
+if [ $? = 0 ]; then
+    for KEY in $KEYS; do
+    rpm -e $KEY
+    done
+fi


### PR DESCRIPTION
#### Description:

-  Add check for auxiliary rpm gpg key on RHEL8.

The auxiliary key is different from the one used in RHEL7 and therefore
has different version+release.

Also added a couple of test scenarios so it can be easily tested.

There might be different ways on how to implement the check, it could be handle at platform level, for example testing if the product is RHEL7 or RHEL8 and so on. I open to suggestions on improving the OVAL check.

#### Rationale:

- RHEL8 auxiliary key is different from the one used in RHEL7