### PR TITLE
Prevent failures of Ansible task for service_enabled and timer_enabled

### DIFF
--- a/shared/templates/create_services_enabled.py
+++ b/shared/templates/create_services_enabled.py
@@ -49,6 +49,7 @@ class ServiceEnabledGenerator(FilesGenerator):
                 "./template_ANSIBLE_service_enabled",
                 {
                     "SERVICENAME": servicename,
+                    "PACKAGENAME": packagename,
                     "DAEMONNAME": daemonname
                 },
                 "./ansible/service_{0}_enabled.yml", servicename

--- a/shared/templates/create_timers_enabled.py
+++ b/shared/templates/create_timers_enabled.py
@@ -43,7 +43,8 @@ class TimerEnabledGenerator(FilesGenerator):
             self.file_from_template(
                 "./template_ANSIBLE_timer_enabled",
                 {
-                    "TIMERNAME": timername
+                    "TIMERNAME": timername,
+                    "PACKAGENAME": packagename
                 },
                 "./ansible/timer_{0}_enabled.yml", timername
             )

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -5,7 +5,7 @@
 # disruption = low
 - name: Enable service {{{ SERVICENAME }}}
   block:
-  - name: Gather the rpm package facts
+  - name: Gather the package facts
     package_facts:
       manager: auto
 

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -5,17 +5,14 @@
 # disruption = low
 - name: Enable service {{{ SERVICENAME }}}
   block:
-  - name: Check if {{{ PACKAGENAME }}} is installed
-    package:
-      name: {{{ PACKAGENAME }}}
-      state: present
-    check_mode: true
-    register: pkg
+  - name: Gather the rpm package facts
+    package_facts:
+      manager: auto
+
   - name: Enable service {{{ SERVICENAME }}}
     service:
       name: "{{{ DAEMONNAME }}}"
       enabled: "yes"
       state: "started"
-    # package would be installed if package module was not run in check mode
-    when: not pkg.changed
-
+    when: |-
+      '{{{ PACKAGENAME }}}' in ansible_facts.packages

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -14,5 +14,5 @@
       name: "{{{ DAEMONNAME }}}"
       enabled: "yes"
       state: "started"
-    when: |-
-      '{{{ PACKAGENAME }}}' in ansible_facts.packages
+    when:
+    - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'

--- a/shared/templates/template_ANSIBLE_service_enabled
+++ b/shared/templates/template_ANSIBLE_service_enabled
@@ -4,8 +4,18 @@
 # complexity = low
 # disruption = low
 - name: Enable service {{{ SERVICENAME }}}
-  service:
-    name: "{{{ DAEMONNAME }}}"
-    enabled: "yes"
-    state: "started"
+  block:
+  - name: Check if {{{ PACKAGENAME }}} is installed
+    package:
+      name: {{{ PACKAGENAME }}}
+      state: present
+    check_mode: true
+    register: pkg
+  - name: Enable service {{{ SERVICENAME }}}
+    service:
+      name: "{{{ DAEMONNAME }}}"
+      enabled: "yes"
+      state: "started"
+    # package would be installed if package module was not run in check mode
+    when: not pkg.changed
 

--- a/shared/templates/template_ANSIBLE_timer_enabled
+++ b/shared/templates/template_ANSIBLE_timer_enabled
@@ -4,8 +4,15 @@
 # complexity = low
 # disruption = low
 - name: Enable timer {{{ TIMERNAME }}}
-  systemd:
-    name: "{{{ TIMERNAME }}}.timer"
-    enabled: "yes"
-    state: "started"
+  block:
+  - name: Gather the rpm package facts
+    package_facts:
+      manager: auto
+  - name: Enable timer {{{ TIMERNAME }}}
+    systemd:
+      name: "{{{ TIMERNAME }}}.timer"
+      enabled: "yes"
+      state: "started"
+    when: |-
+      '{{{ PACKAGENAME }}}' in ansible_facts.packages
 

--- a/shared/templates/template_ANSIBLE_timer_enabled
+++ b/shared/templates/template_ANSIBLE_timer_enabled
@@ -8,11 +8,12 @@
   - name: Gather the package facts
     package_facts:
       manager: auto
+
   - name: Enable timer {{{ TIMERNAME }}}
     systemd:
       name: "{{{ TIMERNAME }}}.timer"
       enabled: "yes"
       state: "started"
-    when: |-
-      '{{{ PACKAGENAME }}}' in ansible_facts.packages
+    when:
+    - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'
 

--- a/shared/templates/template_ANSIBLE_timer_enabled
+++ b/shared/templates/template_ANSIBLE_timer_enabled
@@ -5,7 +5,7 @@
 # disruption = low
 - name: Enable timer {{{ TIMERNAME }}}
   block:
-  - name: Gather the rpm package facts
+  - name: Gather the package facts
     package_facts:
       manager: auto
   - name: Enable timer {{{ TIMERNAME }}}


### PR DESCRIPTION
#### Description:
If the package which provides the service or timer is not present the Ansible task that enables the service or timer will fail because it can not find the unit file which will cause termination of the whole playbook. We can prevent the failure by executing the task only if the given package is present. The code uses Ansible package_facts module to determine if package is present.

#### Rationale:

Partially fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1741455

Addressing:
```
TASK [Enable service fapolicyd] ************************************************
fatal: [192.168.122.24]: FAILED! => {"changed": false, "msg": "Could not find the requested service fapolicyd: host"}
```