### PR TITLE
Fix kubelet_enable_streaming_connections Rule

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/oval/shared.xml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/oval/shared.xml
@@ -10,11 +10,11 @@
     </metadata>
     <criteria operator="AND">
       <extend_definition comment="Runtime configuration is correct" definition_ref="ocp_service_runtime_config_streaming_connection_timeout" />
-      <criterion comment="streaming-connection-timeout is configured" test_ref="test_kubelet_enable_streaming_connections" />
+      <criterion comment="streaming-connection-idle-timeout is configured" test_ref="test_kubelet_enable_streaming_connections" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="streaming-connection-timeout is configured" id="test_kubelet_enable_streaming_connections" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="streaming-connection-idle-timeout is configured" id="test_kubelet_enable_streaming_connections" version="1">
     <ind:object object_ref="object_kubelet_enable_streaming_connections" />
     <ind:state state_ref="state_kubelet_enable_streaming_connections" />
     <ind:state state_ref="state_kubelet_enable_streaming_connections_nonzero" />
@@ -22,7 +22,7 @@
 
   <ind:textfilecontent54_object id="object_kubelet_enable_streaming_connections" version="1">
     <ind:filepath>/etc/origin/node/node-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*kubeletArguments\:(?:[^\n]*\n+)+?[\s]*streaming-connection-timeout\:[\s]*[\n]+[\s]*-[\s]+'(\S+)'[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*kubeletArguments\:(?:[^\n]*\n+)+?[\s]*streaming-connection-idle-timeout\:[\s]*[\n]+[\s]*-[\s]+'(\S+)'[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -34,7 +34,7 @@
     <ind:subexpression datatype="string" operation="equals" var_check="all" var_ref="var_streaming_connection_timeouts" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="external variable for streaming-connection-timeout"
+  <external_variable comment="external variable for streaming-connection-idle-timeout"
   datatype="string" id="var_streaming_connection_timeouts" version="1" />
 </def-group>
 

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -11,7 +11,7 @@ description: |-
     file <tt>/etc/origin/node/node-config.yaml</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>kubeletArguments:
-      streaming-connection-timeout:
+      streaming-connection-idle-timeout:
       - '<sub idref="var_streaming_connection_timeouts"/>'</pre>
 
 rationale: |-
@@ -25,7 +25,7 @@ ocil_clause: 'the streaming connection timeouts are not disabled'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep -A1 streaming-connection-timeout /etc/origin/node/node-config.yaml</pre>
+    <pre>$ sudo grep -A1 streaming-connection-idle-timeout /etc/origin/node/node-config.yaml</pre>
     The output should return <tt><sub idref="var_streaming_connection_timeouts"/></tt>.
 
 identifiers:

--- a/applications/openshift/kubelet/var_streaming_connection_timeouts.var
+++ b/applications/openshift/kubelet/var_streaming_connection_timeouts.var
@@ -13,7 +13,8 @@ operator: equals
 interactive: true
 
 options:
-    default: 4h
+    default: 5m
+    5min: 5m
     10min: 10m
     30min: 30m
     1hour: 1h

--- a/ocp3/templates/csv/ocp_service_runtime_config.csv
+++ b/ocp3/templates/csv/ocp_service_runtime_config.csv
@@ -10,6 +10,6 @@
 /usr/bin/hyperkube kubelet,--feature-gates,RotateKubeletServerCertificate=True,RotateKubeletServerCertificate
 /usr/bin/hyperkube kubelet,--make-iptables-util-chains,true
 /usr/bin/hyperkube kubelet,--protect-kernel-defaults,true
-/usr/bin/hyperkube kubelet,--streaming-connection-timeout,var_streaming_connection_timeouts
+/usr/bin/hyperkube kubelet,--streaming-connection-idle-timeout,var_streaming_connection_timeouts
 /usr/bin/hyperkube kubelet,--allow-privileged,false
 


### PR DESCRIPTION
- Option is streaming-connection-idle-timeout not streaming-connection-timeout
- Set default timeout variable to benchmarck default
- Fixes #3775