### PR TITLE
SSG Test Suite: Continue even when rule is not found on benchmark.

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -213,7 +213,7 @@ class RuleChecker(oscap.Checker):
                     logging.error(
                         "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
                         .format(rule.id, self.benchmark_id, self.datastream))
-                    return
+                    continue
                 remediation_available = self._is_remediation_available(rule)
 
                 self._check_rule(rule, remote_dir, state, remediation_available)


### PR DESCRIPTION
#### Description:

- Continue evaluating rules even when some rule is not found on benchmark.

#### Rationale:

- When using `ALL` in rule mode, the execution will not stop if it encounters a rule which is not present in the tested benchmark from the datastream.

#### Additional Information:

```
ERROR - Rule 'xccdf_org.ssgproject.content_rule_sshd_use_approved_ciphers' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in './content/build/ssg-rhel8-ds.xml'
```