### PR TITLE
Fix typos in auditd_local_events texts.

### DIFF
--- a/linux_os/guide/system/auditing/auditd_local_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_local_events/rule.yml
@@ -8,7 +8,7 @@ description: |-
     This is the default setting.
 
 rationale: |-
-    If local <tt>local_events</tt> isn't set to <tt>yes</tt> only events from
+    If option <tt>local_events</tt> isn't set to <tt>yes</tt> only events from
     network will be aggregated.
 
 severity: medium
@@ -25,5 +25,5 @@ ocil: |-
     To verify that Audit Daemon is configured to include local events, run the
     following command:
     <pre>$ sudo grep local_events /etc/audit/auditd.conf</pre>
-    The output should return the follwoing:
+    The output should return the following:
     <pre>local_events = yes</pre>


### PR DESCRIPTION
#### Description:

- Fix typos in auditd_local_events texts.

#### Rationale:

- With the original words, the text does not read as smoothly.
