### PR TITLE
Fix typo in api_server_admission_control_plugin_NodeRestriction description

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -9,7 +9,7 @@ description: |-
     modify, follow the OpenShift documentation and configure
     <tt>NodeRestriction</tt> plugin on kubelets. Then, edit the API Server pod
     specification file <tt>/etc/origin/master/master-config.yaml</tt>
-    on the master node(s) and set set the <tt>admissionConfig</tt> to include <tt>NodeRestriction</tt>:
+    on the master node(s) and set the <tt>admissionConfig</tt> to include <tt>NodeRestriction</tt>:
     <pre>admissionConfig:
       pluginConfig:
         NodeRestriction:


### PR DESCRIPTION

#### Description:

- Fix typo in api_server_admission_control_plugin_NodeRestriction description.

#### Rationale:

- With the double `set`, the sentence is harder to follow.
