### PR TITLE
Use crypto-policies to configure RHEL8 sshd algorithms

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux8,wrlinux1019,rhel6,rhel7,rhel8,ol7,rhv4
+prodtype: wrlinux8,wrlinux1019,rhel6,rhel7,ol7,rhv4
 
 title: 'Use Only FIPS 140-2 Validated Ciphers'
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel6,rhel7,rhel8,ol7,rhv4
+prodtype: wrlinux1019,rhel6,rhel7,ol7,rhv4
 
 title: 'Use Only FIPS 140-2 Validated MACs'
 

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -1034,15 +1034,8 @@ selections:
     ## Enable SSH Warning Banner
     - sshd_enable_warning_banner
 
-    ## Use Only FIPS 140-2 Validated Ciphers
-    - sshd_use_approved_ciphers
-
     ## TO DO: https://github.com/ComplianceAsCode/content/issues/4469
     #echo -e "PubkeyAcceptedKeyTypes ssh-rsa,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384" >> $CONFIG
-
-    ## Use Only FIPS 140-2 Validated MACs
-    ## SEE ALSO: https://github.com/ComplianceAsCode/content/issues/4470
-    - sshd_use_approved_macs
 
     ## TO DO: https://github.com/ComplianceAsCode/content/issues/4471
     #echo -e "KexAlgorithms diffie-hellman-group14-sha1,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" >> $CONFIG
@@ -1090,6 +1083,10 @@ selections:
     
     ## Enable FIPS Mode
     - enable_fips_mode
+
+    ## Set up Crypto policy
+    - var_system_crypto_policy=fips
+    - configure_crypto_policy
 
     ## TO DO: https://github.com/ComplianceAsCode/content/issues/4500
     # - sysctl_crypto_fips_enabled


### PR DESCRIPTION
#### Description:

- In RHEL8, configure SSHD Ciphers and MACs via system-wide crypto policies

#### Rationale:

- This is inline with done in `harden_sshd_crypto_policy` #4663
