### PR TITLE
Updated the Bash guide wrt introduction of bash jinja macros.

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1176,7 +1176,11 @@ fi
 
 When writing new bash remediations content, please follow the following guidelins:
 
-* Use tabs for indentation rather than spaces.
+* Use four spaces for indentation rather than tabs.
+* You can use macros from `shared/macros-bash.jinja` in the remediation content.
+If the macro is used from a nested block, use the `indent` jinja2 filter assuming the 4-space indentation.
+Typically, you want to call the macro with the intended indentation, and as `indent` doesn't indent the first line by default, you just pass the number of spaces as the only argument.
+See the remediation for rule `ensure_fedora_gpgkey_installed` for reference.
 * Prefer to use `sed` rather than `awk`.
 * Try to keep expressions simple, avoid double negations. Use link:http://tldp.org/LDP/abs/html/list-cons.html[compound lists] with moderation and only link:https://mywiki.wooledge.org/BashPitfalls#cmd1_.26.26_cmd2_.7C.7C_cmd3[if you understand them].
 * Test your script in the "strict mode" with `set -e -o pipefail` specified at the top of it. Make sure that the script doesn't end prematurely in the strict mode.
@@ -1188,11 +1192,13 @@ When writing new bash remediations content, please follow the following guidelin
 Jinja macros that generate Bash remediations can be found in `shared/macros-bash.jinja`.
 
 Available high-level Jinja macros to generate Bash remediations:
+
 - `bash_sshd_config_set` - Set SSH Daemon configuration option in `/etc/ssh/sshd_config`.
 - `bash_auditd_config_set` - Set Audit Daemon option in `/etc/audit/auditd.conf`.
 - `bash_coredump_config_set` -  Set Coredump configuration in `/etc/systemd/coredump.conf`
 
 Available low-level Jinja macros that can be used in Bash remediations:
+
 - `die` - Function to terminate the remediation
 - `set_config_file` - Add an entry to a text configuration file
 

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -5,13 +5,13 @@ dnf install -y gpg
 fedora_version=$(grep -oP '[[:digit:]]+' /etc/redhat-release)
 
 function get_release_fingerprint {
-	if [ "${fedora_version}" -eq "{{{ latest_version }}}" ]; then
-		readonly FEDORA_RELEASE_FINGERPRINT="{{{ latest_release_fingerprint }}}"
-	elif [ "${fedora_version}" -eq "{{{ previous_version }}}" ]; then
-		readonly FEDORA_RELEASE_FINGERPRINT="{{{ previous_release_fingerprint }}}"
-	else
-		{{{ die("This Fedora version '$fedora_version' is not supported anymore, please upgrade to a newer version.", action="return") }}}
-	fi
+    if [ "${fedora_version}" -eq "{{{ latest_version }}}" ]; then
+        readonly FEDORA_RELEASE_FINGERPRINT="{{{ latest_release_fingerprint }}}"
+    elif [ "${fedora_version}" -eq "{{{ previous_version }}}" ]; then
+        readonly FEDORA_RELEASE_FINGERPRINT="{{{ previous_release_fingerprint }}}"
+    else
+        {{{ die("This Fedora version '$fedora_version' is not supported anymore, please upgrade to a newer version.", action="return") | indent(8)}}}
+    fi
 }
 
 # Location of the key we would like to import (once it's integrity verified)
@@ -20,22 +20,22 @@ readonly REDHAT_RELEASE_KEY="/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-${fedora_versio
 RPM_GPG_DIR_PERMS=$(stat -c %a "$(dirname "$REDHAT_RELEASE_KEY")")
 
 function remediate_gpgkey_installed {
-	# Return if there was an issue getting the release fingerprint
-	get_release_fingerprint || return 1
-	# Verify /etc/pki/rpm-gpg directory permissions are safe
-	if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]; then
-		# If they are safe, try to obtain fingerprints from the key file
-		# (to ensure there won't be e.g. CRC error).
-		readarray -t GPG_OUT < <(gpg --show-keys --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '^fpr' | cut -d ":" -f 10)
-		GPG_RESULT=$?
-		# No CRC error, safe to proceed
-		if [ "${GPG_RESULT}" -eq "0" ]; then
-			echo "${GPG_OUT}" | grep -vE "${FEDORA_RELEASE_FINGERPRINT}" || {
-			# If file doesn't contains any keys with unknown fingerprint, import it
-			rpm --import "${REDHAT_RELEASE_KEY}"
-			}
-		fi
-	fi
+    # Return if there was an issue getting the release fingerprint
+    get_release_fingerprint || return 1
+    # Verify /etc/pki/rpm-gpg directory permissions are safe
+    if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]; then
+        # If they are safe, try to obtain fingerprints from the key file
+        # (to ensure there won't be e.g. CRC error).
+        readarray -t GPG_OUT < <(gpg --show-keys --with-fingerprint --with-colons "${REDHAT_RELEASE_KEY}" | grep '^fpr' | cut -d ":" -f 10)
+        GPG_RESULT=$?
+        # No CRC error, safe to proceed
+        if [ "${GPG_RESULT}" -eq "0" ]; then
+            echo "${GPG_OUT}" | grep -vE "${FEDORA_RELEASE_FINGERPRINT}" || {
+            # If file doesn't contain any keys with unknown fingerprint, import it
+            rpm --import "${REDHAT_RELEASE_KEY}"
+            }
+        fi
+    fi
 }
 
 remediate_gpgkey_installed

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -75,12 +75,12 @@ printf '%s\n' '{{{ message }}}' >&2
     {{%- set line_regex = prefix_regex+parameter+separator_regex -%}}
     {{%- set new_line = parameter+separator+value -%}}
 if [ -e "{{{ path }}}" ] ; then
-{{{ lineinfile_absent(path, line_regex, insensitive) | indent(4, True) }}}
+    {{{ lineinfile_absent(path, line_regex, insensitive) | indent(4) }}}
 else
     {{%- if create %}}
     touch "{{{ path }}}"
     {{%- else -%}}
-{{{ die("Path " + path + " wasn't found on this system. Refusing to continue.") | indent(4, True) }}}
+        {{{ die("Path " + path + " wasn't found on this system. Refusing to continue.") | indent(4) }}}
     {{%- endif %}}
 fi
 {{{ lineinfile_present(path, new_line, insert_after, insert_before, insensitive) }}}


### PR DESCRIPTION
- Changed the guidance to use 4-space for indent.
- Cleaned up the example where die is used.