### PR TITLE
Convert functions from include_lineinfile.sh to Jinja macros

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1185,6 +1185,16 @@ When writing new bash remediations content, please follow the following guidelin
 * Run `shellcheck` over your remediation script. Make sure that you fix all warnings that are applicable. If you are not sure, mention those warnings in the pull request description.
 * Use POSIX syntax in regular expressions, so prefer `grep '^[[:space:]]*something'` over `grep '^\s*something'`.
 
+Jinja macros that generate Bash remediations can be found in `shared/macros-bash.jinja`.
+
+Available high-level Jinja macros to generate Bash remediations:
+- `bash_sshd_config_set` - Set SSH Daemon configuration option in `/etc/ssh/sshd_config`.
+- `bash_auditd_config_set` - Set Audit Daemon option in `/etc/audit/auditd.conf`.
+- `bash_coredump_config_set` -  Set Coredump configuration in `/etc/systemd/coredump.conf`
+
+Available low-level Jinja macros that can be used in Bash remediations:
+- `die` - Function to terminate the remediation
+- `set_config_file` - Add an entry to a text configuration file
 
 ==== Templating
 

--- a/linux_os/guide/system/auditing/auditd_write_logs/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_write_logs/bash/shared.sh
@@ -3,7 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-. /usr/share/scap-security-guide/remediation_functions
-include_lineinfile
-
-auditd_config_set "write_logs" "yes"
+{{{ bash_auditd_config_set("write_logs", "yes") }}}

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/bash/shared.sh
@@ -3,7 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-. /usr/share/scap-security-guide/remediation_functions
-include_lineinfile
-
-coredump_config_set ProcessSizeMax 0
+{{{ bash_coredump_config_set("ProcessSizeMax", "0") }}}

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/bash/shared.sh
@@ -3,7 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-. /usr/share/scap-security-guide/remediation_functions
-include_lineinfile
-
 {{{ bash_coredump_config_set("Storage", "none") }}}

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/bash/shared.sh
@@ -6,4 +6,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 include_lineinfile
 
-coredump_config_set Storage none
+{{{ bash_coredump_config_set("Storage", "none") }}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -74,25 +74,16 @@ printf '%s\n' '{{{ message }}}' >&2
 {{%- macro set_config_file(path, parameter, value, create, insert_after, insert_before, insensitive, separator, separator_regex, prefix_regex) -%}}
     {{%- set line_regex = prefix_regex+parameter+separator_regex -%}}
     {{%- set new_line = parameter+separator+value -%}}
-    {{{- lineinfile(path, line_regex, "", false, false, "", "", insensitive) }}}
-    {{{- lineinfile(path, "", new_line, create, true, insert_after, insert_before, insensitive) }}}
-{{%- endmacro -%}}
-
-{{%- macro lineinfile(path, regex, line, create=false, present=true, insert_after="", insert_before="", insensitive=true) -%}}
-    {{%- if not present -%}}
 if [ -e "{{{ path }}}" ] ; then
-{{{ lineinfile_absent(path, regex, insensitive) | indent(4, True) }}}
-fi
-    {{%- else %}}
-if [ ! -e "{{{ path }}}" ] ; then
-            {{%- if create %}}
+{{{ lineinfile_absent(path, line_regex, insensitive) | indent(4, True) }}}
+else
+    {{%- if create %}}
     touch "{{{ path }}}"
-            {{%- else -%}}
+    {{%- else -%}}
 {{{ die("Path " + path + " wasn't found on this system. Refusing to continue.") | indent(4, True) }}}
-            {{%- endif %}}
+    {{%- endif %}}
 fi
-{{{ lineinfile_present(path, line, insert_after, insert_before, insensitive) }}}
-    {{%- endif -%}}
+{{{ lineinfile_present(path, new_line, insert_after, insert_before, insensitive) }}}
 {{%- endmacro -%}}
 
 {{%- macro lineinfile_absent(path, regex, insensitive=true) -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1,3 +1,52 @@
+{{# ##### High level macros ##### #}}
+
+{{%- macro bash_sshd_config_set(parameter, value) -%}}
+    {{{ set_config_file(
+        path="/etc/ssh/sshd_config",
+        parameter=parameter,
+        value=value,
+        create=true,
+        insert_after="",
+        insert_before="^Match",
+        insensitive=true,
+        separator=" ",
+        separator_regex="\s\+",
+        prefix_regex="^\s*")
+    }}}
+{{%- endmacro -%}}
+
+{{%- macro bash_auditd_config_set(parameter, value) -%}}
+    {{{ set_config_file(
+        path="/etc/audit/auditd.conf",
+        parameter=parameter,
+        value=value,
+        create=true,
+        insert_after="",
+        insert_before="",
+        insensitive=true,
+        separator=" = ",
+        separator_regex="\s*=\s*",
+        prefix_regex="^\s*")
+    }}}
+{{%- endmacro -%}}
+
+{{%- macro bash_coredump_config_set(parameter, value) -%}}
+    {{{ set_config_file(
+        path="/etc/systemd/coredump.conf",
+        parameter=parameter,
+        value=value,
+        create=true,
+        insert_after="",
+        insert_before="",
+        insensitive=true,
+        separator="=",
+        separator_regex="\s*=\s*",
+        prefix_regex="^\s*")
+    }}}
+{{%- endmacro -%}}
+
+{{# ##### Low level macros ##### #}}
+
 {{#
 # Print a message to stderr and exit the shell
 # message: The message to print.
@@ -7,3 +56,95 @@
 {{% macro die(message, rc=1, action="exit") -%}}
 { printf '%s\n' '{{{ message }}}' >&2; {{{ action }}} {{{ rc }}}; }
 {{%- endmacro %}}
+
+{{#
+# Add an entry to a text configuration file
+# path: path of the configuration file
+# parameter: the paramenter to be set in the configuration file
+# value: the value of the parameter to be set in the configuration file
+# create: whether create the file specified by path if the file does not exits
+# insert_after: inserts the entry right after first line that matches regular expression specified by this argument, set to EOF to insert at the end of the file
+# insert_before: inserts the entry right before first line that matches regular expression specified by this argument, set to BOF to insert at the beginning of the file
+# insensitive: ignore case
+# separator: separates parameter from the value (literal)
+# separator_regex: regular expression that describes the separator and surrounding whitespace
+# prefix_regex: regular expression describing allowed leading characters at each line
+#}}
+{{%- macro set_config_file(path, parameter, value, create, insert_after, insert_before, insensitive, separator, separator_regex, prefix_regex) -%}}
+    {{%- set line_regex = prefix_regex+parameter+separator_regex -%}}
+    {{%- set new_line = parameter+separator+value -%}}
+    {{{ lineinfile(path, line_regex, "", false, false, "", "", insensitive) }}}
+    {{{ lineinfile(path, "", new_line, create, true, insert_after, insert_before, insensitive) }}}
+{{%- endmacro -%}}
+
+{{%- macro lineinfile(path, regex, line, create=false, present=true, insert_after="", insert_before="", insensitive=true) -%}}
+    {{%- if not present -%}}
+        if [ -e "{{{ path }}}" ] ; then
+            {{{ lineinfile_absent(path, regex, insensitive) }}}
+        fi
+    {{%- else -%}}
+        if [ ! -e "{{{ path }}}" ] ; then
+            {{% if create -%}}
+                touch "{{{ path }}}"
+            {{%- else -%}}
+                {{{ die("Path " + path + " wasn't found on this system. Refusing to continue.") }}}
+            {{%- endif %}}
+        fi
+        {{{ lineinfile_present(path, line, insert_after, insert_before, insensitive) }}}
+    {{%- endif -%}}
+{{%- endmacro -%}}
+
+{{%- macro lineinfile_absent(path, regex, insensitive=true) %}}
+    {{%- if insensitive -%}}
+        {{%- set modifier="Id" -%}}
+    {{%- else -%}}
+        {{%- set modifier="d" -%}}
+    {{%- endif -%}}
+    LC_ALL=C sed -i "/{{{ regex }}}/{{{ modifier }}}" "{{{ path }}}"
+{{%- endmacro -%}}
+
+{{%- macro lineinfile_present(path, line, insert_after="", insert_before="", insensitive=true) -%}}
+    {{%- if insensitive -%}}
+        {{%- set grep_args="-q -m 1 -i" -%}}
+    {{%- else -%}}
+        {{%- set grep_args="-q -m 1" -%}}
+    {{%- endif -%}}
+    {{% if (insert_after == "" and insert_before == "")  or insert_after == "EOF" -%}}
+        # Insert at the end of the file
+        cp "{{{ path }}}" "{{{ path }}}.bak"
+        printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+    {{%- elif insert_before == "BOF" -%}}
+        # Insert at the beginning of the file
+        cp "{{{ path }}}" "{{{ path }}}.bak"
+        printf '%s\n' "{{{ line }}}" > "{{{ path }}}"
+        cat "{{{ path }}}.bak" >> "{{{ path }}}"
+    {{%- elif insert_after != "" -%}}
+        # Insert after the line matching the regex {{{ insert_after }}}
+        cp "{{{ path }}}" "{{{ path }}}.bak"
+        local line_number="$(LC_ALL=C grep -n "{{{ insert_after }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
+        if [ -z "$line_number" ]; then
+            # There was no match of {{{ insert_after }}}, insert at
+            # the end of the file.
+            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+        else
+            head -n "$(( line_number ))" ".bak" > "{{{ path }}}"
+            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+            tail -n "+$(( line_number + 1 ))" "{{{ path }}}.bak" >> "{{{ path }}}"
+        fi
+    {{%- elif insert_before != "" -%}}
+        # Insert before the line matching the regex {{{ insert_before }}}.
+        cp "{{{ path }}}" "{{{ path }}}.bak"
+        local line_number="$(LC_ALL=C grep -n "{{{ insert_before }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
+        if [ -z "$line_number" ]; then
+            # There was no match of {{{ insert_before }}}, insert at
+            # the end of the file.
+            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+        else
+            head -n "$(( line_number - 1 ))" "{{{ path }}}.bak" > "{{{ path }}}"
+            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+            tail -n "+$(( line_number ))" "{{{ path }}}.bak" >> "{{{ path }}}"
+        fi
+    {{%- endif %}}
+    # Clean up after ourselves.
+    rm "{{{ path }}}.bak"
+{{%- endmacro -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1,7 +1,7 @@
 {{# ##### High level macros ##### #}}
 
 {{%- macro bash_sshd_config_set(parameter, value) -%}}
-    {{{ set_config_file(
+{{{ set_config_file(
         path="/etc/ssh/sshd_config",
         parameter=parameter,
         value=value,
@@ -16,7 +16,7 @@
 {{%- endmacro -%}}
 
 {{%- macro bash_auditd_config_set(parameter, value) -%}}
-    {{{ set_config_file(
+{{{ set_config_file(
         path="/etc/audit/auditd.conf",
         parameter=parameter,
         value=value,
@@ -31,7 +31,7 @@
 {{%- endmacro -%}}
 
 {{%- macro bash_coredump_config_set(parameter, value) -%}}
-    {{{ set_config_file(
+{{{ set_config_file(
         path="/etc/systemd/coredump.conf",
         parameter=parameter,
         value=value,
@@ -54,7 +54,8 @@
 # action: What to do (optional, default is 'exit', can be also 'return' or anything else)
 #}}
 {{% macro die(message, rc=1, action="exit") -%}}
-{ printf '%s\n' '{{{ message }}}' >&2; {{{ action }}} {{{ rc }}}; }
+printf '%s\n' '{{{ message }}}' >&2
+{{{ action }}} {{{ rc }}}
 {{%- endmacro %}}
 
 {{#
@@ -73,34 +74,34 @@
 {{%- macro set_config_file(path, parameter, value, create, insert_after, insert_before, insensitive, separator, separator_regex, prefix_regex) -%}}
     {{%- set line_regex = prefix_regex+parameter+separator_regex -%}}
     {{%- set new_line = parameter+separator+value -%}}
-    {{{ lineinfile(path, line_regex, "", false, false, "", "", insensitive) }}}
-    {{{ lineinfile(path, "", new_line, create, true, insert_after, insert_before, insensitive) }}}
+    {{{- lineinfile(path, line_regex, "", false, false, "", "", insensitive) }}}
+    {{{- lineinfile(path, "", new_line, create, true, insert_after, insert_before, insensitive) }}}
 {{%- endmacro -%}}
 
 {{%- macro lineinfile(path, regex, line, create=false, present=true, insert_after="", insert_before="", insensitive=true) -%}}
     {{%- if not present -%}}
-        if [ -e "{{{ path }}}" ] ; then
-            {{{ lineinfile_absent(path, regex, insensitive) }}}
-        fi
-    {{%- else -%}}
-        if [ ! -e "{{{ path }}}" ] ; then
-            {{% if create -%}}
-                touch "{{{ path }}}"
+if [ -e "{{{ path }}}" ] ; then
+{{{ lineinfile_absent(path, regex, insensitive) | indent(4, True) }}}
+fi
+    {{%- else %}}
+if [ ! -e "{{{ path }}}" ] ; then
+            {{%- if create %}}
+    touch "{{{ path }}}"
             {{%- else -%}}
-                {{{ die("Path " + path + " wasn't found on this system. Refusing to continue.") }}}
+{{{ die("Path " + path + " wasn't found on this system. Refusing to continue.") | indent(4, True) }}}
             {{%- endif %}}
-        fi
-        {{{ lineinfile_present(path, line, insert_after, insert_before, insensitive) }}}
+fi
+{{{ lineinfile_present(path, line, insert_after, insert_before, insensitive) }}}
     {{%- endif -%}}
 {{%- endmacro -%}}
 
-{{%- macro lineinfile_absent(path, regex, insensitive=true) %}}
+{{%- macro lineinfile_absent(path, regex, insensitive=true) -%}}
     {{%- if insensitive -%}}
         {{%- set modifier="Id" -%}}
     {{%- else -%}}
         {{%- set modifier="d" -%}}
     {{%- endif -%}}
-    LC_ALL=C sed -i "/{{{ regex }}}/{{{ modifier }}}" "{{{ path }}}"
+LC_ALL=C sed -i "/{{{ regex }}}/{{{ modifier }}}" "{{{ path }}}"
 {{%- endmacro -%}}
 
 {{%- macro lineinfile_present(path, line, insert_after="", insert_before="", insensitive=true) -%}}
@@ -110,41 +111,41 @@
         {{%- set grep_args="-q -m 1" -%}}
     {{%- endif -%}}
     {{% if (insert_after == "" and insert_before == "")  or insert_after == "EOF" -%}}
-        # Insert at the end of the file
-        cp "{{{ path }}}" "{{{ path }}}.bak"
-        printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+# Insert at the end of the file
+cp "{{{ path }}}" "{{{ path }}}.bak"
+printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
     {{%- elif insert_before == "BOF" -%}}
-        # Insert at the beginning of the file
-        cp "{{{ path }}}" "{{{ path }}}.bak"
-        printf '%s\n' "{{{ line }}}" > "{{{ path }}}"
-        cat "{{{ path }}}.bak" >> "{{{ path }}}"
+# Insert at the beginning of the file
+cp "{{{ path }}}" "{{{ path }}}.bak"
+printf '%s\n' "{{{ line }}}" > "{{{ path }}}"
+cat "{{{ path }}}.bak" >> "{{{ path }}}"
     {{%- elif insert_after != "" -%}}
-        # Insert after the line matching the regex {{{ insert_after }}}
-        cp "{{{ path }}}" "{{{ path }}}.bak"
-        local line_number="$(LC_ALL=C grep -n "{{{ insert_after }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
-        if [ -z "$line_number" ]; then
-            # There was no match of {{{ insert_after }}}, insert at
-            # the end of the file.
-            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
-        else
-            head -n "$(( line_number ))" ".bak" > "{{{ path }}}"
-            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
-            tail -n "+$(( line_number + 1 ))" "{{{ path }}}.bak" >> "{{{ path }}}"
-        fi
+# Insert after the line matching the regex {{{ insert_after }}}
+cp "{{{ path }}}" "{{{ path }}}.bak"
+local line_number="$(LC_ALL=C grep -n "{{{ insert_after }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
+if [ -z "$line_number" ]; then
+    # There was no match of {{{ insert_after }}}, insert at
+    # the end of the file.
+    printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+else
+    head -n "$(( line_number ))" ".bak" > "{{{ path }}}"
+    printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+    tail -n "+$(( line_number + 1 ))" "{{{ path }}}.bak" >> "{{{ path }}}"
+fi
     {{%- elif insert_before != "" -%}}
-        # Insert before the line matching the regex {{{ insert_before }}}.
-        cp "{{{ path }}}" "{{{ path }}}.bak"
-        local line_number="$(LC_ALL=C grep -n "{{{ insert_before }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
-        if [ -z "$line_number" ]; then
-            # There was no match of {{{ insert_before }}}, insert at
-            # the end of the file.
-            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
-        else
-            head -n "$(( line_number - 1 ))" "{{{ path }}}.bak" > "{{{ path }}}"
-            printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
-            tail -n "+$(( line_number ))" "{{{ path }}}.bak" >> "{{{ path }}}"
-        fi
+# Insert before the line matching the regex {{{ insert_before }}}.
+cp "{{{ path }}}" "{{{ path }}}.bak"
+local line_number="$(LC_ALL=C grep -n "{{{ insert_before }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
+if [ -z "$line_number" ]; then
+    # There was no match of {{{ insert_before }}}, insert at
+    # the end of the file.
+    printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+else
+    head -n "$(( line_number - 1 ))" "{{{ path }}}.bak" > "{{{ path }}}"
+    printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
+    tail -n "+$(( line_number ))" "{{{ path }}}.bak" >> "{{{ path }}}"
+fi
     {{%- endif %}}
-    # Clean up after ourselves.
-    rm "{{{ path }}}.bak"
+# Clean up after ourselves.
+rm "{{{ path }}}.bak"
 {{%- endmacro -%}}

--- a/shared/templates/template_BASH_auditd_lineinfile
+++ b/shared/templates/template_BASH_auditd_lineinfile
@@ -3,7 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-. /usr/share/scap-security-guide/remediation_functions
-include_lineinfile
-
-auditd_config_set {{{ PARAMETER }}} {{{ VALUE }}}
+{{{ bash_auditd_config_set(parameter=PARAMETER, value=VALUE) }}}

--- a/shared/templates/template_BASH_sshd_lineinfile
+++ b/shared/templates/template_BASH_sshd_lineinfile
@@ -3,7 +3,4 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-. /usr/share/scap-security-guide/remediation_functions
-include_lineinfile
-
-sshd_config_set {{{ PARAMETER }}} {{{ VALUE }}}
+{{{ bash_sshd_config_set(parameter=PARAMETER, value=VALUE) }}}


### PR DESCRIPTION
Currently, the Bash remediation functions are saved in an XCCDF Value
and their code is substituted by OpenSCAP when the remediation is
executed.  However, the way of using the functions in individual
remediation is tedious and hard to understand. People have to source a
non-existent file /usr/share/scap-security-guide/remediation_functions
and then call an empty function to make the function code available in
the remediation. We have discovered that it does not allow to use
multiple functions in a single remediation. Another drawback is that
the function code is duplicated in HTML report each time it is used
which makes the report bigger. This patch aims to simplify creating the
Bash remediation and address the aforementioned problems by converting
the functions to Jinja macro. In Bash remediation you can now simply
call a Jinja macro and a simple, stand-alone Bash code will be generated
for you.  In this patch only the functions from include_lineinfile.sh
are converted to Jinja. Other shared modules can be converted in future
in a similar way.
