### PR TITLE
Add test scenarios for configure_usbguard_auditbackend rule

### DIFF
--- a/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/commented.fail.sh
+++ b/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/commented.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+mkdir -p /etc/usbguard
+cat << EOF > /etc/usbguard/usbguard-daemon.conf
+# AuditBackend=LinuxAudit
+EOF

--- a/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/missing.fail.sh
+++ b/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+mkdir -p /etc/usbguard
+cat << EOF > /etc/usbguard/usbguard-daemon.conf
+# No AuditBackend
+# in usbguard-daemon.conf
+EOF

--- a/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/present.pass.sh
+++ b/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/present.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+mkdir -p /etc/usbguard
+cat << EOF > /etc/usbguard/usbguard-daemon.conf
+#AuditBackend=FileAudit
+
+AuditBackend=LinuxAudit
+EOF

--- a/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/wrong_value.fail.sh
+++ b/tests/data/group_services/group_usbguard/rule_configure_usbguard_auditbackend/wrong_value.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+mkdir -p /etc/usbguard
+cat << EOF > /etc/usbguard/usbguard-daemon.conf
+# AuditBackend=LinuxAudit
+AuditBackend=FileAudit
+EOF


### PR DESCRIPTION
#### Description:
Tests for configure_usbguard_auditbackend rule.

#### Rationale:
During review of #4747 I created these basic test scenarios to ensure that it works as expected.