### PR TITLE
Fix rpm_verify_hashes and rpm_verify permissions ansible remediations

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -15,7 +15,7 @@
 
 - name: "Read files with incorrect hash"
   shell: |
-    set -o pipefail
+    # Do not set 'set -o pipefail' - 'rpm -Va' returns non-zero value because non-empty list of files
     rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/' | awk '{print $NF}'
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect hash using rpm module

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Read list of files with incorrect permissions"
   shell: |
-    set -o pipefail
+    # Do not set 'set -o pipefail' - 'rpm -Va' returns non-zero value because non-empty list of files
     rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)=="M") print $NF }'
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect permissions using rpm module


### PR DESCRIPTION
#### Description:
Remediation was failing because pipeline returns code 1.

#### Rationale:
`set -o pipefail` causes, that pipe returns non-zero value, if any command from pipeline ends with non-zero return code. `rpm -Va` gives me every time return code 1 (not sure why, didn't find any info about that, but it's probably because `-Va` return list of files with incorrect hash and if the list is non-empty then it returns non-zero value) and because of remediation pipeline returned 1, it interrupted remediation run (and also ansible playbook).
