### PR TITLE
Clean up partition before performing test for mount_option_tmp_noexec

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/fstab.fail.sh
@@ -3,6 +3,8 @@
 
 . $SHARED/partition.sh
 
+clean_up_partition /tmp
+
 create_partition
 
 make_fstab_given_partition_line /tmp ext2 nodev

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/runtime.pass.sh
@@ -3,6 +3,8 @@
 
 . $SHARED/partition.sh
 
+clean_up_partition /tmp
+
 create_partition
 
 make_fstab_correct_partition_line /tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/separate.fail.sh
@@ -6,6 +6,8 @@
 
 . $SHARED/partition.sh
 
+clean_up_partition /tmp
+
 create_partition
 
 make_fstab_correct_partition_line /tmp


### PR DESCRIPTION
#### Description:
Add `clean_up_partition` in test scenarios for `mount_option_tmp_noexec` rule.

#### Rationale:
Without cleaning partition it's possible the machine has already mounted tested partition (e.g. `/tmp`) and test scenarios fail because it can't mount it. 
