### PR TITLE
Fix parameter and profile in sysctl_kernel_dmesg_restrict test scenario

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/tests/disabled.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/tests/disabled.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp42
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/sysctl.sh
 
-sysctl_set_kernel_setting_to dmsg_restrict 0
+sysctl_set_kernel_setting_to dmesg_restrict 0


### PR DESCRIPTION
#### Description:
Changes parameter to `dmesg_restrict` and profile to `ospp`.

#### Rationale:
Test scenario was failing when using ansible remediation, because it reloads sysctl and fails, because unknown `dmsg_restrict` parameter.
