### PR TITLE
Port old template preprocessing into new system - simple templates

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -347,3 +347,46 @@
   </linux:dpkginfo_object>
 {{% endif %}}
 {{%- endmacro -%}}
+
+{{#
+  Creates OVAL tests with given test_id which checks if package
+  is installed. Optionally, it can check if a package of a given version (EVR)
+  or newer version is present.
+#}}
+{{%- macro oval_test_package_installed(package='', evr='', test_id='') -%}}
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="{{{ test_id }}}" version="1"
+  comment="package {{{ package }}} is installed">
+    <linux:object object_ref="obj_{{{ test_id }}}" />
+    {{% if evr %}}
+      <linux:state state_ref="ste_{{{ test_id }}}" />
+    {{% endif %}}
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_{{{ test_id }}}" version="1">
+    <linux:name>{{{ package }}}</linux:name>
+  </linux:rpminfo_object>
+  {{% if evr %}}
+    <linux:rpminfo_state id="ste_{{{ test_id }}}" version="1">
+      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ evr }}}</linux:evr>
+    </linux:rpminfo_state>
+  {{% endif %}}
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="{{{ test_id }}}" version="1"
+  comment="package {{{ package }}} is installed">
+    <linux:object object_ref="obj_{{{ test_id }}}" />
+    {{% if evr %}}
+      <linux:state state_ref="ste_{{{ test_id }}}" />
+    {{% endif %}}
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_{{{ test_id }}}" version="1">
+    <linux:name>{{{ package }}}</linux:name>
+  </linux:dpkginfo_object>
+  {{% if evr %}}
+    <linux:dpkginfo_state id="ste_{{{ test_id }}}" version="1">
+      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ evr }}}</linux:evr>
+    </linux:dpkginfo_state>
+  {{% endif %}}
+{{% endif %}}
+{{%- endmacro -%}}

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -321,3 +321,29 @@
 {{%- macro oval_check_ini_file(path='', section='', parameter='', value='', missing_parameter_pass=false, application='', multi_value=false, missing_config_file_fail=true) %}}
 {{{ oval_check_config_file(path=path, prefix_regex="^\s*", parameter=parameter, value=value, separator_regex="[ \\t]*=[ \\t]*", missing_parameter_pass=missing_parameter_pass, application=application, multi_value=multi_value, missing_config_file_fail=missing_config_file_fail, section=section) }}}
 {{%- endmacro %}}
+
+{{#
+  Creates OVAL tests with given test_id which checks if package
+  is not installed.
+#}}
+{{%- macro oval_test_package_removed(package='', test_id='') -%}}
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="none_exist"
+  id="{{{ test_id }}}" version="1"
+  comment="package {{{ package }}} is removed">
+    <linux:object object_ref="obj_{{{ test_id }}}" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_{{{ test_id }}}" version="1">
+    <linux:name>{{{ package }}}</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="none_exist"
+  id="{{{ test_id }}}" version="1"
+  comment="package {{{ package }}} is removed">
+    <linux:object object_ref="obj_{{{ test_id }}}" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_{{{ test_id }}}" version="1">
+    <linux:name>{{{ package }}}</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+{{%- endmacro -%}}

--- a/shared/templates/template_OVAL_package_installed
+++ b/shared/templates/template_OVAL_package_installed
@@ -13,39 +13,5 @@
       test_ref="test_package_{{{ PKGNAME }}}_installed" />
     </criteria>
   </definition>
-{{% if pkg_system == "rpm" %}}
-  <linux:rpminfo_test check="all" check_existence="all_exist"
-  id="test_package_{{{ PKGNAME }}}_installed" version="1"
-  comment="package {{{ PKGNAME }}} is installed">
-    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_installed" />
-    {{% if EVR %}}
-      <linux:state state_ref="ste_package_{{{ PKGNAME }}}_installed" />
-    {{% endif %}}
-  </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_{{{ PKGNAME }}}_installed" version="1">
-    <linux:name>{{{ PKGNAME }}}</linux:name>
-  </linux:rpminfo_object>
-  {{% if EVR %}}
-    <linux:rpminfo_state id="ste_package_{{{ PKGNAME }}}_installed" version="1">
-      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ EVR }}}</linux:evr>
-    </linux:rpminfo_state>
-  {{% endif %}}
-{{% elif pkg_system == "dpkg" %}}
-  <linux:dpkginfo_test check="all" check_existence="all_exist"
-  id="test_package_{{{ PKGNAME }}}_installed" version="1"
-  comment="package {{{ PKGNAME }}} is installed">
-    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_installed" />
-    {{% if EVR %}}
-      <linux:state state_ref="ste_package_{{{ PKGNAME }}}_installed" />
-    {{% endif %}}
-  </linux:dpkginfo_test>
-  <linux:dpkginfo_object id="obj_package_{{{ PKGNAME }}}_installed" version="1">
-    <linux:name>{{{ PKGNAME }}}</linux:name>
-  </linux:dpkginfo_object>
-  {{% if EVR %}}
-    <linux:dpkginfo_state id="ste_package_{{{ PKGNAME }}}_installed" version="1">
-      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ EVR }}}</linux:evr>
-    </linux:dpkginfo_state>
-  {{% endif %}}
-{{% endif %}}
+{{{ oval_test_package_installed(package=PKGNAME, evr=EVR, test_id="test_package_"+PKGNAME+"_installed") }}}
 </def-group>

--- a/shared/templates/template_OVAL_package_removed
+++ b/shared/templates/template_OVAL_package_removed
@@ -13,23 +13,5 @@
       test_ref="test_package_{{{ PKGNAME }}}_removed" />
     </criteria>
   </definition>
-{{% if pkg_system == "rpm" %}}
-  <linux:rpminfo_test check="all" check_existence="none_exist"
-  id="test_package_{{{ PKGNAME }}}_removed" version="1"
-  comment="package {{{ PKGNAME }}} is removed">
-    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_removed" />
-  </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_package_{{{ PKGNAME }}}_removed" version="1">
-    <linux:name>{{{ PKGNAME }}}</linux:name>
-  </linux:rpminfo_object>
-{{% elif pkg_system == "dpkg" %}}
-  <linux:dpkginfo_test check="all" check_existence="none_exist"
-  id="test_package_{{{ PKGNAME }}}_removed" version="1"
-  comment="package {{{ PKGNAME }}} is removed">
-    <linux:object object_ref="obj_package_{{{ PKGNAME }}}_removed" />
-  </linux:dpkginfo_test>
-  <linux:dpkginfo_object id="obj_package_{{{ PKGNAME }}}_removed" version="1">
-    <linux:name>{{{ PKGNAME }}}</linux:name>
-  </linux:dpkginfo_object>
-{{% endif %}}
+{{{ oval_test_package_removed(package=PKGNAME, test_id="test_package_"+PKGNAME+"_removed") }}}
 </def-group>

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -1,5 +1,7 @@
 <def-group>
 
+{{%- set package_removed_test_id = "test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_removed" -%}}
+
 {{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
 
   {{# we are using systemd and our target OVAL version does support the systemd related tests #}}
@@ -13,7 +15,7 @@
       <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
     <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
-      <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
+      <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
       <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
         <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
         {{%- if MASK_SERVICE %}}
@@ -101,7 +103,7 @@
       <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
    <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
-    <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
+    <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
 
     <!-- OVAL <runlevel_test> is not implemented in OpenSCAP when compiled on Ubuntusystems yet:
          https://github.com/OpenSCAP/openscap/blob/maint-1.2/src/OVAL/probes/unix/runlevel.c#L210
@@ -138,7 +140,7 @@
       <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
    <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
-    <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
+    <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
     <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
       <criterion comment="{{{ SERVICENAME }}} runlevel 0" test_ref="test_runlevel0_{{{ SERVICENAME }}}_off" />
       <criterion comment="{{{ SERVICENAME }}} runlevel 1" test_ref="test_runlevel1_{{{ SERVICENAME }}}_off" />
@@ -238,7 +240,7 @@
       <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
     </metadata>
     <criteria comment="package {{{ PACKAGENAME }}} removed or service and socket {{{ SERVICENAME }}} are not configured to start" operator="OR">
-      <extend_definition comment="{{{ PACKAGENAME }}} removed" definition_ref="package_{{{ PACKAGENAME }}}_removed" />
+      <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
       <criteria operator="AND" comment="service and socket {{{ SERVICENAME }}} are disabled">
         <criterion comment="{{{ SERVICENAME }}} disabled in multi-user.target" test_ref="test_{{{ SERVICENAME }}}_disabled_multi_user_target" />
         <criterion comment="{{{ SERVICENAME }}} socket disabled in sockets.target" test_ref="test_{{{ SERVICENAME }}}_socket_disabled_sockets_target" />
@@ -277,5 +279,7 @@
   {{% endif %}}
 
 {{% endif %}}
+
+{{{ oval_test_package_removed(package=PACKAGENAME, test_id=package_removed_test_id) }}}
 
 </def-group>

--- a/shared/templates/template_OVAL_service_enabled
+++ b/shared/templates/template_OVAL_service_enabled
@@ -1,5 +1,7 @@
 <def-group>
 
+{{%- set package_installed_test_id = "test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_installed" -%}}
+
 {{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
 
   <definition class="compliance" id="service_{{{ SERVICENAME }}}_enabled" version="1">
@@ -11,7 +13,7 @@
       <description>The {{{ SERVICENAME }}} service should be enabled if possible.</description>
     </metadata>
     <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
-    <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
+    <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
       <criteria comment="service {{{ SERVICENAME }}} is configured to start and is running" operator="AND">
         <criterion comment="{{{ SERVICENAME }}} is running" test_ref="test_service_running_{{{ SERVICENAME }}}" />
         <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">
@@ -68,7 +70,7 @@
       <description>The {{{ SERVICENAME }}} service should be enabled if possible.</description>
     </metadata>
     <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
-    <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
+    <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
     <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">
       <criterion comment="{{{ SERVICENAME }}} runlevel 0" test_ref="test_runlevel0_{{{ SERVICENAME }}}_on" />
       <criterion comment="{{{ SERVICENAME }}} runlevel 1" test_ref="test_runlevel1_{{{ SERVICENAME }}}_on" />
@@ -156,5 +158,5 @@
   </unix:runlevel_state>
 
 {{% endif %}}
-
+{{{ oval_test_package_installed(package=PACKAGENAME, evr="", test_id=package_installed_test_id) }}}
 </def-group>

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -123,6 +123,10 @@ def sysctl(data, lang):
     return data
 
 
+def package_removed(data, lang):
+    return data
+
+
 templates = {
     "accounts_password": accounts_password,
     "auditd_lineinfile": None,
@@ -149,7 +153,7 @@ templates = {
     "mount_option_var": None,
     "ocp_service_runtime_config": None,
     "package_installed": package_installed,
-    "package_removed": None,
+    "package_removed": package_removed,
     "permissions": None,
     "sebool": None,
     "sebool_var": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -25,6 +25,15 @@ def accounts_password(data, lang):
     return data
 
 
+def audit_rules_login_events(data, lang):
+    path = data["path"]
+    name = re.sub(r'[-\./]', '_', os.path.basename(os.path.normpath(path)))
+    data["name"] = name
+    if lang == "oval":
+        data["path"] = path.replace("/", "\\/")
+    return data
+
+
 def audit_rules_privileged_commands(data, lang):
     path = data["path"]
     name = re.sub(r"[-\./]", "_", os.path.basename(path))
@@ -63,7 +72,7 @@ templates = {
     "auditd_lineinfile": None,
     "audit_rules_dac_modification": None,
     "audit_rules_file_deletion_events": None,
-    "audit_rules_login_events": None,
+    "audit_rules_login_events": audit_rules_login_events,
     "audit_rules_path_syscall": None,
     "audit_rules_privileged_commands": audit_rules_privileged_commands,
     "audit_rules_unsuccessful_file_modification": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -145,6 +145,12 @@ def service_enabled(data, lang):
     return data
 
 
+def timer_enabled(data, lang):
+    if "packagename" not in data:
+        data["packagename"] = data["timername"]
+    return data
+
+
 templates = {
     "accounts_password": accounts_password,
     "auditd_lineinfile": None,
@@ -179,7 +185,7 @@ templates = {
     "service_enabled": service_enabled,
     "sshd_lineinfile": None,
     "sysctl": sysctl,
-    "timer_enabled": None,
+    "timer_enabled": timer_enabled,
 }
 
 

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -34,6 +34,15 @@ def audit_rules_login_events(data, lang):
     return data
 
 
+def audit_rules_path_syscall(data, lang):
+    if lang == "oval":
+        pathid = re.sub(r'[-\./]', '_', data["path"])
+        # remove root slash made into '_'
+        pathid = pathid[1:]
+        data["pathid"] = pathid
+    return data
+
+
 def audit_rules_privileged_commands(data, lang):
     path = data["path"]
     name = re.sub(r"[-\./]", "_", os.path.basename(path))
@@ -73,7 +82,7 @@ templates = {
     "audit_rules_dac_modification": None,
     "audit_rules_file_deletion_events": None,
     "audit_rules_login_events": audit_rules_login_events,
-    "audit_rules_path_syscall": None,
+    "audit_rules_path_syscall": audit_rules_path_syscall,
     "audit_rules_privileged_commands": audit_rules_privileged_commands,
     "audit_rules_unsuccessful_file_modification": None,
     "audit_rules_unsuccessful_file_modification_o_creat": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -62,6 +62,18 @@ def audit_rules_privileged_commands(data, lang):
     return data
 
 
+def audit_rules_unsuccessful_file_modification_o_creat(data, lang):
+    return data
+
+
+def audit_rules_unsuccessful_file_modification_o_trunc_write(data, lang):
+    return data
+
+
+def audit_rules_unsuccessful_file_modification_rule_order(data, lang):
+    return data
+
+
 def audit_rules_usergroup_modification(data, lang):
     path = data["path"]
     name = re.sub(r'[-\./]', '_', os.path.basename(path))
@@ -112,9 +124,9 @@ templates = {
     "audit_rules_path_syscall": audit_rules_path_syscall,
     "audit_rules_privileged_commands": audit_rules_privileged_commands,
     "audit_rules_unsuccessful_file_modification": None,
-    "audit_rules_unsuccessful_file_modification_o_creat": None,
-    "audit_rules_unsuccessful_file_modification_o_trunc_write": None,
-    "audit_rules_unsuccessful_file_modification_rule_order": None,
+    "audit_rules_unsuccessful_file_modification_o_creat": audit_rules_unsuccessful_file_modification_o_creat,
+    "audit_rules_unsuccessful_file_modification_o_trunc_write": audit_rules_unsuccessful_file_modification_o_trunc_write,
+    "audit_rules_unsuccessful_file_modification_rule_order": audit_rules_unsuccessful_file_modification_rule_order,
     "audit_rules_usergroup_modification": audit_rules_usergroup_modification,
     "file_groupowner": None,
     "file_owner": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -68,6 +68,11 @@ def grub2_bootloader_argument(data, lang):
     return data
 
 
+def mount(data, lang):
+    data["pointid"] = re.sub(r'[-\./]', '_', data["mountpoint"])
+    return data
+
+
 def package_installed(data, lang):
     if "evr" in data:
         evr = data["evr"]
@@ -109,7 +114,7 @@ templates = {
     "file_regex_permissions": None,
     "grub2_bootloader_argument": grub2_bootloader_argument,
     "kernel_module_disabled": None,
-    "mount": None,
+    "mount": mount,
     "mount_option": None,
     "mount_option_remote_filesystems": None,
     "mount_option_removable_partitions": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -25,6 +25,10 @@ def accounts_password(data, lang):
     return data
 
 
+def audit_rules_dac_modification(data, lang):
+    return data
+
+
 def audit_rules_login_events(data, lang):
     path = data["path"]
     name = re.sub(r'[-\./]', '_', os.path.basename(os.path.normpath(path)))
@@ -98,7 +102,7 @@ def sysctl(data, lang):
 templates = {
     "accounts_password": accounts_password,
     "auditd_lineinfile": None,
-    "audit_rules_dac_modification": None,
+    "audit_rules_dac_modification": audit_rules_dac_modification,
     "audit_rules_file_deletion_events": None,
     "audit_rules_login_events": audit_rules_login_events,
     "audit_rules_path_syscall": audit_rules_path_syscall,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -56,7 +56,7 @@ def audit_rules_privileged_commands(data, lang):
     name = re.sub(r"[-\./]", "_", os.path.basename(path))
     data["name"] = name
     if lang == "oval":
-        data["id"] = "audit_rules_execution_" + name
+        data["id"] = data["_rule_id"]
         data["title"] = "Record Any Attempts to Run " + name
         data["path"] = path.replace("/", "\\/")
     return data
@@ -260,6 +260,10 @@ class Builder(object):
             raise ValueError(
                 "Rule {0} does not contain mandatory 'vars:' key under "
                 "'template:' key.".format(rule.id_))
+        # Add the rule ID which will be reused in OVAL templates as OVAL
+        # definition ID so that the build system matches the generated
+        # check with the rule.
+        template_vars["_rule_id"] = rule.id_
         template_parameters = self.preprocess_data(
             template_name, lang, template_vars)
         jinja_dict = ssg.utils.merge_dicts(self.env_yaml, template_parameters)

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -29,6 +29,10 @@ def audit_rules_dac_modification(data, lang):
     return data
 
 
+def audit_rules_file_deletion_events(data, lang):
+    return data
+
+
 def audit_rules_login_events(data, lang):
     path = data["path"]
     name = re.sub(r'[-\./]', '_', os.path.basename(os.path.normpath(path)))
@@ -103,7 +107,7 @@ templates = {
     "accounts_password": accounts_password,
     "auditd_lineinfile": None,
     "audit_rules_dac_modification": audit_rules_dac_modification,
-    "audit_rules_file_deletion_events": None,
+    "audit_rules_file_deletion_events": audit_rules_file_deletion_events,
     "audit_rules_login_events": audit_rules_login_events,
     "audit_rules_path_syscall": audit_rules_path_syscall,
     "audit_rules_privileged_commands": audit_rules_privileged_commands,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -127,6 +127,16 @@ def package_removed(data, lang):
     return data
 
 
+def service_disabled(data, lang):
+    if "packagename" not in data:
+        data["packagename"] = data["servicename"]
+    if "daemonname" not in data:
+        data["daemonname"] = data["servicename"]
+    if "mask_service" not in data:
+        data["mask_service"] = "true"
+    return data
+
+
 templates = {
     "accounts_password": accounts_password,
     "auditd_lineinfile": None,
@@ -157,7 +167,7 @@ templates = {
     "permissions": None,
     "sebool": None,
     "sebool_var": None,
-    "service_disabled": None,
+    "service_disabled": service_disabled,
     "service_enabled": None,
     "sshd_lineinfile": None,
     "sysctl": sysctl,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -25,6 +25,17 @@ def accounts_password(data, lang):
     return data
 
 
+def audit_rules_privileged_commands(data, lang):
+    path = data["path"]
+    name = re.sub(r"[-\./]", "_", os.path.basename(path))
+    data["name"] = name
+    if lang == "oval":
+        data["id"] = "audit_rules_execution_" + name
+        data["title"] = "Record Any Attempts to Run " + name
+        data["path"] = path.replace("/", "\\/")
+    return data
+
+
 def package_installed(data, lang):
     if "evr" in data:
         evr = data["evr"]
@@ -54,7 +65,7 @@ templates = {
     "audit_rules_file_deletion_events": None,
     "audit_rules_login_events": None,
     "audit_rules_path_syscall": None,
-    "audit_rules_privileged_commands": None,
+    "audit_rules_privileged_commands": audit_rules_privileged_commands,
     "audit_rules_unsuccessful_file_modification": None,
     "audit_rules_unsuccessful_file_modification_o_creat": None,
     "audit_rules_unsuccessful_file_modification_o_trunc_write": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -137,6 +137,14 @@ def service_disabled(data, lang):
     return data
 
 
+def service_enabled(data, lang):
+    if "packagename" not in data:
+        data["packagename"] = data["servicename"]
+    if "daemonname" not in data:
+        data["daemonname"] = data["servicename"]
+    return data
+
+
 templates = {
     "accounts_password": accounts_password,
     "auditd_lineinfile": None,
@@ -168,7 +176,7 @@ templates = {
     "sebool": None,
     "sebool_var": None,
     "service_disabled": service_disabled,
-    "service_enabled": None,
+    "service_enabled": service_enabled,
     "sshd_lineinfile": None,
     "sysctl": sysctl,
     "timer_enabled": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -19,14 +19,9 @@ lang_to_ext_map = {
 # Callback functions for processing template parameters and/or validating them
 
 
-def sysctl(data, lang):
-    data["sysctlid"] = re.sub(r'[-\.]', '_', data["sysctlvar"])
-    if not data.get("sysctlval"):
-        data["sysctlval"] = ""
-    ipv6_flag = "P"
-    if data["sysctlid"].find("ipv6") >= 0:
-        ipv6_flag = "I"
-    data["flags"] = "SR" + ipv6_flag
+def accounts_password(data, lang):
+    if lang == "oval":
+        data["sign"] = "-?" if data["variable"].endswith("credit") else ""
     return data
 
 
@@ -41,8 +36,19 @@ def package_installed(data, lang):
     return data
 
 
+def sysctl(data, lang):
+    data["sysctlid"] = re.sub(r'[-\.]', '_', data["sysctlvar"])
+    if not data.get("sysctlval"):
+        data["sysctlval"] = ""
+    ipv6_flag = "P"
+    if data["sysctlid"].find("ipv6") >= 0:
+        ipv6_flag = "I"
+    data["flags"] = "SR" + ipv6_flag
+    return data
+
+
 templates = {
-    "accounts_password": None,
+    "accounts_password": accounts_password,
     "auditd_lineinfile": None,
     "audit_rules_dac_modification": None,
     "audit_rules_file_deletion_events": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -54,6 +54,15 @@ def audit_rules_privileged_commands(data, lang):
     return data
 
 
+def audit_rules_usergroup_modification(data, lang):
+    path = data["path"]
+    name = re.sub(r'[-\./]', '_', os.path.basename(path))
+    data["name"] = name
+    if lang == "oval":
+        data["path"] = path.replace("/", "\\/")
+    return data
+
+
 def package_installed(data, lang):
     if "evr" in data:
         evr = data["evr"]
@@ -88,7 +97,7 @@ templates = {
     "audit_rules_unsuccessful_file_modification_o_creat": None,
     "audit_rules_unsuccessful_file_modification_o_trunc_write": None,
     "audit_rules_unsuccessful_file_modification_rule_order": None,
-    "audit_rules_usergroup_modification": None,
+    "audit_rules_usergroup_modification": audit_rules_usergroup_modification,
     "file_groupowner": None,
     "file_owner": None,
     "file_permissions": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -159,10 +159,14 @@ templates = {
     "audit_rules_login_events": audit_rules_login_events,
     "audit_rules_path_syscall": audit_rules_path_syscall,
     "audit_rules_privileged_commands": audit_rules_privileged_commands,
-    "audit_rules_unsuccessful_file_modification": audit_rules_unsuccessful_file_modification,
-    "audit_rules_unsuccessful_file_modification_o_creat": audit_rules_unsuccessful_file_modification_o_creat,
-    "audit_rules_unsuccessful_file_modification_o_trunc_write": audit_rules_unsuccessful_file_modification_o_trunc_write,
-    "audit_rules_unsuccessful_file_modification_rule_order": audit_rules_unsuccessful_file_modification_rule_order,
+    "audit_rules_unsuccessful_file_modification":
+        audit_rules_unsuccessful_file_modification,
+    "audit_rules_unsuccessful_file_modification_o_creat":
+        audit_rules_unsuccessful_file_modification_o_creat,
+    "audit_rules_unsuccessful_file_modification_o_trunc_write":
+        audit_rules_unsuccessful_file_modification_o_trunc_write,
+    "audit_rules_unsuccessful_file_modification_rule_order":
+        audit_rules_unsuccessful_file_modification_rule_order,
     "audit_rules_usergroup_modification": audit_rules_usergroup_modification,
     "file_groupowner": None,
     "file_owner": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -92,6 +92,10 @@ def grub2_bootloader_argument(data, lang):
     return data
 
 
+def kernel_module_disabled(data, lang):
+    return data
+
+
 def mount(data, lang):
     data["pointid"] = re.sub(r'[-\./]', '_', data["mountpoint"])
     return data
@@ -137,7 +141,7 @@ templates = {
     "file_permissions": None,
     "file_regex_permissions": None,
     "grub2_bootloader_argument": grub2_bootloader_argument,
-    "kernel_module_disabled": None,
+    "kernel_module_disabled": kernel_module_disabled,
     "mount": mount,
     "mount_option": None,
     "mount_option_remote_filesystems": None,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -62,6 +62,10 @@ def audit_rules_privileged_commands(data, lang):
     return data
 
 
+def audit_rules_unsuccessful_file_modification(data, lang):
+    return data
+
+
 def audit_rules_unsuccessful_file_modification_o_creat(data, lang):
     return data
 
@@ -123,7 +127,7 @@ templates = {
     "audit_rules_login_events": audit_rules_login_events,
     "audit_rules_path_syscall": audit_rules_path_syscall,
     "audit_rules_privileged_commands": audit_rules_privileged_commands,
-    "audit_rules_unsuccessful_file_modification": None,
+    "audit_rules_unsuccessful_file_modification": audit_rules_unsuccessful_file_modification,
     "audit_rules_unsuccessful_file_modification_o_creat": audit_rules_unsuccessful_file_modification_o_creat,
     "audit_rules_unsuccessful_file_modification_o_trunc_write": audit_rules_unsuccessful_file_modification_o_trunc_write,
     "audit_rules_unsuccessful_file_modification_rule_order": audit_rules_unsuccessful_file_modification_rule_order,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -63,6 +63,11 @@ def audit_rules_usergroup_modification(data, lang):
     return data
 
 
+def grub2_bootloader_argument(data, lang):
+    data["arg_name_value"] = data["arg_name"] + "=" + data["arg_value"]
+    return data
+
+
 def package_installed(data, lang):
     if "evr" in data:
         evr = data["evr"]
@@ -102,7 +107,7 @@ templates = {
     "file_owner": None,
     "file_permissions": None,
     "file_regex_permissions": None,
-    "grub2_bootloader_argument": None,
+    "grub2_bootloader_argument": grub2_bootloader_argument,
     "kernel_module_disabled": None,
     "mount": None,
     "mount_option": None,


### PR DESCRIPTION
#### Description:
For each template it tries to port logic from `shared/templates/create_<template_name>.py` to the new templating system code.

It doesn't have to port everything from these scripts, because most of the stuff like template filepaths or names of generated files are handled by the new templating system automatically. So the functions introduced in this PR contain mostly computing of default values or escaping selected characters in arguments that will be passed to the Jinja engine.

This PR converts only the `create_*.py` scripts that were easy. The pathches the remaining templates which are more difficult or convoluted will be submitted in future as separate PRs.

#### Rationale:
Some templates can't use the data from `template: vars:`in `rule.yml` directly, but there is processing needed. For example escaping values, inferring default values. Currently this is handled by classes defined in `shared/templates/create_<template_name>.py`. It is difficult to reuse these classes in the new system. First, they depend on order of arguments, but we want to have YAML dictionaries of arbitrary order of keys. Second, they have certain paths hardcoded. Third, we will have to create a lot of boilerplate code (importing classes, mapping classes to templates).
