### PR TITLE
Adding SELinux rules into OSPP profile

### DIFF
--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -184,3 +184,14 @@ selections:
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_local_packages
     - ensure_gpgcheck_never_disabled
+
+    ###  SELinux Configuration
+
+    # Ensure SELinux is Enforcing
+    - var_selinux_state=enforcing
+    - selinux_state
+
+    # Configure SELinux Policy
+    - var_selinux_policy_name=targeted
+    - selinux_policytype
+


### PR DESCRIPTION
Basic expectation that SELinux is in enforcing, and policy is set to
targeted should be part of the profile.
