### PR TITLE
ansible_set_sshd: add before first commented Match

### DIFF
--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -138,7 +138,7 @@
   Ansible to pass a file at a different path.
 #}}
 {{%- macro ansible_sshd_set(msg='', parameter='', value='') %}}
-{{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^Match") }}}
+{{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^[#\s]*Match") }}}
 {{%- endmacro %}}
 
 {{#


### PR DESCRIPTION
Previously, we added new configuration values before the first instance
of an uncommented Match block. However, if an admin had a commented-out
Match block and later uncommented it, the configuration file would
likely become invalid.

We thus move the addition to before the first Match, regardless of
whether or not it is commented out.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`


I'd appreciate additional review on this. I *think* the resulting regex is correct...

Per discussion with @redhatrises. 