### PR TITLE
Fix remediation for rule configure_opensc_nss_db

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
@@ -3,17 +3,16 @@
 # strategy = configure
 # complexity = low
 # disruption = low
--   name: Check existence of pkcs11-switch
-    stat:
-        path: /usr/bin/pkcs11-switch
-    register: pkcs11switch
+- name: Check existence of modutil
+  stat:
+    path: /usr/bin/modutil
+  register: modutil_bin
 
-- name: Get NSS database smart card configuration
-  command: /usr/bin/pkcs11-switch
-  changed_when: True
-  register: pkcsw_output
-  when: pkcs11switch.stat.exists
+- name: Remove coolkey module if exists
+  command: modutil -delete "CoolKey PKCS {{ '#' }}11 Module" -dbdir sql:/etc/pki/nssdb/ -force
+  when: modutil_bin.stat.exists
+  ignore_errors: True
 
 - name: "{{{ rule_title }}}"
-  command: /usr/bin/pkcs11-switch opensc
-  when: pkcs11switch.stat.exists and pkcsw_output.stdout != "opensc"
+  command: /usr/bin/modutil -add "OpenSC PKCS {{ '#' }}11 Module" -dbdir sql:/etc/pki/nssdb/ -libfile opensc-pkcs11.so -force
+  when: modutil_bin.stat.exists

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
@@ -4,8 +4,5 @@
 # complexity = low
 # disruption = low
 
-PKCSSW=$(/usr/bin/pkcs11-switch)
-
-if [ ${PKCSSW} != "opensc" ] ; then
-    ${PKCSSW} opensc
-fi
+modutil -delete "CoolKey PKCS #11 Module" -dbdir sql:/etc/pki/nssdb/ -force || true # ignore errors
+modutil -add "OpenSC PKCS #11 Module" -dbdir sql:/etc/pki/nssdb/ -libfile opensc-pkcs11.so -force

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
@@ -9,7 +9,7 @@ description: |-
     <tt>Coolkey PKCS#11</tt> module in the NSS database. To configure the
     NSS database ot use the <tt>opensc</tt> module, run the following
     command:
-    <pre>$ sudo pkcs11-switch opensc</pre>
+    <pre>$ sudo modutil -add "OpenSC PKCS {{ '#' }}11 Module" -dbdir sql:/etc/pki/nssdb/ -libfile opensc-pkcs11.so</pre>
 
 rationale: |-
     Smart card login provides two-factor authentication stronger than
@@ -39,5 +39,5 @@ ocil_clause: 'opensc is not in use by the nss database'
 ocil: |-
     To verify that <tt>opensc</tt> is configured in the NSS database,
     run the following command:
-    <pre>$ pkcs11-switch</pre>
+    <pre>$ modutil -rawlist -dbdir sql:/etc/pki/nssdb/ | grep "^library=\"opensc-pkcs11.so\""</pre>
     The output should return <pre>opensc</pre>

--- a/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_smart_card_login/rule_configure_opensc_nss_db/correct_settings.pass.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_smart_card_login/rule_configure_opensc_nss_db/correct_settings.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ncp
+
+yum install -y opensc nss-utils
+
+modutil -delete "CoolKey PKCS #11 Module" -dbdir sql:/etc/pki/nssdb/ -force
+modutil -add "OpenSC PKCS #11 Module" -dbdir sql:/etc/pki/nssdb/ -libfile opensc-pkcs11.so -force

--- a/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_smart_card_login/rule_configure_opensc_nss_db/wrong_settings.fail.sh
+++ b/tests/data/group_system/group_accounts/group_accounts-physical/group_screen_locking/group_smart_card_login/rule_configure_opensc_nss_db/wrong_settings.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ncp
+
+yum install -y opensc nss-utils
+
+# notice the absence of prefix sql: in -dbdir parameter value, this cause modutil to write in old dabatase format
+# which does not write into /etc/pki/nssdb/pkcs11.txt file (our OVAL checks this file)
+modutil -add "OpenSC PKCS #11 Module" -dbdir /etc/pki/nssdb/ -libfile opensc-pkcs11.so -force


### PR DESCRIPTION
#### Description:

- Aims to move away from `pkcs11-switch` tool as it may not configure the way our OVAL check for this particular rule works. The OVAL check looks for content in file `/etc/pki/nssdb/pkcs11.txt` which is only modified when using `modutil -dbdir sql:/etc/pki/nssdb/ ...` (notice the prefix `sql:`). 

- Also the rule got removed from RHEL8 because in RHEL8 there is no coolkey and it seems to be already configured to use `opensc` library by default. Update1: source: https://access.redhat.com/articles/4253861 (See sections: `Smart cards in Firefox browser or Thunderbird` and `Register third party PKCS #11 module to p11-kit`)

#### Rationale:

- Remediation configures database correctly so OVAL check pass.

#### Additional info:

There are still some uncertainty on how this databases works, but so far they way is proposed it seems to work.
