### PR TITLE
The use of ed25519 is disabled via HostKeyAlgorithms in FIPS crypto policy.

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -996,9 +996,6 @@ selections:
     ## Setup SSH Server
     #################################################################
 
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4466
-    #sed -i "/ed25519/s/HostKey/#HostKey/" $CONFIG
-
     ## Force frequent session key renegotiation
     - sshd_rekey_limit
 


### PR DESCRIPTION
#### Description:

- No need to control the use of keys based on key filenames.

#### Rationale:

- The use of ed25519 is disabled via HostKeyAlgorithms in FIPS crypto policy.
