### PR TITLE
Fail rpm_verify ansible fixes only if rc returns error code greater than 1

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -22,6 +22,7 @@
     executable: /bin/bash
   register: files_with_incorrect_hash
   changed_when: False
+  failed_when: files_with_incorrect_hash.rc > 1
   when: (package_manager_reinstall_cmd is defined)
   check_mode: no
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -11,7 +11,7 @@
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect ownership using rpm module
     executable: /bin/bash
   register: files_with_incorrect_ownership
-  failed_when: False
+  failed_when: files_with_incorrect_ownership.rc > 1
   changed_when: False
   check_mode: no
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/ansible/shared.yml
@@ -11,7 +11,7 @@
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect permissions using rpm module
     executable: /bin/bash
   register: files_with_incorrect_permissions
-  failed_when: False
+  failed_when: files_with_incorrect_permissions.rc > 1
   changed_when: False
   check_mode: no
 


### PR DESCRIPTION
- We can expect a 0 or 1 rc code returned in the rpm_verify ansible fixes.
  We should only fail if the rc code is not 0 or not 1.