### PR TITLE
Add sysclt entries for file system

### DIFF
--- a/rhel8/templates/csv/sysctl_values.csv
+++ b/rhel8/templates/csv/sysctl_values.csv
@@ -2,6 +2,9 @@
 # Add <sysctl_parameter_name, desired_value, value_type> to set a different type, e.g: string
 # Add <sysctl_parameter_name, desired_value> to generate hard-coded OVAL and remediation content.
 # Add <sysctl_parameter_name,> to generate OVAL and remediation content that use the XCCDF value.
+fs.suid_dumpable,0
+fs.protected_hardlinks,1
+fs.protected_symlinks,1
 kernel.dmesg_restrict,1
 kernel.kexec_load_disabled,1
 kernel.kptr_restrict,1


### PR DESCRIPTION
#### Description:

- Add `fs.*` entries to `sysctl_values` CSV file to generate templated content for rules.

#### Rationale:

- This resolves rules such as `sysctl_fs_protected_symlinks` returning `notchecked`