### PR TITLE
Fix identifiers section to have the correct name in rule sysctl_fs_protected_hardlinks.

### DIFF
--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
@@ -12,7 +12,7 @@ rationale: |-
 
 severity: unknown
 
-references:
+identifiers:
    cce@rhel6: 81025-9
    cce@rhel7: 81026-7
    cce@rhel8: 81027-5


### PR DESCRIPTION
#### Description:

- Fix identifiers section in `sysctl_fs_protected_hardlinks` rule to have the correct name.

#### Rationale:

- Even though it is a valid attribute of a rule it doesn't processed correctly the identifiers, therefore we should have it as `identifiers` instead.
