### PR TITLE
IASE was migrated to DOD Cyber Exchange

### DIFF
--- a/chromium/transforms/cci2html.xsl
+++ b/chromium/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/chromium/transforms/table-add-srgitems.xslt
+++ b/chromium/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-chromium-srgmap-flat.xhtml')/html/body/table" />

--- a/chromium/transforms/xccdf2table-profileccirefs.xslt
+++ b/chromium/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/debian8/transforms/xccdf2table-profileccirefs.xslt
+++ b/debian8/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/eap6/transforms/cci2html.xsl
+++ b/eap6/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/eap6/transforms/table-add-srgitems.xslt
+++ b/eap6/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-eap6-srgmap-flat.xhtml')/html/body/table" />

--- a/eap6/transforms/xccdf2table-profileccirefs.xslt
+++ b/eap6/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/example/README.md
+++ b/example/README.md
@@ -447,7 +447,7 @@ EOF
 ```
 cat << EOF >> $NEW_PRODUCT/transforms/xccdf2table-profileccirefs.xslt
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/example/new_product.sh
+++ b/example/new_product.sh
@@ -275,7 +275,7 @@ EOF
 
 cat << EOF >> $NEW_PRODUCT/transforms/xccdf2table-profileccirefs.xslt
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/firefox/transforms/cci2html.xsl
+++ b/firefox/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/firefox/transforms/table-add-srgitems.xslt
+++ b/firefox/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-firefox-srgmap-flat.xhtml')/html/body/table" />

--- a/firefox/transforms/xccdf2table-profileccirefs.xslt
+++ b/firefox/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/fuse6/transforms/cci2html.xsl
+++ b/fuse6/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/fuse6/transforms/table-add-srgitems.xslt
+++ b/fuse6/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-fuse6-srgmap-flat.xhtml')/html/body/table" />

--- a/fuse6/transforms/xccdf2table-profileccirefs.xslt
+++ b/fuse6/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/jre/transforms/cci2html.xsl
+++ b/jre/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/jre/transforms/table-add-srgitems.xslt
+++ b/jre/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-jre-srgmap-flat.xhtml')/html/body/table" />

--- a/jre/transforms/xccdf2table-profileccirefs.xslt
+++ b/jre/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -51,7 +51,7 @@ warnings:
         existing infrastructure. Per DISA guidance, when these supplemental tools interfere
         with proper functioning of SELinux, SELinux takes precedence. Should further
         clarification be required, DISA contact information is published publicly at
-        https://iase.disa.mil/stigs/Pages/contact.aspx.
+        https://public.cyber.mil/stigs/
 
 platform: machine
 

--- a/ocp3/transforms/cci2html.xsl
+++ b/ocp3/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 

--- a/ocp3/transforms/table-add-srgitems.xslt
+++ b/ocp3/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-rhel7-srgmap-flat.xhtml')/html/body/table" />

--- a/ocp3/transforms/xccdf2table-profileccirefs.xslt
+++ b/ocp3/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/rhel6/transforms/cci2html.xsl
+++ b/rhel6/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/rhel6/transforms/table-add-srgitems.xslt
+++ b/rhel6/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-rhel6-srgmap-flat.xhtml')/html/body/table" />

--- a/rhel6/transforms/xccdf2table-profileccirefs.xslt
+++ b/rhel6/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/rhel7/transforms/cci2html.xsl
+++ b/rhel7/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 

--- a/rhel7/transforms/table-add-srgitems.xslt
+++ b/rhel7/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-rhel7-srgmap-flat.xhtml')/html/body/table" />

--- a/rhel7/transforms/xccdf2table-profileccirefs.xslt
+++ b/rhel7/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/rhel8/transforms/cci2html.xsl
+++ b/rhel8/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 

--- a/rhel8/transforms/table-add-srgitems.xslt
+++ b/rhel8/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-rhel8-srgmap-flat.xhtml')/html/body/table" />

--- a/rhel8/transforms/xccdf2table-profileccirefs.xslt
+++ b/rhel8/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/rhosp13/transforms/cci2html.xsl
+++ b/rhosp13/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/rhosp13/transforms/table-add-srgitems.xslt
+++ b/rhosp13/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-rhosp13-srgmap-flat.xhtml')/html/body/table" />

--- a/rhosp13/transforms/xccdf2table-profileccirefs.xslt
+++ b/rhosp13/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/rhv4/transforms/cci2html.xsl
+++ b/rhv4/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 

--- a/rhv4/transforms/table-add-srgitems.xslt
+++ b/rhv4/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-rhel7-srgmap-flat.xhtml')/html/body/table" />

--- a/rhv4/transforms/xccdf2table-profileccirefs.xslt
+++ b/rhv4/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/shared/transforms/shared_cci2html.xsl
+++ b/shared/transforms/shared_cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 	<xsl:decimal-format NaN=""/>
 

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -20,7 +20,7 @@
 <xsl:variable name="disa-stigs-apps-web-server-uri">https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=app-security%2Cweb-servers</xsl:variable>
 <xsl:variable name="disa-stigs-os-mainframe-uri">https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cmainframe</xsl:variable>
 <xsl:variable name="disa-stigs-os-unix-linux-uri">https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux</xsl:variable>
-<xsl:variable name="disa-stigs-virutalization-uri">https://iase.disa.mil/stigs/os/virtualization/Pages/index.aspx</xsl:variable>
+<xsl:variable name="disa-stigs-virutalization-uri">https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cvirtualization</xsl:variable>
 <xsl:variable name="hipaauri">https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf</xsl:variable>
 <xsl:variable name="iso27001-2013uri">https://www.iso.org/standard/54534.html</xsl:variable>
 <xsl:variable name="nist800-171uri">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf</xsl:variable>

--- a/shared/transforms/shared_table-add-srgitems.xslt
+++ b/shared/transforms/shared_table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <!-- this transform "fills out" a table of Rules with any SRG items (from an SRG mapping table)
      that are not already included -->

--- a/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
+++ b/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
@@ -36,7 +36,7 @@
           		If <xsl:value-of select="xccdf:check[@system='ocil-transitional']/xccdf:check-export/@export-name" />, this is a finding.
           		</check-content>
           	</check>
-		  	<ident system="http://iase.disa.mil/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>
+		  	<ident system="https://public.cyber.mil/stigs/cci"><xsl:value-of select="concat('CCI-', format-number($overlay_ref,'000000'))" /></ident>
           	<fixtext><xsl:copy-of select="xccdf:description/node()" /></fixtext>
           </Rule> 
           </Group>

--- a/shared/transforms/shared_xccdf2html.xslt
+++ b/shared/transforms/shared_xccdf2html.xslt
@@ -556,9 +556,6 @@
                     <xsl:when test='./@href = "https://public.cyber.mil/stigs/cci/"'>
                       <a href="{@href}">DISA CCI-<xsl:value-of select="text()"/></a>
                     </xsl:when>
-                    <xsl:when test='./@href = "http://iase.disa.mil/stigs/cci/Pages/index.aspx"'>
-                      <a href="{@href}">DISA CCI-<xsl:value-of select="text()"/></a>
-                    </xsl:when>
                     <xsl:when test='./@href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"'>
                       <a href="{@href}">NIST <xsl:value-of select="text()"/></a>
                     </xsl:when>
@@ -665,9 +662,6 @@
                 <xsl:when test='. != ""'>
                   <xsl:choose>
                     <xsl:when test='./@href = "https://public.cyber.mil/stigs/cci/"'>
-                      <a href="{@href}">DISA CCI-<xsl:value-of select="text()"/></a>
-                    </xsl:when>
-                    <xsl:when test='./@href = "http://iase.disa.mil/stigs/cci/Pages/index.aspx"'>
                       <a href="{@href}">DISA CCI-<xsl:value-of select="text()"/></a>
                     </xsl:when>
                     <xsl:when test='./@href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"'>

--- a/shared/transforms/shared_xccdf2stigformat.xslt
+++ b/shared/transforms/shared_xccdf2stigformat.xslt
@@ -16,12 +16,12 @@ xmlns="http://checklists.nist.gov/xccdf/1.1" id="{$product_stig_id_name}" xml:la
 xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/schema/xccdf-1.1.4.xsd http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
 	<status date="2012-10-01">draft</status>
 	<title>Pre-Draft <xsl:value-of select="$product_long_name" /> Security Technical Implementation Guide</title>
-	<description>The <xsl:value-of select="$product_long_name" /> Security Technical Implementation Guide (STIG) is published as a tool to improve the security of Department of Defense (DoD) information systems. Comments or proposed revisions to this document should be sent via e-mail to the following address: fso_spt@disa.mil.</description>
+	<description>The <xsl:value-of select="$product_long_name" /> Security Technical Implementation Guide (STIG) is published as a tool to improve the security of Department of Defense (DoD) information systems. Comments or proposed revisions to this document should be sent via e-mail to the following address: disa.stig@mail.mil.</description>
 	<notice id="terms-of-use" xml:lang="en" />
-	<reference href="http://iase.disa.mil">
+	<reference href="https://public.cyber.mil">
 	<!-- this is here as a placeholder, prior to any publication.  this is PRE-DRAFT, NON-RELEASE material. -->
          <dc:publisher>DISA, Field Security Operations</dc:publisher>
-         <dc:source>iase.disa.mil</dc:source>
+         <dc:source>public.cyber.mil</dc:source>
 	</reference>
 	<version>0.7</version>
 

--- a/shared/transforms/shared_xccdf2table-profileccirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <!-- this style sheet expects parameter $profile, which is the id of the Profile to be shown -->
 

--- a/sle11/transforms/cci2html.xsl
+++ b/sle11/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/sle11/transforms/table-add-srgitems.xslt
+++ b/sle11/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-sle11-srgmap-flat.xhtml')/html/body/table" />

--- a/sle11/transforms/xccdf2table-profileccirefs.xslt
+++ b/sle11/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/sle12/transforms/cci2html.xsl
+++ b/sle12/transforms/cci2html.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_cci2html.xsl"/>
 	

--- a/sle12/transforms/table-add-srgitems.xslt
+++ b/sle12/transforms/table-add-srgitems.xslt
@@ -1,4 +1,4 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="http://iase.disa.mil/cci">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:cci="https://public.cyber.mil/stigs/cci">
 
 <xsl:include href="../../shared/transforms/shared_table-add-srgitems.xslt"/>
 <xsl:variable name="srgtable" select="document('../output/table-sle12-srgmap-flat.xhtml')/html/body/table" />

--- a/sle12/transforms/xccdf2table-profileccirefs.xslt
+++ b/sle12/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/ubuntu1404/transforms/xccdf2table-profileccirefs.xslt
+++ b/ubuntu1404/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/ubuntu1604/transforms/xccdf2table-profileccirefs.xslt
+++ b/ubuntu1604/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/ubuntu1804/transforms/xccdf2table-profileccirefs.xslt
+++ b/ubuntu1804/transforms/xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <xsl:import href="../../shared/transforms/shared_xccdf2table-profileccirefs.xslt"/>
 

--- a/wrlinux1019/profiles/draft_stig_wrlinux_disa.profile
+++ b/wrlinux1019/profiles/draft_stig_wrlinux_disa.profile
@@ -16,7 +16,7 @@ description: |-
     Note that changes are expected before approval is granted, and those changes
     will be made available in future Wind River Linux Security Profile 1019 RCPL releases.
     More information, including the following, is available from the DISA FAQs
-    at http://iase.disa.mil/stigs/Pages/faqs.aspx#STIG"
+    at https://public.cyber.mil/stigs/faqs/
 
 selections:
     - var_accounts_max_concurrent_login_sessions=10


### PR DESCRIPTION
#### Description:

- Update URL where DISA contact can be found.
- Update all occurences of IASE URL to `public.cyber.mil`

#### Rationale:

- IASE migrated to DOD Cyber Exchange
