### PR TITLE
Fix generated SCAP 1.2 content 

### DIFF
--- a/build-scripts/update_sds_version.py
+++ b/build-scripts/update_sds_version.py
@@ -110,6 +110,7 @@ def move_patches_up_to_date_to_source_data_stream_component(datastreamtree):
 
 def parse_args():
     p = argparse.ArgumentParser()
+    p.add_argument("--version", required=True)
     p.add_argument("--input", required=True)
     p.add_argument("--output", required=True)
 
@@ -121,12 +122,13 @@ def main():
     # Datastream element tree
     datastreamtree = ssg.xml.ElementTree.parse(args.input).getroot()
 
-    # Set SCAP version to 1.3
-    datastreamtree.set('schematron-version', '1.3')
-    datastreamtree.find('{%s}data-stream' % datastream_namespace).set('scap-version', '1.3')
+    if args.version == "1.3":
+        # Set SCAP version to 1.3
+        datastreamtree.set('schematron-version', '1.3')
+        datastreamtree.find('{%s}data-stream' % datastream_namespace).set('scap-version', '1.3')
 
-    # Move reference to remote OVAL content to a source data stream component
-    move_patches_up_to_date_to_source_data_stream_component(datastreamtree)
+        # Move reference to remote OVAL content to a source data stream component
+        move_patches_up_to_date_to_source_data_stream_component(datastreamtree)
 
     ssg.xml.ElementTree.ElementTree(datastreamtree).write(args.output)
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -536,7 +536,7 @@ macro(ssg_build_sds PRODUCT)
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-add --skip-valid "ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-add --skip-valid "ssg-${PRODUCT}-pcidss-xccdf-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/sds_move_ocil_to_checks.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_to_scap_1_3.py" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "${SSG_TARGET_SCAP_VERSION}" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
@@ -560,7 +560,7 @@ macro(ssg_build_sds PRODUCT)
             COMMAND "${SED_EXECUTABLE}" -i 's/schematron-version="[0-9].[0-9]"/schematron-version="1.2"/' "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-add --skip-valid "ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/sds_move_ocil_to_checks.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_to_scap_1_3.py" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "${SSG_TARGET_SCAP_VERSION}" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"


### PR DESCRIPTION

#### Description:

- Fix bug where built SCAP 1.2 DS was actually SCAP 1.3
- Also, renamed script to generic update sds version.
- The script receives target SCAP version and handles update of version.
  - When target version is 1.3, it is updated.
  - When target version is 1.2, nothing is done.

#### Rationale:

Enpower DS version update script to decide when to update or not,
instead of controling this decision on CMake script

This is to avoid defining 4 custom commands to build the DS
in CMake macro ssg_build_ds(). Namely:
1. command for rhel6|7 with 1.2 (includes pci-dss benchmark)
2. command for rhel6|7 with 1.3 (includes pci-dss benchmark)
3. command for other products with 1.2
4. command for other produts with 1.3
