### PR TITLE
Add test scenarios for sshd_set_keepalive rule

### DIFF
--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/comment.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/comment.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^ClientAliveCountMax" $SSHD_CONFIG; then
+	sed -i "s/^ClientAliveCountMax.*/# ClientAliveCountMax 0/" $SSHD_CONFIG
+else
+	echo "# ClientAliveCountMax 0" >> $SSHD_CONFIG
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/correct_value.pass.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^ClientAliveCountMax" $SSHD_CONFIG; then
+	sed -i "s/^ClientAliveCountMax.*/ClientAliveCountMax 0/" $SSHD_CONFIG
+else
+	echo "ClientAliveCountMax 0" >> $SSHD_CONFIG
+fi

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/line_not_there.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/line_not_there.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+sed -i "/^ClientAliveCountMax.*/d" /etc/ssh/sshd_config

--- a/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/wrong_value.fail.sh
+++ b/tests/data/group_services/group_ssh/group_ssh_server/rule_sshd_set_keepalive/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^ClientAliveCountMax" $SSHD_CONFIG; then
+	sed -i "s/^ClientAliveCountMax.*/ClientAliveCountMax 50/" $SSHD_CONFIG
+else
+	echo "ClientAliveCountMax 50" >> $SSHD_CONFIG
+fi


### PR DESCRIPTION
#### Description:
Create test scenarios for sshd_set_keepalive

#### Rationale:
#4709 changed value for `ClientAliveCountMax` from 3 (default value) to 0. These test scenarios ensure, that default value (3) is not valid anymore.