### PR TITLE
Rule grub2_vsyscall_argument is informational in OSPP

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -53,6 +53,8 @@ selections:
 
     ## Disable vsyscalls
     - grub2_vsyscall_argument
+    - grub2_vsyscall_argument.role=unscored
+    - grub2_vsyscall_argument.severity=info
 
 
     #################################################################


### PR DESCRIPTION

#### Description:

- `grub2_vsyscall_argument` is `informational` in OSPP profile
- The rule will be scanned, but results will not affect result of evaluation.

#### Rationale:
- Some use cases may require `vsyscalls` to be enabled.
