### PR TITLE
Add option in build_product to build SCAP 1.2 content.

### DIFF
--- a/build_product
+++ b/build_product
@@ -34,7 +34,7 @@ handle_wrong_argument() {
 	echo
 	echo
 	printf 'Usage:\n'
-	printf '\tbuild-product [--debug] <product-name> [<product-name> ...]\n'
+	printf '\tbuild-product [--debug] [--scap12] <product-name> [<product-name> ...]\n'
 	echo
 	if test -n "$1"; then
 		printf "The argument '%s' is not supported.\\n" "$1"
@@ -42,6 +42,7 @@ handle_wrong_argument() {
 		printf 'Supply product names as arguments to this script.\n'
 	fi
 	printf 'Option --debug can be used to build draft profiles\n'
+	printf 'Option --scap12 can be used to build SCAP 1.2 Content (Default is 1.3)\n'
 
 	printf 'Choose one or more product names from the list: %s' "$possible_products"
 	echo
@@ -79,13 +80,21 @@ if (( $# == 0 )); then
 	handle_wrong_argument
 fi
 
-if [[ "$1" == "--debug" ]]; then
-    debug="-DCMAKE_BUILD_TYPE=Debug"
-    shift
-else
-    debug="-DCMAKE_BUILD_TYPE=Release"
-fi
+scap_version="-DSSG_TARGET_SCAP_VERSION:STRING=1.3"
+build_type="-DCMAKE_BUILD_TYPE=Release"
 
+# currently only two modifier options are available
+for i in {1..2}; do
+	if [[ "$1" == "--debug" ]]; then
+		build_type="-DCMAKE_BUILD_TYPE=Debug"
+		shift
+	else
+		if [[ "$1" == "--scap12" ]]; then
+			scap_version="-DSSG_TARGET_SCAP_VERSION:STRING=1.2"
+			shift
+		fi
+	fi
+done
 
 cmake_enable_args=()
 for chosen_product in "$@"; do
@@ -109,5 +118,5 @@ fi
 set -e
 rm -rf build/*
 cd build
-cmake .. "${debug}" -DSSG_PRODUCT_DEFAULT=OFF "${cmake_enable_args[@]}" -G "$cmake_generator"
+cmake .. "${build_type}" "${scap_version}" -DSSG_PRODUCT_DEFAULT=OFF "${cmake_enable_args[@]}" -G "$cmake_generator"
 $build_command "-j${cores}"


### PR DESCRIPTION
#### Description:

- Add option to build SCAP content version 1.2 using `build_product` script.

#### Rationale:

- OpenSCAP versions prior to 1.3.1 are not able to consume the DS without providing `--fetch-remote-resources` option. This option provides easy way to create SCAP 1.2 content and which can be consumed by older versions of OpenSCAP.

- Relates to #4703
