### PR TITLE
Account for /tmp being on tmpfs in rhel8

### DIFF
--- a/rhel8/templates/csv/mount_options.csv
+++ b/rhel8/templates/csv/mount_options.csv
@@ -11,9 +11,10 @@
 /dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
-/tmp,nodev
-/tmp,noexec
-/tmp,nosuid
+# /tmp is mounted as tmpfs by default by systemd (and thus not in fstab)
+/tmp,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/tmp,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+/tmp,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /home,nosuid
 /home,nodev
 /var,nodev


### PR DESCRIPTION
(Same as 0296f371.)

/tmp is mounted as tmpfs by systemd (and will be explicitly remediated
anyway by the create_fstab_entry_if_needed code).

This fixes an anaconda oscap addon error/question that would stall
an automated install:

  Wrong configuration detected!
  /tmp must be on a separate partition or logical volume and has to be
  created in the partitioning layout before installation can occur with
  a security profile The installation should be aborted.
  Do you wish to continue anyway?
  Please respond 'yes' or 'no':
