### PR TITLE
Rename disable_prelink -> bash_disable_prelink

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1309,7 +1309,7 @@ Available high-level Jinja macros to generate Bash remediations:
 - `bash_coredump_config_set` -  Set Coredump configuration in `/etc/systemd/coredump.conf`
 - `bash_package_install` - Install a package
 - `bash_package_remove` - Remove a package
-- `disable_prelink` - disables prelinking
+- `bash_disable_prelink` - disables prelinking
 - `bash_dconf_settings` - configure DConf settings for RHEL and Fedora systems
 - `bash_dconf_lock` - configure DConf locks for RHEL and Fedora systems
 

--- a/linux_os/guide/system/software/integrity/disable_prelink/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/disable_prelink/bash/shared.sh
@@ -1,2 +1,2 @@
 # platform = multi_platform_all
-{{{ disable_prelink() }}}
+{{{ bash_disable_prelink() }}}

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
@@ -3,7 +3,7 @@
 # include remediation functions library
 . /usr/share/scap-security-guide/remediation_functions
 
-{{{ disable_prelink() }}}
+{{{ bash_disable_prelink() }}}
 
 if grep -q -m1 -o aes /proc/cpuinfo; then
 	{{{ bash_package_install("dracut-fips-aesni") }}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -87,7 +87,7 @@ apt-get remove -y "{{{ package }}}"
 {{%- endif -%}}
 {{%- endmacro -%}}
 
-{{%- macro disable_prelink() -%}}
+{{%- macro bash_disable_prelink() -%}}
 # prelink not installed
 if test ! -e /etc/sysconfig/prelink -a ! -e /usr/sbin/prelink; then
     return 0


### PR DESCRIPTION
Per conversation in #4746, we should probably prefix bash remediation
helpers with the `bash_` prefix. This lets us quickly identify which
language a particular macro is for, especially when macros with similar
functionality behave differently across languages.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`