### PR TITLE
Small fixes for compare_ds.py

### DIFF
--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -182,7 +182,9 @@ def compare_fix_elements(
                 remediation_type, rule_id, old_fix_id, new_fix_id)
         )
     if show_diffs:
-        diff = compare_fix_texts(old_fix.text, new_fix.text)
+        old_fix_text = "".join(old_fix.itertext())
+        new_fix_text = "".join(new_fix.itertext())
+        diff = compare_fix_texts(old_fix_text, new_fix_text)
         if diff:
             print("%s remediation for rule '%s' differs:\n%s" % (
                 remediation_type, rule_id, diff))

--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -102,6 +102,7 @@ def compare_oval_definitions(
             if x[0] == y[0] and x[1] == y[1]:
                 old_els.remove(x)
                 new_els.remove(y)
+                break
     if old_els or new_els:
         print("OVAL definition %s differs:" % (old_oval_def_id))
         print("--- old datastream")


### PR DESCRIPTION
1. Add a `break`
If a comparison was a successful match we shouldn't continue with comparing, otherwise we would match all the items with same value.


2. Concatenate all text within a `fix` element
If there is no string between opening tag of `fix` element and the `sub` element, the `Element.text` property is `None`, which caused a traceback in `compare_fix_texts` function. To get all the text without skipping the child elements we can use `Element.itertext()` method.