### PR TITLE
configure_crypto_policy: Do not check back-end symlink

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -1,37 +1,3 @@
-{{%- if target_oval_version == [5, 11] -%}}
-{{# there is no good alternative for symlink_test for OVAL 5.10 #}}
-{{%- macro crypto_policy_symlink_criterion(library) %}}
-      <criterion comment="Check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to /usr/share/crypto-policies/POLICY/{{{ library }}}.txt" test_ref="test_crypto_policy_{{{ library }}}_symlink" />
-{{%- endmacro %}}
-
-{{%- macro crypto_policy_symlink_check(library) %}}
-  <local_variable id="var_crypto_policy_{{{ library }}}_path" datatype="string" comment="Regex variable for canonical path to targeted {{{ library }}} policy" version="1">
-    <concat>
-      <literal_component>^/usr/share/crypto-policies/</literal_component>
-      <variable_component var_ref="var_system_crypto_policy"/>
-      <literal_component>/{{{ library }}}.txt$</literal_component>
-    </concat>
-  </local_variable>
-
-  <unix:symlink_test id="test_crypto_policy_{{{ library }}}_symlink"
-  comment="check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to correct target library config"
-  check="all" check_existence="all_exist" version="1">
-    <unix:object object_ref="object_crypto_policy_{{{ library }}}_symlink" />
-    <unix:state state_ref="state_crypto_policy_{{{ library }}}_symlink" />
-  </unix:symlink_test>
-
-  <unix:symlink_object id="object_crypto_policy_{{{ library }}}_symlink" version="1">
-    <unix:filepath>/etc/crypto-policies/back-ends/{{{ library }}}.config</unix:filepath>
-  </unix:symlink_object>
-
-  <unix:symlink_state id="state_crypto_policy_{{{ library }}}_symlink" version="1">
-    <unix:filepath>/etc/crypto-policies/back-ends/{{{ library }}}.config</unix:filepath>
-    <unix:canonical_path operation="pattern match" var_ref="var_crypto_policy_{{{ library }}}_path"/>
-  </unix:symlink_state>
-{{%- endmacro %}}
-
-{{% endif %}}
-
 <def-group>
   <definition class="compliance" id="configure_crypto_policy" version="1">
     <metadata>
@@ -49,17 +15,6 @@
       <criterion comment="check for crypto policy correctly configured in /etc/crypto-policy/state/current"
       test_ref="test_configure_crypto_policy_current" />
       <criterion comment="Check if update-crypto-policies has been run after config update" test_ref="test_crypto_policies_updated" />
-{{%- if target_oval_version == [5, 11] -%}}
-      {{{ crypto_policy_symlink_criterion(library="bind") }}}
-      {{{ crypto_policy_symlink_criterion(library="gnutls") }}}
-      {{{ crypto_policy_symlink_criterion(library="java") }}}
-      {{{ crypto_policy_symlink_criterion(library="krb5") }}}
-      {{{ crypto_policy_symlink_criterion(library="libreswan") }}}
-      {{{ crypto_policy_symlink_criterion(library="openssh") }}}
-      {{{ crypto_policy_symlink_criterion(library="opensshserver") }}}
-      {{{ crypto_policy_symlink_criterion(library="openssl") }}}
-  {{% endif %}}
-      <criterion comment="Check if /etc/crypto-policies/back-ends/nss.config exists" test_ref="test_crypto_policy_nss_config" />
     </criteria>
   </definition>
 
@@ -133,25 +88,6 @@ id="object_crypto_policies_config_file_modified_time" version="1">
     <ind:subexpression operation="equals" var_check="all"
     var_ref="var_system_crypto_policy" />
   </ind:textfilecontent54_state>
-
-{{%- if target_oval_version == [5, 11] -%}}
-  {{{ crypto_policy_symlink_check(library="bind") }}}
-  {{{ crypto_policy_symlink_check(library="gnutls") }}}
-  {{{ crypto_policy_symlink_check(library="java") }}}
-  {{{ crypto_policy_symlink_check(library="krb5") }}}
-  {{{ crypto_policy_symlink_check(library="libreswan") }}}
-  {{{ crypto_policy_symlink_check(library="nss") }}}
-  {{{ crypto_policy_symlink_check(library="openssh") }}}
-  {{{ crypto_policy_symlink_check(library="opensshserver") }}}
-  {{{ crypto_policy_symlink_check(library="openssl") }}}
-{{% endif %}}
-
-  <unix:file_test check="all" check_existence="all_exist" comment="Check if /etc/crypto-policies/back-ends/nss.config exists" id="test_crypto_policy_nss_config" version="1">
-    <unix:object object_ref="object_crypto_policy_nss_config" />
-  </unix:file_test>
-  <unix:file_object id="object_crypto_policy_nss_config" version="1">
-    <unix:filepath>/etc/crypto-policies/back-ends/nss.config</unix:filepath>
-  </unix:file_object>
 
   <external_variable comment="defined crypto policy" datatype="string"
   id="var_system_crypto_policy" version="1" />


### PR DESCRIPTION
#### Description:

- Don't check for crypto-policy back-end symlinks.

#### Rationale:

- ~~The fact that they are not symlinks doesn't imply that they haven't been
tampered.~~
EDIT:
- Checking that the back-end `config` is a symlink to policy `txt` doesn't add value, as we don't check that policy `txt`s was not modified. 
- Plus, there are valid scenarios where it is ok not to have symlinks there. For example, by adding configs into `/etc/crypto-policies/local.d/` and running `update-crypto-policy`, the file in `/etc/crypto-policy/back-ends/` is not a symlink anymore.
  - This is done in `harden_sshd_crypto_policy`
