### PR TITLE
Updated Fedora GPG info.

### DIFF
--- a/fedora/product.yml
+++ b/fedora/product.yml
@@ -10,13 +10,21 @@ pkg_manager: "dnf"
 
 init_system: "systemd"
 
-# The fingerprints below are retrieved from https://getfedora.org/keys/
-latest_version: 29
-latest_release_fingerprint: "5A03B4DD8254ECA02FDA1637A20AA56B429476B4"
-latest_pkg_release: "5a886537"
-latest_pkg_version: "429476b4"
+# The fingerprint and pkg_version are retrieved from https://getfedora.org/keys/
+# Future version is not used, but it makes updating latest_version easier.
+future_version: 31
+future_release_fingerprint: "7D22D5867F2A4236474BF7B850CB390B3C3359C4"
+future_pkg_version: "3c3359c4"
+# Obtain the pkg_release like this:
+# sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-x86_64
+# rpm -q gpg-pubkey --qf '%{VERSION}-%{RELEASE}\n' | grep <pkg_version> | cut -f 2 -d -
 
-previous_version: 28
-previous_release_fingerprint: "128CF232A9371991C8A65695E08E7E629DB62FB1"
-previous_pkg_release: "59920156"
-previous_pkg_version: "9db62fb1"
+latest_version: 30
+latest_release_fingerprint: "F1D8EC98F241AAF20DF69420EF3C111FCFC659B9"
+latest_pkg_version: "cfc659b9"
+latest_pkg_release: "5b6eac67"
+
+previous_version: 29
+previous_release_fingerprint: "5A03B4DD8254ECA02FDA1637A20AA56B429476B4"
+previous_pkg_version: "429476b4"
+previous_pkg_release: "5a886537"


### PR DESCRIPTION
The Fedora 30 is out, and info about Fedora 31 is available.
However, how does one determine value of `..._pkg_release`?