### PR TITLE
Fix disk configuration in OSPP anaconda kickstart file.

### DIFF
--- a/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
@@ -110,16 +110,18 @@ part pv.01 --grow --size=1
 volgroup VolGroup --pesize=4096 pv.01
 
 # Create particular logical volumes (optional)
-logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=12288 --grow
-# CCE-26557-9: Ensure /home Located On Separate Partition
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=11264 --grow
+# Ensure /home Located On Separate Partition
 logvol /home --fstype=xfs --name=LogVol02 --vgname=VolGroup --size=1024 --fsoptions="nodev"
-# CCE-26435-8: Ensure /tmp Located On Separate Partition
+# Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=LogVol01 --vgname=VolGroup --size=1024 --fsoptions="nodev,noexec,nosuid"
-# CCE-26639-5: Ensure /var Located On Separate Partition
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=LogVol7 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
 logvol /var --fstype=xfs --name=LogVol03 --vgname=VolGroup --size=2048 --fsoptions="nodev"
-# CCE-26215-4: Ensure /var/log Located On Separate Partition
+# Ensure /var/log Located On Separate Partition
 logvol /var/log --fstype=xfs --name=LogVol04 --vgname=VolGroup --size=1024 --fsoptions="nodev"
-# CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
+# Ensure /var/log/audit Located On Separate Partition
 logvol /var/log/audit --fstype=xfs --name=LogVol05 --vgname=VolGroup --size=512 --fsoptions="nodev"
 logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 

--- a/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
@@ -125,7 +125,7 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 
 %addon org_fedora_oscap
         content-type = scap-security-guide
-        profile = ospp
+        profile = xccdf_org.ssgproject.content_profile_ospp
 %end
 
 # Packages selection (%packages section is required)

--- a/rhel7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
@@ -115,7 +115,7 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 
 %addon org_fedora_oscap
         content-type = scap-security-guide
-        profile = pci-dss
+        profile = xccdf_org.ssgproject.content_profile_pci-dss
 %end
 
 # Packages selection (%packages section is required)

--- a/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
@@ -107,16 +107,18 @@ part pv.01 --grow --size=1
 volgroup VolGroup --pesize=4096 pv.01
 
 # Create particular logical volumes (optional)
-logvol / --fstype=xfs --name=root --vgname=VolGroup --size=12288 --grow
-# CCE-26557-9: Ensure /home Located On Separate Partition
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=11264 --grow
+# Ensure /home Located On Separate Partition
 logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
-# CCE-26435-8: Ensure /tmp Located On Separate Partition
+# Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
-# CCE-26639-5: Ensure /var Located On Separate Partition
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
 logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048 --fsoptions="nodev"
-# CCE-26215-4: Ensure /var/log Located On Separate Partition
+# Ensure /var/log Located On Separate Partition
 logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
-# CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
+# Ensure /var/log/audit Located On Separate Partition
 logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
 logvol swap --name=swap --vgname=VolGroup --size=2016
 

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -86,18 +86,20 @@ part pv.01 --grow --size=1
 volgroup VolGroup --pesize=4096 pv.01
 
 # Create particular logical volumes (optional)
-logvol / --fstype=xfs --name=root --vgname=VolGroup --size=12288 --grow
-# CCE-26557-9: Ensure /home Located On Separate Partition
-logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
-# CCE-26639-5: Ensure /var Located On Separate Partition
-logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048 --fsoptions="nodev"
-# CCE-26215-4: Ensure /var/log Located On Separate Partition
-logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
-# CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
-logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
-# CCE-: Ensure /var/tmp Located On Separate Partition
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=11264 --grow
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
 logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
-logvol swap --name=lv_swap --vgname=VolGroup --size=2016
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
 
 # Packages selection (%packages section is required)
 %packages


### PR DESCRIPTION
#### Description:

- Fix the disk configuration to be aligned with the rules required by OSPP profile. Removed the CCEs as the are referencing CCEs from RHEL 6 and 7 versions.

#### Rationale:

- Kickstart can be properly used to install RHEL8.1 machine using OSPP profile

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740621
