### PR TITLE
Add syslog_files rules test scenarios

### DIFF
--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rsyslog_log_utils.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rsyslog_log_utils.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+RSYSLOG_CONF='/etc/rsyslog.conf'
+LOG_FILE_PREFIX=test
+RSYSLOG_TEST_DIR=/tmp
+declare -a RSYSLOG_TEST_LOGS
+
+# This function creates test rsyslog log files
+# Parameters: $1 - number of log files to be created
+function create_rsyslog_test_logs {
+        local count=$1
+
+        RSYSLOG_TEST_DIR=$(mktemp -d)
+        RSYSLOG_TEST_LOGS=()
+
+        if [ $? -ne 0 ]; then
+            echo "Failed to create RSYSLOG_TEST_DIR"
+            exit 1
+        fi
+
+        if ! [[ "$count" =~ ^[0-9]+$ ]] || [ $count -eq 0 ]; then
+            echo "Argument 'count' is not a positive number: $count"
+            exit 1
+        fi
+
+        for ind in $(seq 1 $count); do
+            local testlog=${RSYSLOG_TEST_DIR}/${LOG_FILE_PREFIX}${ind}.log
+            touch ${testlog}
+            RSYSLOG_TEST_LOGS+=("${testlog}")
+        done;
+}

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/IncludeConfig_is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/IncludeConfig_is_other.fail.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with root group-owner log from rules and
+# non root group-owner log from $IncludeConfig fails.
+
+source ../rsyslog_log_utils.sh
+
+GROUP_TEST=testssg
+groupadd $GROUP_TEST
+
+GROUP_ROOT=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chgrp $GROUP_ROOT ${RSYSLOG_TEST_LOGS[0]}
+chgrp $GROUP_TEST ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*      ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${test_conf}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/IncludeConfig_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/IncludeConfig_is_root.pass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with root group-owner log from rules and
+# root group-owner log from $IncludeConfig passes.
+
+source ../rsyslog_log_utils.sh
+
+GROUP=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[0]}
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${test_conf}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_other.fail.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root group-owner log from rules and
+# non root group-owner log from include() fails.
+
+source ../rsyslog_log_utils.sh
+
+GROUP_TEST=testssg
+groupadd $GROUP_TEST
+
+GROUP_ROOT=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chgrp $GROUP_ROOT ${RSYSLOG_TEST_LOGS[0]}
+chgrp $GROUP_TEST ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*      ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_root.pass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root group-owner log from rules and
+# root group-owner log from include() passes.
+
+source ../rsyslog_log_utils.sh
+
+GROUP=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[0]}
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_root_IncludeConfig_is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_root_IncludeConfig_is_other.fail.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root group-owner log from rules and
+# non root group-owner log from include() fails.
+
+source ../rsyslog_log_utils.sh
+
+GROUP_ROOT=root
+
+GROUP_TEST=testssg
+groupadd $GROUP_TEST
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files ownership
+chgrp $GROUP_ROOT ${RSYSLOG_TEST_LOGS[0]}
+chgrp $GROUP_ROOT ${RSYSLOG_TEST_LOGS[1]}
+chgrp $GROUP_TEST ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create test2 configuration file
+test_conf2=${RSYSLOG_TEST_DIR}/test2.conf
+cat << EOF > ${test_conf2}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+
+\$IncludeConfig ${test_conf2}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_root_IncludeConfig_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_is_root_IncludeConfig_is_root.pass.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root group-owner log from rules and
+# root group-owner log from include() passes.
+
+source ../rsyslog_log_utils.sh
+
+GROUP=root
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files ownership
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[0]}
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[1]}
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create test2 configuration file
+test_conf2=${RSYSLOG_TEST_DIR}/test2.conf
+cat << EOF > ${test_conf2}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+
+\$IncludeConfig ${test_conf2}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_multiline_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/include_multiline_is_root.pass.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root group-owner log from rules and
+# root group-owner log from multiline include() passes.
+
+source ../rsyslog_log_utils.sh
+
+GROUP=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[0]}
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(
+   file="${test_conf}"
+)
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/is_other.fail.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check if log file with non root group-owner in rsyslog.conf fails.
+
+source ../rsyslog_log_utils.sh
+
+GROUP=testssg
+
+groupadd $GROUP
+
+# setup test data
+create_rsyslog_test_logs 1
+
+# setup test log file ownership
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[0]}
+
+# add rule with non-root group owned log file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_groupownership/is_root.pass.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check if log file with root group-owner in rsyslog.conf passes.
+
+source ../rsyslog_log_utils.sh
+
+GROUP=root
+
+# setup test data
+create_rsyslog_test_logs 1
+
+# setup test log file ownership
+chgrp $GROUP ${RSYSLOG_TEST_LOGS[0]}
+
+# add rule with root group owned log file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*        ${RSYSLOG_TEST_LOGS[0]}
+
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/IncludeConfig_is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/IncludeConfig_is_other.fail.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with root user log from rules and
+# non root user log from $IncludeConfig fails.
+
+source ../rsyslog_log_utils.sh
+
+USER_TEST=testssg
+useradd $USER_TEST
+
+USER_ROOT=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chown $USER_ROOT ${RSYSLOG_TEST_LOGS[0]}
+chown $USER_TEST ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*      ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${test_conf}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/IncludeConfig_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/IncludeConfig_is_root.pass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with root user log from rules and
+# root user log from $IncludeConfig passes.
+
+source ../rsyslog_log_utils.sh
+
+USER=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chown $USER ${RSYSLOG_TEST_LOGS[0]}
+chown $USER ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${test_conf}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_other.fail.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root user log from rules and
+# non root user log from include() fails.
+
+source ../rsyslog_log_utils.sh
+
+USER_TEST=testssg
+useradd $USER_TEST
+
+USER_ROOT=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chown $USER_ROOT ${RSYSLOG_TEST_LOGS[0]}
+chown $USER_TEST ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*      ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_root.pass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root user log from rules and
+# root user log from include() passes.
+
+source ../rsyslog_log_utils.sh
+
+USER=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chown $USER ${RSYSLOG_TEST_LOGS[0]}
+chown $USER ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_root_IncludeConfig_is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_root_IncludeConfig_is_other.fail.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root user log from rules and
+# non root user log from include() fails.
+
+source ../rsyslog_log_utils.sh
+
+USER_ROOT=root
+
+USER_TEST=testssg
+useradd $USER_TEST
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files ownership
+chown $USER_ROOT ${RSYSLOG_TEST_LOGS[0]}
+chown $USER_ROOT ${RSYSLOG_TEST_LOGS[1]}
+chown $USER_TEST ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create test2 configuration file
+test_conf2=${RSYSLOG_TEST_DIR}/test2.conf
+cat << EOF > ${test_conf2}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+
+\$IncludeConfig ${test_conf2}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_root_IncludeConfig_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_is_root_IncludeConfig_is_root.pass.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root user log from rules and
+# root user log from include() passes.
+
+source ../rsyslog_log_utils.sh
+
+USER=root
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files ownership
+chown $USER ${RSYSLOG_TEST_LOGS[0]}
+chown $USER ${RSYSLOG_TEST_LOGS[1]}
+chown $USER ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create test2 configuration file
+test_conf2=${RSYSLOG_TEST_DIR}/test2.conf
+cat << EOF > ${test_conf2}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+
+\$IncludeConfig ${test_conf2}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_multiline_is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/include_multiline_is_root.pass.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with root user log from rules and
+# root user log from multiline include() passes.
+
+source ../rsyslog_log_utils.sh
+
+USER=root
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files ownership
+chown $USER ${RSYSLOG_TEST_LOGS[0]}
+chown $USER ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(
+   file="${test_conf}"
+)
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/is_other.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/is_other.fail.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check if log file with non root user in rsyslog.conf fails.
+
+source ../rsyslog_log_utils.sh
+
+USER=testssg
+
+useradd $USER
+
+# setup test data
+create_rsyslog_test_logs 1
+
+# setup test log file ownership
+chown $USER ${RSYSLOG_TEST_LOGS[0]}
+
+# add rule with non-root user owned log file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/is_root.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_ownership/is_root.pass.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check if log file with root user in rsyslog.conf passes.
+
+source ../rsyslog_log_utils.sh
+
+USER=root
+
+# setup test data
+create_rsyslog_test_logs 1
+
+# setup test log file ownership
+chown $USER ${RSYSLOG_TEST_LOGS[0]}
+
+# add rule with root user owned log file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*        ${RSYSLOG_TEST_LOGS[0]}
+
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/IncludeConfig_perms_0600.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/IncludeConfig_perms_0600.pass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0600 from $IncludeConfig passes.
+
+source ../rsyslog_log_utils.sh
+
+PERMS=0600
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${test_conf}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/IncludeConfig_perms_0601.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/IncludeConfig_perms_0601.fail.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0601 from $IncludeConfig fails.
+
+source ../rsyslog_log_utils.sh
+
+PERMS_PASS=0600
+PERMS_FAIL=0601
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*      ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${test_conf}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_multiline_perms_0600.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_multiline_perms_0600.pass.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0600 from multiline include() passes.
+
+source ../rsyslog_log_utils.sh
+
+PERMS=0600
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(
+   file="${test_conf}"
+)
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0600.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0600.pass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0600 from include() passes.
+
+source ../rsyslog_log_utils.sh
+
+PERMS=0600
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0600_IncludeConfig_perms_0600.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0600_IncludeConfig_perms_0600.pass.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with log file permisssions 0600 from rules and
+# log file permissions 0600 from include() passes.
+
+source ../rsyslog_log_utils.sh
+
+PERMS_PASS=0600
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files and permissions
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[1]}
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create test2 configuration file
+test_conf2=${RSYSLOG_TEST_DIR}/test2.conf
+cat << EOF > ${test_conf2}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+
+\$IncludeConfig ${test_conf2}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0600_IncludeConfig_perms_0601.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0600_IncludeConfig_perms_0601.fail.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with log file permisssions 0600 from rules and
+# log file permissions 0601 from include() fails.
+
+source ../rsyslog_log_utils.sh
+
+PERMS_PASS=0600
+PERMS_FAIL=0601
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files and permissions
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[1]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create test2 configuration file
+test_conf2=${RSYSLOG_TEST_DIR}/test2.conf
+cat << EOF > ${test_conf2}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+
+\$IncludeConfig ${test_conf2}
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0601.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/include_perms_0601.fail.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0601 from include() fails.
+
+source ../rsyslog_log_utils.sh
+
+PERMS_FAIL=0601
+
+PERMS_PASS=0600
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*      ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${test_conf}")
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/perms_0600.pass.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/perms_0600.pass.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check if log file with permissions 0600 in rsyslog.conf passes.
+
+source ../rsyslog_log_utils.sh
+
+PERMS=0600
+
+# setup test data
+create_rsyslog_test_logs 1
+
+# setup test log file and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+
+# add rule with 0600 permissions log file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*        ${RSYSLOG_TEST_LOGS[0]}
+
+EOF

--- a/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/perms_0601.fail.sh
+++ b/tests/data/group_system/group_logging/group_ensure_rsyslog_log_file_configuration/rule_rsyslog_files_permissions/perms_0601.fail.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check if log file with permissions 0601 in rsyslog.conf fails.
+
+source ../rsyslog_log_utils.sh
+
+PERMS=0601
+
+# setup test data
+create_rsyslog_test_logs 1
+
+# setup test log file and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+
+# add rule with 0601 permissions log file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+EOF


### PR DESCRIPTION
#### Description:
In order to get  #4379 verified introduced test scenarios for rsyslog_files_* rules.
Test scenarios check include log rules, include() object (rsyslog v8.33.0+: RHEL8, OL8, Fedora) and $IncludeConfig directive.

Added tests for rules:
- rsyslog_files_groupownership
- rsyslog_files_ownership
- rsyslog_files_permissions

#### Testing:
- Checked ol, rhel, and fedora builds to pass
- Using OL7.6 VM libvirt backend checked scenarios to pass
- Verified corresponding DEBUG "*-initial.verbose.log" logs for OVAL definitions to filter and check expected test configs and log files.