### PR TITLE
Improve Bash code based on shellcheck feedback

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
@@ -8,7 +8,7 @@
 # files to check if '-e .*' setting is present in that '*.rules' file already.
 # If found, delete such occurrence since auditctl(8) manual page instructs the
 # '-e 2' rule should be placed as the last rule in the configuration
-find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name *.rules -exec sed -i '/-e[[:space:]]\+.*/d' {} ';'
+find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -exec sed -i '/-e[[:space:]]\+.*/d' {} ';'
 
 # Append '-e 2' requirement at the end of both:
 # * /etc/audit/audit.rules file 		(for auditctl case)

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
@@ -8,7 +8,7 @@
 # files to check if '-f .*' setting is present in that '*.rules' file already.
 # If found, delete such occurrence since auditctl(8) manual page instructs the
 # '-f 2' rule should be placed as the last rule in the configuration
-find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name *.rules -exec sed -i '/-e[[:space:]]\+.*/d' {} ';'
+find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -exec sed -i '/-e[[:space:]]\+.*/d' {} ';'
 
 # Append '-f 2' requirement at the end of both:
 # * /etc/audit/audit.rules file 		(for auditctl case)

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_rhel
-df --local -P | awk {'if (NR!=1) print $6'} \
+df --local -P | awk '{if (NR!=1) print $6}' \
 | xargs -I '{}' find '{}' -xdev -type d \
 \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null \
 | xargs chmod a+t

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/rhel6.sh
@@ -44,23 +44,20 @@ do
                 MOUNT_OPTIONS="$MOUNT_OPTIONS,nodev"
             fi
 
-            # Escape possible slash ('/') characters in target for use as sed
-            # expression below
-            TARGET_ESCAPED=${TARGET//$'/'/$'\/'}
             # This target doesn't contain 'nodev' in mount options yet (and meets
             # the above filtering criteria). Therefore obtain particular /etc/fstab's
             # row into FSTAB_TARGET_ROW variable separating the mount options field with
             # hash '#' character
-            FSTAB_TARGET_ROW=$(sed -n "s/\(.*$TARGET_ESCAPED[$SP]\+$FSTYPE[$SP]\+\)\([^$SP]\+\)/\1#\2#/p" /etc/fstab)
+            FSTAB_TARGET_ROW=$(sed -n "s|\\(.*${TARGET}[$SP]\\+${FSTYPE}[$SP]\\+\\)\\([^$SP]\\+\\)|\\1#\\2#|p" /etc/fstab)
             # Split the retrieved value by the hash '#' delimiter to get the
             # row's head & tail (i.e. columns other than mount options) which won't
             # get modified
             TARGET_HEAD=$(cut -f 1 -d '#' <<< "$FSTAB_TARGET_ROW")
-            TARGET_OPTS=$(cut -f 2 -d '#' <<< "$FSTAB_TARGET_ROW")
+            # TARGET_OPTS=$(cut -f 2 -d '#' <<< "$FSTAB_TARGET_ROW")
             TARGET_TAIL=$(cut -f 3 -d '#' <<< "$FSTAB_TARGET_ROW")
             # Replace old mount options for particular /etc/fstab's row (for this target
             # and fstype) with new mount options
-            sed -i "s#${TARGET_HEAD}\(.*\)${TARGET_TAIL}#${TARGET_HEAD}${MOUNT_OPTIONS}${TARGET_TAIL}#" /etc/fstab
+            sed -i "s|${TARGET_HEAD}\(.*\)${TARGET_TAIL}|${TARGET_HEAD}${MOUNT_OPTIONS}${TARGET_TAIL}|" /etc/fstab
         fi
     fi
 done

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -95,7 +95,7 @@ then
 	if [ ${#files_to_inspect[@]} -eq "0" ]
 	then
 		file_to_inspect="/etc/audit/rules.d/$key.rules"
-		files_to_inspect=("$files_to_inspect")
+		files_to_inspect=("$file_to_inspect")
 		if [ ! -e "$file_to_inspect" ]
 		then
 			touch "$file_to_inspect"

--- a/shared/bash_remediation_functions/include_mount_options_functions.sh
+++ b/shared/bash_remediation_functions/include_mount_options_functions.sh
@@ -8,7 +8,7 @@ function include_mount_options_functions {
 # $4: mount type of new mount point (used when adding new entry in fstab)
 function ensure_mount_option_for_vfstype {
         local _vfstype="$1" _new_opt="$2" _filesystem=$3 _type=$4 _vfstype_points=()
-        readarray -t _vfstype_points < <(grep -E "[[:space:]]$_vfstype[[:space:]]" /etc/fstab | awk '{print $2}')
+        readarray -t _vfstype_points < <(grep -E "[[:space:]]${_vfstype}[[:space:]]" /etc/fstab | awk '{print $2}')
 
         for _vfstype_point in "${_vfstype_points[@]}"
         do

--- a/shared/bash_remediation_functions/perform_audit_adjtimex_settimeofday_stime_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_adjtimex_settimeofday_stime_remediation.sh
@@ -14,7 +14,7 @@ source fix_audit_syscall_rule.sh
 function perform_audit_adjtimex_settimeofday_stime_remediation {
 
 # Retrieve hardware architecture of the underlying system
-[ $(getconf LONG_BIT) = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
 for ARCH in "${RULE_ARCHS[@]}"
 do

--- a/shared/bash_remediation_functions/service_command.sh
+++ b/shared/bash_remediation_functions/service_command.sh
@@ -13,7 +13,9 @@ function service_command {
 # Load function arguments into local variables
 local service_state=$1
 local service=$2
-local xinetd=$(echo $3 | cut -d'=' -f2)
+local xinetd
+
+xinetd=$(echo $3 | cut -d = -f 2)
 
 # Check sanity of the input
 if [ $# -lt "2" ]

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -173,7 +173,7 @@ printf '%s\n' "{{{ line }}}" > "{{{ path }}}"
 cat "{{{ path }}}.bak" >> "{{{ path }}}"
     {{%- elif insert_after %}}
 # Insert after the line matching the regex '{{{ insert_after }}}'
-local line_number="$(LC_ALL=C grep -n "{{{ insert_after }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
+line_number="$(LC_ALL=C grep -n "{{{ insert_after }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
 if [ -z "$line_number" ]; then
     # There was no match of '{{{ insert_after }}}', insert at
     # the end of the file.
@@ -185,7 +185,7 @@ else
 fi
     {{%- elif insert_before %}}
 # Insert before the line matching the regex '{{{ insert_before }}}'.
-local line_number="$(LC_ALL=C grep -n "{{{ insert_before }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
+line_number="$(LC_ALL=C grep -n "{{{ insert_before }}}" "{{{ path }}}.bak" | LC_ALL=C sed 's/:.*//g')"
 if [ -z "$line_number" ]; then
     # There was no match of '{{{ insert_before }}}', insert at
     # the end of the file.


### PR DESCRIPTION
* Quote `find` glob arguments, so they are protected from the shell.
* Quote the whole `awk` command, so shellcheck is not confused by unquoted curly braces.
* Fix a typo of `file_to_inspect` vs `files_to_inspect`.
* Made vars expansion explicit when they are followed by square brackets,
  i.e. `$x[[:space:]]` to `${x}[[:space:]]`
* Separated `local` declarations from assignments using subsells.
  `local` shadows the subshell return code in those cases.
* Removed `local` from the Jinja macro, as there is no function there.
* Changed `sed` separator in `FSTAB_TARGET_ROW` definition to `|`, got rid of `TARGET_ESCAPED`.
* Double-quoted backslashes in double quotes.
* Commented out unused def of `TARGET_OPTS`.