### PR TITLE
Remove rule configure_opensc_nss_db from RHEL8 product.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,Oracle Linux 7
+# platform = Red Hat Enterprise Linux 7,multi_platform_fedora,multi_platform_rhv,Oracle Linux 7
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,Oracle Linux 7
+# platform = Red Hat Enterprise Linux 7,multi_platform_fedora,multi_platform_rhv,Oracle Linux 7
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
@@ -1,16 +1,14 @@
 <def-group>
   <definition class="compliance" id="configure_opensc_nss_db" version="1">
     <metadata>
-      <title>Verify that Interactive Boot is Disabled</title>
+      <title>Check that NSS DB is set to use opensc</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhv</platform>
         <platform>Oracle Linux 7</platform>
       </affected>
-      <description>The ability for users to perform interactive startups should
-      be disabled.</description>
+      <description>The NSS DB should be set to use opensc library.</description>
     </metadata>
     <criteria>
       <criterion test_ref="test_configure_opensc_nss_db"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4,ol7
+prodtype: rhel7,fedora,rhv4,ol7
 
 title: 'Configure NSS DB To Use opensc'
 
@@ -20,7 +20,6 @@ severity: medium
 
 identifiers:
     cce@rhel7: 80567-1
-    cce@rhel8: 80767-7
 
 references:
     disa: 765,766,767,768,771,772,884

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -112,7 +112,6 @@ selections:
     - security_patches_up_to_date
     - package_opensc_installed
     - var_smartcard_drivers=cac
-    - configure_opensc_nss_db
     - configure_opensc_card_drivers
     - force_opensc_card_drivers
     - package_pcsc-lite_installed


### PR DESCRIPTION
#### Description:

- Remove rule configure_opensc_nss_db from RHEL8 product. This PR is part of #4776, but I decided to make the RHEL8 rule removal separated as it can be part of release 0.1.46. This rule is failing on RHEL8 PCI-DSS. See sections `Smart cards in Firefox browser or Thunderbird` and `Register third party PKCS #11 module to p11-kit` on RHEL8 article: https://access.redhat.com/articles/4253861 which confirms that OpenSC is set by default on RHEL8

#### Rationale:

- The rule is not applicable to RHEL8. OpenSC is set by default on RHEL8. Additionally RHEL8 does not contain pkcs11-switch tool.
