### PR TITLE
AIDE periodic crontab check modification

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
@@ -29,7 +29,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide with cron" id="object_test_aide_periodic_cron_checking" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
-    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))([\s]*root)?[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -39,7 +39,7 @@
   <ind:textfilecontent54_object comment="run aide with cron" id="object_test_aide_crond_checking" version="1">
     <ind:path>/etc/cron.d</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))([\s]*root)?[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -48,7 +48,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide with cron" id="object_aide_var_cron_checking" version="1">
     <ind:filepath>/var/spool/cron/root</ind:filepath>
-    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))([\s]*root)?[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -60,7 +60,7 @@ ocil_clause: 'there is no output'
 ocil: |-
     To determine that periodic AIDE execution has been scheduled, run the following command:
     <pre>$ grep aide /etc/crontab</pre>
-    The output should return some similiar to the following:
+    The output should return something similar to the following:
     <pre>05 4 * * * root /usr/sbin/aide --check</pre>
 
     NOTE: The usage of special cron times, such as @daily or @weekly, is acceptable.


### PR DESCRIPTION
#### Description:

Modify OVAL crontab check to allow situations which omit the user.
Also, fix some minor wording.

#### Rationale:

User field isn't necessary to run a cronjob as root in /etc/crontab, /etc/cron.d, and root's personal crontab. The current test fails in this situation, so make it optional.