### PR TITLE
Fix accounts password rules template name

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -56,7 +56,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: less than or equal
         variable: dcredit

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
@@ -57,7 +57,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: greater than or equal
         variable: difok

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: less than or equal
         variable: lcredit

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -48,7 +48,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: less than or equal
         variable: maxclassrepeat

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
@@ -51,7 +51,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: less than or equal
         variable: maxrepeat

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
@@ -65,7 +65,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: greater than or equal
         variable: minclass

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: greater than or equal
         variable: minlen

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -57,7 +57,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: less than or equal
         variable: ocredit

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -54,7 +54,7 @@ ocil: |-
 platform: pam
 
 template:
-    name: package_installed
+    name: accounts_password
     vars:
         operation: less than or equal
         variable: ucredit

--- a/utils/migrate_template_csv_to_rule.py
+++ b/utils/migrate_template_csv_to_rule.py
@@ -18,7 +18,7 @@ def escape_path(path):
 def accounts_password_csv_to_dict(csv_line, csv_data):
     accounts_password = OrderedDict()
     data_accounts_password = {}
-    accounts_password["name"] = "package_installed"
+    accounts_password["name"] = "accounts_password"
 
     variable = csv_line[0]
     rule_id = f"accounts_password_pam_{variable}"


### PR DESCRIPTION
#### Description:

- Fix accounts_password template name in `utils/migrate_template_csv_to_rule.py`
- Update template names in affected rules

#### Rationale:

- Correct template name is `accounts_password`