### PR TITLE
SSG Test suite: Add function to find remediation in the datastream.

### DIFF
--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -107,3 +107,25 @@ def find_rule_in_benchmark(datastream, benchmark_id, rule_id, logging=None):
     benchmark_node = _get_benchmark_node(datastream, benchmark_id, logging)
     rule = benchmark_node.find(".//xccdf:Rule[@id='{0}']".format(rule_id), NAMESPACES)
     return rule
+
+def find_fix_in_benchmark(datastream, benchmark_id, rule_id, fix_type='bash', logging=None):
+    """
+    Return fix from benchmark. None if not found.
+    """
+    rule = find_rule_in_benchmark(datastream, benchmark_id, rule_id, logging)
+    if rule is None:
+        return None
+
+    if fix_type == "bash":
+        system_attribute = "urn:xccdf:fix:script:sh"
+    elif fix_type == "ansible":
+        system_attribute = "urn:xccdf:fix:script:ansible"
+    elif fix_type == "puppet":
+        system_attribute = "urn:xccdf:fix:script:puppet"
+    elif fix_type == "anaconda":
+        system_attribute = "urn:xccdf:fix:script:anaconda"
+    else:
+        system_attribute = "urn:xccdf:fix:script:sh"
+
+    fix = rule.find("xccdf:fix[@system='{0}']".format(system_attribute), NAMESPACES)
+    return fix

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -123,6 +123,7 @@ def find_rule_in_benchmark(datastream, benchmark_id, rule_id, logging=None):
     rule = benchmark_node.find(".//xccdf:Rule[@id='{0}']".format(rule_id), NAMESPACES)
     return rule
 
+
 def find_fix_in_benchmark(datastream, benchmark_id, rule_id, fix_type='bash', logging=None):
     """
     Return fix from benchmark. None if not found.

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -4,11 +4,26 @@ import xml.etree.cElementTree as ET
 import logging
 
 from ssg.constants import OSCAP_RULE
+from ssg.constants import XCCDF12_NS as xccdf_ns
+from ssg.constants import datastream_namespace
+from ssg.constants import xlink_namespace
+from ssg.constants import oval_namespace as oval_ns
+from ssg.constants import bash_system as bash_rem_system
+from ssg.constants import ansible_system as ansible_rem_system
+from ssg.constants import puppet_system as puppet_rem_system
+from ssg.constants import anaconda_system as anaconda_rem_system
+
+SYSTEM_ATTRIBUTE = {
+    'bash': bash_rem_system,
+    'ansible': ansible_rem_system,
+    'puppet': puppet_rem_system,
+    'anaconda': anaconda_rem_system,
+}
 
 NAMESPACES = {
-    'xccdf': "http://checklists.nist.gov/xccdf/1.2",
-    'ds': "http://scap.nist.gov/schema/scap/source/1.2",
-    'xlink': "http://www.w3.org/1999/xlink",
+    'xccdf': xccdf_ns,
+    'ds': datastream_namespace,
+    'xlink': xlink_namespace,
 }
 
 
@@ -116,16 +131,7 @@ def find_fix_in_benchmark(datastream, benchmark_id, rule_id, fix_type='bash', lo
     if rule is None:
         return None
 
-    if fix_type == "bash":
-        system_attribute = "urn:xccdf:fix:script:sh"
-    elif fix_type == "ansible":
-        system_attribute = "urn:xccdf:fix:script:ansible"
-    elif fix_type == "puppet":
-        system_attribute = "urn:xccdf:fix:script:puppet"
-    elif fix_type == "anaconda":
-        system_attribute = "urn:xccdf:fix:script:anaconda"
-    else:
-        system_attribute = "urn:xccdf:fix:script:sh"
+    system_attribute = SYSTEM_ATTRIBUTE.get(fix_type, bash_rem_system)
 
     fix = rule.find("xccdf:fix[@system='{0}']".format(system_attribute), NAMESPACES)
     return fix


### PR DESCRIPTION
#### Description:

- Throw warning when no remediation is found in the datastream so the user
is aware of why the rule failed to remediate.

#### Rationale:

- User knows why the remediation part failed when no remediation is available.

Additional information:
- SSG Test suite log output:
```
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/ggasparb/workspace/github/content/tests/logs/rule-custom-2019-08-20-1627/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_chronyd_client_only
INFO - Script missing.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
WARNING - No remediation is available for rule 'xccdf_org.ssgproject.content_rule_chronyd_client_only'.
INFO - Script nonzero.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
WARNING - No remediation is available for rule 'xccdf_org.ssgproject.content_rule_chronyd_client_only'.
INFO - Script chrony.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp OK
```