### PR TITLE
Remove remaining CCE identifiers from RHEL derivatives.

### DIFF
--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -90,6 +90,7 @@ def main():
     # the vendor/OS.
     ssg.build_derivatives.remove_idents(root, XCCDF11_NS)
     ssg.build_derivatives.remove_idents(root, XCCDF12_NS)
+    ssg.build_derivatives.remove_cce_reference(root, oval_ns)
 
     if len(benchmarks) == 0:
         raise RuntimeError("No Benchmark found!")

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -108,6 +108,17 @@ def remove_idents(tree_root, namespace, prod="RHEL"):
                 fix.text = re.sub(r"CCE-[0-9]*-[0-9]*", "", fix.text)
 
 
+def remove_cce_reference(tree_root, namespace, prod="RHEL"):
+    """
+    Remove CCE identifiers from OVAL checks in XML tree
+    """
+    for definition in tree_root.findall(".//{%s}definition" % (namespace)):
+        for metadata in definition.findall(".//{%s}metadata" % (namespace)):
+            for ref in metadata.findall(".//{%s}reference" % (namespace)):
+                if (re.search(r'CCE-*', ref.get("ref_id"))):
+                    metadata.remove(ref)
+
+
 def profile_handling(tree_root, namespace):
     ns_profiles = []
     for i in standard_profiles:

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -108,7 +108,7 @@ def remove_idents(tree_root, namespace, prod="RHEL"):
                 fix.text = re.sub(r"CCE-[0-9]*-[0-9]*", "", fix.text)
 
 
-def remove_cce_reference(tree_root, namespace, prod="RHEL"):
+def remove_cce_reference(tree_root, namespace):
     """
     Remove CCE identifiers from OVAL checks in XML tree
     """


### PR DESCRIPTION
#### Description:

- Remove remaining CCE identifier references from RHEL datastream derivatives under the `definition` (OVAL check) tag.

#### Rationale:

- CCE identifiers are bound to RHEL and should not appear in derivatives datastreams

Additional information:
- Values such as:
```
<ns3:reference ref_id="CCE-80657-0" source="CCE"/>
```
