### PR TITLE
update rsyslog rules

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
@@ -8,12 +8,11 @@ description: |-
     Configure <tt>rsyslog</tt> to use Transport Layer
     Security (TLS) support for logging to remote server
     for the Forwarding Output Module in <tt>/etc/rsyslog.conf</tt>
-    using action
-    <pre>action(type="omfwd" protocol="tcp" Target="&lt;remote system>" port="6514"
-        StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")
+    using action. You can use the following command:
+    <pre>echo 'action(type="omfwd" protocol="tcp" Target="&lt;remote system>" port="6514"
+        StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")' >> /etc/rsyslog.conf
     </pre>
-    Replace the <tt>&lt;remote system></tt> in the above configuration with an IP address or a host name of the remote logging server.
-
+    Replace the <tt>&lt;remote system></tt> in the above command with an IP address or a host name of the remote logging server.
 
 rationale: |-
     For protection of data being logged, the connection to the

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
@@ -12,6 +12,8 @@ description: |-
     <pre>action(type="omfwd" protocol="tcp" Target="&lt;remote system>" port="6514"
         StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")
     </pre>
+    Replace the <tt>&lt;remote system></tt> in the above configuration with an IP address or a host name of the remote logging server.
+
 
 rationale: |-
     For protection of data being logged, the connection to the
@@ -35,3 +37,4 @@ ocil: |-
     <pre>action(type="omfwd" protocol="tcp" Target="&lt;remote system>" port="6514"
         StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")
     </pre>
+    where the <tt>&lt;remote system></tt> present in the configuration line above must be a valid IP address or a host name of the remote logging server.

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
@@ -8,9 +8,9 @@ description: |-
     Configure CA certificate for <tt>rsyslog</tt> logging
     to remote server using Transport Layer Security (TLS)
     using correct path for the <tt>DefaultNetstreamDriverCAFile</tt>
-    global option in <tt>/etc/rsyslog.conf</tt>, for example
-    <pre>global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*</pre>
-    Replace the <tt>/etc/pki/tls/cert.pem</tt> in the configuration line above with the path to the file with CA certificate generated for the purpose of remote logging.
+    global option in <tt>/etc/rsyslog.conf</tt>, for example with the following command:
+    <pre>echo 'global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*' >> /etc/rsyslog.conf</pre>
+    Replace the <tt>/etc/pki/tls/cert.pem</tt> in the above command with the path to the file with CA certificate generated for the purpose of remote logging.
 
 rationale: |-
     The CA certificate needs to be set or <tt>rsyslog.service</tt>

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
@@ -10,6 +10,7 @@ description: |-
     using correct path for the <tt>DefaultNetstreamDriverCAFile</tt>
     global option in <tt>/etc/rsyslog.conf</tt>, for example
     <pre>global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*</pre>
+    Replace the <tt>/etc/pki/tls/cert.pem</tt> in the configuration line above with the path to the file with CA certificate generated for the purpose of remote logging.
 
 rationale: |-
     The CA certificate needs to be set or <tt>rsyslog.service</tt>
@@ -32,3 +33,4 @@ ocil: |-
     <pre>$ grep DefaultNetstreamDriverCAFile /etc/rsyslog.conf /etc/rsyslog.d/*.conf</pre>
     The output should include record similar to
     <pre>global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*</pre>
+    where the path to the CA file (<tt>/etc/pki/tls/cert.pem</tt> in case above) must point to the correct CA certificate.


### PR DESCRIPTION

#### Description:

provided instructions how to setup remote name and CA
This info was added to rule descriptions and ocil clauses of rsyslog_remote_tls and rsyslog_remote_tls_cacert

#### Rationale:

the description and ocil was not entirely clearAs


