### PR TITLE
Build both scap versions, but 1.3 is default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,16 +36,8 @@ set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}"
 
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")
 
-set(SSG_TARGET_SCAP_VERSION "1.3" CACHE STRING "Which SCAP version we are targetting. Possible choices are 1.3 and 1.2")
-
 set(SSG_TARGET_OVAL_MAJOR_VERSION "5" CACHE STRING "Which major version of OVAL are we targetting. Only 5 is supported at the moment.")
 set(SSG_TARGET_OVAL_MINOR_VERSION "11" CACHE STRING "Which minor version of OVAL are we targetting. Possible choices are 10 or 11.")
-
-# If targetting SCAP 1.2, target OVAL version is 5.10
-if (SSG_TARGET_SCAP_VERSION VERSION_EQUAL "1.2")
-    set(SSG_TARGET_OVAL_MAJOR_VERSION "5" CACHE STRING "Which major version of OVAL are we targetting. Only 5 is supported at the moment.")
-    set(SSG_TARGET_OVAL_MINOR_VERSION "10" CACHE STRING "Which minor version of OVAL are we targetting. Possible choices are 10 or 11.")
-endif()
 
 set(SSG_TARGET_OVAL_VERSION "${SSG_TARGET_OVAL_MAJOR_VERSION}.${SSG_TARGET_OVAL_MINOR_VERSION}")
 
@@ -140,10 +132,6 @@ if (NOT SSG_TARGET_OVAL_VERSION VERSION_EQUAL "5.10" AND NOT SSG_TARGET_OVAL_VER
     message(WARNING "You are targetting OVAL version ${SSG_TARGET_OVAL_VERSION}. In SSG we support/test 5.10 and 5.11 only!")
 endif()
 
-if (NOT SSG_TARGET_SCAP_VERSION VERSION_EQUAL "1.3" AND NOT SSG_TARGET_SCAP_VERSION VERSION_EQUAL "1.2")
-    message(WARNING "You are targetting SCAP version ${SSG_TARGET_SCAP_VERSION}. In SSG we support/test 1.3 and 1.2 only!")
-endif()
-
 execute_process(
     COMMAND "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/oscap_svg_support.py" "${OPENSCAP_OSCAP_EXECUTABLE}"
     RESULT_VARIABLE OSCAP_SVG_SUPPORT_RESULT
@@ -222,7 +210,6 @@ message(STATUS " ")
 
 message(STATUS "Build options:")
 message(STATUS "SSG vendor string: ${SSG_VENDOR}")
-message(STATUS "Target SCAP version: ${SSG_TARGET_SCAP_VERSION}")
 message(STATUS "Target OVAL version: ${SSG_TARGET_OVAL_VERSION}")
 message(STATUS "OVAL schematron validation: ${SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED}")
 message(STATUS "shellcheck bash fixes validation: ${SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED}")
@@ -276,10 +263,10 @@ add_subdirectory("tests")
 
 # Targets 'stats', 'profile-stats' and 'zipfile' need to be added
 # before any product because they will receive dependencies from products added
-if(SSG_TARGET_SCAP_VERSION VERSION_EQUAL "1.3")
+if(SSG_TARGET_OVAL_VERSION VERSION_EQUAL "5.11")
     ssg_build_zipfile_target("scap-security-guide-${SSG_VERSION}")
 else()
-    ssg_build_zipfile_target("scap-security-guide-${SSG_VERSION}-SCAP-1.2")
+    ssg_build_zipfile_target("scap-security-guide-${SSG_VERSION}-oval-${SSG_TARGET_OVAL_VERSION}")
 endif()
 
 add_custom_target(stats)
@@ -367,11 +354,11 @@ endif()
 
 # ZIP only contains source datastreams and kickstarts, people who
 # want sources to build from should get the tarball instead.
-if(SSG_TARGET_SCAP_VERSION VERSION_EQUAL "1.3")
+if(SSG_TARGET_OVAL_VERSION VERSION_EQUAL "5.11")
     ssg_build_zipfile("scap-security-guide-${SSG_VERSION}")
     ssg_build_nist_zipfile("scap-security-guide-${SSG_VERSION}-SCAP-1.3")
 else()
-    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}-SCAP-1.2")
+    ssg_build_zipfile("scap-security-guide-${SSG_VERSION}-oval-${SSG_TARGET_OVAL_VERSION}")
     ssg_build_nist_zipfile("scap-security-guide-${SSG_VERSION}-SCAP-1.2")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,10 +356,10 @@ endif()
 # want sources to build from should get the tarball instead.
 if(SSG_TARGET_OVAL_VERSION VERSION_EQUAL "5.11")
     ssg_build_zipfile("scap-security-guide-${SSG_VERSION}")
-    ssg_build_nist_zipfile("scap-security-guide-${SSG_VERSION}-SCAP-1.3")
+    ssg_build_vendor_zipfile("scap-security-guide-${SSG_VERSION}-SCAP-1.3")
 else()
     ssg_build_zipfile("scap-security-guide-${SSG_VERSION}-oval-${SSG_TARGET_OVAL_VERSION}")
-    ssg_build_nist_zipfile("scap-security-guide-${SSG_VERSION}-SCAP-1.2")
+    ssg_build_vendor_zipfile("scap-security-guide-${SSG_VERSION}-SCAP-1.2")
 endif()
 
 ssg_define_guide_and_table_tests()

--- a/build_product
+++ b/build_product
@@ -34,7 +34,7 @@ handle_wrong_argument() {
 	echo
 	echo
 	printf 'Usage:\n'
-	printf '\tbuild-product [--debug] [--scap12] <product-name> [<product-name> ...]\n'
+	printf '\tbuild-product [--debug] [--oval510] <product-name> [<product-name> ...]\n'
 	echo
 	if test -n "$1"; then
 		printf "The argument '%s' is not supported.\\n" "$1"
@@ -42,7 +42,7 @@ handle_wrong_argument() {
 		printf 'Supply product names as arguments to this script.\n'
 	fi
 	printf 'Option --debug can be used to build draft profiles\n'
-	printf 'Option --scap12 can be used to build SCAP 1.2 Content (Default is 1.3)\n'
+	printf 'Option --oval510 can be used to build Content with OVAL 5.10 (Default is 5.11)\n'
 
 	printf 'Choose one or more product names from the list: %s' "$possible_products"
 	echo
@@ -80,7 +80,7 @@ if (( $# == 0 )); then
 	handle_wrong_argument
 fi
 
-scap_version="-DSSG_TARGET_SCAP_VERSION:STRING=1.3"
+oval_minor_version="-DSSG_TARGET_OVAL_MINOR_VERSION:STRING=11"
 build_type="-DCMAKE_BUILD_TYPE=Release"
 
 # currently only two modifier options are available
@@ -89,8 +89,8 @@ for i in {1..2}; do
 		build_type="-DCMAKE_BUILD_TYPE=Debug"
 		shift
 	else
-		if [[ "$1" == "--scap12" ]]; then
-			scap_version="-DSSG_TARGET_SCAP_VERSION:STRING=1.2"
+		if [[ "$1" == "--oval510" ]]; then
+			oval_minor_version="-DSSG_TARGET_OVAL_MINOR_VERSION:STRING=10"
 			shift
 		fi
 	fi
@@ -118,5 +118,5 @@ fi
 set -e
 rm -rf build/*
 cd build
-cmake .. "${build_type}" "${scap_version}" -DSSG_PRODUCT_DEFAULT=OFF "${cmake_enable_args[@]}" -G "$cmake_generator"
+cmake .. "${build_type}" "${oval_minor_version}" -DSSG_PRODUCT_DEFAULT=OFF "${cmake_enable_args[@]}" -G "$cmake_generator"
 $build_command "-j${cores}"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -536,7 +536,8 @@ macro(ssg_build_sds PRODUCT)
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-add --skip-valid "ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-add --skip-valid "ssg-${PRODUCT}-pcidss-xccdf-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/sds_move_ocil_to_checks.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "${SSG_TARGET_SCAP_VERSION}" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.2" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.3" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
@@ -560,7 +561,8 @@ macro(ssg_build_sds PRODUCT)
             COMMAND "${SED_EXECUTABLE}" -i 's/schematron-version="[0-9].[0-9]"/schematron-version="1.2"/' "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-add --skip-valid "ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/sds_move_ocil_to_checks.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "${SSG_TARGET_SCAP_VERSION}" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.2" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.3" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -529,6 +529,7 @@ macro(ssg_build_sds PRODUCT)
     if("${PRODUCT}" MATCHES "rhel(6|7)")
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
             # use --skip-valid here to avoid repeatedly validating everything
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-compose --skip-valid "ssg-${PRODUCT}-xccdf-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
@@ -539,6 +540,7 @@ macro(ssg_build_sds PRODUCT)
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.2" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.3" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
             DEPENDS generate-ssg-${PRODUCT}-oval.xml
@@ -550,11 +552,12 @@ macro(ssg_build_sds PRODUCT)
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
             DEPENDS generate-ssg-${PRODUCT}-pcidss-xccdf-1.2.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-pcidss-xccdf-1.2.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xml and ssg-${PRODUCT}-ds-1.2.xml"
         )
     else()
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
             # use --skip-valid here to avoid repeatedly validating everything
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-compose --skip-valid "ssg-${PRODUCT}-xccdf-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
@@ -564,6 +567,7 @@ macro(ssg_build_sds PRODUCT)
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.2" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/update_sds_version.py" --version "1.3" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
             DEPENDS generate-ssg-${PRODUCT}-oval.xml
@@ -573,7 +577,7 @@ macro(ssg_build_sds PRODUCT)
             DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xm and lssg-${PRODUCT}-ds-1.2.xml"
         )
     endif()
     add_custom_target(
@@ -845,11 +849,12 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
+        OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         DEPENDS generate-ssg-${ORIGINAL}-ds.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml"
         DEPENDS "${SSG_BUILD_SCRIPTS}/enable_derivatives.py"
-        COMMENT "[${DERIVATIVE}-content] generating ssg-${DERIVATIVE}-ds.xml"
+        COMMENT "[${DERIVATIVE}-content] generating ssg-${DERIVATIVE}-ds.xml and ssg-${DERIVATIVE}-ds-1.2.xml"
     )
     add_custom_target(
         generate-ssg-${DERIVATIVE}-ds.xml
@@ -858,6 +863,10 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
     add_test(
         NAME "validate-ssg-${DERIVATIVE}-ds.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
+    )
+    add_test(
+        NAME "validate-ssg-${DERIVATIVE}-ds-1.2.xml"
+        COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
     )
 
     add_custom_target(${DERIVATIVE} ALL)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1211,68 +1211,40 @@ macro(ssg_build_zipfile_target ZIPNAME)
 endmacro()
 
 macro(ssg_build_nist_zipfile ZIPNAME)
-    # When SCAP1.2 zipfiles are needed no more, these custom commands can be unified
+    # When SCAP1.2 content is no longer built along with 1.3 content, remove the if below
     if("${ZIPNAME}" MATCHES "SCAP-1.3")
-        # Zip only the SCAP1.3 datastream
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
-            COMMAND ${CMAKE_COMMAND} -E remove_directory "nist-zipfile/"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}"
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "nist-zipfile/${ZIPNAME}"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/bash"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/ansible"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/guides"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/tables"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E chdir "nist-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-nist.zip" --format=zip "${ZIPNAME}"
-            COMMENT "Building NIST zipfile at ${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
-            DEPENDS ocp3
-            DEPENDS rhel6
-            DEPENDS rhel7
-            DEPENDS rhel8
-            DEPENDS rhosp13
-            DEPENDS rhv4
-            )
+        set(SCAP_DS_VERSION_SUFFIX  "")
     else()
-        # Zip only the SCAP1.2 datastream
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
-            COMMAND ${CMAKE_COMMAND} -E remove_directory "nist-zipfile/"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}"
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "nist-zipfile/${ZIPNAME}"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds-1.2.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds-1.2.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/bash"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/ansible"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/guides"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/tables"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-            COMMAND ${CMAKE_COMMAND} -E chdir "nist-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-nist.zip" --format=zip "${ZIPNAME}"
-            COMMENT "Building NIST zipfile at ${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
-            DEPENDS ocp3
-            DEPENDS rhel6
-            DEPENDS rhel7
-            DEPENDS rhel8
-            DEPENDS rhosp13
-            DEPENDS rhv4
-            )
+        set(SCAP_DS_VERSION_SUFFIX  "-1.2")
     endif()
+    add_custom_command(
+        OUTPUT "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+        COMMAND ${CMAKE_COMMAND} -E remove_directory "nist-zipfile/"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "nist-zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds${SCAP_DS_VERSION_SUFFIX}.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds${SCAP_DS_VERSION_SUFFIX}.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/bash"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/ansible"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/guides"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/tables"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E chdir "nist-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-nist.zip" --format=zip "${ZIPNAME}"
+        COMMENT "Building NIST zipfile at ${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+        DEPENDS ocp3
+        DEPENDS rhel6
+        DEPENDS rhel7
+        DEPENDS rhel8
+        DEPENDS rhosp13
+        DEPENDS rhv4
+        )
     add_custom_target(
         nist-zipfile
         DEPENDS "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1210,7 +1210,7 @@ macro(ssg_build_zipfile_target ZIPNAME)
     )
 endmacro()
 
-macro(ssg_build_nist_zipfile ZIPNAME)
+macro(ssg_build_vendor_zipfile ZIPNAME)
     # When SCAP1.2 content is no longer built along with 1.3 content, remove the if below
     if("${ZIPNAME}" MATCHES "SCAP-1.3")
         set(SCAP_DS_VERSION_SUFFIX  "")
@@ -1218,26 +1218,26 @@ macro(ssg_build_nist_zipfile ZIPNAME)
         set(SCAP_DS_VERSION_SUFFIX  "-1.2")
     endif()
     add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
-        COMMAND ${CMAKE_COMMAND} -E remove_directory "nist-zipfile/"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}"
-        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "nist-zipfile/${ZIPNAME}"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds${SCAP_DS_VERSION_SUFFIX}.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds${SCAP_DS_VERSION_SUFFIX}.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/bash"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/ansible"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/guides"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/tables"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E chdir "nist-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-nist.zip" --format=zip "${ZIPNAME}"
-        COMMENT "Building NIST zipfile at ${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+        OUTPUT "${CMAKE_BINARY_DIR}/vendor-zipfile/${ZIPNAME}-RedHat.zip"
+        COMMAND ${CMAKE_COMMAND} -E remove_directory "vendor-zipfile/"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "vendor-zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "vendor-zipfile/${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds${SCAP_DS_VERSION_SUFFIX}.xml" -DDEST="vendor-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds${SCAP_DS_VERSION_SUFFIX}.xml" -DDEST="vendor-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "vendor-zipfile/${ZIPNAME}/bash"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="vendor-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="vendor-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "vendor-zipfile/${ZIPNAME}/ansible"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="vendor-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="vendor-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "vendor-zipfile/${ZIPNAME}/guides"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="vendor-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="vendor-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "vendor-zipfile/${ZIPNAME}/tables"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="vendor-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="vendor-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+        COMMAND ${CMAKE_COMMAND} -E chdir "vendor-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-RedHat.zip" --format=zip "${ZIPNAME}"
+        COMMENT "Building Red Hat zipfile at ${CMAKE_BINARY_DIR}/vendor-zipfile/${ZIPNAME}-RedHat.zip"
         DEPENDS ocp3
         DEPENDS rhel6
         DEPENDS rhel7
@@ -1246,7 +1246,7 @@ macro(ssg_build_nist_zipfile ZIPNAME)
         DEPENDS rhv4
         )
     add_custom_target(
-        nist-zipfile
-        DEPENDS "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+        vendor-zipfile
+        DEPENDS "${CMAKE_BINARY_DIR}/vendor-zipfile/${ZIPNAME}-RedHat.zip"
     )
 endmacro()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1201,34 +1201,68 @@ macro(ssg_build_zipfile_target ZIPNAME)
 endmacro()
 
 macro(ssg_build_nist_zipfile ZIPNAME)
-    add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
-        COMMAND ${CMAKE_COMMAND} -E remove_directory "nist-zipfile/"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}"
-        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "nist-zipfile/${ZIPNAME}"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/bash"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/ansible"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/guides"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/tables"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -E chdir "nist-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-nist.zip" --format=zip "${ZIPNAME}"
-        COMMENT "Building NIST zipfile at ${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
-        DEPENDS ocp3
-        DEPENDS rhel6
-        DEPENDS rhel7
-        DEPENDS rhel8
-        DEPENDS rhosp13
-        DEPENDS rhv4
-        )
+    # When SCAP1.2 zipfiles are needed no more, these custom commands can be unified
+    if("${ZIPNAME}" MATCHES "SCAP-1.3")
+        # Zip only the SCAP1.3 datastream
+        add_custom_command(
+            OUTPUT "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+            COMMAND ${CMAKE_COMMAND} -E remove_directory "nist-zipfile/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "nist-zipfile/${ZIPNAME}"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/bash"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/ansible"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/guides"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/tables"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E chdir "nist-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-nist.zip" --format=zip "${ZIPNAME}"
+            COMMENT "Building NIST zipfile at ${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+            DEPENDS ocp3
+            DEPENDS rhel6
+            DEPENDS rhel7
+            DEPENDS rhel8
+            DEPENDS rhosp13
+            DEPENDS rhv4
+            )
+    else()
+        # Zip only the SCAP1.2 datastream
+        add_custom_command(
+            OUTPUT "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+            COMMAND ${CMAKE_COMMAND} -E remove_directory "nist-zipfile/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" "nist-zipfile/${ZIPNAME}"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-rh*-ds-1.2.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-ocp*-ds-1.2.xml" -DDEST="nist-zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/bash"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-rh*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/ssg-ocp*.sh" -DDEST="nist-zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/ansible"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-rh*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ansible/ssg-ocp*.yml" -DDEST="nist-zipfile/${ZIPNAME}/ansible" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/guides"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-rh*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/guides/ssg-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/guides" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "nist-zipfile/${ZIPNAME}/tables"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-rh*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/table-ocp*" -DDEST="nist-zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
+            COMMAND ${CMAKE_COMMAND} -E chdir "nist-zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}-nist.zip" --format=zip "${ZIPNAME}"
+            COMMENT "Building NIST zipfile at ${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"
+            DEPENDS ocp3
+            DEPENDS rhel6
+            DEPENDS rhel7
+            DEPENDS rhel8
+            DEPENDS rhosp13
+            DEPENDS rhv4
+            )
+    endif()
     add_custom_target(
         nist-zipfile
         DEPENDS "${CMAKE_BINARY_DIR}/nist-zipfile/${ZIPNAME}-nist.zip"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -577,7 +577,7 @@ macro(ssg_build_sds PRODUCT)
             DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xm and ssg-${PRODUCT}-ds-1.2.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xml and ssg-${PRODUCT}-ds-1.2.xml"
         )
     endif()
     add_custom_target(

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1217,6 +1217,8 @@ macro(ssg_build_vendor_zipfile ZIPNAME)
     else()
         set(SCAP_DS_VERSION_SUFFIX  "-1.2")
     endif()
+
+    # Red Hat zipfile
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/vendor-zipfile/${ZIPNAME}-RedHat.zip"
         COMMAND ${CMAKE_COMMAND} -E remove_directory "vendor-zipfile/"
@@ -1246,7 +1248,9 @@ macro(ssg_build_vendor_zipfile ZIPNAME)
         DEPENDS rhv4
         )
     add_custom_target(
-        vendor-zipfile
+        redhat-zipfile
         DEPENDS "${CMAKE_BINARY_DIR}/vendor-zipfile/${ZIPNAME}-RedHat.zip"
     )
+    add_custom_target(vendor-zipfile ALL)
+    add_dependencies(vendor-zipfile redhat-zipfile)
 endmacro()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -577,7 +577,7 @@ macro(ssg_build_sds PRODUCT)
             DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
             DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xm and lssg-${PRODUCT}-ds-1.2.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ds.xm and ssg-${PRODUCT}-ds-1.2.xml"
         )
     endif()
     add_custom_target(

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -850,6 +850,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         DEPENDS generate-ssg-${ORIGINAL}-ds.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -585,6 +585,10 @@ macro(ssg_build_sds PRODUCT)
         NAME "validate-ssg-${PRODUCT}-ds.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
     )
+    add_test(
+        NAME "validate-ssg-${PRODUCT}-ds-1.2.xml"
+        COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
+    )
 endmacro()
 
 macro(ssg_build_html_guides PRODUCT)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1251,6 +1251,6 @@ macro(ssg_build_vendor_zipfile ZIPNAME)
         redhat-zipfile
         DEPENDS "${CMAKE_BINARY_DIR}/vendor-zipfile/${ZIPNAME}-RedHat.zip"
     )
-    add_custom_target(vendor-zipfile ALL)
+    add_custom_target(vendor-zipfile)
     add_dependencies(vendor-zipfile redhat-zipfile)
 endmacro()

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -192,31 +192,28 @@ make -j4 html-profile-stats # create statistics for all profiles in all products
 
 If you want to go deeper into statistics, refer to <<Profile Statistics and Utilities>> section.
 
-#### Building SCAP 1.2 content
+#### Building compliant SCAP 1.2 content
 
-By default, the build system builds SCAP content conforming to SCAP version 1.3. It is possible to build SCAP 1.2 content instead.
+By default, the build system builds SCAP content with OVAL 5.11. This means that the SCAP 1.3 datastream conforms to SCAP standard version 1.3. But the SCAP 1.2 datastream is not fully conformant with SCAP standard version 1.2, as up to OVAL 5.10 version is allowed.
+As SCAP 1.3 allows up to OVAL 5.11 and SCAP 1.2 allows up to OVAL 5.10.
 
-If you use `build_product` script, pass `--scap12` option to build SCAP 1.2 content:
+To build fully compliant SCAP 1.2 content:
+
+If you use `build_product` script, pass `--oval510` option:
 
 ```bash
-./build_product --scap12 <product-name>
+./build_product --oval510 <product-name>
 ```
 
-If you use `cmake` command, pass `-DSSG_TARGET_SCAP_VERSION:STRING=1.2` option to build SCAP 1.2 content:
+If you use `cmake` command, pass `-DSSG_TARGET_OVAL_MINOR_VERSION:STRING=10`:
 
 ```bash
 cd build/
-cmake -DSSG_TARGET_SCAP_VERSION:STRING=1.2 ../
+cmake -DSSG_TARGET_OVAL_MINOR_VERSION:STRING=10 ../
 make
 ```
 
-As of SCAP specification, SCAP 1.3 content contains OVAL 5.11 and SCAP 1.2 content content contains OVAL 5.10 checks.
-You can change the OVAL version using CMake variables `SSG_TARGET_OVAL_MAJOR_VERSION` and `SSG_TARGET_OVAL_MINOR_VERSION`.
-For example, to build a non-standard SCAP 1.2 datastream which would contain OVAL 5.11 checks, modify the `cmake` command in the following way:
-
-```bash
-cmake -DSSG_TARGET_OVAL_MINOR_VERSION:STRING=11 -DSSG_TARGET_SCAP_VERSION:STRING=1.2 ../
-```
+And use the datastream with suffix `-1.2.xml`.
 
 ### Build outputs
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -226,15 +226,18 @@ it will be the `content/build` folder.
 
 #### SCAP XML files
 The SCAP XML files will be called `ssg-${PRODUCT}-${TYPE}.xml`. For example
-`ssg-rhel7-ds.xml` is the *Red Hat Enterprise Linux 7* **source datastream**.
-We recommend using **source datastream** if you have a choice but the build
-system also generates separate XCCDF, OVAL, OCIL and CPE files:
+`ssg-rhel7-ds.xml` is the SCAP 1.3 *Red Hat Enterprise Linux 7* **source datastream**,
+and `ssg-rhel7-ds-1.2.xml` is the SCAP 1.2 **source datastream**.
+
+We recommend using **source datastream** if you have a choice.
+The build system also generates separate XCCDF, OVAL, OCIL and CPE files:
 
 ```bash
 $ ls -1 ssg-rhel7-*.xml
 ssg-rhel7-cpe-dictionary.xml
 ssg-rhel7-cpe-oval.xml
 ssg-rhel7-ds.xml
+ssg-rhel7-ds-1.2.xml
 ssg-rhel7-ocil.xml
 ssg-rhel7-oval.xml
 ssg-rhel7-pcidss-xccdf-1.2.xml

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -391,6 +391,16 @@ cd build/
 make zipfile
 ```
 
+There is also target to build zip file containing contents specific for a vendor's product.
+
+```bash
+cd build/
+# To build content zipfiles of all vendors:
+make vendor-zipfile
+# To build Red Hat zipfiles:
+make redhat-zipfile
+```
+
 ### Build the docker container image
 
 Use a suitable Dockerfile present in the

--- a/tests/run_scapval.py
+++ b/tests/run_scapval.py
@@ -107,9 +107,9 @@ def main():
     overall_result = True
     args = parse_args()
     if args.scap_version == "1.2":
-        ds_suffix = "-ds.xml"
+        ds_suffix = "-ds-1.2.xml"
     elif args.scap_version == "1.3":
-        ds_suffix = "-ds-1.3.xml"
+        ds_suffix = "-ds.xml"
     for filename in os.listdir(args.build_dir):
         if filename.endswith(ds_suffix):
             print("Testing %s ..." % filename)


### PR DESCRIPTION
#### Description:

- Follow up from #4689, build both SCAP versions, instead of only one of them.
- Default means that the datastream named `ssg-<product>-ds.xml` is SCAP 1.3.
- The SCAP 1.2 datastream will be named `ssg-<product>-ds-1.2.xml`.
- Updated `build_script` command with option to generate fully compliant SCAP 1.2 with `--oval510`
- Docs also updated

EDIT:
- Also, `nist-zipfile` target changed to `vendor-zipfile` and documented.

#### Rationale:
- SCAP 1.3 is still not widely supported, until then build SCAP 1.2 content
