### PR TITLE
Simplify regexp

### DIFF
--- a/applications/openstack/cinder/cinder_glance_tls/oval/shared.xml
+++ b/applications/openstack/cinder/cinder_glance_tls/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_cinder_glance_api_insecure" version="2">
     <ind:filepath>/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder/cinder_nas_secure_file_permissions/oval/shared.xml
+++ b/applications/openstack/cinder/cinder_nas_secure_file_permissions/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_cinder_nas_secure_file_operations" version="2">
     <ind:filepath>/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)nas_secure_file_operations(?-i)[\s]+auto[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)nas_secure_file_operations(?-i)[\s]+auto[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder/cinder_nova_tls/oval/shared.xml
+++ b/applications/openstack/cinder/cinder_nova_tls/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_cinder_nova_api_insecure" version="2">
     <ind:filepath>/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)nova_api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)nova_api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder/cinder_osapi_max_request_body/oval/shared.xml
+++ b/applications/openstack/cinder/cinder_osapi_max_request_body/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_cinder_osapi_max_request_body_size" version="2">
     <ind:filepath>/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)osapi_max_request_body_size(?-i)[\s]+114688[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)osapi_max_request_body_size(?-i)[\s]+114688[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder/cinder_tls_enabled/oval/shared.xml
+++ b/applications/openstack/cinder/cinder_tls_enabled/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_cinder_auth_protocol" version="2">
     <ind:filepath>/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder/cinder_using_keystone/oval/shared.xml
+++ b/applications/openstack/cinder/cinder_using_keystone/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_cinder_auth_strategy" version="2">
     <ind:filepath>/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder_container/container_cinder_glance_tls/oval/shared.xml
+++ b/applications/openstack/cinder_container/container_cinder_glance_tls/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_cinder_glance_api_insecure" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder_container/container_cinder_nas_secure_file_permissions/oval/shared.xml
+++ b/applications/openstack/cinder_container/container_cinder_nas_secure_file_permissions/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_cinder_nas_secure_file_operations" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)nas_secure_file_operations(?-i)[\s]+auto[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)nas_secure_file_operations(?-i)[\s]+auto[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder_container/container_cinder_nova_tls/oval/shared.xml
+++ b/applications/openstack/cinder_container/container_cinder_nova_tls/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_cinder_nova_api_insecure" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)nova_api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)nova_api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder_container/container_cinder_osapi_max_request_body/oval/shared.xml
+++ b/applications/openstack/cinder_container/container_cinder_osapi_max_request_body/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_cinder_osapi_max_request_body_size" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)osapi_max_request_body_size(?-i)[\s]+114688[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)osapi_max_request_body_size(?-i)[\s]+114688[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder_container/container_cinder_tls_enabled/oval/shared.xml
+++ b/applications/openstack/cinder_container/container_cinder_tls_enabled/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_cinder_auth_protocol" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/cinder_container/container_cinder_using_keystone/oval/shared.xml
+++ b/applications/openstack/cinder_container/container_cinder_using_keystone/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_cinder_auth_strategy" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/cinder/etc/cinder/cinder.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon/horizon_csrf_cookie_secure/oval/shared.xml
+++ b/applications/openstack/horizon/horizon_csrf_cookie_secure/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_horizon_csrf_cookie_secure" version="2">
     <ind:filepath>/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)CSRF_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)CSRF_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon/horizon_disable_password_reveal/oval/shared.xml
+++ b/applications/openstack/horizon/horizon_disable_password_reveal/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_horizon_disable_password_reveal" version="2">
     <ind:filepath>/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)disable_password_reveal(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)disable_password_reveal(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon/horizon_password_autocomplete/oval/shared.xml
+++ b/applications/openstack/horizon/horizon_password_autocomplete/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_horizon_password_autocomplete" version="2">
     <ind:filepath>/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)password_autocomplete(?-i)[\s]+off[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)password_autocomplete(?-i)[\s]+off[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon/horizon_session_cookie_httponly/oval/shared.xml
+++ b/applications/openstack/horizon/horizon_session_cookie_httponly/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_horizon_session_cookie_httponly" version="2">
     <ind:filepath>/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_HTTPONLY(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_HTTPONLY(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon/horizon_session_cookie_secure/oval/shared.xml
+++ b/applications/openstack/horizon/horizon_session_cookie_secure/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_horizon_session_cookie_secure" version="2">
     <ind:filepath>/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon/horizon_use_ssl/oval/shared.xml
+++ b/applications/openstack/horizon/horizon_use_ssl/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_horizon_use_ssl" version="2">
     <ind:filepath>/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)USE_SSL(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)USE_SSL(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon_container/container_horizon_csrf_cookie_secure/oval/shared.xml
+++ b/applications/openstack/horizon_container/container_horizon_csrf_cookie_secure/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_horizon_csrf_cookie_secure" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/horizon/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)CSRF_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)CSRF_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon_container/container_horizon_disable_password_reveal/oval/shared.xml
+++ b/applications/openstack/horizon_container/container_horizon_disable_password_reveal/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_horizon_disable_password_reveal" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/horizon/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)disable_password_reveal(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)disable_password_reveal(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon_container/container_horizon_password_autocomplete/oval/shared.xml
+++ b/applications/openstack/horizon_container/container_horizon_password_autocomplete/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_horizon_password_autocomplete" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/horizon/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)password_autocomplete(?-i)[\s]+off[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)password_autocomplete(?-i)[\s]+off[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon_container/container_horizon_session_cookie_httponly/oval/shared.xml
+++ b/applications/openstack/horizon_container/container_horizon_session_cookie_httponly/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_horizon_session_cookie_httponly" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/horizon/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_HTTPONLY(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_HTTPONLY(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon_container/container_horizon_session_cookie_secure/oval/shared.xml
+++ b/applications/openstack/horizon_container/container_horizon_session_cookie_secure/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_horizon_session_cookie_secure" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/horizon/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)SESSION_COOKIE_SECURE(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/horizon_container/container_horizon_use_ssl/oval/shared.xml
+++ b/applications/openstack/horizon_container/container_horizon_use_ssl/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_horizon_use_ssl" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/horizon/etc/openstack-dashboard/local_settings</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)USE_SSL(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)USE_SSL(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone/keystone_algorithm_hashing/oval/shared.xml
+++ b/applications/openstack/keystone/keystone_algorithm_hashing/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_keystone_hash_algorithm" version="2">
     <ind:filepath>/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)hash_algorithm(?-i)[\s]+SHA256[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)hash_algorithm(?-i)[\s]+SHA256[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone/keystone_disable_admin_token/oval/shared.xml
+++ b/applications/openstack/keystone/keystone_disable_admin_token/oval/shared.xml
@@ -27,13 +27,13 @@
 
   <ind:textfilecontent54_object id="obj_keystone_admin_token" version="2">
     <ind:filepath>/etc/keystone/keystone-paste.ini</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)admin_token(?-i)[\s]+disabled[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)admin_token(?-i)[\s]+disabled[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="obj_keystone_admin_token_auth_middleware" version="2">
     <ind:filepath>/etc/keystone/keystone-paste.ini</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)AdminTokenAuthMiddleware(?-i)[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)AdminTokenAuthMiddleware(?-i)[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone/keystone_disable_user_account_days_inactive/oval/shared.xml
+++ b/applications/openstack/keystone/keystone_disable_user_account_days_inactive/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_keystone_disable_user_account_days_inactive" version="2">
     <ind:filepath>/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)disable_user_account_days_inactive(?-i)[\s]+90[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)disable_user_account_days_inactive(?-i)[\s]+90[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone/keystone_lockout_duration/oval/shared.xml
+++ b/applications/openstack/keystone/keystone_lockout_duration/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_keystone_lockout_duration" version="2">
     <ind:filepath>/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_duration(?-i)[\s]+900[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_duration(?-i)[\s]+900[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone/keystone_lockout_failure_attempts/oval/shared.xml
+++ b/applications/openstack/keystone/keystone_lockout_failure_attempts/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_keystone_lockout_failure_attempts" version="2">
     <ind:filepath>/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_failure_attempts(?-i)[\s]+3[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_failure_attempts(?-i)[\s]+3[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone/keystone_max_request_body_size/oval/shared.xml
+++ b/applications/openstack/keystone/keystone_max_request_body_size/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_keystone_max_request_body_size" version="2">
     <ind:filepath>/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)max_request_body_size(?-i)[\s]+114688[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)max_request_body_size(?-i)[\s]+114688[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone/keystone_use_ssl/oval/shared.xml
+++ b/applications/openstack/keystone/keystone_use_ssl/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_keystone_ssl_enable" version="2">
     <ind:filepath>/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)enable(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)enable(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone_container/container_keystone_algorithm_hashing/oval/shared.xml
+++ b/applications/openstack/keystone_container/container_keystone_algorithm_hashing/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_keystone_hash_algorithm" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)hash_algorithm(?-i)[\s]+SHA256[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)hash_algorithm(?-i)[\s]+SHA256[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone_container/container_keystone_disable_admin_token/oval/shared.xml
+++ b/applications/openstack/keystone_container/container_keystone_disable_admin_token/oval/shared.xml
@@ -27,13 +27,13 @@
 
   <ind:textfilecontent54_object id="obj_container_keystone_admin_token" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone-paste.ini</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)admin_token(?-i)[\s]+disabled[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)admin_token(?-i)[\s]+disabled[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="obj_container_keystone_admin_token_auth_middleware" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone-paste.ini</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)AdminTokenAuthMiddleware(?-i)[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)AdminTokenAuthMiddleware(?-i)[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone_container/container_keystone_disable_user_account_days_inactive/oval/shared.xml
+++ b/applications/openstack/keystone_container/container_keystone_disable_user_account_days_inactive/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_keystone_disable_user_account_days_inactive" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)disable_user_account_days_inactive(?-i)[\s]+90[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)disable_user_account_days_inactive(?-i)[\s]+90[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone_container/container_keystone_lockout_duration/oval/shared.xml
+++ b/applications/openstack/keystone_container/container_keystone_lockout_duration/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_keystone_lockout_duration" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_duration(?-i)[\s]+900[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_duration(?-i)[\s]+900[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone_container/container_keystone_lockout_failure_attempts/oval/shared.xml
+++ b/applications/openstack/keystone_container/container_keystone_lockout_failure_attempts/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_keystone_lockout_failure_attempts" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_failure_attempts(?-i)[\s]+3[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)lockout_failure_attempts(?-i)[\s]+3[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone_container/container_keystone_max_request_body_size/oval/shared.xml
+++ b/applications/openstack/keystone_container/container_keystone_max_request_body_size/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_keystone_max_request_body_size" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)max_request_body_size(?-i)[\s]+114688[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)max_request_body_size(?-i)[\s]+114688[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/keystone_container/container_keystone_use_ssl/oval/shared.xml
+++ b/applications/openstack/keystone_container/container_keystone_use_ssl/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_keystone_ssl_enable" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/keystone/etc/keystone/keystone.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)enable(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)enable(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/neutron/neutron_api_use_ssl/oval/shared.xml
+++ b/applications/openstack/neutron/neutron_api_use_ssl/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_neutron_use_ssl" version="2">
     <ind:filepath>/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)use_ssl(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)use_ssl(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/neutron/neutron_use_https/oval/shared.xml
+++ b/applications/openstack/neutron/neutron_use_https/oval/shared.xml
@@ -24,12 +24,12 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_neutron_auth_protocol" version="2">
     <ind:filepath>/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="obj_neutron_identity_uri" version="2">
     <ind:filepath>/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/neutron/neutron_use_keystone/oval/shared.xml
+++ b/applications/openstack/neutron/neutron_use_keystone/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_neutron_auth_strategy" version="2">
     <ind:filepath>/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/neutron_container/container_neutron_api_use_ssl/oval/shared.xml
+++ b/applications/openstack/neutron_container/container_neutron_api_use_ssl/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_neutron_use_ssl" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)use_ssl(?-i)[\s]+True[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)use_ssl(?-i)[\s]+True[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/neutron_container/container_neutron_use_https/oval/shared.xml
+++ b/applications/openstack/neutron_container/container_neutron_use_https/oval/shared.xml
@@ -24,12 +24,12 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_neutron_auth_protocol" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="obj_container_neutron_identity_uri" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/neutron_container/container_neutron_use_keystone/oval/shared.xml
+++ b/applications/openstack/neutron_container/container_neutron_use_keystone/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_neutron_auth_strategy" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/nova/nova_secure_authentication/oval/shared.xml
+++ b/applications/openstack/nova/nova_secure_authentication/oval/shared.xml
@@ -24,12 +24,12 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_nova_auth_protocol" version="2">
     <ind:filepath>/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="obj_nova_identity_uri" version="2">
     <ind:filepath>/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/nova/nova_secure_glance/oval/shared.xml
+++ b/applications/openstack/nova/nova_secure_glance/oval/shared.xml
@@ -24,12 +24,12 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_nova_glance_api_insecure" version="2">
     <ind:filepath>/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="obj_nova_api_insecure" version="2">
     <ind:filepath>/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/nova/nova_use_keystone/oval/shared.xml
+++ b/applications/openstack/nova/nova_use_keystone/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_nova_auth_strategy" version="2">
     <ind:filepath>/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/nova_container/container_nova_secure_authentication/oval/shared.xml
+++ b/applications/openstack/nova_container/container_nova_secure_authentication/oval/shared.xml
@@ -24,12 +24,12 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_nova_auth_protocol" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_protocol(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="obj_container_nova_identity_uri" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)identity_uri(?-i)[\s]+https[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/nova_container/container_nova_secure_glance/oval/shared.xml
+++ b/applications/openstack/nova_container/container_nova_secure_glance/oval/shared.xml
@@ -24,12 +24,12 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_nova_glance_api_insecure" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)glance_api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="obj_container_nova_api_insecure" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)api_insecure(?-i)[\s]+False[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)api_insecure(?-i)[\s]+False[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/applications/openstack/nova_container/container_nova_use_keystone/oval/shared.xml
+++ b/applications/openstack/nova_container/container_nova_use_keystone/oval/shared.xml
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_container_nova_auth_strategy" version="2">
     <ind:filepath>/var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)auth_strategy(?-i)[\s]+keystone[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/dhcp/dhcp_client_configuration/dhcp_client_restrict_options/oval/rhel6.xml
+++ b/linux_os/guide/services/dhcp/dhcp_client_configuration/dhcp_client_restrict_options/oval/rhel6.xml
@@ -44,7 +44,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_domain-named"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+domain\-name[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+domain\-name[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -55,7 +55,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_domain-name-servers"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+domain\-name\-servers[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+domain\-name\-servers[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -66,7 +66,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_nis-domain"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+nis\-domain[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+nis\-domain[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -77,7 +77,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_nis-servers"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+nis\-servers[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+nis\-servers[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -88,7 +88,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_ntp-servers"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+ntp\-servers[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+ntp\-servers[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -99,7 +99,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_routers"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+routers[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+routers[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -110,7 +110,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_time-offset"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+time\-offset[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+time\-offset[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -121,7 +121,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_subnet-mask"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+subnet\-mask[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+subnet\-mask[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -132,7 +132,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_client_broadcast-address"
   version="1">
     <ind:filepath operation="pattern match">^/etc/dhcp/dhclient.*\.conf$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+broadcast\-address[\s]*.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(request|require|supersede)[\s]+broadcast\-address[\s]*.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_deny_bootp/oval/rhel6.xml
+++ b/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_deny_bootp/oval/rhel6.xml
@@ -24,7 +24,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_server_disable_bootp"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*deny[\s]+bootp\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*deny[\s]+bootp\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_deny_decline/oval/rhel6.xml
+++ b/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_deny_decline/oval/rhel6.xml
@@ -24,7 +24,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_server_deny_declines"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*deny[\s]+declines\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*deny[\s]+declines\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_disable_ddns/oval/rhel6.xml
+++ b/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_disable_ddns/oval/rhel6.xml
@@ -24,7 +24,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_server_disable_ddns"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*ddns\-update\-style[\s]+none\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*ddns\-update\-style[\s]+none\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_minimize_served_info/oval/rhel6.xml
+++ b/linux_os/guide/services/dhcp/dhcp_server_configuration/dhcp_server_minimize_served_info/oval/rhel6.xml
@@ -40,7 +40,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_domain-named_info"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*option[\s]+domain\-name[\s]+.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*option[\s]+domain\-name[\s]+.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
@@ -51,7 +51,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_domain-name-servers_info"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*option[\s]+domain\-name\-servers[\s]+.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*option[\s]+domain\-name\-servers[\s]+.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
@@ -62,7 +62,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_nis-domain_info"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*option[\s]+nis\-domain[\s]+.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*option[\s]+nis\-domain[\s]+.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
@@ -73,7 +73,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_nis-servers_info"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*option[\s]+nis\-servers[\s]+.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*option[\s]+nis\-servers[\s]+.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
@@ -84,7 +84,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_ntp-servers_info"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*option[\s]+ntp\-servers[\s]+.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*option[\s]+ntp\-servers[\s]+.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
@@ -95,7 +95,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_routers_info"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*option[\s]+routers[\s]+.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*option[\s]+routers[\s]+.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
@@ -106,7 +106,7 @@
   <ind:textfilecontent54_object id="obj_dhcp_time-offset_info"
   version="1">
     <ind:filepath>/etc/dhcp/dhcpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*option[\s]+time\-offset[\s]+.*\;[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*option[\s]+time\-offset[\s]+.*\;[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/oval/shared.xml
@@ -47,7 +47,7 @@
   <ind:textfilecontent54_object id="obj_sshd_disable_rhosts_rsa"
   version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)RhostsRSAAuthentication(?-i)[\s]+no[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)RhostsRSAAuthentication(?-i)[\s]+no[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -46,7 +46,7 @@
 
   <ind:textfilecontent54_object id="object_sshd_idle_timeout" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveInterval[\s]+(\d+)[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveInterval[\s]+(\d+)[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
@@ -48,7 +48,7 @@
   </ind:textfilecontent54_state>
   <ind:textfilecontent54_object id="obj_sshd_clientalivecountmax" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveCountMax[\s]+([\d]+)[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveCountMax[\s]+([\d]+)[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/oval/shared.xml
@@ -25,7 +25,7 @@
 
   <ind:textfilecontent54_object id="object_sshd_max_auth_tries" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)MaxAuthTries[\s]+(\d+)[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)MaxAuthTries[\s]+(\d+)[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -61,7 +61,7 @@
 
   <ind:textfilecontent54_object id="obj_sshd_config_macs" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+([\w,-@]+)+[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+([\w,-@]+)+[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
@@ -21,7 +21,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_configure_tmux_lock_after_time" version="1">
     <ind:filepath>/etc/tmux.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-after-time\s+900\s*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-after-time\s+900\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
@@ -21,7 +21,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_configure_tmux_lock_command" version="1">
     <ind:filepath>/etc/tmux.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-command\s+vlock\s*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-command\s+vlock\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/oval/shared.xml
@@ -21,7 +21,7 @@
 
   <ind:textfilecontent54_object id="obj_accounts_have_homedir_login_defs" version="2">
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)CREATE_HOME(?-i)[\s]+yes[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)CREATE_HOME(?-i)[\s]+yes[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/bash/shared.sh
@@ -2,7 +2,7 @@
 
 function remediate_libreswan_crypto_policy() {
     CONFIG_FILE="/etc/ipsec.conf"
-    if ! grep -qP "^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:|(?:#.*))$" "$CONFIG_FILE" ; then
+    if ! grep -qP "^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:#.*)?$" "$CONFIG_FILE" ; then
         echo 'include /etc/crypto-policies/back-ends/libreswan.config' >> "$CONFIG_FILE"
     fi
     return 0

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
@@ -25,7 +25,7 @@
   <ind:textfilecontent54_object id="object_configure_libreswan_crypto_policy"
   version="1">
     <ind:filepath>/etc/ipsec.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:|(?:#.*))$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/oval/shared.xml
@@ -22,7 +22,7 @@
 
   <ind:textfilecontent54_object id="object_enable_dracut_fips_module" version="1">
     <ind:filepath>/etc/dracut.conf.d/40-fips.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*add_dracutmodules\+="\s*(\w*)\s*"\s*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*add_dracutmodules\+="\s*(\w*)\s*"\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_audit_rules_path_syscall
+++ b/shared/templates/template_OVAL_audit_rules_path_syscall
@@ -46,11 +46,11 @@
 
   <!-- Access to /var/log/audit rule regex-->
   <constant_variable id="var_audit_rule_32bit_{{{ SYSCALL }}}_write_{{{ PATHID }}}_regex" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
   </constant_variable>
 
   <constant_variable id="var_audit_rule_64bit_{{{ SYSCALL }}}_write_{{{ PATHID }}}_regex" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
   </constant_variable>
 
   <!-- directory access {{{ PATH }}} augenrule -->

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -50,10 +50,10 @@
 
   <!-- General rule boiler plate -->
   <constant_variable id="var_32bit_arufm_{{{ NAME }}}_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ NAME }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ NAME }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_64bit_arufm_{{{ NAME }}}_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ NAME }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ NAME }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_arufm_{{{ NAME }}}_tail" version="1" datatype="string" comment="audit rule auid and key">
     <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
@@ -54,10 +54,10 @@
 
   <!-- General rule boiler plate -->
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_creat_32bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_creat_64bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_creat_tail" version="1" datatype="string" comment="audit rule auid and key">
     <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
@@ -54,10 +54,10 @@
 
   <!-- General rule boiler plate -->
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_trunc_32bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_trunc_64bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_trunc_tail" version="1" datatype="string" comment="audit rule auid and key">
     <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_rule_order
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_rule_order
@@ -55,10 +55,10 @@
 
   <!-- General rule boiler plate -->
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_order_32bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_order_64bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:|(?:[\S]+,)+)({{{ SYSCALL }}})(?:|(?:,[\S]+)+))[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_order_tail" version="1" datatype="string" comment="audit rule auid and key">
     <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(?:unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>

--- a/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
+++ b/tests/data/group_system/group_software/group_integrity/group_crypto/rule_configure_libreswan_crypto_policy/line_is_there.pass.sh
@@ -6,6 +6,6 @@ yum install -y libreswan
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"
-if ! grep -P '^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:|(?:#.*))$' "$config_file" ; then
+if ! grep -P '^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:#.*)?$' "$config_file" ; then
     echo "include /etc/crypto-policies/back-ends/libreswan.config" >> "$config_file"
 fi


### PR DESCRIPTION
#### Description:

- Simplify regexp.

#### Rationale:

- The `(?:|(?: something ))` really means empty string or ` something `, and empty string is zero occurrences of ` something `, so the regexp can be written as `(?: something )?`.
- The `(?:|(?: something )+)` really means empty string or ` something ` multiple times, but multiple empty strings is still an empty string, and it is zero occurrences of ` something `, so the regexp can be written as `(?: something )*`.
