### PR TITLE
Create configuration files if they don't exist

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/ansible/shared.yml
@@ -10,3 +10,4 @@
     regexp: ^#?crypt_style
     line: crypt_style = sha512
     state: present
+    create: yes

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
@@ -9,3 +9,4 @@
       regexp: ^#?ENCRYPT_METHOD
       line: ENCRYPT_METHOD SHA512
       state: present
+      create: yes

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
@@ -10,4 +10,5 @@
     state: present
     regexp: ^CtrlAltDelBurstAction
     line: "CtrlAltDelBurstAction=none"
+    create: yes
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
@@ -11,3 +11,4 @@
     regexp: "^PASS_MIN_LEN *[0-9]*"
     state: present
     line: "PASS_MIN_LEN        {{ var_accounts_password_minlen_login_defs }}"
+    create: yes

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
@@ -11,3 +11,4 @@
     regexp: "^PASS_WARN_AGE *[0-9]*"
     state: present
     line: "PASS_WARN_AGE        {{ var_accounts_password_warn_age_login_defs }}"
+    create: yes

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
@@ -10,4 +10,5 @@
     dest: /etc/login.defs
     regexp: ^FAIL_DELAY
     line: "FAIL_DELAY {{ var_accounts_fail_delay }}"
+    create: yes
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
@@ -12,3 +12,4 @@
     insertbefore: "^# End of file"
     regexp: "^#?\\*.*maxlogins"
     line: "*           hard    maxlogins     {{ var_accounts_max_concurrent_login_sessions }}"
+    create: yes

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/ansible/shared.yml
@@ -13,3 +13,4 @@
     {{%- endif %}}
     regexp: "^active"
     line: active = yes
+    create: yes

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
@@ -11,4 +11,5 @@
     line: "disk_error_action = {{ var_auditd_disk_error_action }}"
     regexp: '^\s*disk_error_action\s*=\s*.*$'
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
@@ -11,4 +11,5 @@
     line: "disk_full_action = {{ var_auditd_disk_full_action }}"
     regexp: '^\s*disk_full_action\s*=\s*.*$'
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -10,4 +10,5 @@
     dest: /etc/audit/auditd.conf
     line: "action_mail_acct = {{ var_auditd_action_mail_acct }}"
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
@@ -11,4 +11,5 @@
     line: "admin_space_left_action = {{ var_auditd_admin_space_left_action }}"
     regexp: '^\s*admin_space_left_action\s*=\s*.*$'
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
@@ -11,4 +11,5 @@
     regexp: '^\s*flush\s*=\s*.*$'
     line: "flush = {{ var_auditd_flush }}"
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
@@ -11,4 +11,5 @@
     regexp: '^\s*max_log_file\s*=\s*.*$'
     line: "max_log_file = {{ var_auditd_max_log_file }}"
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
@@ -11,4 +11,5 @@
     line: "max_log_file_action = {{ var_auditd_max_log_file_action }}"
     regexp: '^\s*max_log_file_action\s*=\s*.*$'
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
@@ -11,4 +11,5 @@
     line: "num_logs = {{ var_auditd_num_logs }}"
     regexp: '^\s*num_logs\s*=\s*.*$'
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
@@ -11,4 +11,5 @@
     line: "space_left = {{ var_auditd_space_left }}"
     regexp: '^\s*space_left\s*=\s*.*$'
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
@@ -11,4 +11,5 @@
     line: "space_left_action = {{ var_auditd_space_left_action }}"
     regexp: '^\s*space_left_action\s*=\s*.*$'
     state: present
+    create: yes
   #notify: reload auditd

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ansible/shared.yml
@@ -9,3 +9,4 @@
     dest: /etc/security/limits.conf
     regexp: '^[^#].*core'
     line: '*        hard       core      0'
+    create: yes

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
@@ -9,3 +9,4 @@
       regexp: ^#?clean_requirements_on_remove
       line: clean_requirements_on_remove=1
       insertafter: '\[main\]'
+      create: yes

--- a/shared/templates/template_ANSIBLE_audit_rules_dac_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_dac_modification
@@ -54,6 +54,7 @@
     line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
     state: present
     dest: /etc/audit/audit.rules
+    create: yes
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in audit.rules when on x86_64
   lineinfile:

--- a/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
@@ -54,6 +54,7 @@
     line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
     state: present
     dest: /etc/audit/audit.rules
+    create: yes
 
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:

--- a/shared/templates/template_ANSIBLE_audit_rules_login_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_login_events
@@ -48,3 +48,4 @@
     line: "-w {{{ PATH }}} -p wa -k logins"
     state: present
     dest: /etc/audit/audit.rules
+    create: yes

--- a/shared/templates/template_ANSIBLE_audit_rules_path_syscall
+++ b/shared/templates/template_ANSIBLE_audit_rules_path_syscall
@@ -60,6 +60,7 @@
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
+    create: yes
     regexp: "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
   with_items:
     - "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"

--- a/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
@@ -60,6 +60,7 @@
     line: "{{ item }}"
     state: present
     dest: /etc/audit/audit.rules
+    create: yes
   with_items:
     - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
     - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"

--- a/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_usergroup_modification
@@ -48,3 +48,4 @@
     line: "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification"
     state: present
     dest: /etc/audit/audit.rules
+    create: yes


### PR DESCRIPTION

#### Description:
Add "create=yes" to Ansible Tasks where `lineinfile` module is used.


#### Rationale:
Prevents Ansible Playbook from terminating.
Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741455

