### PR TITLE
 Parameterize Red Hat's GPG release public key. 

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -16,7 +16,7 @@
   {{% if product == "rhel8" -%}}
   shell: |
     set -o pipefail
-    gpg --show-key --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
+    gpg --dry-run --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
   {{%- else -%}}
   shell: |
     set -o pipefail
@@ -31,7 +31,7 @@
 
 - name: Set Fact - Valid fingerprints
   set_fact:
-     gpg_valid_fingerprints: ("567E347AD0044ADE55BA8A5F199E2F91FD431D51" "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0")
+     gpg_valid_fingerprints: ("{{{ release_key_fingerprint }}}" "{{{ auxiliary_key_fingerprint }}}")
 
 - name: Import RedHat GPG key
   rpm_key:

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -16,7 +16,7 @@
   {{% if product == "rhel8" -%}}
   shell: |
     set -o pipefail
-    gpg --dry-run --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep "^fpr" | cut -d ":" -f 10
+    gpg --show-keys --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" | grep -A1 "^pub" | grep "^fpr" | cut -d ":" -f 10
   {{%- else -%}}
   shell: |
     set -o pipefail

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -14,7 +14,7 @@ then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
 {{% if product == "rhel8" %}}
-  readarray -t GPG_OUT < <(gpg --dry-run --with-fingerprint  --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
+  readarray -t GPG_OUT < <(gpg --show-keys --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep -A1 "^pub" | grep "^fpr" | cut -d ":" -f 10)
 {{% else %}}
   readarray -t GPG_OUT < <(gpg --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -1,7 +1,8 @@
 # platform = multi_platform_rhel,multi_platform_rhv
 # The two fingerprints below are retrieved from https://access.redhat.com/security/team/key
-readonly REDHAT_RELEASE_2_FINGERPRINT="567E347AD0044ADE55BA8A5F199E2F91FD431D51"
-readonly REDHAT_AUXILIARY_FINGERPRINT="43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
+readonly REDHAT_RELEASE_FINGERPRINT="{{{ release_key_fingerprint }}}"
+readonly REDHAT_AUXILIARY_FINGERPRINT="{{{ auxiliary_key_fingerprint }}}"
+
 # Location of the key we would like to import (once it's integrity verified)
 readonly REDHAT_RELEASE_KEY="/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
 
@@ -13,7 +14,7 @@ then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
 {{% if product == "rhel8" %}}
-  readarray -t GPG_OUT < <(gpg --show-keys --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
+  readarray -t GPG_OUT < <(gpg --dry-run --with-fingerprint  --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
 {{% else %}}
   readarray -t GPG_OUT < <(gpg --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
 {{% endif %}}
@@ -21,7 +22,7 @@ then
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]
   then
-    echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_2_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}" || {
+    echo "${GPG_OUT[*]}" | grep -vE "${REDHAT_RELEASE_FINGERPRINT}|${REDHAT_AUXILIARY_FINGERPRINT}" || {
       # If $REDHAT_RELEASE_KEY file doesn't contain any keys with unknown fingerprint, import it
       rpm --import "${REDHAT_RELEASE_KEY}"
     }

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -17,13 +17,11 @@
           <extend_definition comment="SL6 installed" definition_ref="installed_OS_is_sl6" />
           <extend_definition comment="SL7 installed" definition_ref="installed_OS_is_sl7" />
         </criteria>
-        <criterion comment="package gpg-pubkey-fd431d51-4ae0493b is installed"
-        test_ref="test_package_gpgkey-fd431d51-4ae0493b_installed" />
+        <criterion comment="package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"
+        test_ref="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
         <criteria comment="Auxiliary Red Hat Key Installed" operator="OR">
-          <criterion comment="package gpg-pubkey-2fa658e0-45700c69 is installed"
-          test_ref="test_package_gpgkey-2fa658e0-45700c69_installed" />
-          <criterion comment="package gpg-pubkey-d4082792-5b32db75 is installed"
-          test_ref="test_package_gpgkey-d4082792-5b32db75_installed" />
+          <criterion comment="package gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}} is installed"
+          test_ref="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
         </criteria>
       </criteria>
       <criteria comment="CentOS Vendor Keys" operator="OR">
@@ -47,41 +45,28 @@
   <!-- Perform the particular tests themselves -->
   <!-- Test for Red Hat release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-fd431d51-4ae0493b_installed" version="1"
+  id="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
   comment="Red Hat release key package is installed">
     <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-fd431d51-4ae0493b" />
+    <linux:state state_ref="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-fd431d51-4ae0493b" version="1">
-    <linux:release>4ae0493b</linux:release>
-    <linux:version>fd431d51</linux:version>
+  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
+    <linux:release>{{{ pkg_release }}}</linux:release>
+    <linux:version>{{{ pkg_version }}}</linux:version>
   </linux:rpminfo_state>
 
   <!-- Test for Red Hat auxiliary key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-2fa658e0-45700c69_installed" version="1"
+  id="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" version="1"
   comment="Red Hat auxiliary key package is installed">
     <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-2fa658e0-45700c69" />
+    <linux:state state_ref="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-2fa658e0-45700c69" version="1">
-    <linux:release>45700c69</linux:release>
-    <linux:version>2fa658e0</linux:version>
-  </linux:rpminfo_state>
-
-  <!-- Test for Red Hat auxiliary key -->
-  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-d4082792-5b32db75_installed" version="1"
-  comment="Red Hat auxiliary key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-d4082792-5b32db75" />
-  </linux:rpminfo_test>
-
-  <linux:rpminfo_state id="state_package_gpg-pubkey-d4082792-5b32db75" version="1">
-    <linux:release>5b32db75</linux:release>
-    <linux:version>d4082792</linux:version>
+  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" version="1">
+    <linux:release>{{{ aux_pkg_release }}}</linux:release>
+    <linux:version>{{{ aux_pkg_version }}}</linux:version>
   </linux:rpminfo_state>
 
   <!-- Test for CentOS7 key -->

--- a/rhel6/product.yml
+++ b/rhel6/product.yml
@@ -11,3 +11,13 @@ pkg_manager: "yum"
 init_system: "upstart"
 
 uid_min: 500 # sets the starting value for user ids, also used to set auid
+
+# The fingerprints below are retrieved from https://access.redhat.com/security/team/key
+pkg_release: "4ae0493b"
+pkg_version: "fd431d51"
+aux_pkg_release: "45700c69"
+aux_pkg_version: "2fa658e0"
+
+release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
+auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
+

--- a/rhel6/product.yml
+++ b/rhel6/product.yml
@@ -20,4 +20,3 @@ aux_pkg_version: "2fa658e0"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
-

--- a/rhel7/product.yml
+++ b/rhel7/product.yml
@@ -9,3 +9,12 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+
+# The fingerprints below are retrieved from https://access.redhat.com/security/team/key
+pkg_release: "4ae0493b"
+pkg_version: "fd431d51"
+aux_pkg_release: "45700c69"
+aux_pkg_version: "2fa658e0"
+
+release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
+auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"

--- a/rhel8/product.yml
+++ b/rhel8/product.yml
@@ -9,3 +9,12 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+
+# The fingerprints below are retrieved from https://access.redhat.com/security/team/key
+pkg_release: "4ae0493b"
+pkg_version: "fd431d51"
+aux_pkg_release: "5b32db75"
+aux_pkg_version: "d4082792"
+
+release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
+auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"

--- a/rhv4/product.yml
+++ b/rhv4/product.yml
@@ -9,3 +9,12 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+
+# The fingerprints below are retrieved from https://access.redhat.com/security/team/key
+pkg_release: "4ae0493b"
+pkg_version: "fd431d51"
+aux_pkg_release: "45700c69"
+aux_pkg_version: "2fa658e0"
+
+release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
+auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"

--- a/tests/data/group_system/group_software/group_updating/rule_ensure_redhat_gpgkey_installed/fedora_key.fail.sh
+++ b/tests/data/group_system/group_software/group_updating/rule_ensure_redhat_gpgkey_installed/fedora_key.fail.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+KEYS=$(rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\n')
+
+if [ $? = 0 ]; then
+    for KEY in $KEYS; do
+    rpm -e $KEY
+    done
+fi
+
+cat << EOF >> /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-release
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBFturGcBEACv0xBo91V2n0uEC2vh69ywCiSyvUgN/AQH8EZpCVtM7NyjKgKm
+bbY4G3R0M3ir1xXmvUDvK0493/qOiFrjkplvzXFTGpPTi0ypqGgxc5d0ohRA1M75
+L+0AIlXoOgHQ358/c4uO8X0JAA1NYxCkAW1KSJgFJ3RjukrfqSHWthS1d4o8fhHy
+KJKEnirE5hHqB50dafXrBfgZdaOs3C6ppRIePFe2o4vUEapMTCHFw0woQR8Ah4/R
+n7Z9G9Ln+0Cinmy0nbIDiZJ+pgLAXCOWBfDUzcOjDGKvcpoZharA07c0q1/5ojzO
+4F0Fh4g/BUmtrASwHfcIbjHyCSr1j/3Iz883iy07gJY5Yhiuaqmp0o0f9fgHkG53
+2xCU1owmACqaIBNQMukvXRDtB2GJMuKa/asTZDP6R5re+iXs7+s9ohcRRAKGyAyc
+YKIQKcaA+6M8T7/G+TPHZX6HJWqJJiYB+EC2ERblpvq9TPlLguEWcmvjbVc31nyq
+SDoO3ncFWKFmVsbQPTbP+pKUmlLfJwtb5XqxNR5GEXSwVv4I7IqBmJz1MmRafnBZ
+g0FJUtH668GnldO20XbnSVBr820F5SISMXVwCXDXEvGwwiB8Lt8PvqzXnGIFDAu3
+DlQI5sxSqpPVWSyw08ppKT2Tpmy8adiBotLfaCFl2VTHwOae48X2dMPBvQARAQAB
+tDFGZWRvcmEgKDMwKSA8ZmVkb3JhLTMwLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v
+cmc+iQI4BBMBAgAiBQJbbqxnAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK
+CRDvPBEfz8ZZudTnD/9170LL3nyTVUCFmBjT9wZ4gYnpwtKVPa/pKnxbbS+Bmmac
+g9TrT9pZbqOHrNJLiZ3Zx1Hp+8uxr3Lo6kbYwImLhkOEDrf4aP17HfQ6VYFbQZI8
+f79OFxWJ7si9+3gfzeh9UYFEqOQfzIjLWFyfnas0OnV/P+RMQ1Zr+vPRqO7AR2va
+N9wg+Xl7157dhXPCGYnGMNSoxCbpRs0JNlzvJMuAea5nTTznRaJZtK/xKsqLn51D
+K07k9MHVFXakOH8QtMCUglbwfTfIpO5YRq5imxlWbqsYWVQy1WGJFyW6hWC0+RcJ
+Ox5zGtOfi4/dN+xJ+ibnbyvy/il7Qm+vyFhCYqIPyS5m2UVJUuao3eApE38k78/o
+8aQOTnFQZ+U1Sw+6woFTxjqRQBXlQm2+7Bt3bqGATg4sXXWPbmwdL87Ic+mxn/ml
+SMfQux/5k6iAu1kQhwkO2YJn9eII6HIPkW+2m5N1JsUyJQe4cbtZE5Yh3TRA0dm7
++zoBRfCXkOW4krchbgww/ptVmzMMP7GINJdROrJnsGl5FVeid9qHzV7aZycWSma7
+CxBYB1J8HCbty5NjtD6XMYRrMLxXugvX6Q4NPPH+2NKjzX4SIDejS6JjgrP3KA3O
+pMuo7ZHMfveBngv8yP+ZD/1sS6l+dfExvdaJdOdgFCnp4p3gPbw5+Lv70HrMjA==
+=BfZ/
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-release


### PR DESCRIPTION
#### Description:

- Use parameterized values for Redhat GPG keys as they differ from one release to another.

#### Rationale:

- Bind the public key fingerprint to the product instead of hardcoding values to the OVAL/bash/ansible.
