### PR TITLE
Fix sshd_required logic in OVAL macro

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -102,11 +102,11 @@
 {{%- set suffix_id = "" -%}}
 {{%- if missing_parameter_pass %}}
 {{%- set check_existence = "none_exist" -%}}
-{{%- set prefix_text = "value" -%}}
+{{%- set prefix_text = "absence" -%}}
 {{%- set suffix_id = suffix_id_default_not_overriden -%}}
 {{%- else %}}
 {{%- set check_existence = "all_exist" -%}}
-{{%- set prefix_text = "absence" -%}}
+{{%- set prefix_text = "value" -%}}
 {{%- endif %}}
   <ind:textfilecontent54_test check="all" check_existence="{{{ check_existence }}}"
   comment="tests the {{{ prefix_text }}} of {{{ parameter }}} setting in the {{{ path }}} file"

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -285,6 +285,22 @@
         {{% endif %}}
       </criteria>
 {{%- endmacro %}}
+{{#
+  To be removed macro. Prevents regression on sshd configuration rules.
+#}}
+{{%- macro application_required_or_requirement_unset() -%}}
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
+        <extend_definition comment="rpm package openssh installed"
+        definition_ref="package_openssh_installed" />
+        {{% else %}}
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+        {{% endif %}}
+      {{# Note that a criteria was left open #}}
+{{%- endmacro %}}
 
 {{#
   High level macro which checks configuration in an INI file.

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -40,15 +40,17 @@
     <criteria comment="{{{ application }}} is configured correctly or is not installed"
     operator="OR">
         {{{- application_not_required_or_requirement_unset() }}}
-    {{%- else %}}
+    {{%- endif %}}
     <criteria comment="{{{ application }}} is configured correctly"
     operator="OR">
-    {{%- endif %}}
         {{{- oval_line_in_file_criterion(path, parameter) }}}
         {{%- if missing_parameter_pass %}}
         {{{- oval_line_in_file_criterion(path, parameter, missing_parameter_pass) }}}
         {{%- endif %}}
     </criteria>
+    {{%- if application == "sshd" %}}
+    </criteria>
+    {{%- endif %}}
     {{%- if missing_config_file_fail %}}
         {{{- oval_config_file_exists_criterion(path) }}}
     </criteria>

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -40,6 +40,7 @@
     <criteria comment="{{{ application }}} is configured correctly or is not installed"
     operator="OR">
         {{{- application_not_required_or_requirement_unset() }}}
+        {{{- application_required_or_requirement_unset() }}}
     {{%- endif %}}
     <criteria comment="{{{ application }}} is configured correctly"
     operator="OR">
@@ -49,6 +50,7 @@
         {{%- endif %}}
     </criteria>
     {{%- if application == "sshd" %}}
+    </criteria> {{# close criteria left open in application_required_or_requirement_unset #}}
     </criteria>
     {{%- endif %}}
     {{%- if missing_config_file_fail %}}


### PR DESCRIPTION
#### Description:

- Add macro for `sshd_required_or_requirement_unset`
  - This is the missing counter part of `sshd_not_required_or_unset`

#### Rationale:

- Evaluation of SSH rules that use `sshd_required`are not evaluating correctly
