### PR TITLE
Unselect rule directory_access_var_log_audit in OSPP Profile

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -366,6 +366,10 @@ selections:
     ##  CNSSI 1253 Value or DoD-specific Values:
     ##      - Privilege/Role escalation (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
+    ## Audit All Audit and Log Data Accesses (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Audit and log data access (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
     ## Audit Cryptographic Verification of Software (Success/Failure)
     ##  CNSSI 1253 Value or DoD-specific Values:
     ##      - Applications (e.g. Firefox, Internet Explorer, MS Office Suite,
@@ -374,12 +378,6 @@ selections:
     ## Audit Kernel Module Loading and Unloading Events (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
     - audit_rules_for_ospp
-
-    ## Audit All Audit and Log Data Accesses (Success/Failure)
-    ##  CNSSI 1253 Value or DoD-specific Values:
-    ##      - Audit and log data access (Success/Failure)
-    ## AU-2(a) / FAU_GEN.1.1.c
-    - directory_access_var_log_audit
 
     ## Enable Automatic Software Updates
     ## SI-2 / FMT_MOF_EXT.1


### PR DESCRIPTION

#### Description:

- The rule is already covered by `audit_rules_for_ospp`

#### Rationale:
- The audit rule is part of `30-ospp-v42.rules` which is configured by `audit_rules_for_ospp`

