### PR TITLE
Add suport for rule refinement

### DIFF
--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -70,9 +70,9 @@ def main():
 
         profiles = loader.loaded_group.profiles
         for p in profiles:
-            p.validate_refine_rules(loader.all_rules)
             p.validate_variables(loader.all_values)
             p.validate_rules(loader.all_rules, loader.all_groups)
+            p.validate_refine_rules(loader.all_rules)
 
         loader.export_group_to_file(args.output)
     elif args.action == "list-inputs":

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -70,6 +70,7 @@ def main():
 
         profiles = loader.loaded_group.profiles
         for p in profiles:
+            p.validate_refine_rules(loader.all_rules)
             p.validate_variables(loader.all_values)
             p.validate_rules(loader.all_rules, loader.all_groups)
 

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -433,6 +433,7 @@ selections:
 
     ## Disable the use of user namespaces
     - sysctl_user_max_user_namespaces
+    - sysctl_user_max_user_namespaces.role=unscored
 
     ## Disable Access to Network bpf() Syscall From Unprivileged Processes
     - sysctl_kernel_unprivileged_bpf_disabled

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -434,6 +434,7 @@ selections:
     ## Disable the use of user namespaces
     - sysctl_user_max_user_namespaces
     - sysctl_user_max_user_namespaces.role=unscored
+    - sysctl_user_max_user_namespaces.severity=info
 
     ## Disable Access to Network bpf() Syscall From Unprivileged Processes
     - sysctl_kernel_unprivileged_bpf_disabled

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -196,10 +196,11 @@ class Profile(object):
     def validate_refine_rules(self, rules):
         existing_rule_ids = [r.id_ for r in rules]
         for refine_rule, refinement_list in self.refine_rules.items():
+            # Take first refinement to ilustrate where the error is
+            # all refinements in list are invalid, so it doesn't really matter
+            a_refinement = refinement_list[0]
+
             if refine_rule not in existing_rule_ids:
-                # Take first refinement to ilustrate where the error is
-                # all refinements in list are invalid, so it doesn't really matter
-                a_refinement = refinement_list[0]
                 msg = (
                     "You are trying to refine a rule that doesn't exist. "
                     "Rule '{rule_id}' was not found in the benchmark. "
@@ -207,8 +208,16 @@ class Profile(object):
                     "- {rule_id}.{property_}={value}' in profile {profile_id}."
                     .format(rule_id=refine_rule, profile_id=self.id_,
                             property_=a_refinement[0], value=a_refinement[1])
+                    )
+                raise ValueError(msg)
 
-                )
+            if refine_rule not in self.get_rule_selectors():
+                msg = ("- {rule_id}.{property_}={value}' in profile '{profile_id}' is refining "
+                       "a rule that is not selected by it. The refinement will not have any "
+                       "noticeable effect. Either select the rule or remove the rule refinement."
+                       .format(rule_id=refine_rule, property_=a_refinement[0],
+                               value=a_refinement[1], profile_id=self.id_)
+                       )
                 raise ValueError(msg)
 
     def validate_variables(self, variables):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -12,6 +12,7 @@ import yaml
 from .constants import XCCDF_PLATFORM_TO_CPE
 from .constants import PRODUCT_TO_CPE_MAPPING
 from .constants import STIG_PLATFORM_ID_MAP
+from .constants import XCCDF_REFINABLE_PROPERTIES
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 from .rule_yaml import parse_prodtype
 
@@ -132,6 +133,14 @@ class Profile(object):
             if "." in item:
                 rule, refinement = item.split(".", 1)
                 property_, value = refinement.split("=", 1)
+                if property_ not in XCCDF_REFINABLE_PROPERTIES:
+                    msg = ("Property '{property_}' cannot be refined. "
+                           "Rule properties that can be refined are {refinables}. "
+                           "Fix refinement '{rule_id}.{property_}={value}' in profile '{profile}'."
+                           .format(property_=property_, refinables=XCCDF_REFINABLE_PROPERTIES,
+                                   rule_id=rule, value=value, profile=self.id_)
+                           )
+                    raise ValueError(msg)
                 self.refine_rules[rule].append((property_, value))
             elif "=" in item:
                 varname, value = item.split("=", 1)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -81,6 +81,7 @@ class Profile(object):
         self.selected = []
         self.unselected = []
         self.variables = dict()
+        self.refine_rules = dict()
 
     @staticmethod
     def from_yaml(yaml_file, env_yaml=None):
@@ -127,7 +128,11 @@ class Profile(object):
 
     def _parse_selections(self, entries):
         for item in entries:
-            if "=" in item:
+            if "." in item:
+                rule, refinement = item.split(".", 1)
+                property_, value = refinement.split("=", 1)
+                self.refine_rules[rule] = (property_, value)
+            elif "=" in item:
                 varname, value = item.split("=", 1)
                 self.variables[varname] = value
             elif item.startswith("!"):
@@ -162,6 +167,12 @@ class Profile(object):
             refine_value.set("idref", value_id)
             refine_value.set("selector", selector)
             element.append(refine_value)
+
+        for refined_rule, refinement in self.refine_rules.items():
+            refine_rule = ET.Element("refine-rule")
+            refine_rule.set("idref", refined_rule)
+            refine_rule.set(refinement[0], refinement[1])
+            element.append(refine_rule)
 
         return element
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import os
 import os.path
+from collections import defaultdict
 import datetime
 import sys
 
@@ -81,7 +82,7 @@ class Profile(object):
         self.selected = []
         self.unselected = []
         self.variables = dict()
-        self.refine_rules = dict()
+        self.refine_rules = defaultdict(list)
 
     @staticmethod
     def from_yaml(yaml_file, env_yaml=None):
@@ -131,7 +132,7 @@ class Profile(object):
             if "." in item:
                 rule, refinement = item.split(".", 1)
                 property_, value = refinement.split("=", 1)
-                self.refine_rules[rule] = (property_, value)
+                self.refine_rules[rule].append((property_, value))
             elif "=" in item:
                 varname, value = item.split("=", 1)
                 self.variables[varname] = value
@@ -168,10 +169,11 @@ class Profile(object):
             refine_value.set("selector", selector)
             element.append(refine_value)
 
-        for refined_rule, refinement in self.refine_rules.items():
+        for refined_rule, refinement_list in self.refine_rules.items():
             refine_rule = ET.Element("refine-rule")
             refine_rule.set("idref", refined_rule)
-            refine_rule.set(refinement[0], refinement[1])
+            for refinement in refinement_list:
+                refine_rule.set(refinement[0], refinement[1])
             element.append(refine_rule)
 
         return element

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -184,6 +184,24 @@ class Profile(object):
     def get_variable_selectors(self):
         return self.variables
 
+    def validate_refine_rules(self, rules):
+        existing_rule_ids = [r.id_ for r in rules]
+        for refine_rule, refinement_list in self.refine_rules.items():
+            if refine_rule not in existing_rule_ids:
+                # Take first refinement to ilustrate where the error is
+                # all refinements in list are invalid, so it doesn't really matter
+                a_refinement = refinement_list[0]
+                msg = (
+                    "You are trying to refine a rule that doesn't exist. "
+                    "Rule '{rule_id}' was not found in the benchmark. "
+                    "Please check all rule refinements for rule: '{rule_id}', for example: "
+                    "- {rule_id}.{property_}={value}' in profile {profile_id}."
+                    .format(rule_id=refine_rule, profile_id=self.id_,
+                            property_=a_refinement[0], value=a_refinement[1])
+
+                )
+                raise ValueError(msg)
+
     def validate_variables(self, variables):
         variables_by_id = dict()
         for var in variables:

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -358,6 +358,8 @@ SL_NOTICE = \
     ".</p>" \
     "</div>"
 
+XCCDF_REFINABLE_PROPERTIES = ["weight", "severity", "role", "selector"]
+
 OVAL_TO_XCCDF_DATATYPE_CONSTRAINTS = {
     'int': 'number',
     'float': 'number',


### PR DESCRIPTION
#### Description:

- Implement support for `xccdf:refine-rule`
  - Allows `weight`, `role` and `severity` of a rule to be modified on Profile basis.
- Syntax is: `- rule_id.property=value`
  - Usage is illustrated by rule `sysctl_user_max_user_namespaces` in `ospp` profile.

#### Rationale:
- Optional rules in `ospp` profile can be in the Benchmark as `role=unscored` and its evaluation results will not affect result of evaluation. Rule will be reported as "information"
- `severity=info` is set just for consistency, `role=unscored` is enough to make rule totally informational.
- `informational` rules are never fixed by OpenSCAP
- Kind of expected caveat, all profiles extending `ospp` profile that would like to use the rule "for real" will have to refine the rule again.
  - For example, profile `cui`, also ended up with rule `sysctl_user_max_user_namespaces` as informational.

Report for informational rule:
- Report when evaluation fails: [unscored_report.html.txt](https://github.com/ComplianceAsCode/content/files/3522793/unscored_report.html.txt)
- Report when evaluation passes: [unscored_report_pass.html.txt](https://github.com/ComplianceAsCode/content/files/3522807/unscored_report_pass.html.txt)

I recommend to remove `.txt` extension before pointing your favorite HTML reader to it.

