### PR TITLE
Added stripping of new line when obtaining IP addr by podman inspect

### DIFF
--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -10,7 +10,7 @@ ARG ADDITIONAL_PACKAGES
 # Don't clean all, as the test scenario may require package install.
 RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
-		python \
+		python3 \
 		$ADDITIONAL_PACKAGES \
         && true
 

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -352,7 +352,7 @@ class PodmanTestEnv(ContainerTestEnv):
         except subprocess.CalledProcessError as e:
             msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
             raise RuntimeError(msg)
-        ip_address = podman_output.decode("utf-8")
+        ip_address = podman_output.decode("utf-8").strip()
         return ip_address
 
     def _terminate_current_running_container_if_applicable(self):


### PR DESCRIPTION
#### Description:

- The new line character in IP addr of a container was breaking podman backend of the SSG Test Suite.