### PR TITLE
Remove Ansible from rule service_fapolicyd_enabled

### DIFF
--- a/rhel8/templates/csv/services_enabled.csv
+++ b/rhel8/templates/csv/services_enabled.csv
@@ -2,7 +2,7 @@ auditd,audit,
 chronyd,chrony,
 crond,cronie,
 firewalld,,
-fapolicyd,,
+fapolicyd,, #except-for:ansible
 nails,,
 ntpd,ntp,
 postfix,,


### PR DESCRIPTION
Enabling fapolicyd service disables further execution of Ansible
Playbook and causes the playbook to terminate. The default fapolicyd
policy prevents Ansible from running. This has been reported
to fapolicyd in https://bugzilla.redhat.com/show_bug.cgi?id=1746464
We need to remove the Ansible task from our Playbooks so our Ansible
remediation does not block itself out of the machine.

Partially resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1741455