### PR TITLE
extend oval check of configure_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -1,14 +1,14 @@
 {{%- if target_oval_version == [5, 11] -%}}
 {{# there is no good alternative for symlink_test for OVAL 5.10 #}}
 {{%- macro crypto_policy_symlink_criterion(library) %}}
-      <criteria operator="OR">
+      <criteria operator="OR" comment="checks if /etc/crypto-policies/back-ends/{{{ library }}}.config is either a symlink and in that case a drop in file in /etc/crypto-policies/local.d must not exist or /etc/crypto-policies/back-ends/{{{ library }}}.config is a regular file and the drop in file must exist">
         <criteria operator="AND">
           <criterion comment="Check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to /usr/share/crypto-policies/POLICY/{{{ library }}}.txt" test_ref="test_crypto_policy_{{{ library }}}_symlink" />
           <criterion comment="Checks if there is NOT a drop in file in /etc/crypto-policies/local.d associated with {{{ library }}}." test_ref="test_{{{ library }}}_dropin_file" negate="true" />
         </criteria>
         <criteria operator="AND">
           <criterion comment="checks if the /etc/crypto-policies/back-ends/{{{ library }}}.config file is a regular file." test_ref="test_{{{ library }}}_regular_file"/>
-          <criterion comment="In case the file /etc/crypto-policies/back-ends/{{{ library }}}.config is a regular file, it checks that the appropriate file exists in the /etc/crypto-policies/local.d." test_ref="test_{{{ library }}}_dropin_file" />
+          <criterion comment="Checks if there is a drop in file in /etc/crypto-policies/local.d associated with {{{ library }}}." test_ref="test_{{{ library }}}_dropin_file" />
         </criteria>
       </criteria>
 {{%- endmacro %}}

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -61,7 +61,7 @@
   </unix:file_test>
 
   <unix:file_object id="object_crypto_policy_{{{ library }}}_dropin_file" version="1">
-    <unix:filepath operation="pattern match">^/etc/crypto-policies/local.d/{{{ library }}}.*\.config$</unix:filepath>
+    <unix:filepath operation="pattern match">^/etc/crypto-policies/local\.d/{{{ library }}}-.*\.config$</unix:filepath>
   </unix:file_object>
 
 {{%- endmacro %}}

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -3,7 +3,7 @@
 {{%- macro crypto_policy_symlink_criterion(library) %}}
       <criteria operator="OR">
         <criterion comment="Check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to /usr/share/crypto-policies/POLICY/{{{ library }}}.txt" test_ref="test_crypto_policy_{{{ library }}}_symlink" />
-        <criterion comment="In case the file /etc/crypto-policies/back-ends/{{{ library }}}.config is not a symlink, it checks that the appropriate file exists in the /etc/crypto-policies/local.d and its contents are appended to /etc/crypto-policies/back-ends/{{{ library }}}.config", test_ref="test_{{{ library }}}_file">
+        <criterion comment="In case the file /etc/crypto-policies/back-ends/{{{ library }}}.config is not a symlink, it checks that the appropriate file exists in the /etc/crypto-policies/local.d and its contents are appended to /etc/crypto-policies/back-ends/{{{ library }}}.config" test_ref="test_{{{ library }}}_dropin_file" />
       </criteria>
 {{%- endmacro %}}
 
@@ -12,13 +12,6 @@
     <concat>
       <literal_component>^/usr/share/crypto-policies/</literal_component>
       <variable_component var_ref="var_system_crypto_policy"/>
-      <literal_component>/{{{ library }}}.txt$</literal_component>
-    </concat>
-  </local_variable>
-
-  <local_variable id="var_crypto_policy_{{{ library }}}_dropin_path" datatype="string" comment="Regex variable for canonical path to possible dropin file for {{{ library }}} policy" version="1">
-    <concat>
-      <literal_component>^/etc/crypto-policies/local.d/.*/</literal_component>
       <literal_component>/{{{ library }}}.txt$</literal_component>
     </concat>
   </local_variable>
@@ -38,6 +31,17 @@
     <unix:filepath>/etc/crypto-policies/back-ends/{{{ library }}}.config</unix:filepath>
     <unix:canonical_path operation="pattern match" var_ref="var_crypto_policy_{{{ library }}}_path"/>
   </unix:symlink_state>
+
+  <file_test id="test_{{{ library }}}_dropin_file"
+  comment="Checks if a file exists in /etc/crypto-policies/local.d/ which could be a drop in  file for one of libraries"
+  check_existence="all_exist" version="1">
+    <object object_ref="object_crypto_policy_{{{ library }}}_dropin_file" />
+  </file_test>
+
+  <file_object id="object_crypto_policy_{{{ library }}}_dropin_file" version="1">
+    <path>^/etc/crypto-policies/local.d/.*{{{ library }}}.*\.config$</path>
+  </file_object>
+
 {{%- endmacro %}}
 
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -1,7 +1,10 @@
 {{%- if target_oval_version == [5, 11] -%}}
 {{# there is no good alternative for symlink_test for OVAL 5.10 #}}
 {{%- macro crypto_policy_symlink_criterion(library) %}}
-      <criterion comment="Check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to /usr/share/crypto-policies/POLICY/{{{ library }}}.txt" test_ref="test_crypto_policy_{{{ library }}}_symlink" />
+      <criteria operator="OR">
+        <criterion comment="Check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to /usr/share/crypto-policies/POLICY/{{{ library }}}.txt" test_ref="test_crypto_policy_{{{ library }}}_symlink" />
+        <criterion comment="In case the file /etc/crypto-policies/back-ends/{{{ library }}}.config is not a symlink, it checks that the appropriate file exists in the /etc/crypto-policies/local.d and its contents are appended to /etc/crypto-policies/back-ends/{{{ library }}}.config", test_ref="test_{{{ library }}}_file">
+      </criteria>
 {{%- endmacro %}}
 
 {{%- macro crypto_policy_symlink_check(library) %}}
@@ -9,6 +12,13 @@
     <concat>
       <literal_component>^/usr/share/crypto-policies/</literal_component>
       <variable_component var_ref="var_system_crypto_policy"/>
+      <literal_component>/{{{ library }}}.txt$</literal_component>
+    </concat>
+  </local_variable>
+
+  <local_variable id="var_crypto_policy_{{{ library }}}_dropin_path" datatype="string" comment="Regex variable for canonical path to possible dropin file for {{{ library }}} policy" version="1">
+    <concat>
+      <literal_component>^/etc/crypto-policies/local.d/.*/</literal_component>
       <literal_component>/{{{ library }}}.txt$</literal_component>
     </concat>
   </local_variable>

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -32,15 +32,15 @@
     <unix:canonical_path operation="pattern match" var_ref="var_crypto_policy_{{{ library }}}_path"/>
   </unix:symlink_state>
 
-  <file_test id="test_{{{ library }}}_dropin_file"
+  <unix:file_test id="test_{{{ library }}}_dropin_file"
   comment="Checks if a file exists in /etc/crypto-policies/local.d/ which could be a drop in  file for one of libraries"
   check_existence="all_exist" version="1">
-    <object object_ref="object_crypto_policy_{{{ library }}}_dropin_file" />
-  </file_test>
+    <unix:object object_ref="object_crypto_policy_{{{ library }}}_dropin_file" />
+  </unix:file_test>
 
-  <file_object id="object_crypto_policy_{{{ library }}}_dropin_file" version="1">
-    <path>^/etc/crypto-policies/local.d/.*{{{ library }}}.*\.config$</path>
-  </file_object>
+  <unix:file_object id="object_crypto_policy_{{{ library }}}_dropin_file" version="1">
+    <unix:path>^/etc/crypto-policies/local.d/.*{{{ library }}}.*\.config$</unix:path>
+  </unix:file_object>
 
 {{%- endmacro %}}
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -39,7 +39,7 @@
   </unix:file_test>
 
   <unix:file_object id="object_crypto_policy_{{{ library }}}_dropin_file" version="1">
-    <unix:path>^/etc/crypto-policies/local.d/.*{{{ library }}}.*\.config$</unix:path>
+    <unix:filepath operation="pattern match">^/etc/crypto-policies/local.d/{{{ library }}}.*\.config$</unix:filepath>
   </unix:file_object>
 
 {{%- endmacro %}}

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -34,7 +34,7 @@
 
   <unix:file_test id="test_{{{ library }}}_dropin_file"
   comment="Checks if a file exists in /etc/crypto-policies/local.d/ which could be a drop in  file for one of libraries"
-  check_existence="all_exist" version="1">
+  check="all" check_existence="all_exist" version="1">
     <unix:object object_ref="object_crypto_policy_{{{ library }}}_dropin_file" />
   </unix:file_test>
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -2,8 +2,14 @@
 {{# there is no good alternative for symlink_test for OVAL 5.10 #}}
 {{%- macro crypto_policy_symlink_criterion(library) %}}
       <criteria operator="OR">
-        <criterion comment="Check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to /usr/share/crypto-policies/POLICY/{{{ library }}}.txt" test_ref="test_crypto_policy_{{{ library }}}_symlink" />
-        <criterion comment="In case the file /etc/crypto-policies/back-ends/{{{ library }}}.config is not a symlink, it checks that the appropriate file exists in the /etc/crypto-policies/local.d and its contents are appended to /etc/crypto-policies/back-ends/{{{ library }}}.config" test_ref="test_{{{ library }}}_dropin_file" />
+        <criteria operator="AND">
+          <criterion comment="Check if /etc/crypto-policies/back-ends/{{{ library }}}.config is linked to /usr/share/crypto-policies/POLICY/{{{ library }}}.txt" test_ref="test_crypto_policy_{{{ library }}}_symlink" />
+          <criterion comment="Checks if there is NOT a drop in file in /etc/crypto-policies/local.d associated with {{{ library }}}." test_ref="test_{{{ library }}}_dropin_file" negate="true" />
+        </criteria>
+        <criteria operator="AND">
+          <criterion comment="checks if the /etc/crypto-policies/back-ends/{{{ library }}}.config file is a regular file." test_ref="test_{{{ library }}}_regular_file"/>
+          <criterion comment="In case the file /etc/crypto-policies/back-ends/{{{ library }}}.config is a regular file, it checks that the appropriate file exists in the /etc/crypto-policies/local.d." test_ref="test_{{{ library }}}_dropin_file" />
+        </criteria>
       </criteria>
 {{%- endmacro %}}
 
@@ -31,6 +37,22 @@
     <unix:filepath>/etc/crypto-policies/back-ends/{{{ library }}}.config</unix:filepath>
     <unix:canonical_path operation="pattern match" var_ref="var_crypto_policy_{{{ library }}}_path"/>
   </unix:symlink_state>
+
+  <unix:file_test id="test_{{{ library }}}_regular_file"
+  comment="Checks if a file in /etc/crypto-policies/back-ends/{{{ library }}}.config is a regular file"
+  check="all" check_existence="all_exist" version="1">
+    <unix:object object_ref="object_crypto_policy_{{{ library }}}_regular_file" />
+    <unix:state state_ref="state_crypto_policy_{{{ library }}}_regular_file" />
+  </unix:file_test>
+
+  <unix:file_object id="object_crypto_policy_{{{ library }}}_regular_file" version="1">
+    <unix:filepath>/etc/crypto-policies/back-ends/{{{ library }}}.config</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_state id="state_crypto_policy_{{{ library }}}_regular_file" version="1">
+    <unix:filepath>/etc/crypto-policies/back-ends/{{{ library }}}.config</unix:filepath>
+    <unix:type>regular</unix:type>
+  </unix:file_state>
 
   <unix:file_test id="test_{{{ library }}}_dropin_file"
   comment="Checks if a file exists in /etc/crypto-policies/local.d/ which could be a drop in  file for one of libraries"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
@@ -27,10 +27,18 @@ ocil: |-
     following command:
     <pre>$ update-crypto-policies --show</pre>
     The output should return <pre><sub idref="var_system_crypto_policy" /></pre>.
-    Moreover, check if crypto policy customizations are applied correctly.
-    <pre>$ ls -l /etc/crypto-policies/back-ends/</pre>
-    For every file, check if it is a symbolic link or a regular file. If it is a symbolic link, verify that the target resides in the <pre>/usr/share/crypto-policies/<sub idref="var_system_crypto_policy" />/</pre> directory. If it is a regular file, check that there exists a drop in file in the <pre>/etc/crypto-policies/local.d</pre>. The file name of a drop in file must be formed as <pre>LIBRARY_NAME-ARBITRARY_ID.config</pre>.
-    For example, the drop in file for Openssh server can be named <pre>opensshserver-ospp.config</pre>.
+    Run the command to check if the policy is correctly applied:
+    <pre>$ update-crypto-policies --is-applied</pre>
+    The output should be <pre>The configured policy is applied</pre>.
+    Moreover, check if settings for selected crypto policy are as expected.
+    List all libraries for which it holds that their crypto policies do not have symbolic link in <pre>/etc/crypto-policies/back-ends</pre>.
+    <pre>$ ls -l /etc/crypto-policies/back-ends/ | grep '^[^l]' | tail -n +2 | awk -F' ' '{print $NF}' | awk -F'.' '{print $1}' | sort</pre>
+    Subsequently, check if matching libraries have drop in files in the <pre>/etc/crypto-policies/local.d</pre> directory.
+    <pre>$ ls /etc/crypto-policies/local.d/ | awk -F'-' '{print $1}' | uniq | sort</pre>
+    Outputs of two previous commands should match.
+    Now check if all symbolic links from the <pre>/etc/crypto-policies/back-ends/</pre> are pointing into the <pre>/usr/share/crypto-policies/<sub idref="var_system_crypto_policy" /></pre> directory.
+    <pre>$ find /etc/crypto-policies/back-ends/ -type l -ls | grep -v '/usr/share/crypto-policies/<sub idref="var_system_crypto_policy" />'</pre>
+    No output is expected.
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
@@ -5,9 +5,10 @@ prodtype: fedora,rhel8,ol8
 title: 'Configure System Cryptography Policy'
 
 description: |-
-    To configure the system cyptography policy to use ciphers only from the <tt><sub idref="var_system_crypto_policy" /></tt>
+    To configure the system cryptography policy to use ciphers only from the <tt><sub idref="var_system_crypto_policy" /></tt>
     policy, run the following command:
     <pre>$ sudo update-crypto-policies --set <sub idref="var_system_crypto_policy" /></pre>
+    The rule checks if an appropriate crypto policy is configured. Configuration files in the <tt>/etc/crypto-policies/back-ends</tt> are either symlinks to correct files provided by Crypto-policies package or thei are regular files in case crypto policy customizations are applied.
 
 rationale: |-
     Centralized cryptographic policies simplify applying secure ciphers across an operating system and

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
@@ -8,7 +8,7 @@ description: |-
     To configure the system cryptography policy to use ciphers only from the <tt><sub idref="var_system_crypto_policy" /></tt>
     policy, run the following command:
     <pre>$ sudo update-crypto-policies --set <sub idref="var_system_crypto_policy" /></pre>
-    The rule checks if an appropriate crypto policy is configured. Configuration files in the <tt>/etc/crypto-policies/back-ends</tt> are either symlinks to correct files provided by Crypto-policies package or thei are regular files in case crypto policy customizations are applied.
+    The rule checks if settings for selected crypto policy are configured as expected. Configuration files in the <tt>/etc/crypto-policies/back-ends</tt> are either symlinks to correct files provided by Crypto-policies package or they are regular files in case crypto policy customizations are applied.
 
 rationale: |-
     Centralized cryptographic policies simplify applying secure ciphers across an operating system and
@@ -27,6 +27,10 @@ ocil: |-
     following command:
     <pre>$ update-crypto-policies --show</pre>
     The output should return <pre><sub idref="var_system_crypto_policy" /></pre>.
+    Moreover, check if crypto policy customizations are applied correctly.
+    <pre>$ ls -l /etc/crypto-policies/back-ends/</pre>
+    For every file, check if it is a symbolic link or a regular file. If it is a symbolic link, verify that the target resides in the <pre>/usr/share/crypto-policies/<sub idref="var_system_crypto_policy" />/</pre> directory. If it is a regular file, check that there exists a drop in file in the <pre>/etc/crypto-policies/local.d</pre>. The file name of a drop in file must be formed as <pre>LIBRARY_NAME-ARBITRARY_ID.config</pre>.
+    For example, the drop in file for Openssh server can be named <pre>opensshserver-ospp.config</pre>.
 
 warnings:
     - general: |-

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/dropin_file_and_symlink_exist.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/dropin_file_and_symlink_exist.fail.sh
@@ -5,6 +5,7 @@
 # using example of opensshserver
 DROPIN_FILE="/etc/crypto-policies/local.d/opensshserver-test.config"
 
-update-crypto-policies --set "FIPS"
+update-crypto-policies --set FIPS
 
-echo "testing testing" > "$DROPIN_FILE"
+echo "" > "$DROPIN_FILE"
+echo "CRYPTO_POLICY=" >> "$DROPIN_FILE"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/dropin_file_and_symlink_exist.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/dropin_file_and_symlink_exist.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
+
+# using example of opensshserver
+DROPIN_FILE="/etc/crypto-policies/local.d/opensshserver-test.config"
+
+update-crypto-policies --set "FIPS"
+
+echo "testing testing" > "$DROPIN_FILE"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/file_exists_but_no_file_in_local_d.fail.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/file_exists_but_no_file_in_local_d.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+#using example of openssh server
+CRYPTO_POLICY_FILE="/etc/crypto-policies/back-ends/opensshserver.config"
+
+update-crypto-policies --set "FIPS"
+
+rm -f /etc/crypto-policies/local.d/opensshserver-*.config
+rm -f "$CRYPTO_POLICY_FILE"
+
+echo "pretend that we overide the crrypto policy but no related file is in /etc/crypto-policies/local.d, smart, right?" > "$CRYPTO_POLICY_FILE"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/override_policy.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/override_policy.pass.sh
@@ -5,6 +5,7 @@
 #using openssh server as example
 CRYPTO_POLICY_OVERRIDE_FILE="/etc/crypto-policies/local.d/opensshserver-test.config"
 
-cat "CRYPTO_POLICY=test" > "$CRYPTO_POLICY_OVERRIDE_FILE"
+echo "" > "$CRYPTO_POLICY_OVERRIDE_FILE"
+echo "CRYPTO_POLICY=" >> "$CRYPTO_POLICY_OVERRIDE_FILE"
 
-update-crypto-policies --set "FIPS"
+update-crypto-policies --set FIPS

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/override_policy.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/override_policy.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+#using openssh server as example
+CRYPTO_POLICY_OVERRIDE_FILE="/etc/crypto-policies/local.d/opensshserver-test.config"
+
+update-crypto-policies --set "FIPS"
+
+cat "CRYPTO_POLICY=test" > "$CRYPTO_POLICY_OVERRIDE_FILE"
+
+update-crypto-policies --set "FIPS"

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/override_policy.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_crypto_policy/override_policy.pass.sh
@@ -5,8 +5,6 @@
 #using openssh server as example
 CRYPTO_POLICY_OVERRIDE_FILE="/etc/crypto-policies/local.d/opensshserver-test.config"
 
-update-crypto-policies --set "FIPS"
-
 cat "CRYPTO_POLICY=test" > "$CRYPTO_POLICY_OVERRIDE_FILE"
 
 update-crypto-policies --set "FIPS"


### PR DESCRIPTION
#### Description:

This extends oval check of configure_crypto_policy rule. Additionally it allows file in the /etc/crypto-policies/back-ends/ to be regular files, but appropriate file in /etc/crypto-policy/local.d/ must exist. This is with accordance to customizations of crypto policies.

#### Rationale:

This customization of crypto policies is used in some other rule and therefore should not fail.


