### PR TITLE
Update OL8 OSPP profile

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 
 include_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Disable GNOME3's ability to give users some administrative rights.</description>
     </metadata>

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora
+prodtype: rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Disable User Administration in GNOME3'
 

--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -59,8 +59,9 @@ selections:
     - dconf_gnome_screensaver_user_info
     - dconf_gnome_screensaver_user_locks
     - dconf_gnome_session_idle_user_locks
+    - dconf_gnome_disable_user_admin
     - accounts_tmout
-    - var_accounts_tmout=10_min
+    - var_accounts_tmout=30_min
     - grub2_password
     - grub2_uefi_password
     - grub2_disable_interactive_boot

--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -205,6 +205,12 @@ selections:
     - audit_rules_etc_group_open
     - audit_rules_etc_group_openat
     - audit_rules_etc_group_open_by_handle_at
+    - audit_rules_etc_shadow_open
+    - audit_rules_etc_shadow_openat
+    - audit_rules_etc_shadow_open_by_handle_at
+    - audit_rules_etc_gshadow_open
+    - audit_rules_etc_gshadow_openat
+    - audit_rules_etc_gshadow_open_by_handle_at
     - package_abrt_removed
     - mount_option_dev_shm_nodev
     - mount_option_dev_shm_noexec


### PR DESCRIPTION
#### Description:

Updated OL8 OSPP profile rules:
- enabled and added dconf_gnome_disable_user_admin
- added audit rules for /etc/shadow /etc/gshadow
- updated var_accounts_tmout

#### Testing:
- checked OL8 build to pass
- updated rules checked to work on OL8