### PR TITLE
Fail when a template does not exist

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1658,7 +1658,13 @@ parameters before passing them to the Jinja engine.  For example, this callback 
 provide default values, escape characters, check if parameters are correct, or
 any other processing of the parameters specific for the template.
 
-The callback function should be put into `link:{rootdir}/ssg/templates.py[ssg/templates.py]` and must have 2 parameters:
+The callback functions are located in `link:{rootdir}/ssg/templates.py[ssg/templates.py]`.
+
+The callback function must have the same name as the template name. This is the
+name that is used in `rule.yml` in `name:` key, for example
+`package_installed`.
+
+The callback must have 2 parameters:
 
 - `data` - dictionary which contains the contents of `vars:` dictionary from `rule.yml`
 - `lang` - string, describes language, can be one of: `"anaconda"`, `"ansible"`, `"bash"`, `"oval"`, `"puppet"`
@@ -1670,10 +1676,32 @@ The function must always return the (modified) `data` dictionary.
 The function must be always defined even if no processing of data is needed.
 In that situation the function just returns `data` parameter.
 
-The following example shows the callback function for the template `mount_option`:
+3) Decorate the callback function by the `@template` decorator. The decorator
+will register the template in the templating engine. The decorator has a single
+parameter which is a list of languages that the template provides. The list can
+contain the following values: `"anaconda"`, `"ansible"`, `"bash"`, `"oval"`,
+`"puppet"`. The decorator parameter is mandatory. Insert the `@template`
+decorator on the line before the callback function definition.
+
+For example, if the template name is `package_installed` and it provides
+Ansible template in `shared/templates/template_ANSIBLE_package_installed` and
+OVAL template in `shared/templates/template_OVAL_package_installed`, then there
+must be callback function `package_installed` in
+`link:{rootdir}/ssg/templates.py[ssg/templates.py]` and the callback must be
+decorated by `@template(["ansible", "oval")]`. In this example, decorating the
+callback function lets the templating engine know that Ansible and OVAL should
+be generated if any rule uses `package_installed` in `rule.yml`.
+
+The following example shows the callback function for the template
+`mount_option`, including the `@template` decorator. The example function
+declares that there is a template which name is `mount_option` and it provides
+Ansible, Bash and OVAL content. The code takes the `data` argument which is a
+dictionary with template parameters from `rule.yml` and based on `lang` it
+modifies the template parameters and returns the modified dictionary.
 
 [source,python]
 ----
+@template(["ansible", "bash", "oval"])
 def mount_option(data, lang):
     if lang == "oval":
         data["pointid"] = re.sub(r"[-\./]", "_", data["mountpoint"]).lstrip("_")
@@ -1681,9 +1709,6 @@ def mount_option(data, lang):
         data["mountoption"] = re.sub(" ", ",", data["mountoption"])
     return data
 ----
-
-3) Add the template name to `templates` dictionary in `link:{rootdir}/ssg/templates.py[ssg/templates.py]`. This
-dictionary maps the template name to the callback function name.
 
 
 === Tests (ctest)

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -339,12 +339,20 @@ class Builder(object):
         Builds templated content for a given rule for a given language.
         Writes the output to the correct build directories.
         """
+        template_func = templates[template_name]
+        if lang not in template_func.langs:
+            return
         template_file_name = "template_{0}_{1}".format(
             lang.upper(), template_name)
         template_file_path = os.path.join(
             self.templates_dir, template_file_name)
         if not os.path.exists(template_file_path):
-            return
+            raise RuntimeError(
+                "Rule {0} wants to generate {1} content from template {2}, "
+                "but file {3} which provides this template does not "
+                "exist.".format(
+                    rule_id, lang, template_name, template_file_path)
+            )
         ext = lang_to_ext_map[lang]
         output_file_name = rule_id + ext
         output_filepath = os.path.join(

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -325,10 +325,7 @@ class Builder(object):
         substituted into the Jinja template.
         """
         template_func = templates[template]
-        if template_func is not None:
-            parameters = template_func(raw_parameters.copy(), lang)
-        else:
-            parameters = raw_parameters.copy()
+        parameters = template_func(raw_parameters.copy(), lang)
         # TODO: Remove this right after the variables in templates are renamed
         # to lowercase
         uppercases = dict()
@@ -397,12 +394,6 @@ class Builder(object):
             raise ValueError(
                 "Rule {0} uses template {1} which does not exist.".format(
                     rule_id, template_name))
-        if templates[template_name] is None:
-            sys.stderr.write(
-                "The template {0} has not been completely implemented, no "
-                "content will be generated for rule {1}.\n".format(
-                    template_name, rule_id))
-            return
         try:
             template_vars = template["vars"]
         except KeyError:

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -18,6 +18,7 @@ lang_to_ext_map = {
 
 templates = dict()
 
+
 def template(langs):
     def decorator_template(func):
         func.langs = langs


### PR DESCRIPTION
#### Description:
The current code tries to generate content from any template it finds.
However, that means when it can't find the template it skips it and
continues.  If an existing template goes missing, or is not found by any
reason, it will quietly continue, and  the rule evaluation result in
notchecked without evident reason. 

As suggested by @matejak we will use Python decorators to declare which languages are available for each template. That is better than having the manually created dictionary.

#### Rationale:

In #4809 @yuumasato pointed out problems caused by implicit behavior - see discussion there.
