### PR TITLE
Fix STIG IDs reference processing

### DIFF
--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -176,7 +176,7 @@
                 <xsl:attribute name="system">
                   <xsl:value-of select="$disa-stigs-uri" />
                 </xsl:attribute>
-                <xsl:value-of select="concat(stigid-concat, .)" />
+                <xsl:value-of select="." />
               </xsl:when>
               <xsl:when test="name() = 'custom-cce'">
                 <xsl:attribute name="system">
@@ -341,18 +341,11 @@
           </xsl:if>
         </xsl:attribute>
         <xsl:choose>
-          <xsl:when test="name() = 'stigid'">
-            <xsl:value-of select="normalize-space(concat(stigid-concat, $refitem))" />
+          <xsl:when test="name() = 'disa'">
+            <xsl:value-of select='format-number($refitem, "CCI-000000")' />
           </xsl:when>
           <xsl:otherwise>
-            <xsl:choose>
-              <xsl:when test="name() = 'disa'">
-                <xsl:value-of select='format-number($refitem, "CCI-000000")' />
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="normalize-space($refitem)" />
-              </xsl:otherwise>
-            </xsl:choose>
+            <xsl:value-of select="normalize-space($refitem)" />
           </xsl:otherwise>
         </xsl:choose>
       </reference>

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -683,17 +683,15 @@ class Rule(object):
         return rule
 
     def _make_stigid_product_specific(self, product):
+        stig_id = self.references.get("stigid", None)
+        if not stig_id:
+            return
+        if "," in stig_id:
+            raise ValueError("Rules can not have multiple STIG IDs.")
         stig_platform_id = STIG_PLATFORM_ID_MAP.get(product, product.upper())
-        stig_ids = self.references.get("stigid", None)
-        if stig_ids:
-            references = []
-            for val in stig_ids.split(","):
-                references.append(
-                    "{platform_id}-{stig_id}".format(
-                        platform_id=stig_platform_id, stig_id=val,
-                    )
-                )
-            self.references["stigid"] = ",".join(references)
+        product_specific_stig_id = "{platform_id}-{stig_id}".format(
+            platform_id=stig_platform_id, stig_id=stig_id)
+        self.references["stigid"] = product_specific_stig_id
 
     def normalize(self, product):
         try:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -684,12 +684,16 @@ class Rule(object):
 
     def _make_stigid_product_specific(self, product):
         stig_platform_id = STIG_PLATFORM_ID_MAP.get(product, product.upper())
-        for ref, val in self.references.items():
-            if ref == "stigid":
-                if stig_platform_id and not val.startswith(stig_platform_id):
-                    self.references[ref] = "{platform_id}-{stig_id}".format(
+        stig_ids = self.references.get("stigid", None)
+        if stig_ids:
+            references = []
+            for val in stig_ids.split(","):
+                references.append(
+                    "{platform_id}-{stig_id}".format(
                         platform_id=stig_platform_id, stig_id=val,
                     )
+                )
+            self.references["stigid"] = ",".join(references)
 
     def normalize(self, product):
         try:

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -78,3 +78,10 @@ def test_make_items_product_specific():
     rule.make_refs_and_identifiers_product_specific("rhel6")
     assert rule.references["stigid"] == "RHEL-06-000237"
     assert "stigid@rhel6" not in rule.references
+
+    rule.references = {
+        "stigid@rhel6": "000237",
+        "stigid@rhel7": "040370,057364",
+    }
+    with pytest.raises(ValueError, match="Rules can not have multiple STIG IDs."):
+        rule.make_refs_and_identifiers_product_specific("rhel7")

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -56,7 +56,7 @@ def test_make_items_product_specific():
     assert rule.identifiers["cce"] == "27445-6"
 
     rule.references = {
-        "stigid@rhel6": "RHEL-06-000237",
+        "stigid@rhel6": "000237",
         "stigid@rhel7": "040370",
         "stigid": "tralala",
     }
@@ -65,14 +65,14 @@ def test_make_items_product_specific():
     assert "stigid" in str(exc)
 
     rule.references = {
-        "stigid@rhel6": "RHEL-06-000237",
+        "stigid@rhel6": "000237",
         "stigid@rhel7": "040370",
     }
     rule.make_refs_and_identifiers_product_specific("rhel7")
     assert rule.references["stigid"] == "RHEL-07-040370"
 
     rule.references = {
-        "stigid@rhel6": "RHEL-06-000237",
+        "stigid@rhel6": "000237",
         "stigid@rhel7": "040370",
     }
     rule.make_refs_and_identifiers_product_specific("rhel6")


### PR DESCRIPTION
#### Description:

This PR ~allows to assign a rule multiple STIG IDs using a comma-separated list which is the same way we use for the other references.~ prevents people from  assigning a rule multiple STIG IDs using a comma-separated list because a rule can have only 1 STIG ID. 

There were 2 basic problems:
1. Python code converting YAML to shorthand was not splitting the string at comma. 
2. XSLT template that converts shorhand to XCCDF had a special treatment for STIG IDs which always copies the whole attribute value instead of each identifier which lead to duplicate `reference` elements.

Note: there was some `stigid-concat` which I can't find anywhere and it seems to be evaluated as empty string which means result of concatenating it with any string is that string.


#### Rationale:
In https://github.com/ComplianceAsCode/content/pull/4706 we encountered that using a comma separated list for RHEL7 STIG ID doesn't work.
