### PR TITLE
Profile Restructuring

### DIFF
--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -101,7 +101,6 @@ selections:
     ### Kernel Config
     ## Boot prompt
     - package_dracut-fips_installed
-    - grub2_enable_fips_mode
     - grub2_audit_argument
     - grub2_audit_backlog_limit_argument
     - grub2_slub_debug_argument

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -1,31 +1,25 @@
 documentation_complete: true
 
-title: 'OSPP - Protection Profile for General Purpose Operating Systems v. 4.2.1'
+title: 'OSPP - Protection Profile for General Purpose Operating Systems v4.2.1'
 
 description: |-
     This profile reflects mandatory configuration controls identified in the
     NIAP Configuration Annex to the Protection Profile for General Purpose
     Operating Systems (Protection Profile Version 4.2.1).
 
-    This Annex is consistent with CNSSI-1253, which requires US National Security
-    Systems to adhere to certain configuration parameters. Accordingly, configuration
-    guidance produced according to the requirements of this Annex is suitable for use
-    in US National Security Systems.
+    This configuration profile is consistent with CNSSI-1253, which requires
+    U.S. National Security Systems to adhere to certain configuration
+    parameters. Accordingly, this configuration profile is suitable for
+    use in U.S. National Security Systems.
 
 selections:
-    ### Boot
-    - grub2_uefi_password
 
-    # systemd
-    - require_singleuser_auth
-    - grub2_disable_interactive_boot
-    - disable_ctrlaltdel_reboot
-    - disable_ctrlaltdel_burstaction
-    - service_debug-shell_disabled
-    - service_kdump_disabled
-    - service_autofs_disabled
+    #######################################################
+    ### GENERAL REQUIREMENTS
+    ### Things needed to meet OSPP functional requirements.
+    #######################################################
 
-    # Partitioning
+    ### Partitioning
     - mount_option_home_nodev
     - mount_option_home_nosuid
     - mount_option_tmp_nodev
@@ -37,29 +31,42 @@ selections:
     - mount_option_dev_shm_nodev
     - mount_option_dev_shm_noexec
     - mount_option_dev_shm_nosuid
+    #- mount_option_nodev_nonroot_local_partitions
+    #- mount_option_boot_nodev
+    #- mount_option_boot_nosuid
+    #- partition_for_home
+    #- partition_for_var
+    #- mount_option_var_nodev
+    #- partition_for_var_log
+    #- mount_option_var_log_nodev
+    #- mount_option_var_log_nosuid
+    #- mount_option_var_log_noexec
+    #- partition_for_var_log_audit
+    #- mount_option_var_log_audit_nodev
+    #- mount_option_var_log_audit_nosuid
+    #- mount_option_var_log_audit_noexec
 
-    ### Kernel Config
+    ### Services
+    # sshd
+    - sshd_disable_root_login
+    - sshd_enable_strictmodes
+    - disable_host_auth
+    - sshd_disable_empty_passwords
+    - sshd_disable_kerb_auth
+    - sshd_disable_gssapi_auth
+    #- var_sshd_set_keepalive=0
+    - sshd_set_keepalive
+    - sshd_enable_warning_banner
+    - sshd_disable_rhosts_rsa
+    - sshd_use_approved_ciphers
+    - sshd_use_approved_macs
+    #- sshd_rekey_limit
 
-    # Boot prompt
-    - package_dracut-fips_installed
-    - grub2_enable_fips_mode
-    - grub2_audit_argument
-    - grub2_audit_backlog_limit_argument
-    - grub2_slub_debug_argument
-    - grub2_page_poison_argument
-    - grub2_vsyscall_argument
+    # Time Server
+    #- chronyd_client_only
+    #- chronyd_no_chronyc_network
 
-    # Security Settings
-    - sysctl_kernel_kptr_restrict
-    - sysctl_kernel_dmesg_restrict
-    - sysctl_kernel_kexec_load_disabled
-    - sysctl_kernel_yama_ptrace_scope
-
-    # File System Settings
-    - sysctl_fs_protected_hardlinks
-    - sysctl_fs_protected_symlinks
-
-    # Network Settings
+    ### Network Settings
     - sysctl_net_ipv6_conf_all_accept_ra
     - sysctl_net_ipv6_conf_default_accept_ra
     - sysctl_net_ipv4_conf_all_accept_redirects
@@ -83,81 +90,27 @@ selections:
     - sysctl_net_ipv4_ip_forward
     - sysctl_net_ipv4_tcp_syncookies
 
-    # Module blacklist
-    - kernel_module_usb-storage_disabled
-    - kernel_module_cramfs_disabled
-    - kernel_module_bluetooth_disabled
-    - kernel_module_dccp_disabled
-    - kernel_module_sctp_disabled
+    ### systemd
+    - disable_ctrlaltdel_reboot
+    - disable_ctrlaltdel_burstaction
+    - service_debug-shell_disabled
+    - service_kdump_disabled
+    - service_autofs_disabled
 
-    ### Audit
-    - service_auditd_enabled
+    ### umask
+    #- var_accounts_user_umask=027
+    - accounts_umask_etc_profile
+    - accounts_umask_etc_bashrc
+    - accounts_umask_etc_csh_cshrc
+    #- accounts_umask_etc_login_defs
 
-    # Rules.d
-    - directory_access_var_log_audit
+    ### Software update
+    - ensure_redhat_gpgkey_installed
+    - ensure_gpgcheck_globally_activated
+    - ensure_gpgcheck_local_packages
+    - ensure_gpgcheck_never_disabled
 
-    # Configuration (all are defaults)
-    - var_auditd_flush=incremental_async
-    - auditd_data_retention_flush
-
-    # TODO: check that auditd has rules configured according to
-    #       Configuration Annex for OSPP 4.2.1
-
-    ### Services
-
-    # sshd
-    - sshd_disable_root_login
-    - sshd_enable_strictmodes
-    - disable_host_auth
-    - sshd_disable_empty_passwords
-    - sshd_disable_kerb_auth
-    - sshd_disable_gssapi_auth
-    - sshd_idle_timeout_value=10_minutes
-    - sshd_set_keepalive
-    - sshd_enable_warning_banner
-    - sshd_disable_rhosts_rsa
-    - sshd_use_approved_ciphers
-    - sshd_use_approved_macs
-
-    # rpcbind
-    - service_rpcbind_disabled
-
-    # Firewalld
-    - service_firewalld_enabled
-
-    # abrt
-    - package_abrt_removed
-
-    ### User sessions
-
-    # Login
-    - no_empty_passwords
-    - var_accounts_passwords_pam_faillock_deny=3
-    - accounts_passwords_pam_faillock_deny
-    - var_accounts_passwords_pam_faillock_fail_interval=900
-    - accounts_passwords_pam_faillock_interval
-    - var_accounts_passwords_pam_faillock_unlock_time=never
-    - accounts_passwords_pam_faillock_unlock_time
-    - disable_users_coredumps
-    - var_accounts_max_concurrent_login_sessions=10
-    - accounts_max_concurrent_login_sessions
-    - securetty_root_login_console_only
-    - var_password_pam_unix_remember=5
-    - accounts_password_pam_unix_remember
-
-    # Password
-    - var_accounts_password_minlen_login_defs=12
-    - accounts_password_minlen_login_defs
-    - var_password_pam_minlen=12
-    - accounts_password_pam_minlen
-    - var_password_pam_ocredit=1
-    - accounts_password_pam_ocredit
-    - var_password_pam_dcredit=1
-    - accounts_password_pam_dcredit
-    - var_password_pam_ucredit=1
-    - accounts_password_pam_ucredit
-    - var_password_pam_lcredit=1
-    - accounts_password_pam_lcredit
+    ### Passwords
     - var_password_pam_difok=4
     - accounts_password_pam_difok
     - var_password_pam_maxrepeat=3
@@ -165,25 +118,430 @@ selections:
     - var_password_pam_maxclassrepeat=4
     - accounts_password_pam_maxclassrepeat
 
-    # umask
-    - accounts_umask_etc_profile
-    - accounts_umask_etc_bashrc
-    - accounts_umask_etc_csh_cshrc
+    ### Kernel Config
+    ## Boot prompt
+    - package_dracut-fips_installed
+    - grub2_enable_fips_mode
+    - grub2_audit_argument
+    - grub2_audit_backlog_limit_argument
+    - grub2_slub_debug_argument
+    - grub2_page_poison_argument
+    - grub2_vsyscall_argument
+    #- grub2_pti_argument
 
-    # Console Screen Lock
+    ## Security Settings
+    - sysctl_kernel_kptr_restrict
+    - sysctl_kernel_dmesg_restrict
+    - sysctl_kernel_kexec_load_disabled
+    - sysctl_kernel_yama_ptrace_scope
+    #- sysctl_kernel_perf_event_paranoid
+    #- sysctl_user_max_user_namespaces
+    #- sysctl_kernel_unprivileged_bpf_disabled
+    #- sysctl_net_core_bpf_jit_harden
+
+    ## File System Settings
+    - sysctl_fs_protected_hardlinks
+    - sysctl_fs_protected_symlinks
+
+    ### Audit
+    - service_auditd_enabled
+    - var_auditd_flush=incremental_async
+    - auditd_data_retention_flush
+    #- auditd_local_events
+    #- auditd_write_logs
+    #- auditd_log_format
+    #- auditd_freq
+    #- auditd_name_format
+
+    ### Misc Audit Configuration
+    ### (not required in OSPP)
+    #- audit_rules_session_events
+    #- audit_rules_mac_modification
+
+    ### Module Blacklist
+    - kernel_module_usb-storage_disabled
+    - kernel_module_cramfs_disabled
+    - kernel_module_bluetooth_disabled
+    - kernel_module_dccp_disabled
+    - kernel_module_sctp_disabled
+    #- kernel_module_firewire-core_disabled
+    #- kernel_module_atm_disabled
+    #- kernel_module_can_disabled
+    #- kernel_module_tipc_disabled
+
+    ### rpcbind
+    - service_rpcbind_disabled
+
+    ### Install Required Packages
+    #- package_sssd-ipa_installed
+    #- package_aide_installed
+    #- package_dnf-automatic_installed
+    #- package_firewalld_installed
+    #- package_iptables_installed
+    #- package_libcap-ng-utils_installed
+    #- package_openscap-scanner_installed
+    #- package_policycoreutils_installed
+    #- package_python3-subscription-manager-rhsm_installed
+    #- package_rng-tools_installed
+    #- package_sudo_installed
+    #- package_usbguard_installed
+    #- package_audispd-plugins_installed
+    #- package_scap-security-guide_installed
+    #- package_auditd_installed
+    #- package_libreswan_installed
+    #- package_rsyslog_installed
+
+    ### Remove Prohibited Packages
+    #-package_sendmail_removed
+    #-package_iprutils_removed
+    #-package_gssproxy_removed
+    #-package_nfs-utils_removed
+    #-package_krb5-workstation_removed
+    #-package_abrt-addon-kerneloops_removed
+    #-package_abrt-addon-python_removed
+    #-package_abrt-addon-ccpp_removed
+    #-package_abrt-plugin-rhtsupport_removed
+    #-package_abrt-plugin-logger_removed
+    #-package_abrt-plugin-sosreport_removed
+    #-package_abrt-cli_removed
+    #-package_tuned_removed
+    - package_abrt_removed
+
+    ### Login
+    - disable_users_coredumps
+    #- sysctl_kernel_core_pattern
+    #- coredump_disable_storage
+    #- coredump_disable_backtraces
+    #- service_systemd-coredump_disabled
+    - var_accounts_max_concurrent_login_sessions=10
+    - accounts_max_concurrent_login_sessions
+    - securetty_root_login_console_only
+    - var_password_pam_unix_remember=5
+    - accounts_password_pam_unix_remember
+
+    ### SELinux Configuration
+    #- var_selinux_state=enforcing
+    #- selinux_state
+    #- var_selinux_policy_name=targeted
+    #- selinux_policytype
+
+    ### Application Whitelisting (RHEL 8)
+    #- package_fapolicyd_installed
+    #- service_fapolicyd_enabled
+
+    ### Configure SSSD
+    #- sssd_run_as_sssd_user
+
+    ### Configure USBGuard
+    #- service_usbguard_enabled\
+
+    ### Enable / Configure FIPS
+    -  grub2_enable_fips_mode
+    #- enable_fips_mode
+    #- var_system_crypto_policy=fips
+    #- configure_crypto_policy
+    #- harden_sshd_crypto_policy
+    #- configure_bind_crypto_policy
+    #- configure_openssl_crypto_policy
+    #- configure_libreswan_crypto_policy
+    #- configure_kerberos_crypto_policy
+    #- sysctl_crypto_fips_enabled
+    #- enable_dracut_fips_module
+    #- etc_system_fips_exists
+
+    #######################################################
+    ### CONFIGURATION ANNEX TO THE PROTECTION PROFILE
+    ### FOR GENERAL PURPOSE OPERATING SYSTEMS
+    ### ANNEX RELEASE 1
+    ### FOR PROTECTION PROFILE VERSIONS 4.2
+    ###
+    ### https://www.niap-ccevs.org/MMO/PP/-442ConfigAnnex-/
+    #######################################################
+
+    ## Configure Minimum Password Length to 12 Characters
+    ## IA-5 (1)(a) / FMT_MOF_EXT.1
+    - var_accounts_password_minlen_login_defs=12
+    - accounts_password_minlen_login_defs
+    - var_password_pam_minlen=12
+    - accounts_password_pam_minlen
+
+    ## Require at Least 1 Special Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
+    - var_password_pam_ocredit=1
+    - accounts_password_pam_ocredit
+
+    ## Require at Least 1 Numeric Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
+    - var_password_pam_dcredit=1
+    - accounts_password_pam_dcredit
+
+    ## Require at Least 1 Uppercase Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
+    - var_password_pam_ucredit=1
+    - accounts_password_pam_ucredit
+
+    ## Require at Least 1 Lowercase Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
+    - var_password_pam_lcredit=1
+    - accounts_password_pam_lcredit
+
+    ## Enable Screen Lock
+    ## FMT_MOF_EXT.1
     - package_screen_installed
 
-    # Remote session timeout
+    ## Set Screen Lock Timeout Period to 30 Minutes or Less
+    ## AC-11(a) / FMT_MOF_EXT.1
     - sshd_idle_timeout_value=10_minutes
     - sshd_set_idle_timeout
 
-    ### General Config
+    ## Disable Unauthenticated Login (such as Guest Accounts)
+    ## FIA_AFL.1
+    - require_singleuser_auth
+    - grub2_disable_interactive_boot
+    - grub2_uefi_password
+    - no_empty_passwords
 
-    # Software update
-    - ensure_redhat_gpgkey_installed
-    - ensure_gpgcheck_globally_activated
-    - ensure_gpgcheck_local_packages
-    - ensure_gpgcheck_never_disabled
+    ## Set Maximum Number of Authentication Failures to 3 Within 15 Minutes
+    ## AC-7(a) / FMT_MOF_EXT.1
+    - var_accounts_passwords_pam_faillock_deny=3
+    - accounts_passwords_pam_faillock_deny
+    - var_accounts_passwords_pam_faillock_fail_interval=900
+    - accounts_passwords_pam_faillock_interval
+    - var_accounts_passwords_pam_faillock_unlock_time=never
+    - accounts_passwords_pam_faillock_unlock_time
+
+    ## Enable Host-Based Firewall
+    ## SC-7(12) / FMT_MOF_EXT.1
+    - service_firewalld_enabled
+
+    ## Configure Name/Addres of Remote Management Server
+    ##  From Which to Receive Config Settings
+    ## CM-3(3) / FMT_MOF_EXT.1
+
+    ## Configure the System to Offload Audit Records to a Log
+    ##  Server
+    ## AU-4(1) / FAU_GEN.1.1.c
+    #- auditd_audispd_syslog_plugin_activated
+
+    ## Set Logon Warning Banner
+    ## AC-8(a) / FMT_MOF_EXT.1
+
+    ## Audit All Logons (Success/Failure) and Logoffs (Success)
+    ##  CNSSI 1253 Value or DoD-Specific Values:
+    ##      (1) Logons (Success/Failure)
+    ##      (2) Logoffs (Success)
+    ## AU-2(a) / FAU_GEN.1.1.c
+
+    ## Audit File and Object Events (Unsuccessful)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      (1) Create (Success/Failure)
+    ##      (2) Access (Success/Failure)
+    ##      (3) Delete (Sucess/Failure)
+    ##      (4) Modify (Success/Failure)
+    ##      (5) Permission Modification (Sucess/Failure)
+    ##      (6) Ownership Modification (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    ##
+    ##
+    ## (1) Create (Success/Failure)
+    ##      (open with O_CREAT)
+    ##
+    # openat O_CREAT
+    #- audit_rules_unsuccessful_file_modification_openat_o_creat
+    #- audit_rules_successful_file_modification_openat_o_creat
+
+    # open_by_handle_at O_CREAT
+    #- audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat
+    #- audit_rules_successful_file_modification_open_by_handle_at_o_creat
+
+    # open O_CREAT
+    #- audit_rules_unsuccessful_file_modification_open_o_creat
+    #- audit_rules_successful_file_modification_open_o_creat
+
+    ##
+    ## (4) Modify (Success/Failure)
+    ##
+    ##  NOTE: THESE RULES *MUST* BE ORDERED PRIOR TO
+    ##        THE STANDARD FILE ACCESS RULES (e.g. open, creat, etc)
+    ##
+    # openat O_TRUNC_WRITE
+    #- audit_rules_unsuccessful_file_modification_openat_o_trunc_write
+    #- audit_rules_successful_file_modification_openat_o_trunc_write
+
+    # open_by_handle_at O_TRUNC_WRITE
+    #- audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write
+    #- audit_rules_successful_file_modification_open_by_handle_at_o_trunc_write
+
+    # open O_TRUNC_WRITE
+    #- audit_rules_unsuccessful_file_modification_open_o_trunc_write
+    #- audit_rules_successful_file_modification_open_o_trunc_write
+
+    ##
+    ## (2) Access (Success/Failure)
+    ##
+    # open
+    #- audit_rules_unsuccessful_file_modification_open
+    #- audit_rules_successful_file_modification_open
+
+    # creat
+    #- audit_rules_unsuccessful_file_modification_creat
+    #- audit_rules_successful_file_modification_creat
+
+    # truncate
+    #- audit_rules_unsuccessful_file_modification_truncate
+    #- audit_rules_successful_file_modification_truncate
+
+    # ftruncate
+    #- audit_rules_unsuccessful_file_modification_ftruncate
+    #- audit_rules_successful_file_modification_ftruncate
+
+    # openat
+    #- audit_rules_unsuccessful_file_modification_openat
+    #- audit_rules_successful_file_modification_openat
+
+    # open_by_handle_at
+    #- audit_rules_unsuccessful_file_modification_open_by_handle_at
+    #- audit_rules_successful_file_modification_open_by_handle_at
+
+    ##
+    ## (3) Delete (Success/Failure)
+    ##
+    # unlink
+    #- audit_rules_unsuccessful_file_modification_unlink
+    #- audit_rules_successful_file_modification_unlink
+
+    # unlinkat
+    #- audit_rules_unsuccessful_file_modification_unlinkat
+    #- audit_rules_successful_file_modification_unlinkat
+
+    # rename
+    #- audit_rules_unsuccessful_file_modification_rename
+    #- audit_rules_successful_file_modification_rename
+
+    # renameat
+    #- audit_rules_unsuccessful_file_modification_renameat
+    #- audit_rules_successful_file_modification_renameat
+
+    ##
+    ## (5) Permission Modification (Success/Failure)
+    ##
+    #- audit_rules_unsuccessful_file_modification_chmod
+    #- audit_rules_successful_file_modification_chmod
+    #- audit_rules_unsuccessful_file_modification_fchmod
+    #- audit_rules_successful_file_modification_fchmod
+    #- audit_rules_unsuccessful_file_modification_fchmodat
+    #- audit_rules_successful_file_modification_fchmodat
+    #- audit_rules_unsuccessful_file_modification_setxattr
+    #- audit_rules_successful_file_modification_setxattr
+    #- audit_rules_unsuccessful_file_modification_lsetxattr
+    #- audit_rules_successful_file_modification_lsetxattr
+    #- audit_rules_unsuccessful_file_modification_fsetxattr
+    #- audit_rules_successful_file_modification_fsetxattr
+    #- audit_rules_unsuccessful_file_modification_removexattr
+    #- audit_rules_successful_file_modification_removexattr
+    #- audit_rules_unsuccessful_file_modification_lremovexattr
+    #- audit_rules_successful_file_modification_lremovexattr
+    #- audit_rules_unsuccessful_file_modification_fremovexattr
+    #- audit_rules_successful_file_modification_fremovexattr
+
+    ##
+    ## (6) Ownership Modification (Success/Failure)
+    ##
+    #- audit_rules_unsuccessful_file_modification_lchown
+    #- audit_rules_successful_file_modification_lchown
+    #- audit_rules_unsuccessful_file_modification_fchown
+    #- audit_rules_successful_file_modification_fchown
+    #- audit_rules_unsuccessful_file_modification_chown
+    #- audit_rules_successful_file_modification_chown
+    #- audit_rules_unsuccessful_file_modification_fchownat
+    #- audit_rules_successful_file_modification_fchownat
+
+
+    ## Audit User and Group Management Events (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      (1) User add, delete, modify, disable, enable (Success/Failure)
+    ##      (2) Group/Role add, delete, modify (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    ##
+    ## Generic User and Group Management Events (Success/Failure)
+    ## Selection of setuid programs that relate to
+    ## user accounts.
+    #- audit_rules_privileged_commands_gpasswd
+    #- audit_rules_privileged_commands_newgidmap
+    #- audit_rules_privileged_commands_newgrp
+    #- audit_rules_privileged_commands_newuidmap
+    #- audit_rules_privileged_commands_passwd
+    #- audit_rules_privileged_commands_unix_chkpwd
+    #- audit_rules_privileged_commands_at
+    #- audit_rules_privileged_commands_crontab
+    #- audit_rules_privileged_commands_mount
+    #- audit_rules_execution_seunshare
+    #- audit_rules_privileged_commands_umount
+    #- audit_rules_privileged_commands_userhelper
+    #- audit_rules_privileged_commands_usernetctl
+
+    ##
+    ## CNSSI 1253: (1) User add, delete, modify, disable, enable (Success/Failure)
+    ##
+    # Record Events that Modify User/Group Information via openat syscall - /etc/passwd
+    #- audit_rules_etc_passwd_openat
+
+    # Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/passwd
+    #- audit_rules_etc_passwd_open_by_handle_at
+
+    # Record Events that Modify User/Group Information via open syscall - /etc/passwd
+    #- audit_rules_etc_passwd_open
+
+    # Record Events that Modify User/Group Information via openat syscall - /etc/shadow
+    #- audit_rules_etc_shadow_openat
+
+    # Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/shadow
+    #- audit_rules_etc_shadow_open_by_handle_at
+
+    # Record Events that Modify User/Group Information via open syscall - /etc/shadow
+    #- audit_rules_etc_shadow_open
+
+    ##
+    ## CNSSI 1252: (2) Group/Role add, delete, modify (Success/Failure)
+    ##
+    #- audit_rules_usergroup_modification_group
+    #- audit_rules_usergroup_modification_gshadow
+    #- audit_rules_usergroup_modification_passwd
+    #- audit_rules_usergroup_modification_shadow
+
+    ## Audit Privilege or Role Escalation Events (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Privilege/Role escalation (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+
+    ## Audit All Audit and Log Data Accesses (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Audit and log data access (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    - directory_access_var_log_audit
+
+    ## Audit Cryptographic Verification of Software (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Applications (e.g. Firefox, Internet Explorer, MS Office Suite,
+    ##        etc) initialization (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+
+    ## Audit Kernel Module Loading and Unloading Events (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    #- audit_rules_kernel_module_loading_init
+    #- audit_rules_kernel_module_loading_finit
+    #- audit_rules_kernel_module_loading_delete
+
+    ## Enable Automatic Software Updates
+    ## SI-2 / FMT_MOF_EXT.1
+    # Configure dnf-automatic to Install Only Security Updates
+    #- dnf-automatic_security_updates_only
+
+    # Configure dnf-automatic to Install Available Updates Automatically
+    #- dnf-automatic_apply_updates
+
+    # Enable dnf-automatic Timer
+    #- timer_dnf-automatic_enabled
 
     ###  SELinux Configuration
 

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -31,20 +31,6 @@ selections:
     - mount_option_dev_shm_nodev
     - mount_option_dev_shm_noexec
     - mount_option_dev_shm_nosuid
-    #- mount_option_nodev_nonroot_local_partitions
-    #- mount_option_boot_nodev
-    #- mount_option_boot_nosuid
-    #- partition_for_home
-    #- partition_for_var
-    #- mount_option_var_nodev
-    #- partition_for_var_log
-    #- mount_option_var_log_nodev
-    #- mount_option_var_log_nosuid
-    #- mount_option_var_log_noexec
-    #- partition_for_var_log_audit
-    #- mount_option_var_log_audit_nodev
-    #- mount_option_var_log_audit_nosuid
-    #- mount_option_var_log_audit_noexec
 
     ### Services
     # sshd
@@ -54,17 +40,13 @@ selections:
     - sshd_disable_empty_passwords
     - sshd_disable_kerb_auth
     - sshd_disable_gssapi_auth
-    #- var_sshd_set_keepalive=0
     - sshd_set_keepalive
     - sshd_enable_warning_banner
     - sshd_disable_rhosts_rsa
     - sshd_use_approved_ciphers
     - sshd_use_approved_macs
-    #- sshd_rekey_limit
 
     # Time Server
-    #- chronyd_client_only
-    #- chronyd_no_chronyc_network
 
     ### Network Settings
     - sysctl_net_ipv6_conf_all_accept_ra
@@ -98,11 +80,9 @@ selections:
     - service_autofs_disabled
 
     ### umask
-    #- var_accounts_user_umask=027
     - accounts_umask_etc_profile
     - accounts_umask_etc_bashrc
     - accounts_umask_etc_csh_cshrc
-    #- accounts_umask_etc_login_defs
 
     ### Software update
     - ensure_redhat_gpgkey_installed
@@ -127,17 +107,12 @@ selections:
     - grub2_slub_debug_argument
     - grub2_page_poison_argument
     - grub2_vsyscall_argument
-    #- grub2_pti_argument
 
     ## Security Settings
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_dmesg_restrict
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_yama_ptrace_scope
-    #- sysctl_kernel_perf_event_paranoid
-    #- sysctl_user_max_user_namespaces
-    #- sysctl_kernel_unprivileged_bpf_disabled
-    #- sysctl_net_core_bpf_jit_harden
 
     ## File System Settings
     - sysctl_fs_protected_hardlinks
@@ -147,16 +122,9 @@ selections:
     - service_auditd_enabled
     - var_auditd_flush=incremental_async
     - auditd_data_retention_flush
-    #- auditd_local_events
-    #- auditd_write_logs
-    #- auditd_log_format
-    #- auditd_freq
-    #- auditd_name_format
 
     ### Misc Audit Configuration
     ### (not required in OSPP)
-    #- audit_rules_session_events
-    #- audit_rules_mac_modification
 
     ### Module Blacklist
     - kernel_module_usb-storage_disabled
@@ -164,55 +132,17 @@ selections:
     - kernel_module_bluetooth_disabled
     - kernel_module_dccp_disabled
     - kernel_module_sctp_disabled
-    #- kernel_module_firewire-core_disabled
-    #- kernel_module_atm_disabled
-    #- kernel_module_can_disabled
-    #- kernel_module_tipc_disabled
 
     ### rpcbind
     - service_rpcbind_disabled
 
     ### Install Required Packages
-    #- package_sssd-ipa_installed
-    #- package_aide_installed
-    #- package_dnf-automatic_installed
-    #- package_firewalld_installed
-    #- package_iptables_installed
-    #- package_libcap-ng-utils_installed
-    #- package_openscap-scanner_installed
-    #- package_policycoreutils_installed
-    #- package_python3-subscription-manager-rhsm_installed
-    #- package_rng-tools_installed
-    #- package_sudo_installed
-    #- package_usbguard_installed
-    #- package_audispd-plugins_installed
-    #- package_scap-security-guide_installed
-    #- package_auditd_installed
-    #- package_libreswan_installed
-    #- package_rsyslog_installed
 
     ### Remove Prohibited Packages
-    #-package_sendmail_removed
-    #-package_iprutils_removed
-    #-package_gssproxy_removed
-    #-package_nfs-utils_removed
-    #-package_krb5-workstation_removed
-    #-package_abrt-addon-kerneloops_removed
-    #-package_abrt-addon-python_removed
-    #-package_abrt-addon-ccpp_removed
-    #-package_abrt-plugin-rhtsupport_removed
-    #-package_abrt-plugin-logger_removed
-    #-package_abrt-plugin-sosreport_removed
-    #-package_abrt-cli_removed
-    #-package_tuned_removed
     - package_abrt_removed
 
     ### Login
     - disable_users_coredumps
-    #- sysctl_kernel_core_pattern
-    #- coredump_disable_storage
-    #- coredump_disable_backtraces
-    #- service_systemd-coredump_disabled
     - var_accounts_max_concurrent_login_sessions=10
     - accounts_max_concurrent_login_sessions
     - securetty_root_login_console_only
@@ -220,34 +150,15 @@ selections:
     - accounts_password_pam_unix_remember
 
     ### SELinux Configuration
-    #- var_selinux_state=enforcing
-    #- selinux_state
-    #- var_selinux_policy_name=targeted
-    #- selinux_policytype
 
     ### Application Whitelisting (RHEL 8)
-    #- package_fapolicyd_installed
-    #- service_fapolicyd_enabled
 
     ### Configure SSSD
-    #- sssd_run_as_sssd_user
 
     ### Configure USBGuard
-    #- service_usbguard_enabled\
 
     ### Enable / Configure FIPS
     -  grub2_enable_fips_mode
-    #- enable_fips_mode
-    #- var_system_crypto_policy=fips
-    #- configure_crypto_policy
-    #- harden_sshd_crypto_policy
-    #- configure_bind_crypto_policy
-    #- configure_openssl_crypto_policy
-    #- configure_libreswan_crypto_policy
-    #- configure_kerberos_crypto_policy
-    #- sysctl_crypto_fips_enabled
-    #- enable_dracut_fips_module
-    #- etc_system_fips_exists
 
     #######################################################
     ### CONFIGURATION ANNEX TO THE PROTECTION PROFILE
@@ -321,7 +232,6 @@ selections:
     ## Configure the System to Offload Audit Records to a Log
     ##  Server
     ## AU-4(1) / FAU_GEN.1.1.c
-    #- auditd_audispd_syslog_plugin_activated
 
     ## Set Logon Warning Banner
     ## AC-8(a) / FMT_MOF_EXT.1
@@ -345,117 +255,11 @@ selections:
     ##
     ## (1) Create (Success/Failure)
     ##      (open with O_CREAT)
-    ##
-    # openat O_CREAT
-    #- audit_rules_unsuccessful_file_modification_openat_o_creat
-    #- audit_rules_successful_file_modification_openat_o_creat
-
-    # open_by_handle_at O_CREAT
-    #- audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat
-    #- audit_rules_successful_file_modification_open_by_handle_at_o_creat
-
-    # open O_CREAT
-    #- audit_rules_unsuccessful_file_modification_open_o_creat
-    #- audit_rules_successful_file_modification_open_o_creat
-
-    ##
-    ## (4) Modify (Success/Failure)
-    ##
-    ##  NOTE: THESE RULES *MUST* BE ORDERED PRIOR TO
-    ##        THE STANDARD FILE ACCESS RULES (e.g. open, creat, etc)
-    ##
-    # openat O_TRUNC_WRITE
-    #- audit_rules_unsuccessful_file_modification_openat_o_trunc_write
-    #- audit_rules_successful_file_modification_openat_o_trunc_write
-
-    # open_by_handle_at O_TRUNC_WRITE
-    #- audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write
-    #- audit_rules_successful_file_modification_open_by_handle_at_o_trunc_write
-
-    # open O_TRUNC_WRITE
-    #- audit_rules_unsuccessful_file_modification_open_o_trunc_write
-    #- audit_rules_successful_file_modification_open_o_trunc_write
-
-    ##
     ## (2) Access (Success/Failure)
-    ##
-    # open
-    #- audit_rules_unsuccessful_file_modification_open
-    #- audit_rules_successful_file_modification_open
-
-    # creat
-    #- audit_rules_unsuccessful_file_modification_creat
-    #- audit_rules_successful_file_modification_creat
-
-    # truncate
-    #- audit_rules_unsuccessful_file_modification_truncate
-    #- audit_rules_successful_file_modification_truncate
-
-    # ftruncate
-    #- audit_rules_unsuccessful_file_modification_ftruncate
-    #- audit_rules_successful_file_modification_ftruncate
-
-    # openat
-    #- audit_rules_unsuccessful_file_modification_openat
-    #- audit_rules_successful_file_modification_openat
-
-    # open_by_handle_at
-    #- audit_rules_unsuccessful_file_modification_open_by_handle_at
-    #- audit_rules_successful_file_modification_open_by_handle_at
-
-    ##
     ## (3) Delete (Success/Failure)
-    ##
-    # unlink
-    #- audit_rules_unsuccessful_file_modification_unlink
-    #- audit_rules_successful_file_modification_unlink
-
-    # unlinkat
-    #- audit_rules_unsuccessful_file_modification_unlinkat
-    #- audit_rules_successful_file_modification_unlinkat
-
-    # rename
-    #- audit_rules_unsuccessful_file_modification_rename
-    #- audit_rules_successful_file_modification_rename
-
-    # renameat
-    #- audit_rules_unsuccessful_file_modification_renameat
-    #- audit_rules_successful_file_modification_renameat
-
-    ##
+    ## (4) Modify (Success/Failure)
     ## (5) Permission Modification (Success/Failure)
-    ##
-    #- audit_rules_unsuccessful_file_modification_chmod
-    #- audit_rules_successful_file_modification_chmod
-    #- audit_rules_unsuccessful_file_modification_fchmod
-    #- audit_rules_successful_file_modification_fchmod
-    #- audit_rules_unsuccessful_file_modification_fchmodat
-    #- audit_rules_successful_file_modification_fchmodat
-    #- audit_rules_unsuccessful_file_modification_setxattr
-    #- audit_rules_successful_file_modification_setxattr
-    #- audit_rules_unsuccessful_file_modification_lsetxattr
-    #- audit_rules_successful_file_modification_lsetxattr
-    #- audit_rules_unsuccessful_file_modification_fsetxattr
-    #- audit_rules_successful_file_modification_fsetxattr
-    #- audit_rules_unsuccessful_file_modification_removexattr
-    #- audit_rules_successful_file_modification_removexattr
-    #- audit_rules_unsuccessful_file_modification_lremovexattr
-    #- audit_rules_successful_file_modification_lremovexattr
-    #- audit_rules_unsuccessful_file_modification_fremovexattr
-    #- audit_rules_successful_file_modification_fremovexattr
-
-    ##
     ## (6) Ownership Modification (Success/Failure)
-    ##
-    #- audit_rules_unsuccessful_file_modification_lchown
-    #- audit_rules_successful_file_modification_lchown
-    #- audit_rules_unsuccessful_file_modification_fchown
-    #- audit_rules_successful_file_modification_fchown
-    #- audit_rules_unsuccessful_file_modification_chown
-    #- audit_rules_successful_file_modification_chown
-    #- audit_rules_unsuccessful_file_modification_fchownat
-    #- audit_rules_successful_file_modification_fchownat
-
 
     ## Audit User and Group Management Events (Success/Failure)
     ##  CNSSI 1253 Value or DoD-specific Values:
@@ -466,53 +270,23 @@ selections:
     ## Generic User and Group Management Events (Success/Failure)
     ## Selection of setuid programs that relate to
     ## user accounts.
-    #- audit_rules_privileged_commands_gpasswd
-    #- audit_rules_privileged_commands_newgidmap
-    #- audit_rules_privileged_commands_newgrp
-    #- audit_rules_privileged_commands_newuidmap
-    #- audit_rules_privileged_commands_passwd
-    #- audit_rules_privileged_commands_unix_chkpwd
-    #- audit_rules_privileged_commands_at
-    #- audit_rules_privileged_commands_crontab
-    #- audit_rules_privileged_commands_mount
-    #- audit_rules_execution_seunshare
-    #- audit_rules_privileged_commands_umount
-    #- audit_rules_privileged_commands_userhelper
-    #- audit_rules_privileged_commands_usernetctl
-
     ##
     ## CNSSI 1253: (1) User add, delete, modify, disable, enable (Success/Failure)
     ##
-    # Record Events that Modify User/Group Information via openat syscall - /etc/passwd
-    #- audit_rules_etc_passwd_openat
-
-    # Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/passwd
-    #- audit_rules_etc_passwd_open_by_handle_at
-
-    # Record Events that Modify User/Group Information via open syscall - /etc/passwd
-    #- audit_rules_etc_passwd_open
-
-    # Record Events that Modify User/Group Information via openat syscall - /etc/shadow
-    #- audit_rules_etc_shadow_openat
-
-    # Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/shadow
-    #- audit_rules_etc_shadow_open_by_handle_at
-
-    # Record Events that Modify User/Group Information via open syscall - /etc/shadow
-    #- audit_rules_etc_shadow_open
-
-    ##
     ## CNSSI 1252: (2) Group/Role add, delete, modify (Success/Failure)
     ##
-    #- audit_rules_usergroup_modification_group
-    #- audit_rules_usergroup_modification_gshadow
-    #- audit_rules_usergroup_modification_passwd
-    #- audit_rules_usergroup_modification_shadow
-
     ## Audit Privilege or Role Escalation Events (Success/Failure)
     ##  CNSSI 1253 Value or DoD-specific Values:
     ##      - Privilege/Role escalation (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
+    ## Audit Cryptographic Verification of Software (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Applications (e.g. Firefox, Internet Explorer, MS Office Suite,
+    ##        etc) initialization (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    ## Audit Kernel Module Loading and Unloading Events (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    - audit_rules_for_ospp
 
     ## Audit All Audit and Log Data Accesses (Success/Failure)
     ##  CNSSI 1253 Value or DoD-specific Values:
@@ -520,28 +294,6 @@ selections:
     ## AU-2(a) / FAU_GEN.1.1.c
     - directory_access_var_log_audit
 
-    ## Audit Cryptographic Verification of Software (Success/Failure)
-    ##  CNSSI 1253 Value or DoD-specific Values:
-    ##      - Applications (e.g. Firefox, Internet Explorer, MS Office Suite,
-    ##        etc) initialization (Success/Failure)
-    ## AU-2(a) / FAU_GEN.1.1.c
-
-    ## Audit Kernel Module Loading and Unloading Events (Success/Failure)
-    ## AU-2(a) / FAU_GEN.1.1.c
-    #- audit_rules_kernel_module_loading_init
-    #- audit_rules_kernel_module_loading_finit
-    #- audit_rules_kernel_module_loading_delete
-
-    ## Enable Automatic Software Updates
-    ## SI-2 / FMT_MOF_EXT.1
-    # Configure dnf-automatic to Install Only Security Updates
-    #- dnf-automatic_security_updates_only
-
-    # Configure dnf-automatic to Install Available Updates Automatically
-    #- dnf-automatic_apply_updates
-
-    # Enable dnf-automatic Timer
-    #- timer_dnf-automatic_enabled
 
     ###  SELinux Configuration
 
@@ -552,5 +304,3 @@ selections:
     # Configure SELinux Policy
     - var_selinux_policy_name=targeted
     - selinux_policytype
-
-    - audit_rules_for_ospp

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -5,720 +5,241 @@ title: 'Protection Profile for General Purpose Operating Systems'
 description: |-
     This profile reflects mandatory configuration controls identified in the
     NIAP Configuration Annex to the Protection Profile for General Purpose
-    Operating Systems (Protection Profile Version 4.2).
+    Operating Systems (Protection Profile Version 4.2.1).
+
+    This configuration profile is consistent with CNSSI-1253, which requires
+    U.S. National Security Systems to adhere to certain configuration
+    parameters. Accordingly, this configuration profile is suitable for
+    use in U.S. National Security Systems.
 
 selections:
 
-    #################################################################
-    ## SELinux Configuration
-    #################################################################
+    #######################################################
+    ### GENERAL REQUIREMENTS
+    ### Things needed to meet OSPP functional requirements.
+    #######################################################
 
-    ## Ensure SELinux is Enforcing
-    - var_selinux_state=enforcing
-    - selinux_state
+    ### Partitioning
+    - mount_option_home_nodev
+    - mount_option_home_nosuid
+    - mount_option_tmp_nodev
+    - mount_option_tmp_noexec
+    - mount_option_tmp_nosuid
+    - mount_option_var_tmp_nodev
+    - mount_option_var_tmp_noexec
+    - mount_option_var_tmp_nosuid
+    - mount_option_dev_shm_nodev
+    - mount_option_dev_shm_noexec
+    - mount_option_dev_shm_nosuid
+    - mount_option_nodev_nonroot_local_partitions
+    - mount_option_boot_nodev
+    - mount_option_boot_nosuid
+    - partition_for_home
+    - partition_for_var
+    - mount_option_var_nodev
+    - partition_for_var_log
+    - mount_option_var_log_nodev
+    - mount_option_var_log_nosuid
+    - mount_option_var_log_noexec
+    - partition_for_var_log_audit
+    - mount_option_var_log_audit_nodev
+    - mount_option_var_log_audit_nosuid
+    - mount_option_var_log_audit_noexec
 
-    ## Configure SELinux Policy
-    - var_selinux_policy_name=targeted
-    - selinux_policytype
+    ### Services
+    # sshd
+    - sshd_disable_root_login
+    - sshd_enable_strictmodes
+    - disable_host_auth
+    - sshd_disable_empty_passwords
+    - sshd_disable_kerb_auth
+    - sshd_disable_gssapi_auth
+    - var_sshd_set_keepalive=0
+    - sshd_set_keepalive
+    - sshd_enable_warning_banner
+    #- sshd_disable_rhosts_rsa
+    #- sshd_use_approved_ciphers
+    #- sshd_use_approved_macs
+    - sshd_rekey_limit
 
+    # Time Server
+    - chronyd_client_only
+    - chronyd_no_chronyc_network
 
-    #################################################################
-    ## Bootloader Configuration
-    #################################################################
-    #TO DO: bootloader --location=mbr --append="boot=/dev/vda1 fips=1 "
+    ### Network Settings
+    - sysctl_net_ipv6_conf_all_accept_ra
+    - sysctl_net_ipv6_conf_default_accept_ra
+    - sysctl_net_ipv4_conf_all_accept_redirects
+    - sysctl_net_ipv4_conf_default_accept_redirects
+    - sysctl_net_ipv6_conf_all_accept_redirects
+    - sysctl_net_ipv6_conf_default_accept_redirects
+    - sysctl_net_ipv4_conf_all_accept_source_route
+    - sysctl_net_ipv4_conf_default_accept_source_route
+    - sysctl_net_ipv6_conf_all_accept_source_route
+    - sysctl_net_ipv6_conf_default_accept_source_route
+    - sysctl_net_ipv4_conf_all_secure_redirects
+    - sysctl_net_ipv4_conf_default_secure_redirects
+    - sysctl_net_ipv4_conf_all_send_redirects
+    - sysctl_net_ipv4_conf_default_send_redirects
+    - sysctl_net_ipv4_conf_all_log_martians
+    - sysctl_net_ipv4_conf_default_log_martians
+    - sysctl_net_ipv4_conf_all_rp_filter
+    - sysctl_net_ipv4_conf_default_rp_filter
+    - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+    - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+    - sysctl_net_ipv4_ip_forward
+    - sysctl_net_ipv4_tcp_syncookies
 
-    ## Set the UEFI Boot Loader Password
-    - grub2_uefi_password
+    ### systemd
+    - disable_ctrlaltdel_reboot
+    - disable_ctrlaltdel_burstaction
+    - service_debug-shell_disabled
+    #- service_kdump_disabled
+    #- service_autofs_disabled
 
-    ## Require Authentication for Single User Mode
-    - require_singleuser_auth
+    ### umask
+    - var_accounts_user_umask=027
+    - accounts_umask_etc_profile
+    - accounts_umask_etc_bashrc
+    - accounts_umask_etc_csh_cshrc
+    #- accounts_umask_etc_login_defs
 
-    ## Verify that Interactive Boot is Disabled
-    - grub2_disable_interactive_boot
+    ### Software update
+    - ensure_redhat_gpgkey_installed
+    - ensure_gpgcheck_globally_activated
+    - ensure_gpgcheck_local_packages
+    - ensure_gpgcheck_never_disabled
 
-    ## Enable Auditing for Processes Which Start Prior to the Audit Daemon
+    ### Passwords
+    - var_password_pam_difok=4
+    - accounts_password_pam_difok
+    - var_password_pam_maxrepeat=3
+    - accounts_password_pam_maxrepeat
+    - var_password_pam_maxclassrepeat=4
+    - accounts_password_pam_maxclassrepeat
+
+    ### Kernel Config
+    ## Boot prompt
+    #- package_dracut-fips_installed
     - grub2_audit_argument
-
-    ## Extend Audit Backlog Limit for the Audit Daemon
     - grub2_audit_backlog_limit_argument
-
-    ## Enable SLUB/SLAB allocator poisoning
     - grub2_slub_debug_argument
-
-    ## Enable page allocator poisoning
     - grub2_page_poison_argument
-
-    ## Enable Kernel Page-Table Isolation (KPTI)
-    - grub2_pti_argument
-
-    ## Disable vsyscalls
     - grub2_vsyscall_argument
     - grub2_vsyscall_argument.role=unscored
     - grub2_vsyscall_argument.severity=info
+    - grub2_pti_argument
 
-
-    #################################################################
-    ## Partitioning Configuration
-    #################################################################
-
-    ###########
-    ## /boot
-    ###########
-    # TO DO: /boot on its own partition?!
-
-    ## Add nodev Option to /boot
-    - mount_option_boot_nodev
-
-    ## Add nosuid Option to /boot
-    - mount_option_boot_nosuid
-
-    ###########
-    ## /home
-    ###########
-
-    ## Ensure /home Located On Separate Partition
-    ## SEE ALSO: https://github.com/ComplianceAsCode/content/issues/4484
-    ##  unclear if partition requirements still relevant
-    - partition_for_home
-
-    ## Add nodev Option to /home
-    - mount_option_home_nodev
-
-    ## Add nosuid Option to /home
-    - mount_option_home_nosuid
-
-    ###########
-    ## /var
-    ###########
-
-    ## Ensure /var Located on Separate Partition
-    ## SEE ALSO: https://github.com/ComplianceAsCode/content/issues/4486
-    ##  unclear if partition requirements still exist
-    - partition_for_var
-
-    ## Add nodev Option to /var
-    - mount_option_var_nodev
-
-    ###########
-    ## /var/log
-    ###########
-
-    ## Ensure /var/log Located on Separate Partition
-    - partition_for_var_log
-
-    ## Add nodev Option to /var/log
-    - mount_option_var_log_nodev
-
-    ## Add nosuid Option to /var/log
-    - mount_option_var_log_nosuid
-
-    ## Add noexec Option to /var/log
-    - mount_option_var_log_noexec
-
-    ###########
-    ## /var/log/audit
-    ###########
-    ## Ensure /var/log/audit Located on Separate Partition
-    - partition_for_var_log_audit
-
-    ## Add nodev Option to /var/log/audit
-    - mount_option_var_log_audit_nodev
-
-    ## Add nosuid Option to /var/log/audit
-    - mount_option_var_log_audit_nosuid
-
-    ## Add noexec Option to /var/log/audit
-    - mount_option_var_log_audit_noexec
-
-    ###########
-    ## /var/tmp
-    ###########
-
-    ## Add nodev Option to /var/tmp
-    - mount_option_var_tmp_nodev
-
-    ## Add nosuid Option to /var/tmp
-    - mount_option_var_tmp_nosuid
-
-    ## Add noexec Option to /var/tmp
-    - mount_option_var_tmp_noexec
-
-    ###########
-    ## /tmp
-    ###########
-
-    ## Setup a couple mountpoints by hand to ensure correctness
-    #touch /etc/fstab
-    ## Ensure /tmp Located On Separate Partition
-    #echo -e "tmpfs\t/tmp\t\t\t\ttmpfs\tdefaults,mode=1777,,,nodev,strictatime,size=512M\t0 0" >> /etc/fstab
-
-    ## Add nodev Option to /tmp
-    - mount_option_tmp_nodev
-
-    ## Add noexec Option to /tmp
-    - mount_option_tmp_noexec
-
-    ## Add nosuid Option to /tmp
-    - mount_option_tmp_nosuid
-
-    ###########
-    ## /swap
-    ###########
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4490
-    ##  do we need a swap partition (for security reasons)?
-    #logvol swap --name=lv_swap --vgname=VolGroup --size=2016
-
-    ###########
-    ## /dev/shm
-    ###########
-    ## Make sure /dev/shm is restricted
-    #echo -e "tmpfs\t/dev/shm\t\t\t\ttmpfs\tdefaults,mode=1777,,,strictatime\t0 0" >> /etc/fstab
-
-    ## Add nodev Option to /dev/shm
-    - mount_option_dev_shm_nodev
-
-    ## Add noexec Option to /dev/shm
-    - mount_option_dev_shm_noexec
-
-    ## Add nosuid Option to /dev/shm
-    - mount_option_dev_shm_nosuid
-
-    ###########
-    ## Misc Partitioning
-    ###########
-    ## Add nodev Option to Non-Root Local Partitions
-    - mount_option_nodev_nonroot_local_partitions
-
-    #################################################################
-    ## Required Packages
-    #################################################################
-
-    ## Install sssd-ipa Package
-    - package_sssd-ipa_installed
-
-    ## Install aide Package
-    - package_aide_installed
-
-    ## Install dnf-automatic Package
-    - package_dnf-automatic_installed
-
-    ## Install firewalld Package
-    - package_firewalld_installed
-
-    ## Install iptables Package
-    - package_iptables_installed
-
-    ## Install libcap-ng-utils Package
-    - package_libcap-ng-utils_installed
-
-    ## Install openscap-scanner Package
-    - package_openscap-scanner_installed
-
-    ## Install policycoreutils Package
-    - package_policycoreutils_installed
-
-    ## Install python3-subscription-manager-rhsm Package
-    - package_python3-subscription-manager-rhsm_installed
-
-    ## Install rng-tools Package
-    - package_rng-tools_installed
-
-    ## Install sudo Package
-    - package_sudo_installed
-
-    ## Install tmux Package
-    - package_tmux_installed
-
-    ## Install usbguard Package
-    - package_usbguard_installed
-
-    ## Install audispd-plugins Package
-    - package_audispd-plugins_installed
-
-    ## Install scap-security-guide Package
-    - package_scap-security-guide_installed
-
-    ## Ensure the audit Subsystem is Installed
-    - package_audit_installed
-
-    ## Install libreswan Package
-    - package_libreswan_installed
-
-    ## Ensure rsyslog is Installed
-    - package_rsyslog_installed
-
-    #################################################################
-    ## Remove Prohibited Packages
-    #################################################################
-
-    ## Uninstall Sendmail Package
-    - package_sendmail_removed
-
-    ## Uninstall iprutils Package
-    - package_iprutils_removed
-
-    ## Uninstall gssproxy Package
-    - package_gssproxy_removed
-
-    ## Uninstall nfs-utils Package
-    - package_nfs-utils_removed
-
-    ## Uninstall krb5-workstation Package
-    - package_krb5-workstation_removed
-
-    ## Uninstall abrt-addon-kerneloops Package
-    - package_abrt-addon-kerneloops_removed
-
-    ## Uninstall abrt-addon-python Package
-    - package_abrt-addon-python_removed
-
-    ## Uninstall abrt-addon-ccpp Package
-    - package_abrt-addon-ccpp_removed
-
-    ## Uninstall abrt-plugin-rhtsupport Package
-    - package_abrt-plugin-rhtsupport_removed
-
-    ## Uninstall abrt-plugin-logger Package
-    - package_abrt-plugin-logger_removed
-
-    ## Uninstall abrt-plugin-sosreport Package
-    - package_abrt-plugin-sosreport_removed
-
-    ## Uninstall abrt-cli Package
-    - package_abrt-cli_removed
-
-    ## Uninstall tuned Package
-    - package_tuned_removed
-
-    ## Uninstall Automatic Bug Reporting Tool (abrt)
-    - package_abrt_removed
-
-    #################################################################
-    ##
-    ## Set PATH correctly
-    ##
-    #################################################################
-
-    ## TO DO
-    #PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
-
-    #################################################################
-    ##
-    ## Configure Audit Daemon
-    ##
-    #################################################################
-
-    ## Enable auditd Service
-    - service_auditd_enabled
-
-    - audit_rules_for_ospp
-
-    #################################################################
-    ##
-    ## Audit Attempts to Alter Logging Data
-    ##
-    #################################################################
-
-    ## Record Access Events to Audit Log Directory
-    - directory_access_var_log_audit
-
-    #################################################################
-    ## Audit Configuration
-    #################################################################
-
-    ## Include Local Events in Audit Logs
-    - auditd_local_events
-
-    ## Write Audit Logs to the Disk
-    - auditd_write_logs
-
-    # Resolve information before writing to audit logs
-    - auditd_log_format
-
-    ## Configure auditd flush priority
-    - auditd_data_retention_flush
-    - var_auditd_flush=incremental_async
-
-    # Set number of records to cause an explicit flush to audit logs
-    - auditd_freq
-
-    ## Set hostname as computer node name in audit logs
-    - auditd_name_format
-
-
-    #################################################################
-    ## Audispd plugins
-    #################################################################
-
-    ## Configure auditd to use audispd's syslog plugin
-    - auditd_audispd_syslog_plugin_activated
-
-    #################################################################
-    ## Application Whitelisting
-    #################################################################
-    - package_fapolicyd_installed
-    - service_fapolicyd_enabled
-
-    #################################################################
-    ## Implement locking session after period of inactivity
-    #################################################################
-
-    ## Configure tmux to lock session after inactivity
-    - configure_tmux_lock_after_time
-
-    ## Configure the tmux Lock Command
-    - configure_tmux_lock_command
-
-    ## Ensure tmux is started for bash sessions
-    - configure_bashrc_exec_tmux
-
-    ## Prevent user from disabling the screen lock
-    - no_tmux_in_shells
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4499
-    #set -g status off
-
-    ## setup tmux
-    #mv /tmp/tmux.conf /etc/tmux.conf
-    #restorecon /etc/tmux.conf
-
-    #################################################################
-    ## Harden USB Guard
-    #################################################################
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4496
-    #cat << EOF > /tmp/rules.conf
-    #allow with-interface equals { 09:00:* }
-    #allow with-interface equals { 03:*:* }
-    #allow with-interface equals { 03:*:* 03:*:* }
-    #EOF
-    #}
-
-    #setup_usbguard () {
-    #    chmod 0600 /tmp/rules.conf
-    #    mv /tmp/rules.conf /etc/usbguard/
-    #    restorecon -R /etc/usbguard/
-    #}
-
-    #################################################################
-    ## Software update
-    #################################################################
-
-    ## Ensure Red Hat GPG Key Installed
-    - ensure_redhat_gpgkey_installed
-
-    ## Ensure gpgcheck Enabled In Main yum Configuration
-    - ensure_gpgcheck_globally_activated
-
-    ## Ensure gpgcheck Enabled for Local Packages
-    - ensure_gpgcheck_local_packages
-
-    ## Ensure gpgcheck Enabled for All yum Package Repositories
-    - ensure_gpgcheck_never_disabled
-
-
-    #################################################################
-    ## Kernel Security Settings
-    #################################################################
-
-    ## Restrict Exposed Kernel Pointer Addresses Access
+    ## Security Settings
     - sysctl_kernel_kptr_restrict
-
-    ## Restrict Access to Kernel Message Buffer
     - sysctl_kernel_dmesg_restrict
-
-    ## Disallow kernel profiling by unprivileged users
-    - sysctl_kernel_perf_event_paranoid
-
-    ## Disable Kernel Image Loading
     - sysctl_kernel_kexec_load_disabled
-
-    ## Disable the use of user namespaces
+    - sysctl_kernel_yama_ptrace_scope
+    - sysctl_kernel_perf_event_paranoid
     - sysctl_user_max_user_namespaces
     - sysctl_user_max_user_namespaces.role=unscored
     - sysctl_user_max_user_namespaces.severity=info
-
-    ## Disable Access to Network bpf() Syscall From Unprivileged Processes
     - sysctl_kernel_unprivileged_bpf_disabled
-
-    ## Harden the operation of the BPF just-in-time compiler
     - sysctl_net_core_bpf_jit_harden
 
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4495
-    #cp -f /usr/lib/sysctl.d/10-default-yama-scope.conf /etc/sysctl.d/
-
-    ## Restrict Usage of ptrace To Descendant Processes
-    - sysctl_kernel_yama_ptrace_scope
-
-    #################################################################
-    ## Network Settings
-    #################################################################
-
-    ## Disable Accepting Router Advertisements on All IPv6 Interfaces
-    - sysctl_net_ipv6_conf_all_accept_ra
-
-    ## Disable Accepting Router Advertisements on All IPv6 Interfaces by Default
-    - sysctl_net_ipv6_conf_default_accept_ra
-
-    ## Disable Accepting ICMP Redirects for All IPv4 Interfaces
-    - sysctl_net_ipv4_conf_all_accept_redirects
-
-    ## Disable Accepting ICMP Redirects for All IPv6 Interfaces
-    - sysctl_net_ipv6_conf_all_accept_redirects
-
-    ## Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv4 Interfaces
-    - sysctl_net_ipv4_conf_default_accept_redirects
-
-    ## Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv6 Interfaces
-    - sysctl_net_ipv6_conf_default_accept_redirects
-
-    ## Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv4 Interfaces
-    - sysctl_net_ipv4_conf_all_accept_source_route
-
-    ## Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv6 Interfaces
-    - sysctl_net_ipv6_conf_all_accept_source_route
-
-    ## Disable Kernel Parameter for Accepting Source-Routed Packets on IPv4 Interfaces by Default
-    - sysctl_net_ipv4_conf_default_accept_source_route
-
-    ## Disable Kernel Parameter for Accepting Source-Routed Packets on IPv4 Interfaces by Default
-    - sysctl_net_ipv6_conf_default_accept_source_route
-
-    ## Disable Kernel Parameter for Accepting Secure ICMP Redirects on all IPv4 Interfaces
-    - sysctl_net_ipv4_conf_all_secure_redirects
-
-    ## Disable Kernel Parameter for Accepting Secure ICMP Redirects on all IPv4 Interfaces by Default
-    - sysctl_net_ipv4_conf_default_secure_redirects
-
-    ## Disable Kernel Parameter for Sending ICMP Redirects on all IPv4  Interfaces 
-    - sysctl_net_ipv4_conf_all_send_redirects
-
-    ## Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces by Default
-    - sysctl_net_ipv4_conf_default_send_redirects
-
-    ## Enable Kernel Parameter to Log Martian Packets on all IPv4 Interfaces
-    - sysctl_net_ipv4_conf_all_log_martians
-
-    ## Enable Kernel Paremeter to Log Martian Packets on all IPv4 Interfaces by Default
-    - sysctl_net_ipv4_conf_default_log_martians
-
-    ## Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces
-    - sysctl_net_ipv4_conf_all_rp_filter
-
-    ## Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces by Default
-    - sysctl_net_ipv4_conf_default_rp_filter
-
-    ## Enable Kernel Parameter to Ignore Bogus ICMP Error Responses on IPv4 Interfaces
-    - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-
-    ## Enable Kernel Parameter to Ignore ICMP Broadcast Echo Requests on IPv4 Interfaces
-    - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-
-    ## TO DO: NEED SCAP RULE
-    #echo "net.ipv6.icmp.echo_ignore_all = 0" >> $CONFIG
-
-    ## Disable Kernel Parameter for IP Forwarding on IPv4 Interfaces
-    - sysctl_net_ipv4_ip_forward
-
-    ## Enable Kernel Parameter to Use TCP Syncookies on IPv4 Interfaces
-    - sysctl_net_ipv4_tcp_syncookies
-
-    #################################################################
     ## File System Settings
-    #################################################################
-
-    ## Enable Kernel Parameter to Enforce DAC on Hardlinks
     - sysctl_fs_protected_hardlinks
-
-    ## Enable Kernel Parameter to Enforce DAC on Symlinks
     - sysctl_fs_protected_symlinks
 
+    ### Audit
+    - service_auditd_enabled
+    - var_auditd_flush=incremental_async
+    - auditd_data_retention_flush
+    - auditd_local_events
+    - auditd_write_logs
+    - auditd_log_format
+    - auditd_freq
+    - auditd_name_format
 
-    #################################################################
-    ## Disable Core Dumps
-    #################################################################
-    
-    ## Disable storing core dumps
+    ### Module Blacklist
+    #- kernel_module_usb-storage_disabled
+    - kernel_module_cramfs_disabled
+    - kernel_module_bluetooth_disabled
+    #- kernel_module_dccp_disabled
+    - kernel_module_sctp_disabled
+    - kernel_module_firewire-core_disabled
+    - kernel_module_atm_disabled
+    - kernel_module_can_disabled
+    - kernel_module_tipc_disabled
+
+    ### rpcbind
+    #- service_rpcbind_disabled
+
+    ### Install Required Packages
+    - package_sssd-ipa_installed
+    - package_aide_installed
+    - package_dnf-automatic_installed
+    - package_firewalld_installed
+    - package_iptables_installed
+    - package_libcap-ng-utils_installed
+    - package_openscap-scanner_installed
+    - package_policycoreutils_installed
+    - package_python3-subscription-manager-rhsm_installed
+    - package_rng-tools_installed
+    - package_sudo_installed
+    - package_usbguard_installed
+    - package_audispd-plugins_installed
+    - package_scap-security-guide_installed
+    - package_audit_installed
+    - package_libreswan_installed
+    - package_rsyslog_installed
+
+    ### Remove Prohibited Packages
+    - package_sendmail_removed
+    - package_iprutils_removed
+    - package_gssproxy_removed
+    - package_nfs-utils_removed
+    - package_krb5-workstation_removed
+    - package_abrt-addon-kerneloops_removed
+    - package_abrt-addon-python_removed
+    - package_abrt-addon-ccpp_removed
+    - package_abrt-plugin-rhtsupport_removed
+    - package_abrt-plugin-logger_removed
+    - package_abrt-plugin-sosreport_removed
+    - package_abrt-cli_removed
+    - package_tuned_removed
+    - package_abrt_removed
+
+    ### Login
+    - disable_users_coredumps
     - sysctl_kernel_core_pattern
     - coredump_disable_storage
     - coredump_disable_backtraces
     - service_systemd-coredump_disabled
-    #systemctl mask kdump.service
+    - var_accounts_max_concurrent_login_sessions=10
+    - accounts_max_concurrent_login_sessions
+    - securetty_root_login_console_only
+    - var_password_pam_unix_remember=5
+    - accounts_password_pam_unix_remember
 
-    #################################################################
-    ## Blacklist Risky Kernel Modules
-    #################################################################
+    ### SELinux Configuration
+    - var_selinux_state=enforcing
+    - selinux_state
+    - var_selinux_policy_name=targeted
+    - selinux_policytype
 
-    ## Disable IEEE 1394 (FireWire) Support
-    - kernel_module_firewire-core_disabled
+    ### Application Whitelisting (RHEL 8)
+    - package_fapolicyd_installed
+    - service_fapolicyd_enabled
 
-    ## Disable Mounting of cramfs
-    - kernel_module_cramfs_disabled
-
-    ## Disable ATM Support
-    - kernel_module_atm_disabled
-
-    ## Disable Bluetooth Kernel Module
-    - kernel_module_bluetooth_disabled
-    
-    ## Disable CAN Support
-    - kernel_module_can_disabled
-
-    ## Disable SCTP Support
-    - kernel_module_sctp_disabled
-    
-    ## Disable Transparent Inter Process Communication Support
-    - kernel_module_tipc_disabled
-
-    #################################################################
-    ## Systemd Items
-    #################################################################
-
-    ## Disable Ctrl-Alt-Del Reboot Activation
-    - disable_ctrlaltdel_reboot
-
-    ## Disable Ctrl-Alt-Del Burst Action
-    - disable_ctrlaltdel_burstaction
-
-    ## Disable debug-shell SystemD Service
-    - service_debug-shell_disabled
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4460
-    # sed -i "/^#SystemMaxUse/s/#SystemMaxUse=/SystemMaxUse=200/" /etc/systemd/journald.conf
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4461
-    # systemctl mask systemd-resolved.service
-
-    #################################################################
-    ## Configure Hostname
-    #################################################################
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4462
-    ## echo "ospp" > /etc/hostname
-    ## sed -i "s/localhost\.localdomain/ospp/g" /etc/hosts
-
-    #################################################################
-    ## Audit Daemon Configuration
-    #################################################################
-
-    #chmod -R 640 "$RULES/*"
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4463
-    #sed -i "/name_format/s/NONE/HOSTNAME/" /etc/audit/auditd.conf
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4464
-    #sed -i "/^active/s/no/yes/" /etc/audit/plugins.d/syslog.conf
-
-    ## Point rsyslog to a remote system to collect logs. This will need
-    ## remote_host and port corrected on the Target line.
-    #CONFIG="/etc/rsyslog.conf"
-    #sed -i "/#action/s/^#//" $CONFIG
-    #sed -i "/#queue/s/^#//" $CONFIG
-    #sed -i "/#Target/s/^#//" $CONFIG
-
-    #################################################################
-    ## Firewall & Network Manager
-    #################################################################
-
-    - service_firewalld_enabled
-
-    #################################################################
-    ## Harden chrony (time server)
-    #################################################################
-
-    ## Disable chrony daemon from acting as server
-    - chronyd_client_only
-
-    ## Disable network management of chrony daemon
-    - chronyd_no_chronyc_network
-
-    #################################################################
-    ## Setup SSH Server
-    #################################################################
-
-    ## Force frequent session key renegotiation
-    - sshd_rekey_limit
-
-    ## Disable SSH Root Login
-    - sshd_disable_root_login
-
-    ## Enable Use of Strict Mode Checking
-    - sshd_enable_strictmodes
-
-    ## Disable Host-Based Authentication
-    - disable_host_auth
-
-    ## Disable SSH Access via Empty Passwords
-    - sshd_disable_empty_passwords
-
-    ## Disable Kerberos Authentication
-    - sshd_disable_kerb_auth
-
-    ## Disable GSSAPI Authentication
-    - sshd_disable_gssapi_auth
-
-    ## Set SSH Idle Timeout Interval
-    - sshd_idle_timeout_value=10_minutes
-    - sshd_set_idle_timeout
-
-    ## Disable SSH Client Alive Messages
-    - var_sshd_set_keepalive=0
-    - sshd_set_keepalive
-
-    ## Enable SSH Warning Banner
-    - sshd_enable_warning_banner
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4469
-    #echo -e "PubkeyAcceptedKeyTypes ssh-rsa,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384" >> $CONFIG
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4471
-    #echo -e "KexAlgorithms diffie-hellman-group14-sha1,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" >> $CONFIG
-
-    #################################################################
-    ## Enable rngd Service
-    #################################################################
-
-    ## Enable the Hardware RNG Entropy Gatherer Service
+    ### Enable the Hardware RNG Entropy Gatherer Service
     - service_rngd_enabled
 
-    #################################################################
-    ## sssd Settings
-    #################################################################
-    ## TO DO -- entire section
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4501
-    ## sssd settings
-    ## FIXME: We need to point this to a remote LDAP policy server
-    #CONFIG="/etc/sssd/conf.d/ospp.conf"
-    #touch $CONFIG
-    #chmod 600 $CONFIG
-    #echo -e "[sssd]" >> $CONFIG
-    #echo -e "user = sssd\n" >> $CONFIG
-
-    ## Configure SSSD to run as user sssd
+    ### Configure SSSD
     - sssd_run_as_sssd_user
 
-    #################################################################
-    ## Enable / Configure USB Guard
-    #################################################################
-    
-    ## Log USBGuard daemon audit events using Linux Audit
+    ### Configure USBGuard
+    - service_usbguard_enabled
     - configure_usbguard_auditbackend
 
-    ## TO DO: HOW TO HANDLE??
-    #setup_usbguard
-
-    ## Enable the USBGuard Service
-    - service_usbguard_enabled
-
-    #################################################################
-    ## Enable / Configure FIPS
-    #################################################################
-    
-    ## Enable FIPS Mode
+    ### Enable / Configure FIPS
+    #- grub2_enable_fips_mode
     - enable_fips_mode
-
-    ## Set up Crypto policy
     - var_system_crypto_policy=fips
     - configure_crypto_policy
     - harden_sshd_crypto_policy
@@ -727,132 +248,157 @@ selections:
     - configure_openssl_crypto_policy
     - configure_libreswan_crypto_policy
     - configure_kerberos_crypto_policy
-
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4500
-    # - sysctl_crypto_fips_enabled
-
-    ## Enable Dracut FIPS Module
+    #- sysctl_crypto_fips_enabled
     - enable_dracut_fips_module
+    #- etc_system_fips_exists
 
-    # - etc_system_fips_exists
+    #######################################################
+    ### CONFIGURATION ANNEX TO THE PROTECTION PROFILE
+    ### FOR GENERAL PURPOSE OPERATING SYSTEMS
+    ### ANNEX RELEASE 1
+    ### FOR PROTECTION PROFILE VERSIONS 4.2
+    ###
+    ### https://www.niap-ccevs.org/MMO/PP/-442ConfigAnnex-/
+    #######################################################
 
-    #################################################################
-    ## Libreswan Setup
-    #################################################################
-    
-    ## libreswan setup
-    # FIXME: Need to talk to Paul about generic server/client setups
-    # And for servers, need to punch holes in firewall
-
-    #################################################################
-    ## Account & Password Settings
-    #################################################################
-
-    ## Set Password Minimum Length in login.defs
+    ## Configure Minimum Password Length to 12 Characters
+    ## IA-5 (1)(a) / FMT_MOF_EXT.1
     - var_accounts_password_minlen_login_defs=12
     - accounts_password_minlen_login_defs
-
-    ## Ensure PAM Enforces Password Requirements - Minimum Different Characters
-    - var_password_pam_difok=4
-    - accounts_password_pam_difok
-
-    ## Ensure PAM Enforces Password Requirements - Minimum Length
     - var_password_pam_minlen=12
     - accounts_password_pam_minlen
 
-    ## Minimum Digit Characters
-    - var_password_pam_dcredit=1
-    - accounts_password_pam_dcredit
-
-    ## Ensure PAM Enforces Password Requirements - Minimum Uppercase Characters
-    - var_password_pam_ucredit=1
-    - accounts_password_pam_ucredit
-
-    ## Ensure PAM Enforces Password Requirements - Minimum Lowercase Characters
-    - var_password_pam_lcredit=1
-    - accounts_password_pam_lcredit
-
-    ## Ensure PAM Enforces Password Requirements - Minimum Special Characters
+    ## Require at Least 1 Special Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
     - var_password_pam_ocredit=1
     - accounts_password_pam_ocredit
 
-    ## Set Password Maximum Consecutive Repeating Characters
-    - var_password_pam_maxrepeat=3
-    - accounts_password_pam_maxrepeat
+    ## Require at Least 1 Numeric Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
+    - var_password_pam_dcredit=1
+    - accounts_password_pam_dcredit
 
-    ## Ensure PAM Enforces Password Requirements - Maximum Consecutive Repeating Characters from Same Character Class
-    - var_password_pam_maxclassrepeat=4
-    - accounts_password_pam_maxclassrepeat
+    ## Require at Least 1 Uppercase Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
+    - var_password_pam_ucredit=1
+    - accounts_password_pam_ucredit
 
-    ## Set umask Variable for next few rules
-    - var_accounts_user_umask=027
+    ## Require at Least 1 Lowercase Character in Password
+    ## IA-5(1)(a) / FMT_MOF_EXT.1
+    - var_password_pam_lcredit=1
+    - accounts_password_pam_lcredit
 
-    ## Ensure the Default Umask is Set Correctly in /etc/profile
-    - accounts_umask_etc_profile
+    ## Enable Screen Lock
+    ## FMT_MOF_EXT.1
+    - package_tmux_installed
+    - configure_bashrc_exec_tmux
+    - no_tmux_in_shells
+    - configure_tmux_lock_command
+    - configure_tmux_lock_after_time
 
-    ## Ensure the Default Bash Umask is Set Correctly
-    - accounts_umask_etc_bashrc
+    ## Set Screen Lock Timeout Period to 30 Minutes or Less
+    ## AC-11(a) / FMT_MOF_EXT.1
+    - sshd_idle_timeout_value=10_minutes
+    - sshd_set_idle_timeout
 
-    ## Ensure the Default C Shell Umask is Set Correctly
-    - accounts_umask_etc_csh_cshrc
+    ## Disable Unauthenticated Login (such as Guest Accounts)
+    ## FIA_AFL.1
+    - require_singleuser_auth
+    - grub2_disable_interactive_boot
+    - grub2_uefi_password
+    - no_empty_passwords
 
-    ## SEE ALSO: https://github.com/ComplianceAsCode/content/issues/4475
-    # - accounts_umask_etc_login_defs
-
-    #################################################################
-    ## PAM Setup
-    #################################################################
-
-    ## Disable Core Dumps for All Users
-    - disable_users_coredumps
-
-    ## Limit the Number of Concurrent Login Sessions Allowed Per User
-    - var_accounts_max_concurrent_login_sessions=10
-    - accounts_max_concurrent_login_sessions
-
-    ## RANDOM TO DO
-    #sed -i "6s/^#//" /etc/pam.d/su
-    #sed -i "8iauth        required      pam_faillock.so preauth silent " /etc/pam.d/system-auth
-    #sed -i "8iauth        required      pam_faillock.so preauth silent " /etc/pam.d/password-auth
-
-    # securetty is disabled by default in RHEL8, but it can be enabled just by editing a few files
-    - securetty_root_login_console_only
-
-    ## Limit Password Reuse
-    - accounts_password_pam_unix_remember
-    - var_password_pam_unix_remember=5
-
-    ## Set Deny For Failed Password Attempts
+    ## Set Maximum Number of Authentication Failures to 3 Within 15 Minutes
+    ## AC-7(a) / FMT_MOF_EXT.1
     - var_accounts_passwords_pam_faillock_deny=3
     - accounts_passwords_pam_faillock_deny
-
-    ## Set Interval For Counting Failed Password Attempts
     - var_accounts_passwords_pam_faillock_fail_interval=900
     - accounts_passwords_pam_faillock_interval
-
-    ## Set Lockout Time for Failed Password Attempts
     - var_accounts_passwords_pam_faillock_unlock_time=never
     - accounts_passwords_pam_faillock_unlock_time
 
+    ## Enable Host-Based Firewall
+    ## SC-7(12) / FMT_MOF_EXT.1
+    - service_firewalld_enabled
 
-    ## Prevent Login to Accounts With Empty Password
-    - no_empty_passwords
+    ## Configure Name/Addres of Remote Management Server
+    ##  From Which to Receive Config Settings
+    ## CM-3(3) / FMT_MOF_EXT.1
 
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4480
-    #sed -i 's/nullok//' /etc/pam.d/system-auth
+    ## Configure the System to Offload Audit Records to a Log
+    ##  Server
+    ## AU-4(1) / FAU_GEN.1.1.c
+    - auditd_audispd_syslog_plugin_activated
 
-    ## TO DO: https://github.com/ComplianceAsCode/content/issues/4481
-    #sed -i 's/nullok//' /etc/pam.d/sssd-shadowutils
+    ## Set Logon Warning Banner
+    ## AC-8(a) / FMT_MOF_EXT.1
 
-    #################################################################
+    ## Audit All Logons (Success/Failure) and Logoffs (Success)
+    ##  CNSSI 1253 Value or DoD-Specific Values:
+    ##      (1) Logons (Success/Failure)
+    ##      (2) Logoffs (Success)
+    ## AU-2(a) / FAU_GEN.1.1.c
+
+    ## Audit File and Object Events (Unsuccessful)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      (1) Create (Success/Failure)
+    ##      (2) Access (Success/Failure)
+    ##      (3) Delete (Sucess/Failure)
+    ##      (4) Modify (Success/Failure)
+    ##      (5) Permission Modification (Sucess/Failure)
+    ##      (6) Ownership Modification (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    ##
+    ##
+    ## (1) Create (Success/Failure)
+    ##      (open with O_CREAT)
+    ## (2) Access (Success/Failure)
+    ## (3) Delete (Success/Failure)
+    ## (4) Modify (Success/Failure)
+    ## (5) Permission Modification (Success/Failure)
+    ## (6) Ownership Modification (Success/Failure)
+
+    ## Audit User and Group Management Events (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      (1) User add, delete, modify, disable, enable (Success/Failure)
+    ##      (2) Group/Role add, delete, modify (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    ##
+    ## Generic User and Group Management Events (Success/Failure)
+    ## Selection of setuid programs that relate to
+    ## user accounts.
+    ##
+    ## CNSSI 1253: (1) User add, delete, modify, disable, enable (Success/Failure)
+    ##
+    ## CNSSI 1252: (2) Group/Role add, delete, modify (Success/Failure)
+    ##
+    ## Audit Privilege or Role Escalation Events (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Privilege/Role escalation (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    ## Audit Cryptographic Verification of Software (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Applications (e.g. Firefox, Internet Explorer, MS Office Suite,
+    ##        etc) initialization (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    ## Audit Kernel Module Loading and Unloading Events (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    - audit_rules_for_ospp
+
+    ## Audit All Audit and Log Data Accesses (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Audit and log data access (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
+    - directory_access_var_log_audit
+
     ## Enable Automatic Software Updates
-    #################################################################
-
-    ## Configure dnf-automatic to Install Only Security Updates
+    ## SI-2 / FMT_MOF_EXT.1
+    # Configure dnf-automatic to Install Only Security Updates
     - dnf-automatic_security_updates_only
 
-    ## Configure dnf-automatic to Install Available Updates Automatically
+    # Configure dnf-automatic to Install Available Updates Automatically
     - dnf-automatic_apply_updates
 
-    ## Enable dnf-automatic Timer
+    # Enable dnf-automatic Timer
     - timer_dnf-automatic_enabled
+

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -57,9 +57,6 @@ selections:
     - var_sshd_set_keepalive=0
     - sshd_set_keepalive
     - sshd_enable_warning_banner
-    #- sshd_disable_rhosts_rsa
-    #- sshd_use_approved_ciphers
-    #- sshd_use_approved_macs
     - sshd_rekey_limit
 
     # Time Server
@@ -94,15 +91,12 @@ selections:
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_burstaction
     - service_debug-shell_disabled
-    #- service_kdump_disabled
-    #- service_autofs_disabled
 
     ### umask
     - var_accounts_user_umask=027
     - accounts_umask_etc_profile
     - accounts_umask_etc_bashrc
     - accounts_umask_etc_csh_cshrc
-    #- accounts_umask_etc_login_defs
 
     ### Software update
     - ensure_redhat_gpgkey_installed
@@ -120,7 +114,6 @@ selections:
 
     ### Kernel Config
     ## Boot prompt
-    #- package_dracut-fips_installed
     - grub2_audit_argument
     - grub2_audit_backlog_limit_argument
     - grub2_slub_debug_argument
@@ -157,10 +150,8 @@ selections:
     - auditd_name_format
 
     ### Module Blacklist
-    #- kernel_module_usb-storage_disabled
     - kernel_module_cramfs_disabled
     - kernel_module_bluetooth_disabled
-    #- kernel_module_dccp_disabled
     - kernel_module_sctp_disabled
     - kernel_module_firewire-core_disabled
     - kernel_module_atm_disabled
@@ -168,7 +159,6 @@ selections:
     - kernel_module_tipc_disabled
 
     ### rpcbind
-    #- service_rpcbind_disabled
 
     ### Install Required Packages
     - package_sssd-ipa_installed
@@ -238,7 +228,6 @@ selections:
     - configure_usbguard_auditbackend
 
     ### Enable / Configure FIPS
-    #- grub2_enable_fips_mode
     - enable_fips_mode
     - var_system_crypto_policy=fips
     - configure_crypto_policy
@@ -248,9 +237,7 @@ selections:
     - configure_openssl_crypto_policy
     - configure_libreswan_crypto_policy
     - configure_kerberos_crypto_policy
-    #- sysctl_crypto_fips_enabled
     - enable_dracut_fips_module
-    #- etc_system_fips_exists
 
     #######################################################
     ### CONFIGURATION ANNEX TO THE PROTECTION PROFILE


### PR DESCRIPTION
This is a spiritual successor of #4736

> Adjusts the RHEL7 and RHEL8 OSPP profiles to have the same structure. Makes it easier to see what is missing between them.

Moreover, placeholders in form of commented selections are out.