### PR TITLE
Document building SCAP 1.2 content instead of SCAP 1.3

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -212,7 +212,7 @@ If you want to go deeper into statistics, refer to <<Profile Statistics and Util
 
 By default, the build system builds SCAP content conforming to SCAP version 1.3. It is possible to build SCAP 1.2 content instead.
 
-If you use `build-product` script, pass `--scap12` option to build SCAP 1.2 content:
+If you use `build_product` script, pass `--scap12` option to build SCAP 1.2 content:
 
 ```bash
 ./build_product --scap12 <product-name>

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -226,6 +226,14 @@ cmake -DSSG_TARGET_SCAP_VERSION:STRING=1.2 ../
 make
 ```
 
+As of SCAP specification, SCAP 1.3 content contains OVAL 5.11 and SCAP 1.2 content content contains OVAL 5.10 checks.
+You can change the OVAL version using CMake variables `SSG_TARGET_OVAL_MAJOR_VERSION` and `SSG_TARGET_OVAL_MINOR_VERSION`.
+For example, to build a non-standard SCAP 1.2 datastream which would contain OVAL 5.11 checks, modify the `cmake` command in the following way:
+
+```bash
+cmake -DSSG_TARGET_OVAL_MINOR_VERSION:STRING=11 -DSSG_TARGET_SCAP_VERSION:STRING=1.2 ../
+```
+
 ### Build outputs
 
 When the build has completed, the output will be in the build folder.

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -208,6 +208,24 @@ make -j4 html-profile-stats # create statistics for all profiles in all products
 
 If you want to go deeper into statistics, refer to <<Profile Statistics and Utilities>> section.
 
+#### Building SCAP 1.2 content
+
+By default, the build system builds SCAP content conforming to SCAP version 1.3. It is possible to build SCAP 1.2 content instead.
+
+If you use `build-product` script, pass `--scap12` option to build SCAP 1.2 content:
+
+```bash
+./build_product --scap12 <product-name>
+```
+
+If you use `cmake` command, pass `-DSSG_TARGET_SCAP_VERSION:STRING=1.2` option to build SCAP 1.2 content:
+
+```bash
+cd build/
+cmake -DSSG_TARGET_SCAP_VERSION:STRING=1.2 ../
+make
+```
+
 ### Build outputs
 
 When the build has completed, the output will be in the build folder.


### PR DESCRIPTION
Recently we have switched to building SCAP 1.3 by default.
We still can build SCAP 1.2. This patch adds documentation
describing building SCAP 1.2 content.
