### PR TITLE
Fix _check_rule method call in SSG test suite.

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -73,7 +73,9 @@ class CombinedChecker(rule.RuleChecker):
                 # every entry in the target is expected to be unique.
                 # Let's remove matched targets, so we can track rules not tested
                 target.remove(target_matched)
-                self._check_rule(rule, remote_dir, state)
+                remediation_available = self._is_remediation_available(rule)
+
+                self._check_rule(rule, remote_dir, state, remediation_available)
 
         if len(target) != 0:
             target.sort()

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -152,6 +152,14 @@ class RuleChecker(oscap.Checker):
             logging.error(msg)
         return success
 
+    def _is_remediation_available(self, rule):
+        if xml_operations.find_fix_in_benchmark(
+                self.datastream, self.benchmark_id, rule.id, self.remediate_using) is None:
+            return False
+        else:
+            return True
+
+
     def _get_available_remediations(self, scenario):
         is_supported = set(['all'])
         is_supported.add(
@@ -209,11 +217,7 @@ class RuleChecker(oscap.Checker):
                         "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
                         .format(rule.id, self.benchmark_id, self.datastream))
                     return
-
-                remediation_available = True
-                if xml_operations.find_fix_in_benchmark(
-                        self.datastream, self.benchmark_id, rule.id, self.remediate_using) is None:
-                    remediation_available = False
+                remediation_available = self._is_remediation_available(rule)
 
                 self._check_rule(rule, remote_dir, state, remediation_available)
 


### PR DESCRIPTION
#### Description:
Creates new methos `_is_remediation_available` for checking if remediation exists and use it in rule and combined modes.

#### Rationale:
Combined mode was missing remediation finding and it was attempting to call `_check_rule` method with 3 arguments instead of 4.

```
[mlysonek@localhost tests]$ ./test_suite.py combined --libvirt qemu:///system test-suite-rhel8 --data
stream ../build/ssg-rhel8-ds.xml --remediate-using oscap ospp
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/mlysonek/SCAP/content/tests/logs/combined-custom-2019-08-27-1344/test_suite.log
INFO - Performing combined test using profile: xccdf_org.ssgproject.content_profile_ospp
ERROR - Nothing has been tested!
Traceback (most recent call last):
  File "./test_suite.py", line 315, in <module>
    main()
  File "./test_suite.py", line 311, in main
    options.func(options)
  File "/home/mlysonek/SCAP/content/tests/ssg_test_suite/combined.py", line 112, in perform_combined_check
    checker.test_target(target_rules)
  File "/home/mlysonek/SCAP/content/tests/ssg_test_suite/oscap.py", line 574, in test_target
    self._test_target(target)
  File "/home/mlysonek/SCAP/content/tests/ssg_test_suite/combined.py", line 76, in _test_target
    self._check_rule(rule, remote_dir, state)
TypeError: _check_rule() takes exactly 5 arguments (4 given)
```