### PR TITLE
Set login banner message to /etc/issue in RHEL8 OSPP profile.

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -1222,3 +1222,13 @@ selections:
 
     ## Enable dnf-automatic Timer
     - timer_dnf-automatic_enabled
+
+    #################################################################
+    ## Login Banner
+    #################################################################
+
+    ## Login banner text
+    - login_banner_text=usgcb_default
+
+    ## Set login banner text to /etc/issue file
+    - banner_etc_issue

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -1228,7 +1228,7 @@ selections:
     #################################################################
 
     ## Login banner text
-    - login_banner_text=usgcb_default
+    - login_banner_text=dod_default
 
     ## Set login banner text to /etc/issue file
     - banner_etc_issue


### PR DESCRIPTION
#### Description:

- Set login banner message to /etc/issue in RHEL8 OSPP profile. This banner is consumed by rule sshd_enable_warning_banner.

#### Rationale:

- Unless the banner message is set to /etc/issue, SSH logins will show default message from `issue` file:
```
\S
Kernel \r on an \m

```
