### PR TITLE
Add test scenarios for rsyslog_remote_tls

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_multiline.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_multiline.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+cat >> /etc/rsyslog.conf <<EOF
+action(type="omfwd"
+       protocol="tcp"
+       Target="remote.system.com"
+       port="6514"
+       StreamDriver="gtls"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/name")
+EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_multiline.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_multiline.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cat >> /etc/rsyslog.conf <<EOF
 action(type="omfwd"

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cat >> /etc/rsyslog.conf <<EOF
 action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+cat >> /etc/rsyslog.conf <<EOF
+action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")
+EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+cat >> /etc/rsyslog.conf <<EOF
+action(type="omfwd"
+       protocol="tcp"
+       Target="remote.system.com"
+       port="6514"
+       StreamDriver="gtls"
+       StreamDriverMode="1")
+EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat >> /etc/rsyslog.conf <<EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/wrong_multiline.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/wrong_multiline.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+cat >> /etc/rsyslog.conf <<EOF
+action(type="omfwd"
+       protocol="tcp"
+       Target="remote.system.com"
+       port="6514"
+       StreamDriver="ptcp"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/name")
+EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/wrong_multiline.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/wrong_multiline.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat >> /etc/rsyslog.conf <<EOF


### PR DESCRIPTION
This rule uses a complex regular expression so it might be beneficial to cover the rule by few test scenarios.