### PR TITLE
Stig sle12 initial

### DIFF
--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
@@ -9,6 +9,7 @@
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhv</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_sle</platform>
       </affected>
      <description>
         The operating system installed on the system is supported by a vendor that provides security patches.
@@ -20,6 +21,7 @@
       <extend_definition comment="Installed OS is RHEL8" definition_ref="installed_OS_is_rhel8" />
       <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7_family" />
       <extend_definition comment="Installed OS is OL8" definition_ref="installed_OS_is_ol8_family" />
+      <extend_definition comment="Installed OS is SLE12" definition_ref="installed_OS_is_sle12" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
+prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4,sle12
 
 title: 'The Installed Operating System Is Vendor Supported'
 
@@ -9,6 +9,9 @@ description: |-
 {{% if product in ["ol7", "ol8"] %}}
     Oracle Linux is supported by Oracle Corporation. As the Oracle
     Linux vendor, Oracle Corporation is responsible for providing security patches.
+{{% elif product == "sle12" %}}
+    SUSE Linux Enterprise is supported by SUSE. As the SUSE Linux Enterprise
+    vendor, SUSE is responsible for providing security patches.
 {{% else %}}
     Red Hat Enterprise Linux is supported by Red Hat, Inc. As the Red Hat Enterprise
     Linux vendor, Red Hat, Inc. is responsible for providing security patches.
@@ -29,6 +32,7 @@ severity: high
 
 identifiers:
     cce@rhel8: 80947-5
+    cce@sle12: 83001-8
 
 references:
     disa: "366"
@@ -36,6 +40,7 @@ references:
     nist-csf: ID.RA-1,PR.IP-12
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: "020250"
+    stigid@sle12: "010000"
     isa-62443-2009: 4.2.3,4.2.3.12,4.2.3.7,4.2.3.9
     cobit5: APO12.01,APO12.02,APO12.03,APO12.04,BAI03.10,DSS05.01,DSS05.02
     iso27001-2013: A.12.6.1,A.14.2.3,A.16.1.3,A.18.2.2,A.18.2.3
@@ -50,6 +55,8 @@ ocil: |-
     <pre>$ grep -i "red hat" /etc/redhat-release</pre>
 {{% elif product in ["ol7", "ol8"] %}}
     <pre>$ grep -i "oracle" /etc/oracle-release</pre>
+{{% elif product in ["sle12"] %}}
+    <pre>$ grep -i "suse" /etc/os-release</pre>
 {{% endif %}}
     The output should contain something similar to:
     <pre>{{{ full_name }}}</pre>

--- a/shared/references/disa-stig-sle12-v1r2-xccdf-manual.xml
+++ b/shared/references/disa-stig-sle12-v1r2-xccdf-manual.xml
@@ -1,0 +1,4084 @@
+<?xml version="1.0" encoding="utf-8"?><?xml-stylesheet type='text/xsl' href='STIG_unclass.xsl'?><Benchmark xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/elements/1.1/" id="SLES_12_STIG" xml:lang="en" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/schema/xccdf-1.1.4.xsd http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd" xmlns="http://checklists.nist.gov/xccdf/1.1"><status date="2019-03-12">accepted</status><title>SLES 12 Security Technical Implementation Guide</title><description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</description><notice id="terms-of-use" xml:lang="en"></notice><reference href="http://iase.disa.mil"><dc:publisher>DISA</dc:publisher><dc:source>STIG.DOD.MIL</dc:source></reference><plain-text id="release-info">Release: 2 Benchmark Date: 26 Apr 2019</plain-text><version>1</version><Profile id="MAC-1_Classified"><title>I - Mission Critical Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-1_Public"><title>I - Mission Critical Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-1_Sensitive"><title>I - Mission Critical Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-2_Classified"><title>II - Mission Support Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-2_Public"><title>II - Mission Support Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-2_Sensitive"><title>II - Mission Support Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-3_Classified"><title>III - Administrative Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-3_Public"><title>III - Administrative Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Profile id="MAC-3_Sensitive"><title>III - Administrative Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-77045" selected="true" /><select idref="V-77047" selected="true" /><select idref="V-77049" selected="true" /><select idref="V-77051" selected="true" /><select idref="V-77053" selected="true" /><select idref="V-77055" selected="true" /><select idref="V-77057" selected="true" /><select idref="V-77059" selected="true" /><select idref="V-77061" selected="true" /><select idref="V-77063" selected="true" /><select idref="V-77065" selected="true" /><select idref="V-77067" selected="true" /><select idref="V-77069" selected="true" /><select idref="V-77071" selected="true" /><select idref="V-77073" selected="true" /><select idref="V-77075" selected="true" /><select idref="V-77077" selected="true" /><select idref="V-77079" selected="true" /><select idref="V-77081" selected="true" /><select idref="V-77087" selected="true" /><select idref="V-77089" selected="true" /><select idref="V-77093" selected="true" /><select idref="V-77099" selected="true" /><select idref="V-77105" selected="true" /><select idref="V-77107" selected="true" /><select idref="V-77109" selected="true" /><select idref="V-77111" selected="true" /><select idref="V-77113" selected="true" /><select idref="V-77115" selected="true" /><select idref="V-77117" selected="true" /><select idref="V-77119" selected="true" /><select idref="V-77121" selected="true" /><select idref="V-77123" selected="true" /><select idref="V-77125" selected="true" /><select idref="V-77127" selected="true" /><select idref="V-77129" selected="true" /><select idref="V-77131" selected="true" /><select idref="V-77133" selected="true" /><select idref="V-77135" selected="true" /><select idref="V-77137" selected="true" /><select idref="V-77139" selected="true" /><select idref="V-77141" selected="true" /><select idref="V-77143" selected="true" /><select idref="V-77145" selected="true" /><select idref="V-77147" selected="true" /><select idref="V-77149" selected="true" /><select idref="V-77151" selected="true" /><select idref="V-77153" selected="true" /><select idref="V-77155" selected="true" /><select idref="V-77157" selected="true" /><select idref="V-77159" selected="true" /><select idref="V-77161" selected="true" /><select idref="V-77163" selected="true" /><select idref="V-77165" selected="true" /><select idref="V-77167" selected="true" /><select idref="V-77169" selected="true" /><select idref="V-77171" selected="true" /><select idref="V-77173" selected="true" /><select idref="V-77175" selected="true" /><select idref="V-77177" selected="true" /><select idref="V-77179" selected="true" /><select idref="V-77181" selected="true" /><select idref="V-77183" selected="true" /><select idref="V-77185" selected="true" /><select idref="V-77187" selected="true" /><select idref="V-77193" selected="true" /><select idref="V-77197" selected="true" /><select idref="V-77199" selected="true" /><select idref="V-77203" selected="true" /><select idref="V-77207" selected="true" /><select idref="V-77211" selected="true" /><select idref="V-77215" selected="true" /><select idref="V-77219" selected="true" /><select idref="V-77225" selected="true" /><select idref="V-77229" selected="true" /><select idref="V-77237" selected="true" /><select idref="V-77241" selected="true" /><select idref="V-77251" selected="true" /><select idref="V-77253" selected="true" /><select idref="V-77257" selected="true" /><select idref="V-77261" selected="true" /><select idref="V-77265" selected="true" /><select idref="V-77271" selected="true" /><select idref="V-77273" selected="true" /><select idref="V-77275" selected="true" /><select idref="V-77285" selected="true" /><select idref="V-77287" selected="true" /><select idref="V-77289" selected="true" /><select idref="V-77291" selected="true" /><select idref="V-77293" selected="true" /><select idref="V-77295" selected="true" /><select idref="V-77297" selected="true" /><select idref="V-77299" selected="true" /><select idref="V-77301" selected="true" /><select idref="V-77303" selected="true" /><select idref="V-77305" selected="true" /><select idref="V-77307" selected="true" /><select idref="V-77309" selected="true" /><select idref="V-77311" selected="true" /><select idref="V-77313" selected="true" /><select idref="V-77315" selected="true" /><select idref="V-77317" selected="true" /><select idref="V-77319" selected="true" /><select idref="V-77321" selected="true" /><select idref="V-77323" selected="true" /><select idref="V-77325" selected="true" /><select idref="V-77327" selected="true" /><select idref="V-77329" selected="true" /><select idref="V-77331" selected="true" /><select idref="V-77333" selected="true" /><select idref="V-77335" selected="true" /><select idref="V-77337" selected="true" /><select idref="V-77339" selected="true" /><select idref="V-77341" selected="true" /><select idref="V-77343" selected="true" /><select idref="V-77345" selected="true" /><select idref="V-77347" selected="true" /><select idref="V-77349" selected="true" /><select idref="V-77351" selected="true" /><select idref="V-77353" selected="true" /><select idref="V-77355" selected="true" /><select idref="V-77357" selected="true" /><select idref="V-77359" selected="true" /><select idref="V-77361" selected="true" /><select idref="V-77363" selected="true" /><select idref="V-77365" selected="true" /><select idref="V-77367" selected="true" /><select idref="V-77369" selected="true" /><select idref="V-77371" selected="true" /><select idref="V-77373" selected="true" /><select idref="V-77375" selected="true" /><select idref="V-77377" selected="true" /><select idref="V-77379" selected="true" /><select idref="V-77381" selected="true" /><select idref="V-77383" selected="true" /><select idref="V-77385" selected="true" /><select idref="V-77387" selected="true" /><select idref="V-77389" selected="true" /><select idref="V-77391" selected="true" /><select idref="V-77393" selected="true" /><select idref="V-77395" selected="true" /><select idref="V-77397" selected="true" /><select idref="V-77399" selected="true" /><select idref="V-77401" selected="true" /><select idref="V-77403" selected="true" /><select idref="V-77405" selected="true" /><select idref="V-77407" selected="true" /><select idref="V-77409" selected="true" /><select idref="V-77411" selected="true" /><select idref="V-77413" selected="true" /><select idref="V-77415" selected="true" /><select idref="V-77417" selected="true" /><select idref="V-77419" selected="true" /><select idref="V-77421" selected="true" /><select idref="V-77423" selected="true" /><select idref="V-77425" selected="true" /><select idref="V-77427" selected="true" /><select idref="V-77429" selected="true" /><select idref="V-77431" selected="true" /><select idref="V-77433" selected="true" /><select idref="V-77435" selected="true" /><select idref="V-77437" selected="true" /><select idref="V-77439" selected="true" /><select idref="V-77441" selected="true" /><select idref="V-77443" selected="true" /><select idref="V-77445" selected="true" /><select idref="V-77447" selected="true" /><select idref="V-77449" selected="true" /><select idref="V-77451" selected="true" /><select idref="V-77455" selected="true" /><select idref="V-77457" selected="true" /><select idref="V-77459" selected="true" /><select idref="V-77461" selected="true" /><select idref="V-77463" selected="true" /><select idref="V-77465" selected="true" /><select idref="V-77467" selected="true" /><select idref="V-77469" selected="true" /><select idref="V-77471" selected="true" /><select idref="V-77473" selected="true" /><select idref="V-77475" selected="true" /><select idref="V-77477" selected="true" /><select idref="V-77479" selected="true" /><select idref="V-77481" selected="true" /><select idref="V-77483" selected="true" /><select idref="V-77485" selected="true" /><select idref="V-77487" selected="true" /><select idref="V-77489" selected="true" /><select idref="V-77491" selected="true" /><select idref="V-77493" selected="true" /><select idref="V-77495" selected="true" /><select idref="V-77497" selected="true" /><select idref="V-77499" selected="true" /><select idref="V-77501" selected="true" /><select idref="V-77503" selected="true" /><select idref="V-77505" selected="true" /><select idref="V-77507" selected="true" /><select idref="V-77509" selected="true" /><select idref="V-77511" selected="true" /><select idref="V-77513" selected="true" /><select idref="V-81709" selected="true" /><select idref="V-81785" selected="true" /><select idref="V-81801" selected="true" /><select idref="V-81803" selected="true" /><select idref="V-81805" selected="true" /><select idref="V-92249" selected="true" /></Profile><Group id="V-77045"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91741r2_rule" severity="high" weight="10.0"><version>SLES-12-010000</version><title>The SUSE operating system must be a vendor-supported release.</title><description>&lt;VulnDiscussion&gt;A SUSE operating system release is considered "supported" if the vendor continues to provide security patches for the product. With an unsupported release, it will not be possible to resolve security issues discovered in the system software.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001230</ident><fixtext fixref="F-83741r2_fix">Upgrade the SUSE operating system to a version supported by the vendor. If the system is not registered with the SUSE Customer Center, register the system against the correct subscription.
+
+If the system requires Long-Term Service Pack Support (LTSS), obtain the correct LTSS subscription for the system.</fixtext><fix id="F-83741r2_fix" /><check system="C-76653r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system is a vendor-supported release.
+
+Check that the SUSE operating system is a vendor-supported release with the following command:
+
+# cat /etc/os-release
+
+NAME="SLES"
+VERSION="12"
+
+Current End of Life for SLES 12 is 31 Oct 2024.
+
+If the release is not supported by the vendor, this is a finding.</check-content></check></Rule></Group><Group id="V-77047"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91743r2_rule" severity="medium" weight="10.0"><version>SLES-12-010010</version><title>Vendor-packaged SUSE operating system security patches and updates must be installed and up to date.</title><description>&lt;VulnDiscussion&gt;Timely patching is critical for maintaining the operational availability, confidentiality, and integrity of information technology (IT) systems. However, failure to keep SUSE operating system and application software patched is a common mistake made by IT professionals. New patches are released frequently, and it is often difficult for even experienced System Administrators (SAs) to keep abreast of all the new patches. When new weaknesses in a SUSE operating system exist, patches are usually made available by the vendor to resolve the problems. If the most recent security patches and updates are not installed, unauthorized users may take advantage of weaknesses in the unpatched software. The lack of prompt attention to patching could result in a system compromise.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001227</ident><fixtext fixref="F-83745r2_fix">Install the applicable SUSE operating system patches available from SUSE by running the following command:
+
+# sudo zypper patch</fixtext><fix id="F-83745r2_fix" /><check system="C-76657r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system security patches and updates are installed and up to date.
+
+Note: Updates are required to be applied with a frequency determined by the site or Program Management Office (PMO).
+
+Check for required SUSE operating system patches and updates with the following command:
+
+# sudo zypper patch-check
+
+0 patches needed (0 security patches)
+
+If the patch repository data is corrupt check that the available package security updates have been installed on the system with the following command:
+
+# cut -d "|" -f 1-4 -s --output-delimiter " | " /var/log/zypp/history | grep -v " radd "
+
+2016-12-14 11:59:36 | install | libapparmor1-32bit | 2.8.0-2.4.1
+2016-12-14 11:59:36 | install | pam_apparmor | 2.8.0-2.4.1
+2016-12-14 11:59:36 | install | pam_apparmor-32bit | 2.8.0-2.4.1
+
+If the SUSE operating system has not been patched within the site or PMO frequency, this is a finding.</check-content></check></Rule></Group><Group id="V-77049"><title>SRG-OS-000023-GPOS-00006</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91745r3_rule" severity="medium" weight="10.0"><version>SLES-12-010020</version><title>The SUSE operating system must display the Standard Mandatory DoD Notice and Consent Banner until users acknowledge the usage conditions and take explicit actions to log on for further access to the local graphical user interface (GUI).</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+The banner must be acknowledged by the user prior to allowing the user access to the SUSE operating system. This provides assurance that the user has seen the message and accepted the conditions for access. If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for the SUSE operating system:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+Satisfies: SRG-OS-000023-GPOS-00006, SRG-OS-000024-GPOS-00007&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000048</ident><ident system="http://iase.disa.mil/cci">CCI-000050</ident><fixtext fixref="F-83747r2_fix">Configure the SUSE operating system to display the Standard Mandatory DoD Notice and Consent Banner until users acknowledge the usage conditions and take explicit actions to log on for further access.
+
+Note: If GNOME is not installed, this requirement is Not Applicable.
+
+Edit the file "/etc/gdm/Xsession".
+
+Add the following content to the file "/etc/gdm/Xsession" below the line #!/bin/sh:
+
+if ! zenity --text-info \
+ --title "Consent" \
+ --filename=/etc/gdm/banner \
+ --no-markup \
+ --checkbox="Accept." 10 10; then
+  sleep 1;
+  exit 1;
+fi
+
+Save the file "/etc/gdm/Xsession".</fixtext><fix id="F-83747r2_fix" /><check system="C-76659r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system displays the Standard Mandatory DoD Notice and Consent Banner until users acknowledge the usage conditions and take explicit actions to log on via the local GUI. 
+
+Note: If GNOME is not installed, this requirement is Not Applicable.
+
+Check the configuration by running the following command:
+
+# more /etc/gdm/Xsession
+
+The beginning of the file must contain the following text immediately after (#!/bin/sh):
+
+if ! zenity --text-info \
+ --title "Consent" \
+ --filename=/etc/gdm/banner \
+ --no-markup \
+ --checkbox="Accept." 10 10; then
+  sleep 1;
+  exit 1;
+fi
+
+If the beginning of the file does not contain the above text immediately after the line (#!/bin/sh), this is a finding.</check-content></check></Rule></Group><Group id="V-77051"><title>SRG-OS-000023-GPOS-00006</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91747r2_rule" severity="medium" weight="10.0"><version>SLES-12-010030</version><title>The SUSE operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting access via local console.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+The banner must be acknowledged by the user prior to allowing the user access to the SUSE operating system. This provides assurance that the user has seen the message and accepted the conditions for access. If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for SUSE operating system:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000048</ident><fixtext fixref="F-83749r2_fix">Configure the SUSE operating system to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via local console by performing the following tasks:
+
+Edit the "motd" file and replace the default text inside with the Standard Mandatory DoD banner text:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."</fixtext><fix id="F-83749r2_fix" /><check system="C-76661r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via local console.
+
+Check the "motd" (message of the day) file to verify that it contains the DoD required banner text:
+
+# more /etc/motd
+
+The output must display the following DoD-required banner text: 
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+If the output does not display the correct banner text, this is a finding.</check-content></check></Rule></Group><Group id="V-77053"><title>SRG-OS-000228-GPOS-00088</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91749r2_rule" severity="medium" weight="10.0"><version>SLES-12-010040</version><title>The SUSE operating system must display a banner before granting local or remote access to the system via a graphical user logon.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+The banner must be acknowledged by the user prior to allowing the user access to the SUSE operating system. This provides assurance that the user has seen the message and accepted the conditions for access. If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for SUSE operating system:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001384</ident><ident system="http://iase.disa.mil/cci">CCI-001385</ident><ident system="http://iase.disa.mil/cci">CCI-001386</ident><ident system="http://iase.disa.mil/cci">CCI-001387</ident><ident system="http://iase.disa.mil/cci">CCI-001388</ident><fixtext fixref="F-83751r1_fix">Configure the SUSE operating system to display a banner before local or remote access to the system via a graphical user logon.
+
+Create a database that will contain the system wide graphical user logon settings (if it does not already exist) with the following command:
+
+# sudo touch /etc/dconf/db/local.d/01-banner-message
+
+Add the following line to the "[org/gnome/login-screen]" section of the "/etc/dconf/db/local.d/01-banner-message" file:
+
+[org/gnome/login-screen]
+banner-message-enable=true</fixtext><fix id="F-83751r1_fix" /><check system="C-76663r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system to display a banner before local or remote access to the system via a graphical user logon.
+
+Check that the SUSE operating system displays a banner at the logon screen by performing the following command:
+
+# grep banner-message-enable /etc/dconf/db/local.d/*
+banner-message-enable=true
+
+If "banner-message-enable" is set to "false" or is missing completely, this is a finding.</check-content></check></Rule></Group><Group id="V-77055"><title>SRG-OS-000228-GPOS-00088</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91751r4_rule" severity="medium" weight="10.0"><version>SLES-12-010050</version><title>The SUSE operating system must display the approved Standard Mandatory DoD Notice before granting local or remote access to the system via a graphical user logon.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+The banner must be acknowledged by the user prior to allowing the user access to the SUSE operating system. This provides assurance that the user has seen the message and accepted the conditions for access. If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for SUSE operating system:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001384</ident><ident system="http://iase.disa.mil/cci">CCI-001385</ident><ident system="http://iase.disa.mil/cci">CCI-001386</ident><ident system="http://iase.disa.mil/cci">CCI-001387</ident><ident system="http://iase.disa.mil/cci">CCI-001388</ident><fixtext fixref="F-83753r5_fix">Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command must be run from an X11 session; otherwise, the command will not work correctly.
+
+Configure the SUSE operating system to display the approved Standard Mandatory DoD Notice before granting local or remote access to the system via a graphical user logon.
+
+Create a database to contain the system wide graphical user logon settings (if it does not already exist) by performing the following command:
+
+# touch /etc/dconf/db/local.d/01-banner-message
+
+Add the following lines to the "[org/gnome/login-screen]" section of the "dconf/db/local.d/01-banner-message" file:
+
+[org/gnome/login-screen]
+banner-message-text="You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.\nBy using this IS (which includes any device attached to this IS), you consent to the following conditions:\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n-At any time, the USG may inspect and seize data stored on this IS.\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+Note: The "\n" characters are for formatting only. They will not be displayed on the GUI.
+
+Run the following command to update the database:
+# dconf update</fixtext><fix id="F-83753r5_fix" /><check system="C-76665r5_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system displays the approved Standard Mandatory DoD Notice before granting local or remote access to the system via a graphical user logon.
+
+Check that the SUSE operating system displays the exact approved Standard Mandatory DoD Notice and Consent Banner text by performing the following command:
+
+# grep banner-message-text /etc/dconf/db/local.d/*
+banner-message-text=
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.\nBy using this IS (which includes any device attached to this IS), you consent to the following conditions:\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n-At any time, the USG may inspect and seize data stored on this IS.\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+Note: The "\n" characters are for formatting only. They will not be displayed on the GUI.
+
+If the banner text does not exactly match the approved Standard Mandatory DoD Notice and Consent Banner, this is a finding.</check-content></check></Rule></Group><Group id="V-77057"><title>SRG-OS-000028-GPOS-00009</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91753r2_rule" severity="medium" weight="10.0"><version>SLES-12-010060</version><title>The SUSE operating system must be able to lock the graphical user interface (GUI).</title><description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
+
+The session lock is implemented at the point where session activity can be determined.
+
+Regardless of where the session lock is determined and implemented, once invoked, the session lock must remain in place until the user reauthenticates. No other activity aside from reauthentication must unlock the system.
+
+Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000030-GPOS-00011&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000056</ident><ident system="http://iase.disa.mil/cci">CCI-000058</ident><ident system="http://iase.disa.mil/cci">CCI-000060</ident><fixtext fixref="F-83755r2_fix">Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command must be run from an X11 session; otherwise, the command will not work correctly.
+
+Configure the SUSE operating system to allow the user to lock the GUI.
+
+Run the following command to configure the SUSE operating system to allow the user to lock the GUI:
+
+# gsettings set org.gnome.desktop.lockdown disable-lock-screen false</fixtext><fix id="F-83755r2_fix" /><check system="C-76667r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system allows the user to lock the GUI. 
+
+Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command must be run from an X11 session, otherwise the command will not work correctly.
+
+Run the following command:
+
+# gsettings get org.gnome.desktop.lockdown disable-lock-screen
+
+If the result is "true", this is a finding.</check-content></check></Rule></Group><Group id="V-77059"><title>SRG-OS-000028-GPOS-00009</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91755r2_rule" severity="low" weight="10.0"><version>SLES-12-010070</version><title>The SUSE operating system must have vlock installed to allow for session locking.</title><description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
+
+The session lock is implemented at the point where session activity can be determined.
+
+Regardless of where the session lock is determined and implemented, once invoked, the session lock must remain in place until the user reauthenticates. No other activity aside from reauthentication must unlock the system.
+
+Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000030-GPOS-00011, SRG-OS-000031-GPOS-00012&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000056</ident><ident system="http://iase.disa.mil/cci">CCI-000058</ident><ident system="http://iase.disa.mil/cci">CCI-000060</ident><fixtext fixref="F-83757r2_fix">Configure the SUSE operating system to allow the user to perform a GUI session lock.
+
+Allow users to lock the console by installing the "vlock" package using zypper:
+
+# sudo zypper install vlock</fixtext><fix id="F-83757r2_fix" /><check system="C-76669r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system allows the user to perform a graphical user interface (GUI) session lock.
+
+Check that the SUSE operating system has the "vlock" package installed by running the following command:
+
+# zypper if vlock | grep "Installed:"
+
+Installed: Yes
+
+If "vlock" is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-77061"><title>SRG-OS-000029-GPOS-00010</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91757r2_rule" severity="medium" weight="10.0"><version>SLES-12-010080</version><title>The SUSE operating system must initiate a session lock after a 15-minute period of inactivity for the graphical user interface (GUI).</title><description>&lt;VulnDiscussion&gt;A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence. 
+
+Rather than relying on the users to manually lock their SUSE operating system session prior to vacating the vicinity, the SUSE operating system needs to be able to identify when a user's session has idled and take action to initiate the session lock.
+
+The session lock is implemented at the point where session activity can be determined and/or controlled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000057</ident><fixtext fixref="F-83759r1_fix">Configure the SUSE operating system to initiate a session lock after a 15-minute period of inactivity of the graphical user interface (GUI) by running the following command:
+
+Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command must be run from an X11 session, otherwise the command will not work correctly.
+
+# gsettings set org.gnome.desktop.session idle-delay 900</fixtext><fix id="F-83759r1_fix" /><check system="C-76671r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system initiates a session lock after a 15-minute period of inactivity via the graphical user interface (GUI) by running the following command:
+
+Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command must be run from an X11 session, otherwise the command will not work correctly.
+
+# gsettings get org.gnome.desktop.session idle-delay
+
+uint32 900
+
+If the command does not return a value less than or equal to "900", this is a finding.</check-content></check></Rule></Group><Group id="V-77063"><title>SRG-OS-000029-GPOS-00010</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91759r1_rule" severity="medium" weight="10.0"><version>SLES-12-010090</version><title>The SUSE operating system must initiate a session lock after a 15-minute period of inactivity.</title><description>&lt;VulnDiscussion&gt;A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence. 
+
+Rather than relying on the users to manually lock their SUSE operating system session prior to vacating the vicinity, the SUSE operating system needs to be able to identify when a user's session has idled and take action to initiate the session lock.
+
+The session lock is implemented at the point where session activity can be determined and/or controlled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000057</ident><fixtext fixref="F-83761r1_fix">Configure the SUSE operating system to initiate a session lock after a 15-minute period of inactivity by modifying or creating (if it does not already exist) the "/etc/profile.d/autologout.sh" file and add the following lines to it:
+
+TMOUT=900
+readonly TMOUT
+export TMOUT
+
+Set the proper permissions for the "/etc/profile.d/autologout.sh" file with the following command:
+
+# sudo chmod +x /etc/profile.d/autologout.sh</fixtext><fix id="F-83761r1_fix" /><check system="C-76673r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system must initiate a session logout after a 15-minute period of inactivity for all connection types. 
+
+Check the proper script exists to kill an idle session after a 15-minute period of inactivity with the following command:
+
+# cat /etc/profile.d/autologout.sh
+TMOUT=900
+readonly TMOUT
+export TMOUT
+
+If the file "/etc/profile.d/autologout.sh" does not exist or the output from the function call is not the same, this is a finding.</check-content></check></Rule></Group><Group id="V-77065"><title>SRG-OS-000031-GPOS-00012</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91761r2_rule" severity="low" weight="10.0"><version>SLES-12-010100</version><title>The SUSE operating system must conceal, via the session lock, information previously visible on the display with a publicly viewable image in the graphical user interface (GUI).</title><description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence.
+
+The session lock is implemented at the point where session activity can be determined. The SUSE operating system session lock event must include an obfuscation of the display screen to prevent other users from reading what was previously displayed.
+
+Publicly viewable images can include static or dynamic images, such as patterns used with screen savers, photographic images, solid colors, a clock, a battery life indicator, or a blank screen, with the additional caveat that none of the images conveys sensitive information.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000060</ident><fixtext fixref="F-83763r2_fix">Note: If the system does not have X Windows installed, this requirement is Not Applicable.
+
+Configure the SUSE operating system to use a publically viewable image by finding the Settings menu and then navigate to the Background selection section: 
+
+- Click "Applications" on the bottom left.
+- Hover over "System Tools" with the mouse.
+- Click the "Settings" icon under System Tools.
+- Click "Background" and then "Lock Screen".
+- Set the Lock Screen image to the user's choice.
+- Click "Select".
+- Exit Settings Dialog.</fixtext><fix id="F-83763r2_fix" /><check system="C-76675r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system conceals via the session lock information previously visible on the display with a publicly viewable image in the graphical user interface (GUI).
+
+Note: If the system does not have X Windows installed, this requirement is Not Applicable.
+
+Check that the lock screen is set to a publicly viewable image by running the following command:
+
+# gsettings get org.gnome.desktop.screensaver picture-uri 
+'file:///usr/share/wallpapers/SLE-default-static.xml'
+
+If nothing is returned or "org.gnome.desktop.screensaver" is not set, this is a finding.</check-content></check></Rule></Group><Group id="V-77067"><title>SRG-OS-000373-GPOS-00156</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91763r2_rule" severity="high" weight="10.0"><version>SLES-12-010110</version><title>The SUSE operating system must reauthenticate users when changing authenticators, roles, or escalating privileges.</title><description>&lt;VulnDiscussion&gt;Without reauthentication, users may access resources or perform tasks for which they do not have authorization. 
+
+When SUSE operating system provide the capability to change user authenticators, change security roles, or escalate a functional capability, it is critical the user reauthenticate.
+
+Satisfies: SRG-OS-000373-GPOS-00156, SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00158&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002038</ident><fixtext fixref="F-83765r2_fix">Configure the SUSE operating system to remove any occurrence of "NOPASSWD" or "!authenticate" found in the "/etc/sudoers" file. If the system does not use passwords for authentication, the "NOPASSWD" tag may exist in the file.</fixtext><fix id="F-83765r2_fix" /><check system="C-76677r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system requires reauthentication when changing authenticators, roles, or escalating privileges.
+
+Check that "/etc/sudoers" has no occurrences of "NOPASSWD" or "!authenticate" with the following command:
+
+# sudo egrep -i '(nopasswd|!authenticate)' /etc/sudoers
+%wheel ALL=(ALL) NOPASSWD: ALL
+
+If any occurrences of "!authenticate" are returned, or occurrences of "NOPASSWD" are returned and active accounts on the system have valid passwords, this is a finding.</check-content></check></Rule></Group><Group id="V-77069"><title>SRG-OS-000027-GPOS-00008</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91765r2_rule" severity="low" weight="10.0"><version>SLES-12-010120</version><title>The SUSE operating system must limit the number of concurrent sessions to 10 for all accounts and/or account types.</title><description>&lt;VulnDiscussion&gt;SUSE operating system management includes the ability to control the number of users and user sessions that utilize a SUSE operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to Denial-of-Service (DoS) attacks.
+
+This requirement addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts. The maximum number of concurrent sessions should be defined based on mission needs and the operational environment for each system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000054</ident><fixtext fixref="F-83767r1_fix">Configure the SUSE operating system to limit the number of concurrent sessions to 10 or less for all accounts and/or account types.
+
+Add the following line to the file "/etc/security/limits.conf":
+
+* hard maxlogins 10</fixtext><fix id="F-83767r1_fix" /><check system="C-76679r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system limits the number of concurrent sessions to 10 for all accounts and/or account types by running the following command:
+
+# grep "maxlogins" /etc/security/limits.conf
+
+The result must contain the following line:
+
+* hard maxlogins 10
+
+If the "maxlogins" item is missing, the line does not begin with a star symbol, or the value is not set to "10" or less, this is a finding.</check-content></check></Rule></Group><Group id="V-77071"><title>SRG-OS-000021-GPOS-00005</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91767r2_rule" severity="medium" weight="10.0"><version>SLES-12-010130</version><title>The SUSE operating system must lock an account after three consecutive invalid logon attempts.</title><description>&lt;VulnDiscussion&gt;By limiting the number of failed logon attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-force attacks, is reduced. Limits are imposed by locking the account.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000044</ident><fixtext fixref="F-83769r2_fix">Configure the SUSE operating system to lock a user account until the locked account is released by an administrator after three consecutive failed logon attempts.
+
+Add or modify the following line in the auth section of the "/etc/pam.d/login" file (or other services being used) to match the following: 
+
+auth     required       pam_tally2.so deny=3</fixtext><fix id="F-83769r2_fix" /><check system="C-76681r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system locks a user account until the locked account is released by an administrator after three consecutive failed logon attempts.
+
+Check that the systems locks a user account after three consecutive failed login attempts with the following command:
+
+# grep pam_tally2.so /etc/pam.d/login
+
+auth     required       pam_tally2.so deny=3
+
+If the "deny" option is greater than "3" or is missing, this is a finding.</check-content></check></Rule></Group><Group id="V-77073"><title>SRG-OS-000480-GPOS-00226</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91769r1_rule" severity="medium" weight="10.0"><version>SLES-12-010140</version><title>The SUSE operating system must enforce a delay of at least four (4) seconds between logon prompts following a failed logon attempt.</title><description>&lt;VulnDiscussion&gt;Limiting the number of logon attempts over a certain time interval reduces the chances that an unauthorized user may gain access to an account.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83771r1_fix">Configure the SUSE operating system to enforce a delay of at least four (4) seconds between logon prompts following a failed logon attempt.
+
+Add or update the following variable in "/etc/login.defs" to match the line below ("FAIL_DELAY" must have a value of "4" or higher):
+
+FAIL_DELAY 4</fixtext><fix id="F-83771r1_fix" /><check system="C-76683r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces a delay of at least four (4) seconds between logon prompts following a failed logon attempt.
+
+Check that the SUSE operating system enforces a delay of at least four (4) seconds between logon prompts following a failed logon attempt with the following command:
+
+# grep FAIL_DELAY /etc/login.defs
+FAIL_DELAY 4
+
+If the value of "FAIL_DELAY" is not set to "4", "FAIL_DELAY" is commented out, or "FAIL_DELAY" is missing, then this is a finding.</check-content></check></Rule></Group><Group id="V-77075"><title>SRG-OS-000069-GPOS-00037</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91771r3_rule" severity="medium" weight="10.0"><version>SLES-12-010150</version><title>The SUSE operating system must enforce passwords that contain at least one upper-case character.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000192</ident><fixtext fixref="F-83773r2_fix">Configure the SUSE operating system to enforce password complexity by requiring at least one upper-case character.
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_cracklib.so" to contain the option "ucredit=-1" after the third column.</fixtext><fix id="F-83773r2_fix" /><check system="C-76685r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces password complexity by requiring that at least one upper-case character.
+
+Check that the operating system enforces password complexity by requiring that at least one upper-case character be used by using the following command:
+
+# grep pam_cracklib.so /etc/pam.d/common-password
+password requisite pam_cracklib.so ucredit=-1
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "requisite", or does not contain "ucredit=-1", this is a finding.</check-content></check></Rule></Group><Group id="V-77077"><title>SRG-OS-000070-GPOS-00038</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91773r3_rule" severity="medium" weight="10.0"><version>SLES-12-010160</version><title>The SUSE operating system must enforce passwords that contain at least one lower-case character.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000193</ident><fixtext fixref="F-83775r2_fix">Configure the SUSE operating system to enforce password complexity by requiring at least one lower-case character.
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_cracklib.so" to contain the option "lcredit=-1" after the third column.</fixtext><fix id="F-83775r2_fix" /><check system="C-76687r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces password complexity by requiring that at least one lower-case character.
+
+Check that the operating system enforces password complexity by requiring that at least one lower-case character be used by using the following command:
+
+# grep pam_cracklib.so /etc/pam.d/common-password
+password requisite pam_cracklib.so lcredit=-1
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "requisite", or does not contain "lcredit=-1", this is a finding.</check-content></check></Rule></Group><Group id="V-77079"><title>SRG-OS-000071-GPOS-00039</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91775r3_rule" severity="medium" weight="10.0"><version>SLES-12-010170</version><title>The SUSE operating system must enforce passwords that contain at least one numeric character.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000194</ident><fixtext fixref="F-83777r2_fix">Configure the SUSE operating system to enforce password complexity by requiring at least one numeric character.
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_cracklib.so" to contain the option "dcredit=-1" after the third column.</fixtext><fix id="F-83777r2_fix" /><check system="C-76689r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces password complexity by requiring that at least one numeric character.
+
+Check that the operating system enforces password complexity by requiring that at least one numeric character be used by using the following command:
+
+# grep pam_cracklib.so /etc/pam.d/common-password
+password requisite pam_cracklib.so dcredit=-1
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "requisite", or does not contain "dcredit=-1", this is a finding.</check-content></check></Rule></Group><Group id="V-77081"><title>SRG-OS-000266-GPOS-00101</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91777r3_rule" severity="medium" weight="10.0"><version>SLES-12-010180</version><title>The SUSE operating system must enforce passwords that contain at least one special character.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps increase the time and resources required to compromise the password. Password complexity or strength is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor in determining how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.
+
+Special characters are not alphanumeric. Examples include: ~ ! @ # $ % ^ *.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001619</ident><fixtext fixref="F-83779r2_fix">Configure the SUSE operating system to enforce password complexity by requiring at least one special character.
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_cracklib.so" to contain the option "ocredit=-1" after the third column.</fixtext><fix id="F-83779r2_fix" /><check system="C-76691r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces password complexity by requiring that at least one special character.
+
+Check that the operating system enforces password complexity by requiring that at least one special character be used by using the following command:
+
+# grep pam_cracklib.so /etc/pam.d/common-password
+password requisite pam_cracklib.so ocredit=-1
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "requisite", or does not contain "ocredit=-1", this is a finding.</check-content></check></Rule></Group><Group id="V-77087"><title>SRG-OS-000072-GPOS-00040</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91783r3_rule" severity="medium" weight="10.0"><version>SLES-12-010190</version><title>The SUSE operating system must require the change of at least eight (8) of the total number of characters when passwords are changed.</title><description>&lt;VulnDiscussion&gt;If the SUSE operating system allows the user to consecutively reuse extensive portions of passwords, this increases the chances of password compromise by increasing the window of opportunity for attempts at guessing and brute-force attacks.
+
+The number of changed characters refers to the number of changes required with respect to the total number of positions in the current password. In other words, characters may be the same within the two passwords; however, the positions of the like characters must be different.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000195</ident><fixtext fixref="F-83785r2_fix">Configure the SUSE operating system to require at least eight characters be changed between the old and new passwords during a password change with the following command:
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_cracklib.so" to contain the option "difok=8" after the third column.</fixtext><fix id="F-83785r2_fix" /><check system="C-76697r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system requires at least eight (8) characters be changed between the old and new passwords during a password change.
+
+Check that the operating system requires at least eight (8) characters be changed between the old and new passwords during a password change by running the following command:
+
+# grep pam_cracklib.so /etc/pam.d/common-password
+password requisite pam_cracklib.so difok=8
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "requisite", or does not contain "difok", or the value is less than "8", this is a finding.</check-content></check></Rule></Group><Group id="V-77089"><title>SRG-OS-000120-GPOS-00061</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91785r3_rule" severity="medium" weight="10.0"><version>SLES-12-010200</version><title>The SUSE operating system must employ FIPS 140-2 approved cryptographic hashing algorithm for system authentication (system-auth).</title><description>&lt;VulnDiscussion&gt;Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore cannot be relied on to provide confidentiality or integrity, and DoD data may be compromised.
+
+SUSE operating systems using encryption are required to use FIPS-compliant mechanisms for authenticating to cryptographic modules. 
+
+FIPS 140-2 is the current standard for validating that mechanisms used to access cryptographic modules use authentication that meets DoD requirements. This allows for Security Levels 1, 2, 3, or 4 for use on a general-purpose computing system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000803</ident><fixtext fixref="F-83787r2_fix">Configure the SUSE operating system to require "pam_unix.so auth" to use SHA512.
+
+Edit "/etc/pam.d/common-auth" and edit the line containing "pam_unix.so" to contain the option "sha512" after the third column.</fixtext><fix id="F-83787r2_fix" /><check system="C-76699r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system requires that "pam_unix.so auth" is configured to use SHA512
+
+Check the algorithms that are used to hash system passwords with the command:
+
+# grep pam_unix.so /etc/pam.d/common-auth
+auth required pam_unix.so sha512 try_first_pass
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "required", or does not contain "sha512", this is a finding.</check-content></check></Rule></Group><Group id="V-77093"><title>SRG-OS-000120-GPOS-00061</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91789r2_rule" severity="medium" weight="10.0"><version>SLES-12-010210</version><title>The SUSE operating system must employ FIPS 140-2 approved cryptographic hashing algorithm for system authentication (login.defs).</title><description>&lt;VulnDiscussion&gt;Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore cannot be relied on to provide confidentiality or integrity, and DoD data may be compromised.
+
+SUSE operating systems using encryption are required to use FIPS-compliant mechanisms for authenticating to cryptographic modules. 
+
+FIPS 140-2 is the current standard for validating that mechanisms used to access cryptographic modules use authentication that meets DoD requirements. This allows for Security Levels 1, 2, 3, or 4 for use on a general purpose computing system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000803</ident><fixtext fixref="F-83789r2_fix">Configure the SUSE operating system to require "ENCRYPT_METHOD" in "/etc/login.defs" be set to "SHA512" by running the following command as a superuser:
+
+# sudo grep -q '^.*ENCRYPT_METHOD' /etc/login.defs &amp;&amp; sudo sed -i 's/^.*ENCRYPT_METHOD.*/ENCRYPT_METHOD SHA512/' /etc/login.defs || sudo echo 'ENCRYPT_METHOD SHA512' &gt;&gt; /etc/login.defs</fixtext><fix id="F-83789r2_fix" /><check system="C-76701r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system requires that the "ENCRYPT_METHOD" value in "/etc/login.defs" is set to "SHA512".
+
+Check the value of "ENCRYPT_METHOD" value in "/etc/login.defs" with the following command:
+
+# cat /etc/login.defs | grep -i encrypt_method
+
+ENCRYPT_METHOD SHA512
+
+If "ENCRYPT_METHOD" is not set to "SHA512", if any values other that "SHA512" are configured, or "ENCRYPT_METHOD" is commented out or not set, this is a finding.</check-content></check></Rule></Group><Group id="V-77099"><title>SRG-OS-000073-GPOS-00041</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91795r2_rule" severity="medium" weight="10.0"><version>SLES-12-010220</version><title>The SUSE operating system must employ FIPS 140-2-approved cryptographic hashing algorithms for all stored passwords.</title><description>&lt;VulnDiscussion&gt;The system must use a strong hashing algorithm to store the password. The system must use a sufficient number of hashing rounds to ensure the required level of entropy.
+
+Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.
+
+Satisfies: SRG-OS-000073-GPOS-00041, SRG-OS-000120-GPOS-00061&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000196</ident><ident system="http://iase.disa.mil/cci">CCI-000803</ident><fixtext fixref="F-83797r2_fix">Configure the SUSE operating system to encrypt all stored passwords with a strong cryptographic hash.
+
+Set "ENCRYPT_METHOD" in "/etc/login.defs" to "SHA512" by running the following command as a superuser:
+
+# sudo grep -q '^.*ENCRYPT_METHOD' /etc/login.defs &amp;&amp; sudo sed -i 's/^.*ENCRYPT_METHOD.*/ENCRYPT_METHOD SHA512/' /etc/login.defs || sudo echo 'ENCRYPT_METHOD SHA512' &gt;&gt; /etc/login.defs
+
+Lock all interactive user accounts not using SHA512 hashing until the passwords can be regenerated.</fixtext><fix id="F-83797r2_fix" /><check system="C-76709r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system requires the shadow password suite configuration be set to encrypt interactive user passwords using a strong cryptographic hash.
+
+Check that the interactive user account passwords are using a strong password hash with the following command:
+
+# sudo cut -d: -f2 /etc/shadow
+
+$6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/
+
+Password hashes "!" or "*" indicate inactive accounts not available for logon and are not evaluated. 
+
+If any interactive user password hash does not begin with "$6", this is a finding.</check-content></check></Rule></Group><Group id="V-77105"><title>SRG-OS-000073-GPOS-00041</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91801r3_rule" severity="medium" weight="10.0"><version>SLES-12-010230</version><title>The SUSE operating system must configure the Linux Pluggable Authentication Modules (PAM) to only store encrypted representations of passwords.</title><description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000196</ident><fixtext fixref="F-83803r2_fix">Configure the SUSE operating system Linux PAM to only store encrypted representations of passwords. All account passwords must be hashed with SHA512 encryption strength.
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_unix.so" to contain the SHA512 keyword after third column. Remove the "nullok" option.</fixtext><fix id="F-83803r2_fix" /><check system="C-76715r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system configures the Linux PAM to only store encrypted representations of passwords. All account passwords must be hashed with SHA512 encryption strength.
+
+Check that PAM is configured to create SHA512 hashed passwords by running the following command:
+
+# grep pam_unix.so /etc/pam.d/common-password
+password required pam_unix.so sha512
+
+If the command does not return anything or the returned line is commented out, has a second column value different from "required", or does not contain "sha512", this is a finding.</check-content></check></Rule></Group><Group id="V-77107"><title>SRG-OS-000073-GPOS-00041</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91803r2_rule" severity="medium" weight="10.0"><version>SLES-12-010240</version><title>The SUSE operating system must employ FIPS 140-2-approved cryptographic hashing algorithms for all stored passwords.</title><description>&lt;VulnDiscussion&gt;The system must use a strong hashing algorithm to store the password. The system must use a sufficient number of hashing rounds to ensure the required level of entropy.
+
+Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.
+
+Satisfies: SRG-OS-000073-GPOS-00041, SRG-OS-000120-GPOS-00061&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000196</ident><ident system="http://iase.disa.mil/cci">CCI-000803</ident><fixtext fixref="F-83805r2_fix">Configure the SUSE operating system to encrypt all stored passwords with a strong cryptographic hash.
+
+Edit/modify the following line in the "/etc/login.defs" file and set "SHA_CRYPT_MIN_ROUNDS" to a value no lower than "5000":
+
+SHA_CRYPT_MIN_ROUNDS 5000</fixtext><fix id="F-83805r2_fix" /><check system="C-76717r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system configures the shadow password suite configuration to encrypt passwords using a strong cryptographic hash.
+
+Check that a minimum number of hash rounds is configured by running the following command:
+
+egrep "^SHA_CRYPT_" /etc/login.defs
+
+If only one of "SHA_CRYPT_MIN_ROUNDS" or "SHA_CRYPT_MAX_ROUNDS" is set, and this value is below "5000", this is a finding.
+
+If both "SHA_CRYPT_MIN_ROUNDS" and "SHA_CRYPT_MAX_ROUNDS" are set, and the highest value for either is below "5000", this is a finding.</check-content></check></Rule></Group><Group id="V-77109"><title>SRG-OS-000078-GPOS-00046</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91805r3_rule" severity="medium" weight="10.0"><version>SLES-12-010250</version><title>The SUSE operating system must employ passwords with a minimum of 15 characters.</title><description>&lt;VulnDiscussion&gt;The shorter the password, the lower the number of possible combinations that need to be tested before the password is compromised.
+
+Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password length is one factor of several that helps determine strength and how long it takes to crack a password. Use of more characters in a password helps exponentially increase the time and/or resources required to compromise the password.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000205</ident><fixtext fixref="F-84157r2_fix">Configure the SUSE operating system to enforce a minimum 15-character password length.
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_cracklib.so" to contain the option "minlen=15" after the third column.
+
+The DoD standard requires a minimum 15-character password length.</fixtext><fix id="F-84157r2_fix" /><check system="C-76719r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces a minimum 15-character password length.
+
+Check that the operating system enforces a minimum 15-character password length with the following command:
+
+# grep pam_cracklib.so /etc/pam.d/common-password
+password requisite pam_cracklib.so minlen=15
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "requisite", or does not contain "minlen" value, or the value is less than "15", this is a finding.</check-content></check></Rule></Group><Group id="V-77111"><title>SRG-OS-000075-GPOS-00043</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91807r2_rule" severity="medium" weight="10.0"><version>SLES-12-010260</version><title>The SUSE operating system must be configured to create or update passwords with a minimum lifetime of 24 hours (1 day).</title><description>&lt;VulnDiscussion&gt;Enforcing a minimum password lifetime helps prevent repeated password changes to defeat the password reuse or history enforcement requirement. If users are allowed to immediately and continually change their password, the password could be repeatedly changed in a short period of time to defeat the organization's policy regarding password reuse.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000198</ident><fixtext fixref="F-83807r1_fix">Configure the SUSE operating system to enforce 24 hours/1 day or greater as the minimum password age.
+
+Edit the file "/etc/login.defs" and add or correct the following line. Replace [DAYS] with the appropriate amount of days:
+
+PASS_MIN_DAYS [DAYS]
+
+The DoD requirement is "1" but a greater value is acceptable.</fixtext><fix id="F-83807r1_fix" /><check system="C-76721r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system to create or update passwords with minimum password age of "1" day or greater.
+
+Check that the SUSE operating system enforces 24 hours/1 day as the minimum password age, run the following command:
+
+# grep PASS_MIN_DAYS /etc/login.defs
+
+PASS_MIN_DAYS 1
+
+If "PASS_MIN_DAYS" does not have a value of "1" or greater, this is a finding.</check-content></check></Rule></Group><Group id="V-77113"><title>SRG-OS-000075-GPOS-00043</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91809r1_rule" severity="medium" weight="10.0"><version>SLES-12-010270</version><title>The SUSE operating system must employ user passwords with a minimum lifetime of 24 hours (1 day).</title><description>&lt;VulnDiscussion&gt;Enforcing a minimum password lifetime helps prevent repeated password changes to defeat the password reuse or history enforcement requirement. If users are allowed to immediately and continually change their password, the password could be repeatedly changed in a short period of time to defeat the organization's policy regarding password reuse.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000198</ident><fixtext fixref="F-83809r1_fix">Configure the SUSE operating system to enforce 24 hours/1 day or greater as the minimum password age for user accounts.
+
+Change the minimum time period between password changes for each [USER] account to "1" day with the command, replacing [USER] with the user account that must be changed:
+
+# sudo passwd -n 1 [USER]</fixtext><fix id="F-83809r1_fix" /><check system="C-76723r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces a minimum time period between password changes for each user account of "1" day or greater.
+
+Check the minimum time period between password changes for each user account with the following command:
+
+# sudo cat /etc/shadow | cut -d ':' -f1,4 | grep -v 1 | grep -v ":$"
+
+smithj:1
+
+If any account has a value of "0", this is a finding.</check-content></check></Rule></Group><Group id="V-77115"><title>SRG-OS-000076-GPOS-00044</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91811r2_rule" severity="medium" weight="10.0"><version>SLES-12-010280</version><title>The SUSE operating system must be configured to create or update passwords with a maximum lifetime of 60 days.</title><description>&lt;VulnDiscussion&gt;Any password, no matter how complex, can eventually be cracked. Therefore, passwords need to be changed periodically. If the SUSE operating system does not limit the lifetime of passwords and force users to change their passwords, there is the risk that the SUSE operating system passwords could be compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000199</ident><fixtext fixref="F-83811r1_fix">Configure the SUSE operating system to enforce a maximum password age of "60" days or less.
+
+Edit the file "/etc/login.defs" and add or correct the following line. Replace [DAYS] with the appropriate amount of days:
+
+PASS_MAX_DAYS [DAYS]
+
+The DoD requirement is "60" days or less (greater than zero, as zero days will lock the account immediately).</fixtext><fix id="F-83811r1_fix" /><check system="C-76725r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system is configured to create or update passwords with a maximum password age of "60" days or less.
+
+Check that the SUSE operating system enforces "60" days or less as the maximum password age with the following command:
+
+# grep PASS_MAX_DAYS /etc/login.defs
+
+The DoD requirement is "60" days or less (greater than zero, as zero days will lock the account immediately).
+
+If PASS_MAX_DAYS is not set to "60" days or less , this is a finding.</check-content></check></Rule></Group><Group id="V-77117"><title>SRG-OS-000076-GPOS-00044</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91813r1_rule" severity="medium" weight="10.0"><version>SLES-12-010290</version><title>The SUSE operating system must employ user passwords with a maximum lifetime of 60 days.</title><description>&lt;VulnDiscussion&gt;Any password, no matter how complex, can eventually be cracked. Therefore, passwords need to be changed periodically. If the SUSE operating system does not limit the lifetime of passwords and force users to change their passwords, there is the risk that the SUSE operating system passwords could be compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000199</ident><fixtext fixref="F-83813r1_fix">Configure the SUSE operating system to enforce a maximum password age of each [USER] account to "60" days. The command in the check text will give a list of users that need to be updated to be in compliance:
+
+# sudo passwd -x 60 [USER]
+
+The DoD requirement is "60" days.</fixtext><fix id="F-83813r1_fix" /><check system="C-76727r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system enforces a maximum user password age of "60" days or less.
+
+Check that the SUSE operating system enforces "60" days or less as the maximum user password age with the following command:
+
+# sudo cat /etc/shadow | cut -d':' -f1,5 | egrep -v "([0|60])" | grep -v ":$"
+
+If any results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-77119"><title>SRG-OS-000077-GPOS-00045</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91815r1_rule" severity="medium" weight="10.0"><version>SLES-12-010300</version><title>The SUSE operating system must employ a password history file.</title><description>&lt;VulnDiscussion&gt;Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to consecutively reuse their password when that password has exceeded its defined lifetime, the end result is a password that is not changed as per policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000200</ident><fixtext fixref="F-83815r1_fix">Configure the SUSE operating system to create the password history file with the following commands:
+
+# sudo touch /etc/security/opasswd
+# sudo chown root:root /etc/security/opasswd
+# sudo chmod 0600 /etc/security/opasswd</fixtext><fix id="F-83815r1_fix" /><check system="C-76729r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the password history file exists on the SUSE operating system.
+
+Check that the password history file exists with the following command:
+
+# ls -al /etc/security/opasswd
+
+-rw------- 1 root root 7 Dec 13 17:21 /etc/security/opasswd
+
+If "/etc/security/opasswd" does not exist, this is a finding.</check-content></check></Rule></Group><Group id="V-77121"><title>SRG-OS-000077-GPOS-00045</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91817r3_rule" severity="medium" weight="10.0"><version>SLES-12-010310</version><title>The SUSE operating system must not allow passwords to be reused for a minimum of five (5) generations.</title><description>&lt;VulnDiscussion&gt;Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to consecutively reuse their password when that password has exceeded its defined lifetime, the end result is a password that is not changed as per policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000200</ident><fixtext fixref="F-83817r3_fix">Configure the SUSE operating system password history to prohibit the reuse of a password for a minimum of five generations.
+
+Edit "/etc/pam.d/common-password" and edit the line containing "pam_pwhistory.so" to contain the option "remember=5 useauthtok" after the third column.</fixtext><fix id="F-83817r3_fix" /><check system="C-76731r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system prohibits the reuse of a password for a minimum of five (5) generations.
+
+Check that the SUSE operating system prohibits the reuse of a password for a minimum of five (5) generations with the following command:
+
+# grep pam_pwhistory.so /etc/pam.d/common-password
+
+password requisite pam_pwhistory.so remember=5 useauthtok
+
+If the command does not return anything, the returned line is commented out, or has a second column value different from "requisite", or does not contain "remember" value, or the value is less than "5", or is missing the "useauthtok" keyword, this is a finding.</check-content></check></Rule></Group><Group id="V-77123"><title>SRG-OS-000480-GPOS-00225</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91819r2_rule" severity="medium" weight="10.0"><version>SLES-12-010320</version><title>The SUSE operating system must prevent the use of dictionary words for passwords.</title><description>&lt;VulnDiscussion&gt;If the SUSE operating system allows the user to select passwords based on dictionary words, this increases the chances of password compromise by increasing the opportunity for successful guesses and brute-force attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83819r2_fix">Configure the SUSE operating system to prevent the use of dictionary words for passwords.
+
+Edit "/etc/pam.d/common-password" and add the following line:
+
+password requisite pam_cracklib.so</fixtext><fix id="F-83819r2_fix" /><check system="C-76733r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system prevents the use of dictionary words for passwords.
+
+Check that the SUSE operating system prevents the use of dictionary words for passwords with the following command:
+
+# grep pam_cracklib.so /etc/pam.d/common-password
+password requisite pam_cracklib.so
+
+If the command does not return anything, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77125"><title>SRG-OS-000123-GPOS-00064</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91821r2_rule" severity="medium" weight="10.0"><version>SLES-12-010330</version><title>The SUSE operating system must never automatically remove or disable emergency administrator accounts.</title><description>&lt;VulnDiscussion&gt;Emergency accounts are privileged accounts that are established in response to crisis situations where the need for rapid account activation is required. Therefore, emergency account activation may bypass normal account authorization processes. If these accounts are automatically disabled, system maintenance during emergencies may not be possible, thus adversely affecting system availability. 
+
+Emergency accounts are different from infrequently used accounts (i.e., local logon accounts used by the organization's system administrators when network or normal logon/access is not available). Infrequently used accounts are not subject to automatic termination dates. Emergency accounts are accounts created in response to crisis situations, usually for use by maintenance personnel. The automatic expiration or disabling time period may be extended as needed until the crisis is resolved; however, it must not be extended indefinitely. A permanent account should be established for privileged users who need long-term maintenance accounts.
+
+To address access requirements the SUSE operating system can be integrated with enterprise-level authentication/access mechanisms that meet or exceed access control policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001682</ident><fixtext fixref="F-83821r1_fix">Configure the SUSE operating system to never automatically remove or disable emergency administrator accounts.
+
+Replace "[Emergency_Administrator]" in the following command with the correct emergency administrator account. Run the following command as an administrator:
+
+# sudo chage -I -1 -M 99999 [Emergency_Administrator]</fixtext><fix id="F-83821r1_fix" /><check system="C-76735r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is configured such that emergency administrator accounts are never automatically removed or disabled. 
+
+Note: Root is typically the "account of last resort" on a system and is also used as the example emergency administrator account. If another account is being used as the emergency administrator account, the command should be used against that account. 
+
+Check to see if the root account password or account expires with the following command:
+
+# sudo chage -l [Emergency_Administrator]
+
+Password expires:never
+
+If "Password expires" or "Account expires" is set to anything other than "never", this is a finding.</check-content></check></Rule></Group><Group id="V-77127"><title>SRG-OS-000118-GPOS-00060</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91823r1_rule" severity="medium" weight="10.0"><version>SLES-12-010340</version><title>The SUSE operating system must disable account identifiers (individuals, groups, roles, and devices) after 35 days of inactivity after password expiration.</title><description>&lt;VulnDiscussion&gt;Inactive identifiers pose a risk to systems and applications because attackers may exploit an inactive identifier and potentially obtain undetected access to the system. Owners of inactive accounts will not notice if unauthorized access to their user account has been obtained.
+
+The SUSE operating system needs to track periods of inactivity and disable application identifiers after 35 days of inactivity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000795</ident><fixtext fixref="F-83823r1_fix">Configure the SUSE operating system to disable account identifiers after "35" days of inactivity after the password expiration. 
+
+Run the following command to change the configuration for "useradd" to disable the account identifier after "35" days:
+
+# sudo useradd -D -f 35
+
+DoD recommendation is "35" days, but a lower value greater than "0" is acceptable.</fixtext><fix id="F-83823r1_fix" /><check system="C-76737r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system disables account identifiers after "35" days of inactivity after the password expiration
+
+Check the account inactivity value by performing the following command:
+
+# sudo grep -i inactive /etc/default/useradd
+
+INACTIVE=35
+
+If "INACTIVE" is not set to a value greater than "0" and less than or equal to "35", this is a finding.</check-content></check></Rule></Group><Group id="V-77129"><title>SRG-OS-000002-GPOS-00002</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91825r2_rule" severity="medium" weight="10.0"><version>SLES-12-010360</version><title>The SUSE operating system must provision temporary accounts with an expiration date for 72 hours.</title><description>&lt;VulnDiscussion&gt;If temporary user accounts remain active when no longer needed or for an excessive period, these accounts may be used to gain unauthorized access. To mitigate this risk, automated termination of all temporary accounts must be set upon account creation.
+
+Temporary accounts are established as part of normal account activation procedures when there is a need for short-term accounts without the demand for immediacy in account activation.
+
+If temporary accounts are used, the SUSE operating system must be configured to automatically terminate these types of accounts after a DoD-defined time period of 72 hours.
+
+To address access requirements, many SUSE operating systems may be integrated with enterprise-level authentication/access mechanisms that meet or exceed access control policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000016</ident><fixtext fixref="F-83825r1_fix">In the event temporary accounts are required, configure the SUSE operating system to terminate them after "72" hours. 
+
+For every temporary account, run the following command to set an expiration date on it, substituting "system_account_name" with the appropriate value:
+
+# sudo chage -E `date -d "+3 days" +%Y-%m-%d` system_account_name
+
+`date -d "+3 days" +%Y-%m-%d` sets the 72-hour expiration date for the account at the time the command is run.</fixtext><fix id="F-83825r1_fix" /><check system="C-76739r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system provisions temporary accounts with an expiration date for "72" hours.
+
+Ask the System Administrator if any temporary accounts have been added to the system. For every existing temporary account, run the following command to obtain its account expiration information:
+
+# sudo chage -l system_account_name
+
+Verify each of these accounts has an expiration date that is within "72" hours of its creation.
+
+If any temporary accounts have no expiration date set or do not expire within "72" hours of their creation, this is a finding.</check-content></check></Rule></Group><Group id="V-77131"><title>SRG-OS-000480-GPOS-00226</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91827r2_rule" severity="medium" weight="10.0"><version>SLES-12-010370</version><title>The SUSE operating system must enforce a delay of at least four seconds between logon prompts following a failed logon attempt.</title><description>&lt;VulnDiscussion&gt;Limiting the number of logon attempts over a certain time interval reduces the chances that an unauthorized user may gain access to an account.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83827r2_fix">Configure the SUSE operating system to enforce a delay of at least four seconds between logon prompts following a failed logon attempt.
+
+Edit the file "/etc/pam.d/common-auth".
+
+Add a parameter "pam_faildelay" and set it to:
+
+# delay is in micro seconds
+auth    required    pam_faildelay.so    delay=4000000</fixtext><fix id="F-83827r2_fix" /><check system="C-76741r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system enforces a delay of at least four seconds between logon prompts following a failed logon attempt.
+
+# grep pam_faildelay /etc/pam.d/common-auth*
+auth    required    pam_faildelay.so    delay=4000000
+
+If the value of "delay" is not set to "4000000", "delay" is commented out, "delay" is missing, or the "pam_faildelay" line is missing completely, this is a finding.</check-content></check></Rule></Group><Group id="V-77133"><title>SRG-OS-000480-GPOS-00229</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91829r2_rule" severity="high" weight="10.0"><version>SLES-12-010380</version><title>The SUSE operating system must not allow unattended or automatic logon via the graphical user interface (GUI).</title><description>&lt;VulnDiscussion&gt;Failure to restrict system access to authenticated users negatively impacts SUSE operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83829r2_fix">Note: If GNOME is not installed, this requirement is Not Applicable.
+
+Configure the SUSE operating system GUI to not allow unattended or automatic logon to the system.
+
+Add or edit the following line in the "/etc/gdm/custom.conf" file directly below the "[daemon]" tag:
+
+AutomaticLoginEnable=false</fixtext><fix id="F-83829r2_fix" /><check system="C-76743r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Note: If GNOME is not installed, this requirement is Not Applicable.
+
+Verify the SUSE operating system does not allow unattended or automatic logon via the GUI.
+
+Check that unattended or automatic login is disabled with the following command:
+
+# sudo grep -i automaticloginenable /etc/gdm/custom.conf
+
+AutomaticLoginEnable=false
+
+If the "AutomaticLoginEnable" parameter is not set to "false", this is a finding.</check-content></check></Rule></Group><Group id="V-77135"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91831r2_rule" severity="low" weight="10.0"><version>SLES-12-010390</version><title>The SUSE operating system must display the date and time of the last successful account logon upon logon.</title><description>&lt;VulnDiscussion&gt;Providing users with feedback on when account accesses last occurred facilitates user recognition and reporting of unauthorized account use.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83831r2_fix">Configure the SUSE operating system to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/login". 
+
+Add the following line to the top of "/etc/pam.d/login":
+
+session     required      pam_lastlog.so showfailed</fixtext><fix id="F-83831r2_fix" /><check system="C-76745r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system users are provided with feedback on when account accesses last occurred.
+
+Check that "pam_lastlog" is used and not silent with the following command:
+
+# grep pam_lastlog /etc/pam.d/login
+
+session required pam_lastlog.so showfailed 
+
+If "pam_lastlog" is missing from "/etc/pam.d/login" file, or the "silent" option is present, this is a finding.</check-content></check></Rule></Group><Group id="V-77137"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91833r1_rule" severity="high" weight="10.0"><version>SLES-12-010400</version><title>There must be no .shosts files on the SUSE operating system.</title><description>&lt;VulnDiscussion&gt;The .shosts files are used to configure host-based authentication for individual users or the system via SSH. Host-based authentication is not sufficient for preventing unauthorized access to the system, as it does not require interactive identification and authentication of a connection request, or for the use of two-factor authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83833r1_fix">Remove any ".shosts" files found on the SUSE operating system.
+
+# rm /[path]/[to]/[file]/.shosts</fixtext><fix id="F-83833r1_fix" /><check system="C-76747r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify there are no ".shosts" files on the SUSE operating system.
+
+Check the system for the existence of these files with the following command:
+
+# find / -name '*.shosts'
+
+If any ".shosts" files are found on the system, this is a finding.</check-content></check></Rule></Group><Group id="V-77139"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91835r1_rule" severity="high" weight="10.0"><version>SLES-12-010410</version><title>There must be no shosts.equiv files on the SUSE operating system.</title><description>&lt;VulnDiscussion&gt;The shosts.equiv files are used to configure host-based authentication for the system via SSH. Host-based authentication is not sufficient for preventing unauthorized access to the system, as it does not require interactive identification and authentication of a connection request, or for the use of two-factor authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83835r1_fix">Remove any ".shosts.equiv" files found on the SUSE operating system.
+
+# rm /etc/ssh/shosts.equiv</fixtext><fix id="F-83835r1_fix" /><check system="C-76749r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify there are no "shosts.equiv" files on the SUSE operating system.
+
+Check the system for the existence of these files with the following command:
+
+# ls -al /etc/ssh/shosts.equiv
+
+If any "shosts.equiv" files are found on the system, this is a finding.</check-content></check></Rule></Group><Group id="V-77141"><title>SRG-OS-000478-GPOS-00223</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91837r2_rule" severity="medium" weight="10.0"><version>SLES-12-010420</version><title>FIPS 140-2 mode must be enabled on the SUSE operating system.</title><description>&lt;VulnDiscussion&gt;Use of weak or untested encryption algorithms undermines the purposes of using encryption to protect data. The SUSE operating system must implement cryptographic modules adhering to the higher standards approved by the federal government since this provides assurance they have been tested and validated.
+
+Satisfies: SRG-OS-000396-GPOS-00176, SRG-OS-000478-GPOS-00223&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002450</ident><fixtext fixref="F-83837r1_fix">To configure the SUSE operating system to run in FIPS mode, add "fips=1" to the kernel parameter during the SUSE operating system install.
+
+Enabling FIPS mode on a preexisting system involves a number of modifications to the SUSE operating system. Refer to section 9.1, "Crypto Officer Guidance", of the following document for installation guidance:
+
+http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2435.pdf</fixtext><fix id="F-83837r1_fix" /><check system="C-76751r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is running in FIPS mode by running the following command.
+
+# cat /proc/sys/crypto/fips_enabled 
+
+1
+
+If nothing is returned, the file does not exist, or the value returned is "0", this is a finding.</check-content></check></Rule></Group><Group id="V-77143"><title>SRG-OS-000080-GPOS-00048</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91839r3_rule" severity="medium" weight="10.0"><version>SLES-12-010430</version><title>SUSE operating systems with a basic input/output system (BIOS) must require authentication upon booting into single-user and maintenance modes.</title><description>&lt;VulnDiscussion&gt;To mitigate the risk of unauthorized access to sensitive information by entities that have been issued certificates by DoD-approved PKIs, all DoD systems (e.g., web servers and web portals) must be properly configured to incorporate access control methods that do not rely solely on the possession of a certificate for access. Successful authentication must not automatically give an entity access to an asset or security boundary. Authorization procedures and controls must be implemented to ensure each authenticated entity also has a validated and current authorization. Authorization is the process of determining whether an entity, once authenticated, is permitted to access a specific asset. Information systems use access control policies and enforcement mechanisms to implement this requirement.
+
+Access control policies include identity-based policies, role-based policies, and attribute-based policies. Access enforcement mechanisms include access control lists, access control matrices, and cryptography. These policies and mechanisms must be employed by the application to control access between users (or processes acting on behalf of users) and objects (e.g., devices, files, records, processes, programs, and domains) in the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000213</ident><fixtext fixref="F-83839r2_fix">Note: If the system does not use a basic input/output system (BIOS) this requirement is Not Applicable.
+
+Configure the SUSE operating system to encrypt the boot password.
+
+Generate an encrypted (GRUB2) password for root with the following command:
+
+# sudo grub2-mkpasswd-pbkdf2
+Enter Password:
+Reenter Password:
+PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.MFU48934NJD84NF8NSD39993JDHF84NG
+
+Using the hash from the output, modify the "/etc/grub.d/40_custom" file with the following command to add a boot password for the root entry:
+
+# cat &lt;&lt; EOF
+set superusers="root"
+password_pbkdf2 root grub.pbkdf2.sha512.VeryLongString
+EOF
+
+Generate an updated "grub.conf" file with the new password using the following commands:
+
+# sudo grub2-mkconfig --output=/tmp/grub2.cfg
+# sudo mv /tmp/grub2.cfg /boot/grub2/grub.cfg</fixtext><fix id="F-83839r2_fix" /><check system="C-76753r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system has set an encrypted root password. 
+
+Note: If the system does not use a basic input/output system (BIOS) this requirement is Not Applicable.
+
+Check that the encrypted password is set for root with the following command:
+
+# sudo cat /boot/grub2/grub.cfg | grep -i password 
+
+password_pbkdf2 root grub.pbkdf2.sha512.10000.VeryLongString
+
+If the root password entry does not begin with "password_pbkdf2", this is a finding.</check-content></check></Rule></Group><Group id="V-77145"><title>SRG-OS-000080-GPOS-00048</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91841r3_rule" severity="medium" weight="10.0"><version>SLES-12-010440</version><title>SUSE operating systems with Unified Extensible Firmware Interface (UEFI) implemented must require authentication upon booting into single-user mode and maintenance.</title><description>&lt;VulnDiscussion&gt;If the system allows a user to boot into single-user or maintenance mode without authentication, any user that invokes single-user or maintenance mode is granted privileged access to all system information.
+
+If the system is running in EFI mode, SLES 12 by default will use GRUB 2 EFI as the boot loader.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000213</ident><fixtext fixref="F-83841r3_fix">Note: If the system does not use UEFI, this requirement is Not Applicable.
+
+Configure the SUSE operating system to encrypt the boot password.
+
+Generate an encrypted (GRUB 2) password for root with the following command:
+
+# sudo grub2-mkpasswd-pbkdf2
+Enter Password:
+Reenter Password:
+PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.MFU48934NJD84NF8NSD39993JDHF84NG
+
+Using the hash from the output, modify the "/etc/grub.d/40_custom" file with the following command to add a boot password for the root entry:
+
+# cat &lt;&lt; EOF
+set superusers="root"
+password_pbkdf2 root grub.pbkdf2.sha512.VeryLongString
+EOF
+
+Generate an updated "grub.conf" file with the new password using the following commands:
+
+# sudo grub2-mkconfig --output=/tmp/grub2.cfg
+# sudo mv /tmp/grub2.cfg /boot/efi/EFI/sles12/grub.cfg</fixtext><fix id="F-83841r3_fix" /><check system="C-76755r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system has set an encrypted root password. 
+
+Note: If the system does not use Unified Extensible Firmware Interface (UEFI) this requirement is Not Applicable.
+
+Check that the encrypted password is set for root with the following command:
+
+# sudo cat /boot/efi/EFI/sles12/grub.cfg | grep -i password 
+
+password_pbkdf2 root grub.pbkdf2.sha512.10000.VeryLongString
+
+If the root password entry does not begin with "password_pbkdf2", this is a finding.</check-content></check></Rule></Group><Group id="V-77147"><title>SRG-OS-000185-GPOS-00079</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91843r3_rule" severity="medium" weight="10.0"><version>SLES-12-010450</version><title>All SUSE operating system persistent disk partitions must implement cryptographic mechanisms to prevent unauthorized disclosure or modification of all information that requires at rest protection.</title><description>&lt;VulnDiscussion&gt;SUSE operating systems handling data requiring "data at rest" protections must employ cryptographic mechanisms to prevent unauthorized disclosure and modification of the information at rest.
+
+Selection of a cryptographic mechanism is based on the need to protect the integrity of organizational information. The strength of the mechanism is commensurate with the security category and/or classification of the information. Organizations have the flexibility to either encrypt all information on storage devices (i.e., full disk encryption) or encrypt specific data structures (e.g., files, records, or fields).
+
+Satisfies: SRG-OS-000185-GPOS-00079, SRG-OS-000404-GPOS-00183, SRG-OS-000405-GPOS-00184&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001199</ident><ident system="http://iase.disa.mil/cci">CCI-002475</ident><fixtext fixref="F-83843r1_fix">Configure the SUSE operating system to prevent unauthorized modification of all information at rest by using disk encryption. 
+
+Encrypting a partition in an already-installed system is more difficult because of the need to resize and change existing partitions. To encrypt an entire partition, dedicate a partition for encryption in the partition layout. The standard partitioning proposal as suggested by YaST (installation and configuration tool for Linux) does not include an encrypted partition by default. Add it manually in the partitioning dialog.
+
+Refer to the document "SUSE 12 Security Guide", Section 11.1, for a detailed disk encryption guide:
+
+https://www.suse.com/documentation/sles-12/book_security/data/sec_security_cryptofs_y2.html#sec_security_cryptofs_y2_part_run</fixtext><fix id="F-83843r1_fix" /><check system="C-76757r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system prevents unauthorized disclosure or modification of all information requiring at rest protection by using disk encryption. 
+
+Determine the partition layout for the system with the following command:
+
+# sudo fdisk -l
+
+Device     Boot    Start       End  Sectors  Size Id Type
+/dev/sda1           2048   4208639  4206592    2G 82 Linux swap / Solaris
+/dev/sda2  *     4208640  53479423 49270784 23.5G 83 Linux
+/dev/sda3       53479424 125829119 72349696 34.5G 83 Linux
+
+Verify the system partitions are all encrypted with the following command: 
+
+# sudo more /etc/crypttab
+
+luks       UUID=114167a-2a94-6cda-f1e7-15ad146c258b
+swap       /dev/sda1       /dev/urandom       swap
+truecrypt  /dev/sda2       /etc/container_password  tcrypt
+truecrypt  /dev/sda3       /etc/container_password  tcrypt
+
+Every persistent disk partition present on the system must have an entry in the file. 
+
+If any partitions other than pseudo file systems (such as /proc or /sys) are not listed or "/etc/crypttab" does not exist, this is a finding.</check-content></check></Rule></Group><Group id="V-77149"><title>SRG-OS-000138-GPOS-00069</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91845r2_rule" severity="medium" weight="10.0"><version>SLES-12-010460</version><title>The sticky bit must be set on all SUSE operating system world-writable directories.</title><description>&lt;VulnDiscussion&gt;Preventing unauthorized information transfers mitigates the risk of information, including encrypted representations of information, produced by the actions of prior users/roles (or the actions of processes acting on behalf of prior users/roles) from being available to any current users/roles (or current processes) that obtain access to shared system resources (e.g., registers, main memory, and hard disks) after those resources have been released back to information systems. The control of information in shared resources is also commonly referred to as object reuse and residual information protection.
+
+This requirement generally applies to the design of an information technology product, but it can also apply to the configuration of particular information system components that are, or use, such products. This can be verified by acceptance/validation processes in DoD or other government agencies.
+
+There may be shared resources with configurable protections (e.g., files in storage) that may be assessed on specific information system components.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001090</ident><fixtext fixref="F-83845r1_fix">Configure the SUSE operating system shared system resources to prevent any unauthorized and unintended information transfer by setting the sticky bit for all world-writable directories.
+
+An example of a world-writable directory is "/tmp" directory. Set the sticky bit on all of the world-writable directories (using the "/tmp" directory as an example) with the following command:
+
+# sudo chmod 1777 /tmp
+
+For every world-writable directory, replace "/tmp" in the command above with the world-writable directory that does not have the sticky bit set.</fixtext><fix id="F-83845r1_fix" /><check system="C-76759r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system prevents unauthorized and unintended information transfer via the shared system resources.
+
+Check that world-writable directories have the sticky bit set with the following command:
+
+# sudo find / -xdev -perm -002 -type d -fstype xfs -exec ls -lLd {} \;
+
+256 0 drwxrwxrwt 1 root root 4096 Jun 14 06:45 /tmp
+
+If any of the returned directories do not have the sticky bit set, or are not documented as having the write permission for the other class, this is a finding.</check-content></check></Rule></Group><Group id="V-77151"><title>SRG-OS-000363-GPOS-00150</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91847r3_rule" severity="medium" weight="10.0"><version>SLES-12-010500</version><title>Advanced Intrusion Detection Environment (AIDE) must verify the baseline SUSE operating system configuration at least weekly.</title><description>&lt;VulnDiscussion&gt;Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the SUSE operating system. Changes to SUSE operating system configurations can have unintended side effects, some of which may be relevant to security.
+
+Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the SUSE operating system. The SUSE operating system's Information Management Officer (IMO)/Information System Security Officer (ISSO) and System Administrator (SAs) must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001744</ident><ident system="http://iase.disa.mil/cci">CCI-002696</ident><ident system="http://iase.disa.mil/cci">CCI-002699</ident><fixtext fixref="F-83847r2_fix">Configure the SUSE operating system to check the baseline configuration for unauthorized changes at least once weekly.
+
+If the "aide" package is not installed, install it with the following command:
+
+# sudo zypper in aide
+
+Configure the file integrity tool to automatically run on the system at least weekly. The following example output is generic. It will set cron to run AIDE weekly, but other file integrity tools may be used:
+
+# cat /etc/cron.weekly/aide 
+0 0 * * * /usr/sbin/aide --check | /bin/mail -s "aide integrity check run for &lt;system name&gt;" root@notareal.email</fixtext><fix id="F-83847r2_fix" /><check system="C-76761r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system checks the baseline configuration for unauthorized changes at least once weekly.
+
+Note: A file integrity tool other than Advanced Intrusion Detection Environment (AIDE) may be used, but the tool must be executed at least once per week.
+
+Check to see if the "aide" package is installed on the system with the following command:
+
+# sudo zypper if aide | grep "Installed"
+
+Installed: Yes
+
+If the "aide" package is not installed, ask the System Administrator (SA) how file integrity checks are performed on the system.
+
+Check for the presence of a cron job running daily or weekly on the system that executes AIDE to scan for changes to the system baseline. The command used in the following example looks at the daily cron job:
+
+Check the "/etc/cron" subdirectories for a "crontab" file controlling the execution of the file integrity application. For example, if AIDE is installed on the system, use the following command:
+
+# grep aide etc/crontab etc/cron.*
+/etc/crontab: 30 04 * * * /etc/aide
+
+If the file integrity application does not exist, or a "crontab" file does not exist in "/etc/crontab", the "/etc/cron.daily" subdirectory, or "/etc/cron.weekly" subdirectory, this is a finding.</check-content></check></Rule></Group><Group id="V-77153"><title>SRG-OS-000447-GPOS-00201</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91849r2_rule" severity="medium" weight="10.0"><version>SLES-12-010510</version><title>The SUSE operating system must notify the System Administrator (SA) when AIDE discovers anomalies in the operation of any security functions.</title><description>&lt;VulnDiscussion&gt;If anomalies are not acted on, security functions may fail to secure the system. 
+
+Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters.
+
+Notifications provided by information systems include messages to local computer consoles and/or hardware indications, such as lights.
+
+This capability must take into account operational requirements for availability for selecting an appropriate response. The organization may choose to shut down or restart the information system upon security function anomaly detection.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002702</ident><fixtext fixref="F-83849r2_fix">Configure the SUSE operating system to notify the SA when AIDE discovers anomalies in the operation of any security functions.
+
+Create the aide crontab file in "/etc/cron.daily" and add following command replacing the "[E-MAIL]" parameter with a proper email address for the SA:
+
+0 0 * * * /usr/sbin/aide --check | /bin/mail -s "aide integrity check run for &lt;system name&gt;" root@notareal.email</fixtext><fix id="F-83849r2_fix" /><check system="C-76763r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system notifies the SA when AIDE discovers anomalies in the operation of any security functions.
+
+Check to see if the aide cron job sends an email when executed with the following command:
+
+# sudo grep -i "aide" /etc/cron.*/aide 
+0 0 * * * /usr/sbin/aide --check | /bin/mail -s "aide integrity check run for &lt;system name&gt;" root@notareal.email
+
+If the "aide" file does not exist under the "/etc/cron" directory structure or the cron job is not configured to execute a binary to send an email (such as "/usr/bin/mail"), this is a finding.</check-content></check></Rule></Group><Group id="V-77155"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91851r1_rule" severity="low" weight="10.0"><version>SLES-12-010520</version><title>The SUSE operating system file integrity tool must be configured to verify Access Control Lists (ACLs).</title><description>&lt;VulnDiscussion&gt;ACLs can provide permissions beyond those permitted through the file mode and must be verified by file integrity tools.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83851r1_fix">Configure the SUSE operating system file integrity tool to check file and directory ACLs. 
+
+If AIDE is installed, ensure the "acl" rule is present on all file and directory selection lists.</fixtext><fix id="F-83851r1_fix" /><check system="C-76765r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system file integrity tool is configured to verify extended attributes.
+
+Check to see if Advanced Intrusion Detection Environment (AIDE) is installed on the system with the following command:
+
+# sudo zypper if aide | grep "Installed"
+
+Installed: Yes
+
+If AIDE is not installed, ask the System Administrator how file integrity checks are performed on the system.
+
+If there is no application installed to perform integrity checks, this is a finding.
+
+Note: AIDE is highly configurable at install time. These commands assume the "aide.conf" file is under the "/etc" directory. 
+
+Use the following command to determine if the file is in another location:
+
+# find / -name aide.conf
+
+Check the "aide.conf" file to determine if the "xattrs" rule has been added to the rule list being applied to the files and directories selection lists.
+
+An example rule that includes the "acl" rule follows:
+
+All= p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+/bin All # apply the custom rule to the files in bin 
+/sbin All # apply the same custom rule to the files in sbin 
+
+If the "acl" rule is not being used on all selection lines in the "/etc/aide.conf" file, or extended attributes are not being checked by another file integrity tool, this is a finding.</check-content></check></Rule></Group><Group id="V-77157"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91853r1_rule" severity="low" weight="10.0"><version>SLES-12-010530</version><title>The SUSE operating system file integrity tool must be configured to verify extended attributes.</title><description>&lt;VulnDiscussion&gt;Extended attributes in file systems are used to contain arbitrary data and file metadata with security implications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83853r1_fix">Configure the SUSE operating system file integrity tool to check file and directory extended attributes. 
+
+If AIDE is installed, ensure the "xattrs" rule is present on all file and directory selection lists.</fixtext><fix id="F-83853r1_fix" /><check system="C-76767r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system file integrity tool is configured to verify extended attributes.
+
+Check to see if Advanced Intrusion Detection Environment (AIDE) is installed on the system with the following command:
+
+# sudo zypper if aide | grep "Installed"
+
+Installed: Yes
+
+If AIDE is not installed, ask the System Administrator how file integrity checks are performed on the system.
+
+If there is no application installed to perform integrity checks, this is a finding.
+
+Note: AIDE is highly configurable at install time. These commands assume the "aide.conf" file is under the "/etc" directory. 
+
+Use the following command to determine if the file is in another location:
+
+# find / -name aide.conf
+
+Check the "aide.conf" file to determine if the "xattrs" rule has been added to the rule list being applied to the files and directories selection lists.
+
+An example rule that includes the "xattrs" rule follows:
+
+All= p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+/bin All # apply the custom rule to the files in bin 
+/sbin All # apply the same custom rule to the files in sbin 
+
+If the "xattrs" rule is not being used on all selection lines in the "/etc/aide.conf" file, or extended attributes are not being checked by another file integrity tool, this is a finding.</check-content></check></Rule></Group><Group id="V-77159"><title>SRG-OS-000278-GPOS-00108</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91855r1_rule" severity="medium" weight="10.0"><version>SLES-12-010540</version><title>The SUSE operating system file integrity tool must be configured to protect the integrity of the audit tools.</title><description>&lt;VulnDiscussion&gt;Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Audit information includes all information (e.g., audit records, audit settings, and audit reports) needed to successfully audit information system activity.
+
+Audit tools include but are not limited to vendor-provided and open-source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.
+
+It is not uncommon for attackers to replace the audit tools or inject code into the existing tools to provide the capability to hide or erase system activity from the audit logs.
+
+To address this risk, audit tools must be cryptographically signed to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001496</ident><fixtext fixref="F-83855r1_fix">Configure the SUSE operating system file integrity tool to protect the integrity of the audit tools.
+
+Add or update the following lines to "/etc/aide.conf" to protect the integrity of the audit tools:
+
+# audit tools
+/usr/sbin/auditctl p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/auditd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/ausearch p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/aureport p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/autrace p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/audispd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/augenrules p+i+n+u+g+s+b+acl+selinux+xattrs+sha512</fixtext><fix id="F-83855r1_fix" /><check system="C-76769r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system file integrity tool is configured to protect the integrity of the audit tools.
+
+Check that AIDE is properly configured to protect the integrity of the audit tools by running the following command:
+
+# sudo cat /etc/aide.conf | grep /usr/sbin/au
+
+/usr/sbin/auditctl p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/auditd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/ausearch p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/aureport p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/autrace p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/audispd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+/usr/sbin/augenrules p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+
+If AIDE is configured properly to protect the integrity of the audit tools, all lines listed above will be returned from the command. 
+
+If one or more lines are missing, this is a finding.</check-content></check></Rule></Group><Group id="V-77161"><title>SRG-OS-000366-GPOS-00153</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91857r2_rule" severity="medium" weight="10.0"><version>SLES-12-010550</version><title>The SUSE operating system tool zypper must have gpgcheck enabled.</title><description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the SUSE operating system. This requirement ensures the software has not been tampered with and has been provided by a trusted vendor.
+
+Accordingly, patches, service packs, device drivers, or SUSE operating system components must be signed with a certificate recognized and approved by the organization.
+
+Verifying the authenticity of the software prior to installation validates the integrity of the patch or upgrade received from a vendor. This ensures the software has not been tampered with and that it has been provided by a trusted vendor. Self-signed certificates are disallowed by this requirement. The SUSE operating system should not have to verify the software again. This requirement does not mandate DoD certificates for this purpose; however, the certificate used to verify the software must be from an approved Certification Authority (CA).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001749</ident><fixtext fixref="F-83857r2_fix">Configure that the SUSE operating system tool zypper to enable pgpcheck by editing or adding the following line to "/etc/zypp/zypp.conf":
+
+gpgcheck = 1</fixtext><fix id="F-83857r2_fix" /><check system="C-76771r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system tool zypper has pgpcheck enabled.
+
+Check that zypper has gpgcheck enabled with the following command: 
+
+# cat /etc/zypp/zypp.conf | grep -i gpgcheck
+
+gpgcheck = 1
+
+If "gpgcheck" is set to "0", "off", "no", or "false", this is a finding.</check-content></check></Rule></Group><Group id="V-77163"><title>SRG-OS-000437-GPOS-00194</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91859r2_rule" severity="medium" weight="10.0"><version>SLES-12-010570</version><title>The SUSE operating system must remove all outdated software components after updated versions have been installed.</title><description>&lt;VulnDiscussion&gt;Previous versions of software components that are not removed from the information system after updates have been installed may be exploited by adversaries. Some information technology products may remove older versions of software automatically from the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002617</ident><fixtext fixref="F-83859r1_fix">Configure the SUSE operating system to remove all outdated software components after an update by editing the following line in "/etc/zypp/zypp.conf" to match the one provided below:
+
+solver.upgradeRemoveDroppedPackages = true</fixtext><fix id="F-83859r1_fix" /><check system="C-76773r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system removes all outdated software components after updated version have been installed by running the following command:
+
+# grep -i upgraderemovedroppedpackages /etc/zypp/zypp.conf 
+
+solver.upgradeRemoveDroppedPackages = true
+
+If "solver.upgradeRemoveDroppedPackages" is commented out, is set to "false", or is missing completely, this is a finding.</check-content></check></Rule></Group><Group id="V-77165"><title>SRG-OS-000378-GPOS-00163</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91861r2_rule" severity="medium" weight="10.0"><version>SLES-12-010580</version><title>The SUSE operating system must disable the USB mass storage kernel module.</title><description>&lt;VulnDiscussion&gt;Without identifying devices, unidentified or unknown devices may be introduced, thereby facilitating malicious activity.
+
+Peripherals include but are not limited to such devices as flash drives, external storage, and printers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001958</ident><fixtext fixref="F-83861r1_fix">Configure the SUSE operating system to prevent USB mass storage devices from automounting when connected to the host.
+
+Add or update the following line to the "/etc/modprobe.d/50-blacklist.conf" file:
+
+blacklist usb-storage</fixtext><fix id="F-83861r1_fix" /><check system="C-76775r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not automount USB mass storage devices when connected to the host.
+
+Check that "usb-storage" is blacklisted in the "/etc/modprobe.d/50-blacklist.conf" file with the following command:
+
+# grep usb-storage /etc/modprobe.d/50-blacklist.conf
+blacklist usb-storage
+
+If nothing is output from the command, this is a finding.</check-content></check></Rule></Group><Group id="V-77167"><title>SRG-OS-000114-GPOS-00059</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91863r2_rule" severity="medium" weight="10.0"><version>SLES-12-010590</version><title>The SUSE operating system must disable the file system automounter unless required.</title><description>&lt;VulnDiscussion&gt;Automatically mounting file systems permits easy introduction of unknown devices, thereby facilitating malicious activity.
+
+Satisfies: SRG-OS-000114-GPOS-00059, SRG-OS-000378-GPOS-00163, SRG-OS-000480-GPOS-00227&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><ident system="http://iase.disa.mil/cci">CCI-000778</ident><ident system="http://iase.disa.mil/cci">CCI-001958</ident><fixtext fixref="F-83863r2_fix">Configure the SUSE operating system to disable the ability to automount devices.
+
+Turn off the automount service with the following command:
+
+# systemctl stop autofs
+# systemctl disable autofs
+
+If "autofs" is required for Network File System (NFS), it must be documented with the ISSO.</fixtext><fix id="F-83863r2_fix" /><check system="C-76777r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system disables the ability to automount devices.
+
+Check to see if automounter service is active with the following command:
+
+# systemctl status autofs
+autofs.service - Automounts filesystems on demand
+Loaded: loaded (/usr/lib/systemd/system/autofs.service; disabled)
+Active: inactive (dead)
+
+If the "autofs" status is set to "active" and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.</check-content></check></Rule></Group><Group id="V-77169"><title>SRG-OS-000312-GPOS-00122</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91865r3_rule" severity="medium" weight="10.0"><version>SLES-12-010600</version><title>The SUSE operating system Apparmor tool must be configured to control whitelisted applications and user home directory access control.</title><description>&lt;VulnDiscussion&gt;Using a whitelist provides a configuration management method for allowing the execution of only authorized software. Using only authorized software decreases risk by limiting the number of potential vulnerabilities.
+
+The organization must identify authorized software programs and permit execution of authorized software by adding each authorized program to the "pam_apparmor" exception policy. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
+
+Verification of whitelisted software occurs prior to execution or at system startup.
+
+Users' home directories/folders may contain information of a sensitive nature. Nonprivileged users should coordinate any sharing of information with a System Administrator (SA) through shared resources.
+
+Apparmor can confine users to their home directory, not allowing them to make any changes outside of their own home directories. Confining users to their home directory will minimize the risk of sharing information.
+
+Satisfies: SRG-OS-000312-GPOS-00122, SRG-OS-000312-GPOS-00123SRG-OS-000312-GPOS-00124, SRG-OS-000324-GPOS-00125, SRG-OS-000326-GPOS-00126, SRG-OS-000370-GPOS-00155, SRG-OS-000480-GPOS-00230&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001774</ident><ident system="http://iase.disa.mil/cci">CCI-002165</ident><ident system="http://iase.disa.mil/cci">CCI-002233</ident><ident system="http://iase.disa.mil/cci">CCI-002235</ident><fixtext fixref="F-83865r2_fix">Configure the SUSE operating system to blacklist all applications by default and permit by whitelist.
+
+Install "pam_apparmor" (if it is not installed) with the following command:
+
+# sudo zypper in pam_apparmor
+
+Enable/activate "Apparmor" (if it is not already active) with the following command:
+
+# sudo systemctl enable apparmor.service
+
+Start "Apparmor" with the following command:
+
+# sudo systemctl start apparmor.service
+
+Note: "pam_apparmor" must have properly configured profiles. All configurations will be based on the actual system setup and organization. See the "pam_apparmor" documentation for more information on configuring profiles.</fixtext><fix id="F-83865r2_fix" /><check system="C-76779r5_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>If an HBSS or HIPS is active on the system, this is Not Applicable.
+
+Verify that the SUSE operating system Apparmor tool is configured to control whitelisted applications and user home directory access control.
+
+Check that "pam_apparmor" is installed on the system with the following command:
+
+# zypper se pam_apparmor
+
+If the package "pam_apparmor" is not installed on the system, this is a finding.
+
+Check that the "apparmor" daemon is running with the following command:
+
+# systemctl status apparmor.service | grep -i active
+
+Active: active (exited) since Fri 2017-01-13 01:01:01 GMT; 1day 1h ago
+
+If something other than "Active: active" is returned, this is a finding.
+
+Note: "pam_apparmor" must have properly configured profiles. All configurations will be based on the actual system setup and organization. See the "pam_apparmor" documentation for more information on configuring profiles.</check-content></check></Rule></Group><Group id="V-77171"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91867r3_rule" severity="high" weight="10.0"><version>SLES-12-010610</version><title>The SUSE operating system must disable the x86 Ctrl-Alt-Delete key sequence.</title><description>&lt;VulnDiscussion&gt;A locally logged-on user who presses Ctrl-Alt-Delete, when at the console, can reboot the system. If accidentally pressed, as could happen in the case of a mixed OS environment, this can create the risk of short-term loss of availability of systems due to unintentional reboot. In the GNOME graphical environment, risk of unintentional reboot from the Ctrl-Alt-Delete sequence is reduced because the user will be prompted before any action is taken.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83867r2_fix">Configure the system to disable the Ctrl-Alt-Delete sequence for the command line with the following command:
+
+# sudo systemctl mask ctrl-alt-del.target
+
+And reload the daemon to take effect 
+
+# sudo systemctl daemon-reload
+
+If GNOME is active on the system, create a database to contain the system-wide setting (if it does not already exist) with the following command: 
+
+# cat /etc/dconf/db/local.d/00-disable-CAD 
+
+Add the setting to disable the Ctrl-Alt-Delete sequence for GNOME:
+
+[org/gnome/settings-daemon/plugins/media-keys]
+logout=''</fixtext><fix id="F-83867r2_fix" /><check system="C-76781r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is not configured to reboot the system when Ctrl-Alt-Delete is pressed.
+
+Check that the ctrl-alt-del.service is not active with the following command:
+
+# systemctl status ctrl-alt-del.target
+reboot.target - Reboot
+   Loaded: loaded (/usr/lib/systemd/system/reboot.target; disabled)
+   Active: inactive (dead)
+     Docs: man:systemd.special(7)
+
+If the ctrl-alt-del.service is active, this is a finding.</check-content></check></Rule></Group><Group id="V-77173"><title>SRG-OS-000480-GPOS-00228</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91869r1_rule" severity="medium" weight="10.0"><version>SLES-12-010620</version><title>The SUSE operating system default permissions must be defined in such a way that all authenticated users can only read and modify their own files.</title><description>&lt;VulnDiscussion&gt;Setting the most restrictive default permissions ensures that when new accounts are created, they do not have unnecessary access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83869r1_fix">Configure the SUSE operating system to define the default permissions for all authenticated users in such a way that the users can only read and modify their own files.
+
+Add or edit the "UMASK" parameter in the "/etc/login.defs" file to match the example below:
+
+UMASK 077</fixtext><fix id="F-83869r1_fix" /><check system="C-76783r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system defines default permissions for all authenticated users in such a way that the users can only read and modify their own files. 
+
+Check the system default permissions with the following command:
+
+# grep -i "umask" /etc/login.defs
+
+UMASK 077
+
+If the "UMASK" variable is set to "000", the severity is raised to a CAT I, and this is a finding.
+
+If the value of "UMASK" is not set to "077", "UMASK" is commented out, or "UMASK" is missing completely, this is a finding.</check-content></check></Rule></Group><Group id="V-77175"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91871r1_rule" severity="medium" weight="10.0"><version>SLES-12-010630</version><title>The SUSE operating system must not have unnecessary accounts.</title><description>&lt;VulnDiscussion&gt;Accounts providing no operational purpose provide additional opportunities for system compromise. Unnecessary accounts include user accounts for individuals not requiring access to the system and application accounts for applications not installed on the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83871r1_fix">Configure the SUSE operating system so all accounts on the system are assigned to an active system, application, or user account. 
+
+Remove accounts that do not support approved system activities or that allow for a normal user to perform administrative-level actions. 
+
+Document all authorized accounts on the system.</fixtext><fix id="F-83871r1_fix" /><check system="C-76785r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify all SUSE operating system accounts are assigned to an active system, application, or user account.
+
+Obtain the list of authorized system accounts from the Information System Security Officer (ISSO).
+
+Check the system accounts on the system with the following command:
+
+# more /etc/passwd
+root:x:0:0:root:/root:/bin/bash
+...
+games:x:12:100:Games account:/var/games:/bin/bash
+
+Accounts such as "games" and "gopher" are not authorized accounts as they do not support authorized system functions. 
+
+If the accounts on the system do not match the provided documentation, this is a finding.</check-content></check></Rule></Group><Group id="V-77177"><title>SRG-OS-000104-GPOS-00051</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91873r2_rule" severity="medium" weight="10.0"><version>SLES-12-010640</version><title>The SUSE operating system must not have duplicate User IDs (UIDs) for interactive users.</title><description>&lt;VulnDiscussion&gt;To assure accountability and prevent unauthenticated access, interactive users must be identified and authenticated to prevent potential misuse and compromise of the system.
+
+Interactive users include organizational employees or individuals the organization deems to have equivalent status of employees (e.g., contractors). Interactive users (and processes acting on behalf of users) must be uniquely identified and authenticated to all accesses, except for the following: 
+
+1) Accesses explicitly identified and documented by the organization. Organizations document specific user actions that can be performed on the information system without identification or authentication; and
+
+2) Accesses that occur through authorized use of group authenticators without individual authentication. Organizations may require unique identification of individuals in group accounts (e.g., shared privilege accounts) or for detailed accountability of individual activity.
+
+Satisfies: SRG-OS-000104-GPOS-00051, SRG-OS-000121-GPOS-00062&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000764</ident><ident system="http://iase.disa.mil/cci">CCI-000804</ident><fixtext fixref="F-83873r1_fix">Configure the SUSE operating system to contain no duplicate UIDs for interactive users.
+
+Edit the file "/etc/passwd" and provide each interactive user account that has a duplicate UID with a unique UID.</fixtext><fix id="F-83873r1_fix" /><check system="C-76787r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system contains no duplicate UIDs for interactive users.
+
+Check that the SUSE operating system contains no duplicate UIDs for interactive users by running the following command:
+
+# awk -F ":" 'list[$3]++{print $1, $3}' /etc/passwd
+
+If output is produced, this is a finding.</check-content></check></Rule></Group><Group id="V-77179"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91875r2_rule" severity="high" weight="10.0"><version>SLES-12-010650</version><title>The SUSE operating system root account must be the only account having unrestricted access to the system.</title><description>&lt;VulnDiscussion&gt;If an account other than root also has a User Identifier (UID) of "0", it has root authority, giving that account unrestricted access to the entire SUSE operating system. Multiple accounts with a UID of "0" afford an opportunity for potential intruders to guess a password for a privileged account.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83875r2_fix">Change the UID of any account on the SUSE operating system, other than the root account, that has a UID of "0". 
+
+If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "1000". Otherwise, assign a UID of greater than "1000" that has not already been assigned.</fixtext><fix id="F-83875r2_fix" /><check system="C-76789r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system root account is the only account with unrestricted access to the system.
+
+Check the system for duplicate UID "0" assignments with the following command:
+
+# awk -F: '$3 == 0 {print $1}' /etc/passwd
+
+root
+
+If any accounts other than root have a UID of "0", this is a finding.</check-content></check></Rule></Group><Group id="V-77181"><title>SRG-OS-000380-GPOS-00165</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91877r1_rule" severity="medium" weight="10.0"><version>SLES-12-010660</version><title>Temporary passwords for SUSE operating system logons must require an immediate change to a permanent password.</title><description>&lt;VulnDiscussion&gt;Without providing this capability, an account may be created without a password. Nonrepudiation cannot be guaranteed once an account is created if a user is not forced to change the temporary password upon initial logon.
+
+Temporary passwords are typically used to allow access when new accounts are created or passwords are changed. It is common practice for administrators to create temporary passwords for user accounts that allow the users to log on, yet force them to change the password once they have successfully authenticated.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002041</ident><fixtext fixref="F-83877r1_fix">Configure the SUSE operating system to allow the use of a temporary password for system logons with an immediate change to a permanent password. 
+
+Using one of the acceptable methods listed below, force a user to change their password on their next logon by replacing "[UserName]" in the one of the following commands:
+
+# chage -d 0 [UserName]
+# passwd -e [UserName]</fixtext><fix id="F-83877r1_fix" /><check system="C-76791r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that a policy exists that ensures when a user is created, it is creating using a method that forces a user to change their password upon their next login.
+
+If a policy does not exist, then this is a finding.</check-content></check></Rule></Group><Group id="V-77183"><title>SRG-OS-000383-GPOS-00166</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91879r3_rule" severity="medium" weight="10.0"><version>SLES-12-010670</version><title>If Network Security Services (NSS) is being used by the SUSE operating system it must prohibit the use of cached authentications after one day.</title><description>&lt;VulnDiscussion&gt;If cached authentication information is out of date, the validity of the authentication information may be questionable.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002007</ident><fixtext fixref="F-83879r2_fix">Configure NSS, if used by the SUSE operating system, to prohibit the use of cached authentications after one day. 
+
+Add or change the following line in "/etc/sssd/sssd.conf" just below the line "[nss]":
+
+memcache_timeout = 86400</fixtext><fix id="F-83879r2_fix" /><check system="C-76793r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>If Network Security Services (NSS) is being used by the SUSE operating system verify that it prohibits the use of cached authentications after one day.
+
+Check that cached authentications cannot be used after one day with the following command:
+
+# sudo grep -i "memcache_timeout" /etc/sssd/sssd.conf
+
+memcache_timeout = 86400
+
+If "memcache_timeout" has a value greater than "86400", or is missing, this is a finding.</check-content></check></Rule></Group><Group id="V-77185"><title>SRG-OS-000383-GPOS-00166</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91881r2_rule" severity="medium" weight="10.0"><version>SLES-12-010680</version><title>The SUSE operating system must configure the Linux Pluggable Authentication Modules (PAM) to prohibit the use of cached offline authentications after one day.</title><description>&lt;VulnDiscussion&gt;If cached authentication information is out of date, the validity of the authentication information may be questionable.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002007</ident><fixtext fixref="F-83881r2_fix">Configure the SUSE operating system PAM to prohibit the use of cached authentications after one day. 
+
+Add or change the following line in "/etc/sssd/sssd.conf" just below the line "[pam]":
+
+offline_credentials_expiration = 1</fixtext><fix id="F-83881r2_fix" /><check system="C-76795r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system Pluggable Authentication Modules (PAM) prohibits the use of cached off line authentications after one day.
+
+Check that cached off line authentications cannot be used after one day with the following command:
+
+# sudo grep "offline_credentials_expiration" /etc/sssd/sssd.conf
+
+offline_credentials_expiration = 1
+
+If "offline_credentials_expiration" is not set to a value of "1", this is a finding.</check-content></check></Rule></Group><Group id="V-77187"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91883r3_rule" severity="medium" weight="10.0"><version>SLES-12-010690</version><title>All SUSE operating system files and directories must have a valid owner.</title><description>&lt;VulnDiscussion&gt;Unowned files and directories may be unintentionally inherited if a user is assigned the same User Identifier (UID) as the UID of the unowned files.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002165</ident><fixtext fixref="F-83883r1_fix">Either remove all files and directories from the SUSE operating system that do not have a valid user, or assign a valid user to all unowned files and directories on the system with the "chown" command:
+
+# sudo chown &lt;user&gt; &lt;file&gt;</fixtext><fix id="F-83883r1_fix" /><check system="C-76797r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that all SUSE operating system files and directories on the system have a valid owner.
+
+Check the owner of all files and directories with the following command:
+
+Note: The value after -fstype must be replaced with the filesystem type. XFS is used as an example.
+
+# find / -fstype xfs -nouser
+
+If any files on the system do not have an assigned owner, this is a finding.</check-content></check></Rule></Group><Group id="V-77193"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91889r2_rule" severity="medium" weight="10.0"><version>SLES-12-010700</version><title>All SUSE operating system files and directories must have a valid group owner.</title><description>&lt;VulnDiscussion&gt;Files without a valid group owner may be unintentionally inherited if a group is assigned the same Group Identifier (GID) as the GID of the files without a valid group owner.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002165</ident><fixtext fixref="F-83885r1_fix">Either remove all files and directories from the SUSE operating system that do not have a valid group, or assign a valid group to all files and directories on the system with the "chgrp" command:
+
+# sudo chgrp &lt;group&gt; &lt;file&gt;</fixtext><fix id="F-83885r1_fix" /><check system="C-76799r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify all SUSE operating system files and directories on the system have a valid group.
+
+Check the owner of all files and directories with the following command:
+
+Note: The value after -fstype must be replaced with the filesystem type. XFS is used as an example.
+
+# find / -fstype xfs -nogroup
+
+If any files on the system do not have an assigned group, this is a finding.</check-content></check></Rule></Group><Group id="V-77197"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91893r1_rule" severity="medium" weight="10.0"><version>SLES-12-010710</version><title>All SUSE operating system local interactive users must have a home directory assigned in the /etc/passwd file.</title><description>&lt;VulnDiscussion&gt;If local interactive users are not assigned a valid home directory, there is no place for the storage and control of files they should own.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83887r1_fix">Assign home directories to all SUSE operating system local interactive users that currently do not have a home directory assigned.
+
+Assign a home directory to users via the usermod command:
+
+# usermod -d /home/smithj smithj</fixtext><fix id="F-83887r1_fix" /><check system="C-76801r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify SUSE operating system local interactive users on the system have a home directory assigned.
+
+Check for missing local interactive user home directories with the following command:
+
+# sudo pwck -r
+user 'smithj': directory '/home/smithj' does not exist
+
+Ask the System Administrator (SA) if any users found without home directories are local interactive users. If the SA is unable to provide a response, check for users with a User Identifier (UID) of 1000 or greater with the following command:
+
+# sudo cut -d: -f 1,3 /etc/passwd | egrep ":[1-4][0-9]{2}$|:[0-9]{1,2}$"
+
+If any interactive users do not have a home directory assigned, this is a finding.</check-content></check></Rule></Group><Group id="V-77199"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91895r1_rule" severity="medium" weight="10.0"><version>SLES-12-010720</version><title>All SUSE operating system local interactive user accounts, upon creation, must be assigned a home directory.</title><description>&lt;VulnDiscussion&gt;If local interactive users are not assigned a valid home directory, there is no place for the storage and control of files they should own.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83889r1_fix">Configure the SUSE operating system to assign home directories to all new local interactive users by setting the "CREATE_HOME" parameter in "/etc/login.defs" to "yes" as follows.
+
+CREATE_HOME yes</fixtext><fix id="F-83889r1_fix" /><check system="C-76803r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify all SUSE operating system local interactive users on the system are assigned a home directory upon creation.
+
+Check to see if the system is configured to create home directories for local interactive users with the following command:
+
+# grep -i create_home /etc/login.defs
+CREATE_HOME yes
+
+If the value for "CREATE_HOME" parameter is not set to "yes", the line is missing, or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77203"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91899r1_rule" severity="medium" weight="10.0"><version>SLES-12-010730</version><title>All SUSE operating system local interactive user home directories defined in the /etc/passwd file must exist.</title><description>&lt;VulnDiscussion&gt;If a local interactive user has a home directory defined that does not exist, the user may be given access to the / directory as the current working directory upon logon. This could create a Denial of Service because the user would not be able to access their logon configuration files, and it may give them visibility to system files they normally would not be able to access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83891r1_fix">Create home directories to all SUSE operating system local interactive users that currently do not have a home directory assigned. Use the following commands to create the user home directory assigned in "/etc/ passwd":
+
+Note: The example will be for the user smithj, who has a home directory of "/home/smithj", a UID of "smithj", and a Group Identifier (GID) of "users assigned" in "/etc/passwd".
+
+# mkdir /home/smithj 
+# chown smithj /home/smithj
+# chgrp users /home/smithj
+# chmod 0750 /home/smithj</fixtext><fix id="F-83891r1_fix" /><check system="C-76805r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the assigned home directory of all SUSE operating system local interactive users on the system exists.
+
+Check the home directory assignment for all local interactive non-privileged users on the system with the following command:
+
+# egrep ':[1-9][0-9]{3,4}' /etc/passwd | cut -d: -f1,6
+
+smithj /home/smithj
+
+Note: This may miss interactive users that have been assigned a privileged UID. Evidence of interactive use may be obtained from a number of log files containing system logon information.
+
+Check that all referenced home directories exist with the following command:
+
+# pwck -r
+
+user 'smithj': directory '/home/smithj' does not exist
+
+If any home directories referenced in "/etc/passwd" are returned as not defined, this is a finding.</check-content></check></Rule></Group><Group id="V-77207"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91903r3_rule" severity="medium" weight="10.0"><version>SLES-12-010740</version><title>All SUSE operating system local interactive user home directories must have mode 0750 or less permissive.</title><description>&lt;VulnDiscussion&gt;Excessive permissions on local interactive user home directories may allow unauthorized access to user files by other users.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83893r3_fix">Change the mode of SUSE operating system local interactive user's home directories to "0750". To change the mode of a local interactive user's home directory, use the following command:
+
+Note: The example will be for the user "smithj".
+
+# chmod 0750 /home/smithj</fixtext><fix id="F-83893r3_fix" /><check system="C-76807r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the assigned home directory of all SUSE operating system local interactive users has a mode of "0750" or less permissive.
+
+Check the home directory assignment for all non-privileged users on the system with the following command:
+
+Note: This may miss interactive users that have been assigned a privileged User Identifier (UID). Evidence of interactive use may be obtained from a number of log files containing system logon information.
+
+# ls -ld $(egrep ':[0-9]{4}' /etc/passwd | cut -d: -f6)
+-rwxr-x--- 1 smithj users  18 Mar  5 17:06 /home/smithj
+
+If home directories referenced in "/etc/passwd" do not have a mode of "0750" or less permissive, this is a finding.</check-content></check></Rule></Group><Group id="V-77211"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91907r2_rule" severity="medium" weight="10.0"><version>SLES-12-010750</version><title>All SUSE operating system local interactive user home directories must be group-owned by the home directory owners primary group.</title><description>&lt;VulnDiscussion&gt;If the Group Identifier (GID) of a local interactive user’s home directory is not the same as the primary GID of the user, this would allow unauthorized access to the user’s files, and users that share the same group may not be able to access files that they legitimately should.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83895r2_fix">Change the group owner of a SUSE operating system local interactive user's home directory to the group found in "/etc/passwd". To change the group owner of a local interactive user's home directory, use the following command:
+
+Note: The example will be for the user "smithj", who has a home directory of "/home/smithj", and has a primary group of users.
+
+# chgrp users /home/smithj</fixtext><fix id="F-83895r2_fix" /><check system="C-76809r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the assigned home directory of all SUSE operating system local interactive users is group-owned by that user's primary GID.
+
+Check the home directory assignment for all non-privileged users on the system with the following command:
+
+Note: This may miss local interactive users that have been assigned a privileged UID. Evidence of interactive use may be obtained from a number of log files containing system logon information. The returned directory "/home/smithj" is used as an example.
+
+# egrep ':[0-9]{4}' /etc/passwd | cut -d: -f4,6
+250:/home/smithj
+
+Check the user's primary group with the following command:
+
+# grep users /etc/group
+users:x:250:smithj,jonesj,jacksons
+
+If the user home directory referenced in "/etc/passwd" is not group-owned by that user's primary GID, this is a finding.</check-content></check></Rule></Group><Group id="V-77215"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91911r2_rule" severity="medium" weight="10.0"><version>SLES-12-010760</version><title>All SUSE operating system local initialization files must have mode 0740 or less permissive.</title><description>&lt;VulnDiscussion&gt;Local initialization files are used to configure the user's shell environment upon logon. Malicious modification of these files could compromise accounts upon logon.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83897r1_fix">Set the mode of SUSE operating system local initialization files to "0740" with the following command:
+
+Note: The example will be for the smithj user, who has a home directory of "/home/smithj".
+
+# chmod 0740 /home/smithj/.&lt;INIT_FILE&gt;</fixtext><fix id="F-83897r1_fix" /><check system="C-76811r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that all SUSE operating system local initialization files have a mode of "0740" or less permissive.
+
+Check the mode on all SUSE operating system local initialization files with the following command:
+
+Note: The example will be for the user "smithj", who has a home directory of "/home/smithj".
+
+# ls -al /home/smithj/.* | more
+-rwxr-xr-x  1 smithj users   896 Mar 10  2011 .profile
+-rwxr-xr-x  1 smithj users   497 Jan  6  2007 .login
+-rwxr-xr-x  1 smithj users   886 Jan  6  2007 .something
+
+If any local initialization files have a mode more permissive than "0740", this is a finding.</check-content></check></Rule></Group><Group id="V-77219"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91915r3_rule" severity="medium" weight="10.0"><version>SLES-12-010770</version><title>All SUSE operating system local interactive user initialization files executable search paths must contain only paths that resolve to the users home directory.</title><description>&lt;VulnDiscussion&gt;The executable search path (typically the PATH environment variable) contains a list of directories for the shell to search to find executables. If this path includes the current working directory (other than the user's home directory), executables in these directories may be executed instead of system commands. This variable is formatted as a colon-separated list of directories. If there is an empty entry, such as a leading or trailing colon or two consecutive colons, this is interpreted as the current working directory. If deviations from the default system search path for the local interactive user are required, they must be documented with the Information System Security Officer (ISSO).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83899r2_fix">Edit the SUSE operating system local interactive user initialization files to change any PATH variable statements for executables that reference directories other than their home directory. If a local interactive user requires path variables to reference a directory owned by the application, it must be documented with the ISSO.</fixtext><fix id="F-83899r2_fix" /><check system="C-76813r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that all SUSE operating system local interactive user initialization files executable search path statements do not contain statements that will reference a working directory other than the user's home directory.
+
+Check the executable search path statement for all operating system local interactive user initialization files in the users' home directory with the following commands:
+
+Note: The example will be for the user "smithj", who has a home directory of "/home/smithj".
+
+# sudo grep -i path /home/smithj/.*
+/home/smithj/.bash_profile:PATH=$PATH:$HOME/.local/bin:$HOME/bin
+/home/smithj/.bash_profile:export PATH
+
+If any local interactive user initialization files have executable search path statements that include directories outside of their home directory, and the additional path statements are not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.</check-content></check></Rule></Group><Group id="V-77225"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91921r1_rule" severity="medium" weight="10.0"><version>SLES-12-010780</version><title>All SUSE operating system local initialization files must not execute world-writable programs.</title><description>&lt;VulnDiscussion&gt;If user start-up files execute world-writable programs, especially in unprotected directories, they could be maliciously modified to destroy user files or otherwise compromise the system at the user level. If the system is compromised at the user level, it is easier to elevate privileges to eventually compromise the system at the root and network level.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83901r1_fix">Remove the world-writable permission of files referenced by SUSE operating system local initialization scripts, or remove the references to these files in the local initialization scripts.</fixtext><fix id="F-83901r1_fix" /><check system="C-76815r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that SUSE operating system local initialization files do not execute world-writable programs.
+
+For each home directory on the system make a list of files referenced within any local initialization script. Show the mode for each file and its parent directory.
+
+# FILES=".bashrc .bash_login .bash_logout .bash_profile .cshrc .kshrc .login .logout .profile .tcshrc .env .dtprofile .dispatch .emacs .exrc";
+
+# for HOMEDIR in `cut -d: -f6 /etc/passwd|sort|uniq`;do for INIFILE in $FILES;do REFLIST=`egrep " [\"~]?/" ${HOMEDIR}/${INIFILE} 2&gt;/dev/null|sed "s/.*\([~ \"]\/[\.0-9A-Za-z_\/\-]*\).*/\1/"`;for REFFILE in $REFLIST;do FULLREF=`echo $REFFILE|sed "s:\~:${HOMEDIR}:g"|sed "s:^\s*::g"`;dirname $FULLREF|xargs stat -c "dir:%a:%n";stat -c "file:%:%n" $FULLREF;done;done;
+done|sort|uniq
+
+If any local initialization file executes a world-writable program or script or a script from a world-writable directory, this is a finding.</check-content></check></Rule></Group><Group id="V-77229"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91925r2_rule" severity="medium" weight="10.0"><version>SLES-12-010790</version><title>SUSE operating system file systems that contain user home directories must be mounted to prevent files with the setuid and setgid bit set from being executed.</title><description>&lt;VulnDiscussion&gt;The "nosuid" mount option causes the system to not execute setuid and setgid files with owner privileges. This option must be used for mounting any file system not containing approved setuid and setguid files. Executing files from untrusted file systems increases the opportunity for unprivileged users to attain unauthorized administrative access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83903r1_fix">Configure the SUSE operating system "/etc/fstab" file to use the "nosuid" option on file systems that contain user home directories for interactive users.
+
+Re-mount the filesystems.
+
+# mount -o remount /home</fixtext><fix id="F-83903r1_fix" /><check system="C-76817r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that SUSE operating system file systems that contain user home directories are mounted with the "nosuid" option.
+
+Print the currently active file system mount options of the file system(s) that contain the user home directories with the following command:
+
+# for X in `egrep "^[^:]{1,}:x:[1-4][0-9]{3}:" /etc/passwd | cut -d: -f6`; do findmnt -nkT $X; done | sort -r
+/home  /dev/mapper/system-home ext4   rw,nosuid,relatime,data=ordered
+
+If a file system containing user home directories is not mounted with the FSTYPE OPTION nosuid, this is a finding.
+
+Note: If a separate file system has not been created for the user home directories (user home directories are mounted under "/"), this is not a finding as the "nosuid" option cannot be used on the "/" system.</check-content></check></Rule></Group><Group id="V-77237"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91933r2_rule" severity="medium" weight="10.0"><version>SLES-12-010800</version><title>SUSE operating system file systems that are used with removable media must be mounted to prevent files with the setuid and setgid bit set from being executed.</title><description>&lt;VulnDiscussion&gt;The "nosuid" mount option causes the system to not execute "setuid" and "setgid" files with owner privileges. This option must be used for mounting any file system not containing approved "setuid" and "setguid" files. Executing files from untrusted file systems increases the opportunity for unprivileged users to attain unauthorized administrative access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83905r1_fix">Configure the SUSE operating system "/etc/fstab" file to use the "nosuid" option on file systems that are associated with removable media.</fixtext><fix id="F-83905r1_fix" /><check system="C-76819r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that SUSE operating system file systems that are used for removable media are mounted with the "nouid" option.
+
+Check the file systems that are mounted at boot time with the following command:
+
+# more /etc/fstab
+
+UUID=2bc871e4-e2a3-4f29-9ece-3be60c835222    /mnt/usbflash   vfat   noauto,owner,ro,nosuid   0 0
+
+If a file system found in "/etc/fstab" refers to removable media and it does not have the "nosuid" option set, this is a finding.
+</check-content></check></Rule></Group><Group id="V-77241"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91937r2_rule" severity="medium" weight="10.0"><version>SLES-12-010810</version><title>SUSE operating system file systems that are being imported via Network File System (NFS) must be mounted to prevent files with the setuid and setgid bit set from being executed.</title><description>&lt;VulnDiscussion&gt;The "nosuid" mount option causes the system to not execute "setuid" and "setgid" files with owner privileges. This option must be used for mounting any file system not containing approved "setuid" and "setguid" files. Executing files from untrusted file systems increases the opportunity for unprivileged users to attain unauthorized administrative access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83907r1_fix">Configure the SUSE operating system "/etc/fstab" file to use the "nosuid" option on file systems that are being exported via NFS.</fixtext><fix id="F-83907r1_fix" /><check system="C-76821r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify SUSE operating system file systems that are being NFS exported are mounted with the "nosuid" option.
+
+Find the file system(s) that contain the directories being exported with the following command:
+
+# more /etc/fstab | grep nfs
+
+UUID=e06097bb-cfcd-437b-9e4d-a691f5662a7d   /store   nfs   rw,nosuid   0 0
+
+If a file system found in "/etc/fstab" refers to NFS and it does not have the "nosuid" option set, this is a finding.</check-content></check></Rule></Group><Group id="V-77251"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91947r2_rule" severity="medium" weight="10.0"><version>SLES-12-010820</version><title>SUSE operating system file systems that are being imported via Network File System (NFS) must be mounted to prevent binary files from being executed.</title><description>&lt;VulnDiscussion&gt;The "noexec" mount option causes the system to not execute binary files. This option must be used for mounting any file system not containing approved binary files as they may be incompatible. Executing files from untrusted file systems increases the opportunity for unprivileged users to attain unauthorized administrative access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83909r1_fix">Configure the SUSE operating system "/etc/fstab" file to use the "noexec" option on file systems that are being exported via NFS.</fixtext><fix id="F-83909r1_fix" /><check system="C-76823r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system file systems that are being NFS exported are mounted with the "noexec" option.
+
+Find the file system(s) that contain the directories being exported with the following command:
+
+# more /etc/fstab | grep nfs
+
+UUID=e06097bb-cfcd-437b-9e4d-a691f5662a7d   /store   nfs   rw,noexec   0 0
+
+If a file system found in "/etc/fstab" refers to NFS and it does not have the "noexec" option set, and use of NFS exported binaries is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.</check-content></check></Rule></Group><Group id="V-77253"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91949r1_rule" severity="medium" weight="10.0"><version>SLES-12-010830</version><title>All SUSE operating system world-writable directories must be group-owned by root, sys, bin, or an application group.</title><description>&lt;VulnDiscussion&gt;If a world-writable directory has the sticky bit set and is not group-owned by a privileged Group Identifier (GID), unauthorized users may be able to modify files created by others.
+
+The only authorized public directories are those temporary directories supplied with the system or those designed to be temporary file repositories. The setting is normally reserved for directories used by the system and by users for temporary file storage, (e.g., /tmp), and for directories requiring global read/write access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83911r1_fix">Change the group of the SUSE operating system world-writable directories to root with the following command:
+
+# chgrp root &lt;directory&gt;</fixtext><fix id="F-83911r1_fix" /><check system="C-76825r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify all SUSE operating system world-writable directories are group-owned by root, sys, bin, or an application group.
+
+Check the system for world-writable directories with the following command:
+
+Note: The value after -fstype must be replaced with the filesystem type. XFS is used as an example.
+
+# find / -xdev -perm -002 -type d -fstype xfs -exec ls -lLd {} \;
+drwxrwxrwt. 2 root root 40 Aug 26 13:07 /dev/mqueue
+drwxrwxrwt. 2 root root 220 Aug 26 13:23 /dev/shm
+drwxrwxrwt. 14 root root 4096 Aug 26 13:29 /tmp
+
+If any world-writable directories are not owned by root, sys, bin, or an application group associated with the directory, this is a finding.</check-content></check></Rule></Group><Group id="V-77257"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91953r2_rule" severity="medium" weight="10.0"><version>SLES-12-010840</version><title>SUSE operating system kernel core dumps must be disabled unless needed.</title><description>&lt;VulnDiscussion&gt;Kernel core dumps may contain the full contents of system memory at the time of the crash. Kernel core dumps may consume a considerable amount of disk space and may result in denial of service by exhausting the available space on the target file system partition.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83913r2_fix">If SUSE operating system kernel core dumps are not required, disable the "kdump" service with the following command:
+
+# systemctl disable kdump.service
+
+If kernel core dumps are required, document the need with the ISSO.</fixtext><fix id="F-83913r2_fix" /><check system="C-76827r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that SUSE operating system kernel core dumps are disabled unless needed.
+
+Check the status of the "kdump" service with the following command:
+
+# systemctl status kdump.service
+ Loaded: not-found (Reason: No such file or directory)
+   Active: inactive (dead)
+
+If the "kdump" service is active, ask the System Administrator if the use of the service is required and documented with the Information System Security Officer (ISSO).
+
+If the service is active and is not documented, this is a finding.</check-content></check></Rule></Group><Group id="V-77261"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91957r3_rule" severity="low" weight="10.0"><version>SLES-12-010850</version><title>A separate file system must be used for SUSE operating system user home directories (such as /home or an equivalent).</title><description>&lt;VulnDiscussion&gt;The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83915r1_fix">Create a separate file system/partition for SUSE operating system non-privileged local interactive user home directories.
+
+Migrate the non-privileged local interactive user home directories onto the separate file system/partition.</fixtext><fix id="F-83915r1_fix" /><check system="C-76829r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that a separate file system/partition has been created for SUSE operating system non-privileged local interactive user home directories.
+
+Check the home directory assignment for all non-privileged users (those with a UID greater than 1000) on the system with the following command:
+
+# cut -d: -f 1,3,6,7 /etc/passwd | egrep ":[1-4][0-9]{3}" | tr ":" "\t"
+
+adamsj 1002  /home/adamsj /bin/bash
+jacksonm 1003 /home/jacksonm /bin/bash
+smithj  1001 /home/smithj /bin/bash
+
+The output of the command will give the directory/partition that contains the home directories for the non-privileged users on the system (in this example, /home) and user's shell. All accounts with a valid shell (such as /bin/bash) are considered interactive users.
+
+Check that a file system/partition has been created for the non-privileged interactive users with the following command:
+
+Note: The partition of /home is used in the example.
+
+# grep /home /etc/fstab
+UUID=333ada18    /home   ext4   noatime,nobarrier,nodev   1 2
+
+If a separate entry for the file system/partition that contains the non-privileged interactive users' home directories does not exist, this is a finding.</check-content></check></Rule></Group><Group id="V-77265"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91961r2_rule" severity="low" weight="10.0"><version>SLES-12-010860</version><title>The SUSE operating system must use a separate file system for /var.</title><description>&lt;VulnDiscussion&gt;The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83917r1_fix">Create a separate file system/partition on the SUSE operating system for "/var".
+
+Migrate "/var" onto the separate file system/partition.</fixtext><fix id="F-83917r1_fix" /><check system="C-76831r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system has a separate file system/partition for "/var".
+
+Check that a file system/partition has been created for "/var" with the following command:
+
+# grep /var /etc/fstab
+UUID=c274f65f    /var   ext4   noatime,nobarrier   1 2
+
+If a separate entry for "/var" is not in use, this is a finding.</check-content></check></Rule></Group><Group id="V-77271"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91967r2_rule" severity="low" weight="10.0"><version>SLES-12-010870</version><title>The SUSE operating system must use a separate file system for the system audit data path.</title><description>&lt;VulnDiscussion&gt;The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83919r1_fix">Migrate the SUSE operating system audit data path onto a separate file system.</fixtext><fix id="F-83919r1_fix" /><check system="C-76833r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system has a separate file system/partition for the system audit data path.
+
+Check that a file system/partition has been created for the system audit data path with the following command:
+
+Note: "/var/log/audit" is used as the example as it is a common location.
+
+#grep /var/log/audit /etc/fstab
+UUID=3645951a   /var/log/audit   ext4   defaults   1 2
+
+If a separate entry for the system audit data path (in this example the "/var/log/audit" path) does not exist, ask the System Administrator if the system audit logs are being written to a different file system/partition on the system and then grep for that file system/partition. 
+
+If a separate file system/partition does not exist for the system audit data path, this is a finding.</check-content></check></Rule></Group><Group id="V-77273"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91969r1_rule" severity="medium" weight="10.0"><version>SLES-12-010880</version><title>SUSE operating system commands and libraries must have the proper permissions to protect from unauthorized access.</title><description>&lt;VulnDiscussion&gt;If the SUSE operating system were to allow any user to make changes to software libraries, those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to SUSE operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs that execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components to initiate changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001499</ident><fixtext fixref="F-83921r1_fix">Configure the SUSE operating system to prevent unauthorized users from accessing system command and library files.
+
+Set the correct permissions with the following command:
+
+# sudo chkstat --set --system</fixtext><fix id="F-83921r1_fix" /><check system="C-76835r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system prevents unauthorized users from accessing system command and library files.
+
+Check that all of the audit information files and folders have the correct permissions with the following command:
+
+# sudo chkstat --warn --system
+
+If the command returns any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77275"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91971r1_rule" severity="medium" weight="10.0"><version>SLES-12-010890</version><title>The SUSE operating system must prevent unauthorized users from accessing system error messages.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the SUSE operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001314</ident><fixtext fixref="F-83923r1_fix">Configure the SUSE operating system to prevent unauthorized users from accessing system error messages.
+
+Add or update the following rules in "/etc/permissions.local":
+
+/var/log/messages root:root 640
+
+Set the correct permissions with the following command:
+
+# sudo chkstat --set --system</fixtext><fix id="F-83923r1_fix" /><check system="C-76837r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system prevents unauthorized users from accessing system error messages.
+
+Check that "permissions.local" file contains the correct permissions rules with the following command:
+
+# grep -i messages /etc/permissions.local
+
+/var/log/messages root:root 640
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77285"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91981r2_rule" severity="medium" weight="10.0"><version>SLES-12-010910</version><title>The SUSE operating system must be configured to not overwrite Pluggable Authentication Modules (PAM) configuration on package changes.</title><description>&lt;VulnDiscussion&gt;"pam-config" is a command line utility that automatically generates a system PAM configuration as packages are installed, updated or removed from the system. "pam-config" removes configurations for PAM modules and parameters that it does not know about. It may render ineffective PAM configuration by the system administrator and thus impact system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-83927r2_fix">Remove the SUSE operating system soft links for the PAM configuration files with the following command:
+
+# find /etc/pam.d/ -type l -iname "common-*" -delete
+
+Copy the PAM configuration files to their static locations:
+
+# for X in /etc/pam.d/common-*-pc; do cp -ivp $X ${X:0:-3}; done
+
+Additional information on the configuration of multifactor authentication on the SUSE operating system can be found at https://www.suse.com/communities/blog/configuring-smart-card-authentication-suse-linux-enterprise/.</fixtext><fix id="F-83927r2_fix" /><check system="C-76841r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is configured to not overwrite Pluggable Authentication Modules (PAM) configuration on package changes.
+
+Check that soft links between PAM configuration files are removed with the following command:
+
+# find /etc/pam.d/ -type l -iname "common-*"
+
+If any results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-77287"><title>SRG-OS-000337-GPOS-00129</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91983r3_rule" severity="medium" weight="10.0"><version>SLES-12-020000</version><title>The SUSE operating system must have the auditing package installed.</title><description>&lt;VulnDiscussion&gt;Without establishing what type of events occurred, the source of events, where events occurred, and the outcome of events, it would be difficult to establish, correlate, and investigate the events leading up to an outage or attack.
+
+Audit record content that may be necessary to satisfy this requirement includes, for example, time stamps, source and destination addresses, user/process identifiers, event descriptions, success/fail indications, filenames involved, and access control or flow control rules invoked.
+
+Associating event types with detected events in the SUSE operating system audit logs provides a means of investigating an attack, recognizing resource utilization or capacity thresholds, or identifying an improperly configured SUSE operating system.
+
+Satisfies: SRG-OS-000337-GPOS-00129, SRG-OS-000348-GPOS-00136, SRG-OS-000349-GPOS-00137, SRG-OS-000350-GPOS-00138, SRG-OS-000351-GPOS-00139, SRG-OS-000352-GPOS-00140, SRG-OS-000353-GPOS-00141, SRG-OS-000354-GPOS-00142, SRG-OS-000358-GPOS-00145, SRG-OS-000359-GPOS-00146, SRG-OS-000365-GPOS-00152, SRG-OS-000474-GPOS-00219, SRG-OS-000475-GPOS-00220&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-001814</ident><ident system="http://iase.disa.mil/cci">CCI-001875</ident><ident system="http://iase.disa.mil/cci">CCI-001877</ident><ident system="http://iase.disa.mil/cci">CCI-001878</ident><ident system="http://iase.disa.mil/cci">CCI-001879</ident><ident system="http://iase.disa.mil/cci">CCI-001880</ident><ident system="http://iase.disa.mil/cci">CCI-001881</ident><ident system="http://iase.disa.mil/cci">CCI-001882</ident><ident system="http://iase.disa.mil/cci">CCI-001889</ident><ident system="http://iase.disa.mil/cci">CCI-001914</ident><fixtext fixref="F-83929r3_fix">The SUSE operating system auditd package must be installed on the system. If it is not installed, use the following command to install it:
+
+# sudo zypper in auditd</fixtext><fix id="F-83929r3_fix" /><check system="C-76843r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system auditing package is installed.
+
+Check that the "audit" package is installed by performing the following command:
+
+# zypper se audit 
+
+i | audit | User Space Tools for 2.6 Kernel Auditing 
+
+If the package "audit" is not installed on the system, then this is a finding.</check-content></check></Rule></Group><Group id="V-77289"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91985r1_rule" severity="medium" weight="10.0"><version>SLES-12-020010</version><title>SUSE operating system audit records must contain information to establish what type of events occurred, the source of events, where events occurred, and the outcome of events.</title><description>&lt;VulnDiscussion&gt;Without establishing what type of events occurred, the source of events, where events occurred, and the outcome of events, it would be difficult to establish, correlate, and investigate the events leading up to an outage or attack.
+
+Audit record content that may be necessary to satisfy this requirement includes, for example, time stamps, source and destination addresses, user/process identifiers, event descriptions, success/fail indications, filenames involved, and access control or flow control rules invoked.
+
+Associating event types with detected events in the SUSE operating system audit logs provides a means of investigating an attack, recognizing resource utilization or capacity thresholds, or identifying an improperly configured SUSE operating system.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000038-GPOS-00016, SRG-OS-000039-GPOS-00017, SRG-OS-000040-GPOS-00018, SRG-OS-000041-GPOS-00019, SRG-OS-000042-GPOS-00021, SRG-OS-000051-GPOS-00024, SRG-OS-000054-GPOS-00025, SRG-OS-000122-GPOS-00063, SRG-OS-000254-GPOS-00095, SRG-OS-000255-GPOS-00096, SRG-OS-000392-GPOS-00172, SRG-OS-000480-GPOS-00227&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000131</ident><ident system="http://iase.disa.mil/cci">CCI-000132</ident><ident system="http://iase.disa.mil/cci">CCI-000133</ident><ident system="http://iase.disa.mil/cci">CCI-000134</ident><ident system="http://iase.disa.mil/cci">CCI-000135</ident><ident system="http://iase.disa.mil/cci">CCI-000154</ident><ident system="http://iase.disa.mil/cci">CCI-000158</ident><ident system="http://iase.disa.mil/cci">CCI-000366</ident><ident system="http://iase.disa.mil/cci">CCI-001464</ident><ident system="http://iase.disa.mil/cci">CCI-001487</ident><ident system="http://iase.disa.mil/cci">CCI-001876</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83931r1_fix">Enable the SUSE operating system auditd service by performing the following commands:
+
+# sudo systemctl enable auditd.service
+# sudo systemctl start auditd.service</fixtext><fix id="F-83931r1_fix" /><check system="C-76845r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system produces audit records.
+
+Check that the SUSE operating system produces audit records by running the following command to determine the current status of the auditd service:
+
+# systemctl status auditd.service
+
+If the service is enabled, the returned message must contain the following text:
+
+Active: active (running)
+
+If the service is not running, this is a finding.</check-content></check></Rule></Group><Group id="V-77291"><title>SRG-OS-000341-GPOS-00132</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91987r3_rule" severity="medium" weight="10.0"><version>SLES-12-020020</version><title>The SUSE operating system must allocate audit record storage capacity to store at least one weeks worth of audit records when audit records are not immediately sent to a central audit record storage facility.</title><description>&lt;VulnDiscussion&gt;To ensure SUSE operating systems have a sufficient storage capacity in which to write the audit logs, SUSE operating systems need to be able to allocate audit record storage capacity.
+
+The task of allocating audit record storage capacity is usually performed during initial installation of the SUSE operating system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001849</ident><fixtext fixref="F-83933r1_fix">Allocate enough storage capacity for at least one week's worth of SUSE operating system audit records when audit records are not immediately sent to a central audit record storage facility.
+
+If audit records are stored on a partition made specifically for audit records, use the "YaST2 - Partitioner" program (installation and configuration tool for Linux) to resize the partition with sufficient space to contain one week's worth of audit records.
+
+If audit records are not stored on a partition made specifically for audit records, a new partition with sufficient amount of space will need be to be created. The new partition can be created using the "YaST2 - Partitioner" program on the system.</fixtext><fix id="F-83933r1_fix" /><check system="C-76847r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system allocates audit record storage capacity to store at least one week's worth of audit records when audit records are not immediately sent to a central audit record storage facility.
+
+Determine which partition the audit records are being written to with the following command:
+
+# sudo grep log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Check the size of the partition that audit records are written to (with the example being /var/log/audit/) with the following command:
+
+# df -h /var/log/audit/
+/dev/sda2 24G 10.4G 13.6G 43% /var/log/audit
+
+If the audit records are not written to a partition made specifically for audit records (/var/log/audit is a separate partition), determine the amount of space being used by other files in the partition with the following command:
+
+#du -sh [audit_partition]
+1.8G /var/log/audit
+
+The partition size needed to capture a week's worth of audit records is based on the activity level of the system and the total storage capacity available. In normal circumstances, 10.0 GB of storage space for audit records will be sufficient.
+
+If the audit record partition is not allocated sufficient storage capacity, this is a finding.</check-content></check></Rule></Group><Group id="V-77293"><title>SRG-OS-000343-GPOS-00134</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91989r1_rule" severity="medium" weight="10.0"><version>SLES-12-020030</version><title>The SUSE operating system auditd service must notify the System Administrator (SA) and Information System Security Officer (ISSO) immediately when audit storage capacity is 75 percent full.</title><description>&lt;VulnDiscussion&gt;If security personnel are not notified immediately when storage volume reaches 75 percent utilization, they are unable to plan for audit record storage capacity expansion.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001855</ident><fixtext fixref="F-83935r1_fix">Edit the SUSE operating system "/etc/audit/auditd.conf" by adding or editing the following line:
+
+space_left = 75</fixtext><fix id="F-83935r1_fix" /><check system="C-76849r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Determine if the SUSE operating system auditd is configured to notify the System Administrator (SA) and Information System Security Officer (ISSO) when the audit record storage volume reaches 75 percent of the storage capacity: 
+
+# sudo grep space_left /etc/audit/auditd.conf
+
+space_left = 75
+
+If "space_left" is not set to "75", this is a finding.</check-content></check></Rule></Group><Group id="V-77295"><title>SRG-OS-000046-GPOS-00022</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91991r2_rule" severity="medium" weight="10.0"><version>SLES-12-020040</version><title>The Information System Security Officer (ISSO) and System Administrator (SA), at a minimum, must be alerted of a SUSE operating system audit processing failure event.</title><description>&lt;VulnDiscussion&gt;It is critical for the appropriate personnel to be aware if a system is at risk of failing to process audit logs as required. Without this notification, the security personnel may be unaware of an impending failure of the audit capability, and system operation may be adversely affected.
+
+Audit processing failures include software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded.
+
+This requirement applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the centralized audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000139</ident><fixtext fixref="F-83937r1_fix">Configure the auditd service to notify the administrators in the event of a SUSE operating system audit processing failure. 
+
+Edit the following line in "/etc/audit/auditd.conf" to ensure that administrators are notified via email for those situations:
+
+action_mail_acct = root</fixtext><fix id="F-83937r1_fix" /><check system="C-76851r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the administrators are notified in the event of a SUSE operating system audit processing failure by inspecting "/etc/audit/auditd.conf".
+
+Check if the system is configured to send email to an account when it needs to notify an administrator with the following command: 
+
+sudo grep action_mail /etc/audit/auditd.conf
+
+action_mail_acct = root
+
+If the value of the "action_mail_acct" keyword is not set to "root" and/or other accounts for security personnel, the "action_mail_acct" keyword is missing, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77297"><title>SRG-OS-000046-GPOS-00022</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91993r2_rule" severity="medium" weight="10.0"><version>SLES-12-020050</version><title>The Information System Security Officer (ISSO) and System Administrator (SA), at a minimum, must have mail aliases to be notified of a SUSE operating system audit processing failure.</title><description>&lt;VulnDiscussion&gt;It is critical for the appropriate personnel to be aware if a system is at risk of failing to process audit logs as required. Without this notification, the security personnel may be unaware of an impending failure of the audit capability, and system operation may be adversely affected.
+
+Audit processing failures include software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded.
+
+This requirement applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the centralized audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000139</ident><fixtext fixref="F-83939r1_fix">Configure the auditd service to notify the administrators in the event of a SUSE operating system audit processing failure. 
+
+Configure "/etc/aliases" to define a value for root (if it does not already exist). Add the following line in "/etc/aliases":
+
+postmaster: root</fixtext><fix id="F-83939r1_fix" /><check system="C-76853r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the administrators are notified in the event of a SUSE operating system audit processing failure by checking that "/etc/aliases" has a defined value for root.
+
+# grep postmaster /etc/aliases
+
+postmaster:      root
+
+If the above command does not return a value of "root", this is a finding.</check-content></check></Rule></Group><Group id="V-77299"><title>SRG-OS-000047-GPOS-00023</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91995r1_rule" severity="medium" weight="10.0"><version>SLES-12-020060</version><title>The SUSE operating system audit system must take appropriate action when the audit storage volume is full.</title><description>&lt;VulnDiscussion&gt;It is critical that when the SUSE operating system is at risk of failing to process audit logs as required, it takes action to mitigate the failure. Audit processing failures include software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded. Responses to audit failure depend on the nature of the failure mode.
+
+When availability is an overriding concern, other approved actions in response to an audit failure are as follows: 
+
+1) If the failure was caused by the lack of audit record storage capacity, the SUSE operating system must continue generating audit records if possible (automatically restarting the audit service if necessary), overwriting the oldest audit records in a first-in-first-out manner.
+
+2) If audit records are sent to a centralized collection server and communication with this server is lost or the server fails, the SUSE operating system must queue audit records locally until communication is restored or until the audit records are retrieved manually. Upon restoration of the connection to the centralized collection server, action should be taken to synchronize the local audit data with the collection server.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000140</ident><fixtext fixref="F-83941r1_fix">Configure the SUSE operating system to shut down by default upon audit failure (unless availability is an overriding concern).
+
+Add or update the following line (depending on configuration "disk_full_action" can be set to "SYSLOG", "SINGLE", or "HALT" depending on configuration) in "/etc/audit/auditd.conf" file:
+
+disk_full_action = HALT</fixtext><fix id="F-83941r1_fix" /><check system="C-76855r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system takes the appropriate action when the audit storage volume is full. 
+
+Check that the SUSE operating system takes the appropriate action when the audit storage volume is full with the following command:
+
+# sudo grep disk_full_action /etc/audit/auditd.conf
+
+disk_full_action = SYSLOG
+
+If the value of the "disk_full_action" option is not "SYSLOG", "SINGLE", or "HALT", or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77301"><title>SRG-OS-000342-GPOS-00133</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91997r1_rule" severity="medium" weight="10.0"><version>SLES-12-020070</version><title>The audit-audispd-plugins must be installed on the SUSE operating system.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001851</ident><fixtext fixref="F-83943r1_fix">Install the "audit-audispd-plugins" package on the SUSE operating system by running the following command:
+
+# sudo zypper install audit-audispd-plugins</fixtext><fix id="F-83943r1_fix" /><check system="C-76857r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the "audit-audispd-plugins" package is installed on the SUSE operating. 
+
+Check that the "audit-audispd-plugins" package is installed on the SUSE operating system with the following command:
+
+# zypper se audit-audispd-plugins
+
+If the "audit-audispd-plugins" package is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-77303"><title>SRG-OS-000342-GPOS-00133</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-91999r2_rule" severity="low" weight="10.0"><version>SLES-12-020080</version><title>The SUSE operating system audit event multiplexor must be configured to use Kerberos.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Allowing devices and users to connect to or from the system without first authenticating them allows untrusted access and can lead to a compromise or attack. Audit events may include sensitive data must be encrypted prior to transmission. Kerberos provides a mechanism to provide both authentication and encryption for audit event records.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001851</ident><fixtext fixref="F-83945r2_fix">Configure the SUSE operating system audit event multiplexor to use Kerberos by editing the "/etc/audisp/audisp-remote.conf" file. 
+
+Edit or add the following line to match the text below:
+
+enable_krb5 = yes</fixtext><fix id="F-83945r2_fix" /><check system="C-76859r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Determine if the SUSE operating system audit event multiplexor is configured to use Kerberos by running the following command:
+
+# sudo cat /etc/audisp/audisp-remote.conf | grep enable_krb5
+enable_krb5 = yes
+
+If "enable-krb5" is not set to "yes", this is a finding.</check-content></check></Rule></Group><Group id="V-77305"><title>SRG-OS-000342-GPOS-00133</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92001r1_rule" severity="low" weight="10.0"><version>SLES-12-020090</version><title>Audispd must off-load audit records onto a different system or media from the SUSE operating system being audited.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001851</ident><fixtext fixref="F-83947r1_fix">Configure the SUSE operating system "/etc/audisp/audisp-remote.conf" file to off-load audit records onto a different system or media by adding or editing the following line with the correct IP address:
+
+remote_server = [IP ADDRESS]</fixtext><fix id="F-83947r1_fix" /><check system="C-76861r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify "audispd" off-loads audit records onto a different system or media from the SUSE operating system being audited.
+
+Check if "audispd" is configured to off-load audit records onto a different system or media from the SUSE operating system by running the following command:
+
+# sudo cat /etc/audisp/audisp-remote.conf | grep remote_server
+remote_server = 192.168.1.101
+
+If "remote_server" is not set to an external server or media, this is a finding.</check-content></check></Rule></Group><Group id="V-77307"><title>SRG-OS-000479-GPOS-00224</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92003r2_rule" severity="medium" weight="10.0"><version>SLES-12-020100</version><title>The SUSE operating system must off-load audit records onto a different system or media from the system being audited.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001851</ident><fixtext fixref="F-83949r1_fix">Configure the SUSE operating system to take the appropriate action if it cannot off-load audit records to a different system or storage media from the system being audited due to a network failure.
+
+Uncomment the "network_failure_action" option in "/etc/audisp/audisp-remote.conf" and set it to "syslog", "single", or "halt". See the example below:
+
+network_failure_action = syslog</fixtext><fix id="F-83949r1_fix" /><check system="C-76863r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify what action the audit system takes if it cannot off-load audit records to a different system or storage media from the SUSE operating system being audited.
+
+Check the action that the audit system takes in the event of a network failure with the following command:
+
+# sudo grep -i "network_failure_action" /etc/audisp/audisp-remote.conf
+
+network_failure_action = syslog
+
+If the "network_failure_action" option is not set to "syslog", "single", or "halt" or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77309"><title>SRG-OS-000479-GPOS-00224</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92005r1_rule" severity="medium" weight="10.0"><version>SLES-12-020110</version><title>Audispd must take appropriate action when the SUSE operating system audit storage is full.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001851</ident><fixtext fixref="F-83951r1_fix">Configure the SUSE operating system to take the appropriate action if the audit storage is full.
+
+Add, edit, or uncomment the "disk_full_action" option in "/etc/audisp/audisp-remote.conf". Set it to "syslog", "single" or "halt" as in the example below:
+
+disk_full_action = syslog</fixtext><fix id="F-83951r1_fix" /><check system="C-76865r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the audit system off-loads audit records if the SUSE operating system storage volume becomes full.
+
+Check that the records are properly off-loaded to a remote server with the following command:
+
+# sudo grep -i "disk_full_action" /etc/audisp/audisp-remote.conf
+disk_full_action = syslog
+
+If "disk_full_action" is not set to "syslog", "single", or "halt" or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77311"><title>SRG-OS-000057-GPOS-00027</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92007r1_rule" severity="medium" weight="10.0"><version>SLES-12-020120</version><title>The SUSE operating system must protect audit rules from unauthorized modification.</title><description>&lt;VulnDiscussion&gt;Without the capability to restrict which roles and individuals can select which events are audited, unauthorized personnel may be able to prevent the auditing of critical events. Misconfigured audits may degrade the system's performance by overwhelming the audit log. Misconfigured audits may also make it more difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000162</ident><ident system="http://iase.disa.mil/cci">CCI-000163</ident><ident system="http://iase.disa.mil/cci">CCI-000164</ident><fixtext fixref="F-83953r1_fix">Configure the SUSE operating system to protect audit rules from unauthorized modification.
+
+Add or update the following rules in "/etc/permissions.local":
+
+/var/log/audit root:root 600
+/var/log/audit/audit.log root:root 600
+/etc/audit/audit.rules root:root 640
+
+Set the correct permissions with the following command:
+
+# sudo chkstat --set /etc/permissions.local</fixtext><fix id="F-83953r1_fix" /><check system="C-76867r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system protects audit rules from unauthorized modification.
+
+Check that "permissions.local" file contains the correct permissions rules with the following command:
+
+# grep -i audit /etc/permissions.local
+
+/var/log/audit root:root 600
+/var/log/audit/audit.log root:root 600
+/etc/audit/audit.rules root:root 640
+
+If the command does not return any output, this is a finding.
+
+Check that all of the audit information files and folders have the correct permissions with the following command:
+
+# sudo chkstat /etc/permissions.local
+
+If the command returns any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77313"><title>SRG-OS-000256-GPOS-00097</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92009r2_rule" severity="medium" weight="10.0"><version>SLES-12-020130</version><title>The SUSE operating system audit tools must have the proper permissions configured to protect against unauthorized access.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information.
+
+SUSE operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys to make access decisions regarding the access to audit tools.
+
+Audit tools include but are not limited to vendor-provided and open-source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.
+
+Satisfies: SRG-OS-000256-GPOS-00097, SRG-OS-000257-GPOS-00098, SRG-OS-000258-GPOS-00099&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001493</ident><ident system="http://iase.disa.mil/cci">CCI-001494</ident><ident system="http://iase.disa.mil/cci">CCI-001495</ident><fixtext fixref="F-83955r2_fix">Configure the SUSE operating system audit tools to have with proper permissions set in the permissions profile to protect from unauthorized access.
+
+Edit the file "/etc/permissions.local" and insert the following text:
+
+/usr/sbin/audispd       root:root 0750
+/usr/sbin/auditctl      root:root 0750
+/usr/sbin/auditd        root:root 0750
+/usr/sbin/ausearch      root:root 0755
+/usr/sbin/aureport      root:root 0755
+/usr/sbin/autrace       root:root 0750
+/usr/sbin/augenrules    root:root 0750Set the correct permissions with the following command:
+
+# sudo chkstat --set /etc/permissions.local</fixtext><fix id="F-83955r2_fix" /><check system="C-76869r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system audit tools have the proper permissions configured in the permissions profile to protect from unauthorized access.
+
+Check that "permissions.local" file contains the correct permissions rules with the following command:
+
+grep "^/usr/sbin/au" /etc/permissions.local
+
+/usr/sbin/audispd root:root 0750
+/usr/sbin/auditctl root:root 0750
+/usr/sbin/auditd root:root 0750
+/usr/sbin/ausearch root:root 0755
+/usr/sbin/aureport root:root 0755
+/usr/sbin/autrace root:root 0750
+/usr/sbin/augenrules root:root 0750
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77315"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92011r1_rule" severity="medium" weight="10.0"><version>SLES-12-020200</version><title>The SUSE operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes initial access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to simply create a new account. Auditing of account creation mitigates this risk.
+
+To address access requirements, many SUSE operating systems may be integrated with enterprise-level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000304-GPOS-00121, SRG-OS-000470-GPOS-00214, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000018</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-001403</ident><ident system="http://iase.disa.mil/cci">CCI-002130</ident><ident system="http://iase.disa.mil/cci">CCI-002132</ident><fixtext fixref="F-83957r1_fix">Configure the SUSE operating system to generate an audit record when all modifications to the "/etc/passwd" file occur.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-w /etc/passwd -p wa -k account_mod
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83957r1_fix" /><check system="C-76871r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when all modifications occur to the "/etc/passwd" file.
+
+Check that the following file is being watched by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep /etc/passwd /etc/audit/audit.rules
+
+-w /etc/passwd -p wa -k account_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77317"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92013r2_rule" severity="medium" weight="10.0"><version>SLES-12-020210</version><title>The SUSE operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/group.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes initial access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to simply create a new account. Auditing of account creation mitigates this risk.
+
+To address access requirements, many SUSE operating systems may be integrated with enterprise-level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000018</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-001403</ident><ident system="http://iase.disa.mil/cci">CCI-002130</ident><ident system="http://iase.disa.mil/cci">CCI-002132</ident><fixtext fixref="F-83959r1_fix">Configure the SUSE operating system to generate an audit record when all modifications to the "/etc/group" file occur.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-w /etc/group -p wa -k account_mod
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83959r1_fix" /><check system="C-76873r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when modifications occur to the "/etc/group" file.
+
+Check that the following file is being watched by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep /etc/group /etc/audit/audit.rules
+
+-w /etc/group -p wa -k account_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77319"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92015r3_rule" severity="medium" weight="10.0"><version>SLES-12-020220</version><title>The SUSE operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes initial access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to simply create a new account. Auditing of account creation mitigates this risk.
+
+To address access requirements, many SUSE operating systems may be integrated with enterprise-level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000018</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-001403</ident><ident system="http://iase.disa.mil/cci">CCI-002130</ident><ident system="http://iase.disa.mil/cci">CCI-002132</ident><fixtext fixref="F-83961r1_fix">Configure the SUSE operating system to generate an audit record when all modifications to the "/etc/shadow" file occur.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-w /etc/shadow -p wa -k account_mod
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83961r1_fix" /><check system="C-76875r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when modifications occur to the "/etc/shadow" file.
+
+Check that the following file is being watched by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep /etc/shadow /etc/audit/audit.rules
+
+-w /etc/shadow -p wa -k account_mod
+
+If the command does not return a line, or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77321"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92017r2_rule" severity="medium" weight="10.0"><version>SLES-12-020230</version><title>The SUSE operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/opasswd.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes initial access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to simply create a new account. Auditing of account creation mitigates this risk.
+
+To address access requirements, many SUSE operating systems may be integrated with enterprise-level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000018</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-001403</ident><ident system="http://iase.disa.mil/cci">CCI-002130</ident><ident system="http://iase.disa.mil/cci">CCI-002132</ident><fixtext fixref="F-83963r1_fix">Configure the SUSE operating system to generate an audit record when all modifications to the "/etc/security/opasswd" file occur.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-w /etc/security/opasswd -p wa -k account_mod
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83963r1_fix" /><check system="C-76877r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when modifications occur to the "/etc/security/opasswd" file.
+
+Check that the following file is being watched by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# grep /etc/security/opasswd /etc/audit/audit.rules
+
+-w /etc/security/opasswd -p wa -k account_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77323"><title>SRG-OS-000327-GPOS-00127</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92019r1_rule" severity="low" weight="10.0"><version>SLES-12-020240</version><title>The SUSE operating system must generate audit records for all uses of the privileged functions.</title><description>&lt;VulnDiscussion&gt;Misuse of privileged functions, either intentionally or unintentionally by authorized users, or by unauthorized external entities that have compromised information system accounts, is a serious and ongoing concern and can have significant adverse impacts on organizations. Auditing the use of privileged functions is one way to detect such misuse and identify the risk from insider threats and the advanced persistent threat.
+
+Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000337-GPOS-00129, SRG-OS-000348-GPOS-00136, SRG-OS-000349-GPOS-00137, SRG-OS-000350-GPOS-00138, SRG-OS-000351-GPOS-00139, SRG-OS-000352-GPOS-00140, SRG-OS-000353-GPOS-00141, SRG-OS-000354-GPOS-00142, SRG-OS-000358-GPOS-00145, SRG-OS-000359-GPOS-00146, SRG-OS-000365-GPOS-00152&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001814</ident><ident system="http://iase.disa.mil/cci">CCI-001875</ident><ident system="http://iase.disa.mil/cci">CCI-001877</ident><ident system="http://iase.disa.mil/cci">CCI-001878</ident><ident system="http://iase.disa.mil/cci">CCI-001879</ident><ident system="http://iase.disa.mil/cci">CCI-001880</ident><ident system="http://iase.disa.mil/cci">CCI-001881</ident><ident system="http://iase.disa.mil/cci">CCI-001882</ident><ident system="http://iase.disa.mil/cci">CCI-001889</ident><ident system="http://iase.disa.mil/cci">CCI-001914</ident><ident system="http://iase.disa.mil/cci">CCI-002234</ident><fixtext fixref="F-83965r1_fix">Configure the SUSE operating system to generate an audit record for all uses of privileged functions.
+
+Find relevant setuid programs using the following command once for each local system partition, replacing "[PARTITION]" with each local system partition:
+
+# sudo find [PARTITION] -xdev -type f \( -perm -4000 -o -perm -2000 \) 2&gt;/dev/null
+
+For every setuid program not covered by an audit rule for a subdirectory, add a line for each setuid program in "/etc/audit/audit.rules", replacing "[SETUID_FILE_PATH]" with the full path to the setuid program from the list above:
+
+-w [SETUID_FILE_PATH] -p wa -k privilege_function</fixtext><fix id="F-83965r1_fix" /><check system="C-76879r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when privileged functions are executed.
+
+Find relevant setuid programs using the following command once for each local system partition, replacing "[PARTITION]" with each local system partition:
+
+# sudo find [PARTITION] -xdev -type f \( -perm -4000 -o -perm -2000 \) 2&gt;/dev/null
+
+Verify all of the programs found with the command above are listed in the audit file by running the following command for every program found, replacing "[FILE_PATH]" with each program to include the full path:
+
+# grep [FILE_PATH] /etc/audit/audit.rules
+
+-w [SETUID_FILE_PATH] -p wa -k privilege_function
+
+All setuid programs on the system must have a corresponding audit rule, or there must be an audit rule for the subdirectory that contains the setuid file.
+
+If any of the setuid programs/files on the system do not have an audit rule, this is a finding.</check-content></check></Rule></Group><Group id="V-77325"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92021r2_rule" severity="medium" weight="10.0"><version>SLES-12-020250</version><title>The SUSE operating system must generate audit records for all uses of the su command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83967r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "su" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F -arch=b32 path=/usr/bin/su -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F -arch=b64 path=/usr/bin/su -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-priv_change
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-83967r2_fix" /><check system="C-76881r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for any use of the "su" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo egrep "\/usr\/bin\/su\s" /etc/audit/audit.rules
+
+-a always,exit -F -arch=b32 path=/usr/bin/su -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F -arch=b64 path=/usr/bin/su -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-priv_change
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77327"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92023r2_rule" severity="low" weight="10.0"><version>SLES-12-020260</version><title>The SUSE operating system must generate audit records for all uses of the sudo command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83969r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "sudo" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F -arch=b32 path=/usr/bin/sudo -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudo
+-a always,exit -F -arch=b64 path=/usr/bin/sudo -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudo
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83969r2_fix" /><check system="C-76883r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for any use of the "sudo" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i sudo /etc/audit/audit.rules
+
+-a always,exit -F -arch=b32 path=/usr/bin/sudo -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudo
+-a always,exit -F -arch=b64 path=/usr/bin/sudo -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudo
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77329"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92025r2_rule" severity="medium" weight="10.0"><version>SLES-12-020270</version><title>The SUSE operating system must generate audit records for all uses of the sudoedit command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83971r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "sudoedit" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F -arch=b32 path=/usr/bin/sudoedit -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudoedit
+-a always,exit -F -arch=b64 path=/usr/bin/sudoedit -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudoedit
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-83971r2_fix" /><check system="C-76885r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify an audit record is generated for all uses of the "sudoedit" command. 
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i 'sudoedit' /etc/audit/audit.rules
+
+-a always,exit -F -arch=b32 path=/usr/bin/sudoedit -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudoedit
+-a always,exit -F -arch=b64 path=/usr/bin/sudoedit -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-sudoedit
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77331"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92027r2_rule" severity="low" weight="10.0"><version>SLES-12-020280</version><title>The SUSE operating system must generate audit records for all uses of the chfn command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83973r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "chfn" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F -arch=b32 path=/usr/bin/chfn -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chfn
+-a always,exit -F -arch=b64 path=/usr/bin/chfn -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chfn
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83973r2_fix" /><check system="C-76887r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "chfn" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i chfn /etc/audit/audit.rules
+
+-a always,exit -F -arch=b32 path=/usr/bin/chfn -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chfn
+-a always,exit -F -arch=b64 path=/usr/bin/chfn -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chfn
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77333"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92029r2_rule" severity="low" weight="10.0"><version>SLES-12-020290</version><title>The SUSE operating system must generate audit records for all uses of the mount command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83975r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "mount" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=32 -S mount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=64 -S mount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-mount
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83975r2_fix" /><check system="C-76889r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "mount" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i mount /etc/audit/audit.rules
+
+-a always,exit -F arch=32 -S mount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=64 -S mount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-mount
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77335"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92031r2_rule" severity="low" weight="10.0"><version>SLES-12-020300</version><title>The SUSE operating system must generate audit records for all uses of the umount command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83977r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "umount" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=32 -S umount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-umount
+-a always,exit -F arch=64 -S umount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-umount
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83977r2_fix" /><check system="C-76891r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "umount" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i umount /etc/audit/audit.rules
+
+-a always,exit -F arch=32 -S umount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-umount
+-a always,exit -F arch=64 -S umount -F auid&gt;=1000 -F auid!=4294967295 -k privileged-umount
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77337"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92033r2_rule" severity="low" weight="10.0"><version>SLES-12-020310</version><title>The SUSE operating system must generate audit records for all uses of the ssh-agent command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83979r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "ssh-agent" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=32 path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-agent
+-a always,exit -F arch=64 path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-agent
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83979r2_fix" /><check system="C-76893r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "ssh-agent" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i ssh-agent /etc/audit/audit.rules
+
+-a always,exit -F arch=32 path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-agent
+-a always,exit -F arch=64 path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-agent
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77339"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92035r2_rule" severity="low" weight="10.0"><version>SLES-12-020320</version><title>The SUSE operating system must generate audit records for all uses of the ssh-keysign command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83981r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "ssh-keysign" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=32 path=/usr/lib/ssh/ssh-keysign -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-keysign
+-a always,exit -F arch=64 path=/usr/lib/ssh/ssh-keysign -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-keysign
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-83981r2_fix" /><check system="C-76895r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "ssh-keysign" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i ssh-keysign /etc/audit/audit.rules
+
+-a always,exit -F arch=32 path=/usr/lib/ssh/ssh-keysign -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-keysign
+-a always,exit -F arch=64 path=/usr/lib/ssh/ssh-keysign -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-ssh-keysign
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77341"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92037r1_rule" severity="medium" weight="10.0"><version>SLES-12-020330</version><title>The SUSE operating system must generate audit records for all uses of the insmod command.</title><description>&lt;VulnDiscussion&gt;Without the capability to generate audit records, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
+
+DoD has defined the following list of events for which the SUSE operating system will provide an audit record generation capability: 
+
+1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
+
+2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
+
+3) All account creations, modifications, disabling, and terminations; and 
+
+4) All kernel module load, unload, and restart actions.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215, SRG-OS-000471-GPOS-00216, SRG-OS-000477-GPOS-00222&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83983r1_fix">Configure the SUSE operating system to audit the execution of the module management program "insmod" by adding the following line to "/etc/audit/audit.rules":
+
+-w /sbin/insmod -p x -k modules</fixtext><fix id="F-83983r1_fix" /><check system="C-76897r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is generates an audit record for all uses of the "insmod" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep insmod /etc/audit/audit.rules
+
+-w /sbin/insmod -p x -k modules
+
+If the system is configured to audit the execution of the module management program "insmod", the command will return a line. 
+
+If the command does not return a line, this is a finding.</check-content></check></Rule></Group><Group id="V-77343"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92039r1_rule" severity="medium" weight="10.0"><version>SLES-12-020340</version><title>The SUSE operating system must generate audit records for all uses of the rmmod command.</title><description>&lt;VulnDiscussion&gt;Without the capability to generate audit records, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
+
+DoD has defined the following list of events for which the SUSE operating system will provide an audit record generation capability: 
+
+1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
+
+2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
+
+3) All account creations, modifications, disabling, and terminations; and 
+
+4) All kernel module load, unload, and restart actions.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83985r1_fix">Configure the SUSE operating system to audit the execution of the module management program "rmmod" by adding the following line to "/etc/audit/audit.rules":
+
+-w /sbin/rmmod -p x -k modules</fixtext><fix id="F-83985r1_fix" /><check system="C-76899r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "rmmod" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep rmmod /etc/audit/audit.rules
+
+-w /sbin/rmmod -p x -k modules
+
+If the system is configured to audit the execution of the module management program "rmmod", the command will return a line. 
+
+If the command does not return a line, this is a finding.</check-content></check></Rule></Group><Group id="V-77345"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92041r1_rule" severity="medium" weight="10.0"><version>SLES-12-020350</version><title>The SUSE operating system must generate audit records for all uses of the modprobe command.</title><description>&lt;VulnDiscussion&gt;Without the capability to generate audit records, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
+
+DoD has defined the following list of events for which the SUSE operating system will provide an audit record generation capability: 
+
+1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
+
+2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
+
+3) All account creations, modifications, disabling, and terminations; and 
+
+4) All kernel module load, unload, and restart actions.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83987r1_fix">Configure the SUSE operating system to audit the execution of the module management program "modprobe" by adding the following line to "/etc/audit/audit.rules":
+
+-w /sbin/modprobe -p x -k modules</fixtext><fix id="F-83987r1_fix" /><check system="C-76901r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "modprobe" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep modprobe /etc/audit/audit.rules
+
+-w /sbin/modprobe -p x -k modules
+
+If the system is configured to audit the execution of the module management program "modprobe", the command will return a line. 
+
+If the command does not return a line, this is a finding.</check-content></check></Rule></Group><Group id="V-77347"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92043r1_rule" severity="medium" weight="10.0"><version>SLES-12-020360</version><title>The SUSE operating system must generate audit records for all uses of the kmod command.</title><description>&lt;VulnDiscussion&gt;Without the capability to generate audit records, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
+
+DoD has defined the following list of events for which the SUSE operating system will provide an audit record generation capability: 
+
+1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
+
+2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
+
+3) All account creations, modifications, disabling, and terminations; and 
+
+4) All kernel module load, unload, and restart actions.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83989r1_fix">Configure the SUSE operating system to audit the execution of the module management program "kmod" by adding the following line to "/etc/audit/audit.rules":
+
+-w /usr/bin/kmod -p x -k modules</fixtext><fix id="F-83989r1_fix" /><check system="C-76903r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "kmod" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep kmod /etc/audit/audit.rules
+
+-w /usr/bin/kmod -p x -k modules
+
+If the system is configured to audit the execution of the module management program "kmod", the command will return a line. 
+
+If the command does not return a line, this is a finding.</check-content></check></Rule></Group><Group id="V-77349"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92045r2_rule" severity="medium" weight="10.0"><version>SLES-12-020370</version><title>The SUSE operating system must generate audit records for all uses of the setxattr command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83991r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "setxattr" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-83991r2_fix" /><check system="C-76905r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "setxattr" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i setxattr /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77351"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92047r2_rule" severity="medium" weight="10.0"><version>SLES-12-020380</version><title>The SUSE operating system must generate audit records for all uses of the fsetxattr command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83993r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "fsetxattr" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-83993r2_fix" /><check system="C-76907r3_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "fsetxattr" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i fsetxattr /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77353"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92049r2_rule" severity="medium" weight="10.0"><version>SLES-12-020390</version><title>The SUSE operating system must generate audit records for all uses of the removexattr command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83995r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "removexattr" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-83995r2_fix" /><check system="C-76909r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "removexattr" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i removexattr /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77355"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92051r2_rule" severity="medium" weight="10.0"><version>SLES-12-020400</version><title>The SUSE operating system must generate audit records for all uses of the lremovexattr command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83997r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "lremovexattr" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-83997r2_fix" /><check system="C-76911r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "lremovexattr" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i lremovexattr /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77357"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92053r2_rule" severity="medium" weight="10.0"><version>SLES-12-020410</version><title>The SUSE operating system must generate audit records for all uses of the fremovexattr command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-83999r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "fremovexattr" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-83999r2_fix" /><check system="C-76913r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "fremovexattr" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i fremovexattr /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77359"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92055r2_rule" severity="medium" weight="10.0"><version>SLES-12-020420</version><title>The SUSE operating system must generate audit records for all uses of the chown command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84001r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "chown" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84001r2_fix" /><check system="C-76915r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "chown" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i chown /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77361"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92057r2_rule" severity="medium" weight="10.0"><version>SLES-12-020430</version><title>The SUSE operating system must generate audit records for all uses of the fchown command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84003r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "fchown" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S fchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84003r2_fix" /><check system="C-76917r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "fchown" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i fchown /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S fchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77363"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92059r2_rule" severity="medium" weight="10.0"><version>SLES-12-020440</version><title>The SUSE operating system must generate audit records for all uses of the lchown command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84005r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "lchown" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84005r2_fix" /><check system="C-76919r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "lchown" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i lchown /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77365"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92061r2_rule" severity="medium" weight="10.0"><version>SLES-12-020450</version><title>The SUSE operating system must generate audit records for all uses of the fchownat command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84007r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "fchownat" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S fchownat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchownat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84007r2_fix" /><check system="C-76921r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "fchownat" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i fchownat /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S fchownat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchownat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77367"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92063r2_rule" severity="medium" weight="10.0"><version>SLES-12-020460</version><title>The SUSE operating system must generate audit records for all uses of the chmod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84009r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "chmod" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84009r2_fix" /><check system="C-76923r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "chmod" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i chmod /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77369"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92065r2_rule" severity="medium" weight="10.0"><version>SLES-12-020470</version><title>The SUSE operating system must generate audit records for all uses of the fchmod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84011r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "fchmod" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84011r2_fix" /><check system="C-76925r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "fchmod" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i fchmod /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77371"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92067r2_rule" severity="medium" weight="10.0"><version>SLES-12-020480</version><title>The SUSE operating system must generate audit records for all uses of the fchmodat command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84013r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "fchmodat" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84013r2_fix" /><check system="C-76927r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "fchmodat" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i fchmodat /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77373"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92069r2_rule" severity="medium" weight="10.0"><version>SLES-12-020490</version><title>The SUSE operating system must generate audit records for all uses of the open command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84015r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "open" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84015r2_fix" /><check system="C-76929r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "open" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i open /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77375"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92071r2_rule" severity="medium" weight="10.0"><version>SLES-12-020500</version><title>The SUSE operating system must generate audit records for all uses of the truncate command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000458-GPOS-00203&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000172</ident><fixtext fixref="F-84017r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "truncate" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84017r2_fix" /><check system="C-76931r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "truncate" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i truncate /etc/audit/audit.rules
+
+
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77377"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92073r2_rule" severity="medium" weight="10.0"><version>SLES-12-020510</version><title>The SUSE operating system must generate audit records for all uses of the ftruncate command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84019r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "ftruncate" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84019r2_fix" /><check system="C-76933r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "ftruncate" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i ftruncate /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77379"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92075r2_rule" severity="medium" weight="10.0"><version>SLES-12-020520</version><title>The SUSE operating system must generate audit records for all uses of the creat command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84021r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "creat" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84021r2_fix" /><check system="C-76935r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "creat" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i creat /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77381"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92077r2_rule" severity="medium" weight="10.0"><version>SLES-12-020530</version><title>The SUSE operating system must generate audit records for all uses of the openat command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84023r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "openat" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84023r2_fix" /><check system="C-76937r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "openat" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i openat /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77383"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92079r2_rule" severity="medium" weight="10.0"><version>SLES-12-020540</version><title>The SUSE operating system must generate audit records for all uses of the open_by_handle_at command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84025r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "open_by_handle_at" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84025r2_fix" /><check system="C-76939r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "open_by_handle_at" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i open_by_handle_at /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77385"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92081r2_rule" severity="low" weight="10.0"><version>SLES-12-020550</version><title>The SUSE operating system must generate audit records for all uses of the passwd command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84159r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "passwd" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+-a always,exit -F arch=b32 path=/usr/bin/passwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F arch=b64 path=/usr/bin/passwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passwd
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-84159r2_fix" /><check system="C-76941r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "passwd" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i /usr/bin/passwd /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/passwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F arch=b64 path=/usr/bin/passwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passwd
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77387"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92083r2_rule" severity="low" weight="10.0"><version>SLES-12-020560</version><title>The SUSE operating system must generate audit records for all uses of the gpasswd command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84027r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "gpasswd" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=b32 path=/usr/bin/gpasswd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-gpasswd
+-a always,exit -F arch=b64 path=/usr/bin/gpasswd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-gpasswd
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-84027r2_fix" /><check system="C-76943r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "gpasswd" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i gpasswd /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/gpasswd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-gpasswd
+-a always,exit -F arch=b64 path=/usr/bin/gpasswd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-gpasswd
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77389"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92085r2_rule" severity="low" weight="10.0"><version>SLES-12-020570</version><title>The SUSE operating system must generate audit records for all uses of the newgrp command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84029r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "newgrp" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=b32 path=/usr/bin/newgrp -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-newgrp
+-a always,exit -F arch=b64 path=/usr/bin/newgrp -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-newgrp
+
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-84029r2_fix" /><check system="C-76945r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "newgrp" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i newgrp /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/newgrp -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-newgrp
+-a always,exit -F arch=b64 path=/usr/bin/newgrp -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-newgrp
+
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77391"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92087r2_rule" severity="low" weight="10.0"><version>SLES-12-020580</version><title>The SUSE operating system must generate audit records for a uses of the chsh command.</title><description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+At a minimum, the organization must audit the full-text recording of privileged commands. The organization must maintain audit trails in sufficient detail to reconstruct events to determine the cause and impact of compromise.
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84031r2_fix">Configure the SUSE operating system to generate an audit record for all uses the "chsh" command.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=b32 path=/usr/bin/chsh -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chsh
+-a always,exit -F arch=b64 path=/usr/bin/chsh -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chsh
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-84031r2_fix" /><check system="C-76947r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "chsh" command.
+
+Check that the following command call is being audited by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i chsh /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/chsh -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chsh
+-a always,exit -F arch=b64 path=/usr/bin/chsh -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chsh
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77393"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92089r1_rule" severity="medium" weight="10.0"><version>SLES-12-020590</version><title>The SUSE operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes initial access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to simply create a new account. Auditing of account creation mitigates this risk.
+
+To address access requirements, many SUSE operating systems may be integrated with enterprise-level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000018</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-001403</ident><ident system="http://iase.disa.mil/cci">CCI-002130</ident><fixtext fixref="F-84033r1_fix">Configure the SUSE operating system to generate an audit record when all modifications to the "/etc/gshadow" file occur.
+
+Add or update the following rule to "/etc/audit/audit.rules":
+
+-w /etc/gshadow -p wa -k account_mod
+
+The audit daemon must be restarted for any changes to take effect.</fixtext><fix id="F-84033r1_fix" /><check system="C-76949r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when all modifications occur to the "/etc/gshadow" file.
+
+Check that the following file is being watched by performing the following command on the system rules in "/etc/audit/audit.rules":
+
+# sudo grep /etc/gshadow /etc/audit/audit.rules
+
+-w /etc/gshadow -p wa -k account_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77395"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92091r2_rule" severity="medium" weight="10.0"><version>SLES-12-020600</version><title>The SUSE operating system must generate audit records for all uses of the chmod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84035r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "chmod" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/bin/chmod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/chmod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84035r2_fix" /><check system="C-76951r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "chmod" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i chmod /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/chmod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/chmod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77397"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92093r2_rule" severity="medium" weight="10.0"><version>SLES-12-020610</version><title>The SUSE operating system must generate audit records for all uses of the setfacl command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84037r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "setfacl" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/bin/setfacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/setfacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84037r2_fix" /><check system="C-76953r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "setfacl" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i setfacl /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/setfacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/setfacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77399"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92095r2_rule" severity="medium" weight="10.0"><version>SLES-12-020620</version><title>The SUSE operating system must generate audit records for all uses of the chacl command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84039r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "chacl" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/bin/chacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/chacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84039r2_fix" /><check system="C-76955r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "chacl" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i chacl /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/chacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/chacl -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77401"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92097r2_rule" severity="medium" weight="10.0"><version>SLES-12-020630</version><title>Successful/unsuccessful attempts to modify categories of information (e.g., classification levels) must generate audit records.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84041r2_fix">Configure the SUSE operating system to generate audit records when successful/unsuccessful attempts to modify categories of information (e.g., classification levels) occur. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/bin/chcon -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/chcon -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84041r2_fix" /><check system="C-76957r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify audit records are generated when successful/unsuccessful attempts to modify categories of information (e.g., classification levels) occur.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i 'chcon' /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/chcon -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/chcon -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77403"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92099r2_rule" severity="medium" weight="10.0"><version>SLES-12-020640</version><title>The SUSE operating system must generate audit records for all uses of the rm command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84043r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "rm" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/bin/rm -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/rm -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84043r2_fix" /><check system="C-76959r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "rm" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i rm /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/rm -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+-a always,exit -F arch=b64 path=/usr/bin/rm -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k prim_mod
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77405"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92101r1_rule" severity="medium" weight="10.0"><version>SLES-12-020650</version><title>The SUSE operating system must generate audit records for all modifications to the tallylog file must generate an audit record.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215, SRG-OS-000473-GPOS-00218&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84045r1_fix">Configure the SUSE operating system to generate an audit record for any all modifications to the "tallylog" file occur. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-w /var/log/tallylog -p wa -k logins
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84045r1_fix" /><check system="C-76961r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when all modifications to the "tallylog" file occur.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i tallylog /etc/audit/audit.rules
+
+-w /var/log/tallylog -p wa -k logins
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77407"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92103r1_rule" severity="medium" weight="10.0"><version>SLES-12-020660</version><title>The SUSE operating system must generate audit records for all modifications to the lastlog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84047r1_fix">Configure the SUSE operating system to generate an audit record for any all modifications to the "lastlog" file occur. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-w /var/log/lastlog -p wa -k logins
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84047r1_fix" /><check system="C-76963r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when all modifications to the "lastlog" file occur.
+
+Check that the following is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i lastlog /etc/audit/audit.rules
+
+-w /var/log/lastlog -p wa -k logins
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77409"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92105r2_rule" severity="medium" weight="10.0"><version>SLES-12-020670</version><title>The SUSE operating system must generate audit records for all uses of the passmass command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84049r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "passmass" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/bin/passmass -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passmass
+-a always,exit -F arch=b64 path=/usr/bin/passmass -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passmass
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84049r2_fix" /><check system="C-76965r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "passmass" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i passmass /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/passmass -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passmass
+-a always,exit -F arch=b64 path=/usr/bin/passmass -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passmass
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77411"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92107r2_rule" severity="medium" weight="10.0"><version>SLES-12-020680</version><title>The SUSE operating system must generate audit records for all uses of the unix_chkpwd command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84051r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "unix_chkpwd" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/sbin/unix_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix-chkpwd
+-a always,exit -F arch=b64 path=/sbin/unix_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix-chkpwd
+
+-a always,exit -F arch=b32 path=/sbin/unix2_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix2-chkpwd
+-a always,exit -F arch=b64 path=/sbin/unix2_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix2-chkpwd
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84051r2_fix" /><check system="C-76967r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify an audit record is generated for all uses of the "unix_chkpwd" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo egrep -i '(unix_chkpwd|unix2_chkpwd)' /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/sbin/unix_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix-chkpwd
+-a always,exit -F arch=b64 path=/sbin/unix_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix-chkpwd
+
+-a always,exit -F arch=b32 path=/sbin/unix2_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix2-chkpwd
+-a always,exit -F arch=b64 path=/sbin/unix2_chkpwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-unix2-chkpwd
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77413"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92109r2_rule" severity="medium" weight="10.0"><version>SLES-12-020690</version><title>The SUSE operating system must generate audit records for all uses of the chage command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84053r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "chage" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/bin/chage -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chage
+-a always,exit -F arch=b64 path=/usr/bin/chage -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chage
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84053r2_fix" /><check system="C-76969r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify an audit record is generated for all uses of the "chage" command. Perform the verification by running the following command:
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i 'chage' /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/chage -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chage
+-a always,exit -F arch=b64 path=/usr/bin/chage -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-chage
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77415"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92111r2_rule" severity="medium" weight="10.0"><version>SLES-12-020700</version><title>The SUSE operating system must generate audit records for all uses of the usermod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84055r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "usermod" command. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 path=/usr/sbin/usermod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-usermod
+-a always,exit -F arch=b64 path=/usr/sbin/usermod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-usermod
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84055r2_fix" /><check system="C-76971r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify an audit record is generated for all uses of the "usermod" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i 'usermod' /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/sbin/usermod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-usermod
+-a always,exit -F arch=b64 path=/usr/sbin/usermod -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-usermod
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77417"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92113r2_rule" severity="medium" weight="10.0"><version>SLES-12-020710</version><title>The SUSE operating system must generate audit records for all uses of the crontab command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84057r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "crontab" command.
+
+Add or update the following rules to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=b32 path=/usr/bin/crontab -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-crontab
+-a always,exit -F arch=b64 path=/usr/bin/crontab -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-crontab
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84057r2_fix" /><check system="C-76973r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify an audit record is generated for all uses of the "crontab" command.
+
+Check for the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i 'crontab' /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/usr/bin/crontab -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-crontab
+-a always,exit -F arch=b64 path=/usr/bin/crontab -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-crontab
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77419"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92115r2_rule" severity="medium" weight="10.0"><version>SLES-12-020720</version><title>The SUSE operating system must generate audit records for all uses of the pam_timestamp_check command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84059r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "pam_timestamp_check" command. Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+Add or update the following rules to "/etc/audit/audit.rules":
+
+-a always,exit -F arch=b32 path=/sbin/pam_timestamp_check -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-pam_timestamp_check
+-a always,exit -F arch=b64 path=/sbin/pam_timestamp_check -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-pam_timestamp_check
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84059r2_fix" /><check system="C-76975r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify an audit record is generated for all uses of the "pam_timestamp_check" command.
+
+Check for the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i 'pam_timestamp_check' /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 path=/sbin/pam_timestamp_check -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-pam_timestamp_check
+-a always,exit -F arch=b64 path=/sbin/pam_timestamp_check -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-pam_timestamp_check
+
+If command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77421"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92117r2_rule" severity="medium" weight="10.0"><version>SLES-12-020730</version><title>The SUSE operating system must generate audit records for all uses of the delete_module command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84061r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "delete_module" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k unload_module
+-a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k unload_module
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84061r2_fix" /><check system="C-76977r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "delete_module" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i delete_module /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k unload_module
+-a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k unload_module
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77423"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92119r2_rule" severity="medium" weight="10.0"><version>SLES-12-020740</version><title>The SUSE operating system must generate audit records for all uses of the finit_module command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84063r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "finit_module" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+-a always,exit -F arch=b64 -S finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84063r2_fix" /><check system="C-76979r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "finit_module" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i finit_module /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+-a always,exit -F arch=b64 -S finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77425"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92121r2_rule" severity="medium" weight="10.0"><version>SLES-12-020750</version><title>The SUSE operating system must generate audit records for all uses of the init_module command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84065r2_fix">Configure the SUSE operating system to generate an audit record for all uses of the "init_module" command. 
+
+Add or update the following rule in the "/etc/audit/audit.rules" file:
+
+-a always,exit -F arch=b32 -S init_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+-a always,exit -F arch=b64 -S init_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84065r2_fix" /><check system="C-76981r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record for all uses of the "init_module" command.
+
+Check that the following command call is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i init_module /etc/audit/audit.rules
+
+-a always,exit -F arch=b32 -S init_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+-a always,exit -F arch=b64 -S init_module -F auid&gt;=1000 -F auid!=4294967295 -k module-load
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77427"><title>SRG-OS-000037-GPOS-00015</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92123r1_rule" severity="medium" weight="10.0"><version>SLES-12-020760</version><title>The SUSE operating system must generate audit records for all modifications to the faillog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000062-GPOS-00031, SRG-OS-000392-GPOS-00172, SRG-OS-000462-GPOS-00206, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000130</ident><ident system="http://iase.disa.mil/cci">CCI-000169</ident><ident system="http://iase.disa.mil/cci">CCI-000172</ident><ident system="http://iase.disa.mil/cci">CCI-002884</ident><fixtext fixref="F-84067r1_fix">Configure the SUSE operating system to generate an audit record for any all modifications to the "faillog" file occur. 
+
+Add or update the following rules in the "/etc/audit/audit.rules" file:
+
+-w /var/log/faillog -p wa -k logins
+
+The audit daemon must be restarted for the changes to take effect.
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-84067r1_fix" /><check system="C-76983r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system generates an audit record when all modifications to the "faillog" file occur.
+
+Check that the following is being audited by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+
+# sudo grep -i faillog /etc/audit/audit.rules
+
+-w /var/log/faillog -p wa -k logins
+
+If the command does not return any output, this is a finding.</check-content></check></Rule></Group><Group id="V-77429"><title>SRG-OS-000074-GPOS-00042</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92125r1_rule" severity="medium" weight="10.0"><version>SLES-12-030000</version><title>The SUSE operating system must not have the telnet-server package installed.</title><description>&lt;VulnDiscussion&gt;It is detrimental for SUSE operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
+
+SUSE operating systems are capable of providing a wide variety of functions and services. Some of the functions and services, provided by default, may not be necessary to support essential organizational operations (e.g., key missions and functions).
+
+Examples of nonessential capabilities include but are not limited to games, software packages, tools, and demonstration software not related to requirements or providing a wide array of functionality not required for every mission but which cannot be disabled.
+
+Satisfies: SRG-OS-000074-GPOS-00042, SRG-OS-000095-GPOS-00049&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000197</ident><ident system="http://iase.disa.mil/cci">CCI-000381</ident><fixtext fixref="F-84069r1_fix">Remove the telnet-server package from the SUSE operating system by running the following command:
+
+# sudo zypper remove telnet-server</fixtext><fix id="F-84069r1_fix" /><check system="C-76985r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the telnet-server package is not installed on the SUSE operating system.
+
+Check that the telnet-server package is not installed on the SUSE operating system by running the following command:
+
+# zypper se telnet-server
+
+If the telnet-server package is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-77431"><title>SRG-OS-000023-GPOS-00006</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92127r3_rule" severity="medium" weight="10.0"><version>SLES-12-030010</version><title>The SUSE operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting access via SFTP/FTP.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for SUSE operating systems that can accommodate banners of 1300 characters:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000048</ident><fixtext fixref="F-84071r2_fix">Configure the SUSE operating system to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via VSFTP by running the following commands:
+
+Edit the "vsftpd.conf" file:
+
+# sudo sed -i 's/^.*\bftpd_banner\b.*$/ftpd_banner=\/etc\/issue/' /etc/vsftpd.conf
+
+Restart the vsftp daemon:
+
+# sudo systemctl restart vsftpd.service
+
+If "/etc/issue" does not contain the Standard Mandatory DoD banner, add the following text to "/etc/issue":
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."</fixtext><fix id="F-84071r2_fix" /><check system="C-76987r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via VSFTP.
+
+Check the issue file to verify that it contains one of the DoD-required banners. If it does not, this is a finding.
+
+# more /etc/issue
+
+The output must display the following DoD-required banner text. 
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+If the output does not display the banner text, this is a finding.
+
+Check the banner setting in vsftpd.conf:
+
+# sudo grep "ftpd_banner" /etc/vsftpd.conf
+
+The output must show the value of "ftpd_banner" set to "/etc/issue". An example is shown below:
+
+# sudo grep Banner" /etc/vsftpd.conf
+ftpd_banner=/etc/issue
+
+If the output does not show the value of "ftpd_banner" set to "/etc/issue", this is a finding.</check-content></check></Rule></Group><Group id="V-77433"><title>SRG-OS-000024-GPOS-00007</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92129r1_rule" severity="medium" weight="10.0"><version>SLES-12-030020</version><title>The SUSE operating system file /etc/gdm/banner must contain the Standard Mandatory DoD Notice and Consent banner text.</title><description>&lt;VulnDiscussion&gt;The banner must be acknowledged by the user prior to allowing the user access to the SUSE operating system. This provides assurance that the user has seen the message and accepted the conditions for access. If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.
+
+To establish acceptance of the application usage policy, a click-through banner at system logon is required. The system must prevent further activity until the user executes a positive action to manifest agreement by clicking on a box indicating "OK".&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000050</ident><fixtext fixref="F-84073r1_fix">Configure the SUSE operating system file "/etc/gdm/banner" to contain the Standard Mandatory DoD Notice and Consent Banner by running the following commands:
+
+# sudo vi /etc/gdm/banner
+
+Add the following information to the file:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."</fixtext><fix id="F-84073r1_fix" /><check system="C-76989r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system file "/etc/gdm/banner" contains the Standard Mandatory DoD Notice and Consent Banner text by running the following command:
+
+# more /etc/gdm/banner
+
+If the file does not contain the following text, this is a finding.
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."</check-content></check></Rule></Group><Group id="V-77435"><title>SRG-OS-000096-GPOS-00050</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92131r1_rule" severity="medium" weight="10.0"><version>SLES-12-030030</version><title>The SUSE operating system must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services as defined in the Ports, Protocols, and Services Management (PPSM) Category Assignments List (CAL) and vulnerability assessments.</title><description>&lt;VulnDiscussion&gt;To prevent unauthorized connection of devices, unauthorized transfer of information, or unauthorized tunneling (i.e., embedding of data types within data types), organizations must disable or restrict unused or unnecessary physical and logical ports/protocols on information systems.
+
+SUSE operating systems are capable of providing a wide variety of functions and services. Some of the functions and services provided by default may not be necessary to support essential organizational operations. Additionally, it is sometimes convenient to provide multiple services from a single component (e.g., VPN and IPS); however, doing so increases risk over limiting the services provided by any one component.
+
+To support the requirements and principles of least functionality, the SUSE operating system must support the organizational requirements, providing only essential capabilities and limiting the use of ports, protocols, and/or services to only those required, authorized, and approved to conduct official business or address authorized quality-of-life issues.
+
+Satisfies: SRG-OS-000096-GPOS-00050, SRG-OS-000297-GPOS-00115, SRG-OS-000480-GPOS-00231, SRG-OS-000480-GPOS-00232&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000382</ident><ident system="http://iase.disa.mil/cci">CCI-002080</ident><ident system="http://iase.disa.mil/cci">CCI-002314</ident><fixtext fixref="F-84075r1_fix">Configure the SUSE operating system is configured to prohibit or restrict the use of functions, ports, protocols, and/or services as defined in the Ports, Protocols, and Services Management (PPSM) Category Assignments List (CAL) and vulnerability assessments.
+
+Add/modify /etc/sysconfig/SuSEfirewall2 file to comply with the Ports, Protocols, and Services Management (PPSM) Category Assignments List (CAL).
+
+Enable the "SuSEfirewall2.service" by running the following command:
+
+# systemctl enable SuSEfirewall2.service
+
+Start the "SuSEfirewall2.service" by running the following command:
+
+# systemctl start SuSEfirewall2.service</fixtext><fix id="F-84075r1_fix" /><check system="C-76991r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is configured to prohibit or restrict the use of functions, ports, protocols, and/or services as defined in the Ports, Protocols, and Services Management (PPSM) Category Assignments List (CAL) and vulnerability assessments.
+
+Check that the "SuSEfirewall2.service" is enabled and running by running the following command:
+
+# systemctl status SuSEfirewall2.service
+* SuSEfirewall2.service - SuSEfirewall2 phase 2
+Loaded: loaded (/usr/lib/systemd/system/SuSEfirewall2.service; enabled; vendor preset: disabled)
+Active: active (exited) since Thu 2017-03-09 17:33:29 UTC; 6 days ago
+Main PID: 2533 (code=exited, status=0/SUCCESS)
+Tasks: 0 (limit: 512)
+Memory: 0B
+CPU: 0
+CGroup: /system.slice/SuSEfirewall2.service
+
+If the service is not enabled, this is a finding.
+
+If the service is not active, this is a finding.
+
+Check the firewall configuration for any unnecessary or prohibited functions, ports, protocols, and/or services by running the following command:
+
+# grep ^FW_ /etc/sysconfig/SuSEfirewall2
+
+Ask the System Administrator for the site or program PPSM Component Local Services Assessment (Component Local Services Assessment (CLSA). Verify the services allowed by the firewall match the PPSM CLSA. 
+
+If there are any additional ports, protocols, or services that are not included in the PPSM CLSA, this is a finding.
+
+If there are any ports, protocols, or services that are prohibited by the PPSM CAL, this is a finding.</check-content></check></Rule></Group><Group id="V-77437"><title>SRG-OS-000420-GPOS-00186</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92133r3_rule" severity="high" weight="10.0"><version>SLES-12-030040</version><title>SuSEfirewall2 must protect against or limit the effects of Denial-of-Service (DoS) attacks on the SUSE operating system by implementing rate-limiting measures on impacted network interfaces.</title><description>&lt;VulnDiscussion&gt;DoS is a condition when a resource is not available for legitimate users. When this occurs, the organization either cannot accomplish its mission or must operate at degraded capacity.
+
+This requirement addresses the configuration of the SUSE operating system to mitigate the impact on system availability of DoS attacks that have occurred or are ongoing. For each system, known and potential DoS attacks must be identified and solutions for each type implemented. A variety of technologies exist to limit or, in some cases, eliminate the effects of DoS attacks (e.g., limiting processes or establishing memory partitions). Employing increased capacity and bandwidth, combined with service redundancy, may reduce the susceptibility to some DoS attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002385</ident><fixtext fixref="F-84077r2_fix">Configure "SuSEfirewall2" to protect the SUSE operating system against or limit the effects of DoS attacks by implementing rate-limiting measures on impacted network interfaces.
+
+Add or replace the following line in "/etc/sysconfig/SuSEfirewall2":
+
+FW_SERVICES_ACCEPT_EXT="0/0,tcp,22,,hitcount=3,blockseconds=60,recentname=ssh"
+
+The firewall must be restarted in order for the changes to take effect.
+
+# sudo systemctl restart SuSEfirewall2.service</fixtext><fix id="F-84077r2_fix" /><check system="C-76993r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify "SuSEfirewall2" is configured to protect the SUSE operating system against or limit the effects of DoS attacks. 
+
+Run the following command:
+
+# grep -i fw_services_accept_ext /etc/sysconfig/SuSEfirewall2
+FW_SERVICES_ACCEPT_EXT="0/0,tcp,22,,hitcount=3,blockseconds=60,recentname=ssh"
+
+If the "FW_SERVICES_ACCEPT_EXT" rule does not contain both the "hitcount" and "blockseconds" parameters, this is a finding.</check-content></check></Rule></Group><Group id="V-77439"><title>SRG-OS-000023-GPOS-00006</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92135r3_rule" severity="medium" weight="10.0"><version>SLES-12-030050</version><title>The SUSE operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting access via SSH.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for SUSE operating systems that can accommodate banners of 1300 characters:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000048</ident><fixtext fixref="F-84079r2_fix">Configure the SUSE operating system to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system by running the following commands:
+
+Edit the "sshd_config" file and edit the Banner flag to be the following:
+
+Banner /etc/issue/
+
+Restart the sshd daemon:
+
+# sudo systemctl restart sshd.service
+
+To configure the system logon banner, edit the "/etc/issue" file. Replace the default text inside with the Standard Mandatory DoD banner text:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."</fixtext><fix id="F-84079r2_fix" /><check system="C-76995r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via SSH.
+
+Check the issue file to verify that it contains one of the DoD required banners. If it does not, this is a finding.
+
+# more /etc/issue
+
+The output must display the following DoD-required banner text. 
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+If the output does not display the banner text, this is a finding.
+
+Check the banner setting for sshd_config:
+
+# sudo grep "Banner" /etc/ssh/sshd_config
+
+The output must show the value of "Banner" set to "/etc/issue". An example is shown below:
+
+# sudo grep "Banner" /etc/ssh/sshd_config
+Banner /etc/issue
+
+If it does not, this is a finding.</check-content></check></Rule></Group><Group id="V-77441"><title>SRG-OS-000423-GPOS-00187</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92137r2_rule" severity="high" weight="10.0"><version>SLES-12-030100</version><title>All networked SUSE operating systems must have and implement SSH to protect the confidentiality and integrity of transmitted and received information, as well as information during preparation for transmission.</title><description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
+
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+
+Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, logical means (cryptography) do not have to be employed, and vice versa.
+
+Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188, SRG-OS-000425-GPOS-00189, SRG-OS-000426-GPOS-00190&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002418</ident><ident system="http://iase.disa.mil/cci">CCI-002420</ident><ident system="http://iase.disa.mil/cci">CCI-002421</ident><ident system="http://iase.disa.mil/cci">CCI-002422</ident><fixtext fixref="F-84081r2_fix">Note: If the system is not networked this requirement is Not Applicable.
+
+Configure the SUSE operating system to implement SSH to protect the confidentiality and integrity of transmitted and received information, as well as information during preparation for transmission.
+
+Install the OpenSSH package on the SUSE operating system with the following command:
+
+# sudo zypper in openssh
+
+Enable the OpenSSH service to start automatically on reboot with the following command:
+
+# sudo systemctl enable sshd.service
+
+For the changes to take effect immediately, start the service with the following command:
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-84081r2_fix" /><check system="C-76997r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Note: If the system is not networked this requirement is Not Applicable.
+
+Verify that the SUSE operating system implements SSH to protect the confidentiality and integrity of transmitted and received information, as well as information during preparation for transmission.
+
+Check that the OpenSSH package is installed on the SUSE operating system with the following command:
+
+# zypper se openssh
+
+S | Name                  | Summary                                                                     | Type
+--+---------------- --+------------------------------------------------------+--------
+i | openssh              | Secure Shell Client and Server (Remote L-&gt; | package
+
+If the OpenSSH package is not installed, this is a finding.
+
+Check that the OpenSSH service active on the SUSE operating system with the following command:
+
+# systemctl status sshd.service | grep -i "active:"
+
+Active: active (running) since Thu 2017-01-12 15:03:38 UTC; 1 months 4 days ago
+
+If OpenSSH service is not active, this is a finding.</check-content></check></Rule></Group><Group id="V-77443"><title>SRG-OS-000032-GPOS-00013</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92139r1_rule" severity="medium" weight="10.0"><version>SLES-12-030110</version><title>The SUSE operating system must log SSH connection attempts and failures to the server.</title><description>&lt;VulnDiscussion&gt;Remote access services, such as those providing remote access to network devices and information systems, which lack automated monitoring capabilities, increase risk and make remote user access management difficult at best.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, nonorganization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Automated monitoring of remote access sessions allows organizations to detect cyber attacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote access capabilities, such as Remote Desktop Protocol (RDP), on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000067</ident><fixtext fixref="F-84083r1_fix">Configure SSH to verbosely log connection attempts and failed logon attempts to the SUSE operating system.
+
+Add or update the following line in the "/etc/ssh/sshd_config" file:
+
+LogLevel VERBOSE
+
+The SSH service will need to be restarted in order for the changes to take effect.</fixtext><fix id="F-84083r1_fix" /><check system="C-76999r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify SSH is configured to verbosely log connection attempts and failed logon attempts to the SUSE operating system.
+
+Check that the SSH daemon configuration verbosely logs connection attempts and failed logon attempts to the server with the following command:
+
+# sudo grep -i loglevel /etc/ssh/sshd_config
+
+The output message must contain the following text:
+
+LogLevel VERBOSE
+
+If the output message does not contain "VERBOSE", the LogLevel keyword is missing, or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77445"><title>SRG-OS-000228-GPOS-00088</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92141r2_rule" severity="medium" weight="10.0"><version>SLES-12-030120</version><title>The SUSE operating system must be configured to display the Standard Mandatory DoD Notice and Consent Banner immediately prior to, or as part of, SSH logon prompts.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the publicly accessible SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for SUSE operating systems that can accommodate banners of 1300 characters:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001384</ident><ident system="http://iase.disa.mil/cci">CCI-001385</ident><ident system="http://iase.disa.mil/cci">CCI-001386</ident><ident system="http://iase.disa.mil/cci">CCI-001387</ident><ident system="http://iase.disa.mil/cci">CCI-001388</ident><fixtext fixref="F-84085r1_fix">Configure the SUSE operating system to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via the SSH.
+
+Edit the "/etc/ssh/sshd_config" file to uncomment the banner keyword and configure it to point to a file that will contain the logon banner (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor). An example configuration line is:
+
+Banner=/etc/issue
+
+Either create the file containing the banner or replace the text in the file with the Standard Mandatory DoD Notice and Consent Banner. The DoD required text is:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests -- not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."</fixtext><fix id="F-84085r1_fix" /><check system="C-77001r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify all remote connections via SSH to the SUSE operating system display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system.
+
+Check for the location of the file containing the Standard Mandatory DoD Notice and Consent Banner being used by performing the following command:
+
+# sudo grep -i banner /etc/ssh/sshd_config
+Banner=/etc/issue
+
+The command will return the "Banner" keyword and the path of the file that contains the Standard Mandatory DoD Notice and Consent Banner. It is standard practice for this to be stored in "/etc/issue". If the line is commented out, this is a finding.
+
+Check the file that was specified by the "Banner" keyword above and check that it matches the Standard Mandatory DoD Notice and Consent Banner text exactly:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests-not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+If the text in the file does not match the Standard Mandatory DoD Notice and Consent Banner exactly, this is a finding.</check-content></check></Rule></Group><Group id="V-77447"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92143r1_rule" severity="medium" weight="10.0"><version>SLES-12-030130</version><title>The SUSE operating system must display the date and time of the last successful account logon upon an SSH logon.</title><description>&lt;VulnDiscussion&gt;Providing users with feedback on when account accesses via SSH last occurred facilitates user recognition and reporting of unauthorized account use.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84087r1_fix">Configure the SUSE operating system to provide users with feedback on when account accesses last occurred.
+
+Add or edit the following lines in the "/etc/ssh/sshd_config" file:
+
+PrintLastLog yes</fixtext><fix id="F-84087r1_fix" /><check system="C-77005r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify all remote connections via SSH to the SUSE operating system display feedback on when account accesses last occurred.
+
+Check that "PrintLastLog" keyword in the sshd daemon configuration file is used and set to "yes" with the following command:
+
+# sudo grep -i printlastlog /etc/ssh/sshd_config
+PrintLastLog yes
+
+If the "PrintLastLog" keyword is set to "no", is missing, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77449"><title>SRG-OS-000109-GPOS-00056</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92145r2_rule" severity="medium" weight="10.0"><version>SLES-12-030140</version><title>The SUSE operating system must deny direct logons to the root account using remote access via SSH.</title><description>&lt;VulnDiscussion&gt;To assure individual accountability and prevent unauthorized access, organizational users must be individually identified and authenticated.
+
+A group authenticator is a generic account used by multiple individuals. Use of a group authenticator alone does not uniquely identify individual users. Examples of the group authenticator is the UNIX OS "root" user account, the Windows "Administrator" account, the "sa" account, or a "helpdesk" account.
+
+For example, the UNIX and Windows SUSE operating systems offer a "switch user" capability, allowing users to authenticate with their individual credentials and, when needed, "switch" to the administrator role. This method provides for unique individual authentication prior to using a group authenticator.
+
+Users (and any processes acting on behalf of users) need to be uniquely identified and authenticated for all accesses other than those accesses explicitly identified and documented by the organization, which outlines specific user actions that can be performed on the SUSE operating system without identification or authentication.
+
+Requiring individuals to be authenticated with an individual authenticator prior to using a group authenticator allows for traceability of actions, as well as adding an additional level of protection of the actions that can be taken with group account knowledge.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000770</ident><fixtext fixref="F-84089r1_fix">Configure the SUSE operating system to deny direct logons to the root account using remote access via SSH.
+
+Edit the appropriate "/etc/ssh/sshd_config" file, add or uncomment the line for "PermitRootLogin" and set its value to "no" (this file may be named differently or be in a different location):
+
+PermitRootLogin no</fixtext><fix id="F-84089r1_fix" /><check system="C-77007r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system denies direct logons to the root account using remote access via SSH.
+
+Check that SSH denies any user trying to log on directly as root with the following command:
+
+# sudo grep -i permitrootlogin /etc/ssh/sshd_config
+PermitRootLogin no
+
+If the "PermitRootLogin" keyword is set to "yes", is missing, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77451"><title>SRG-OS-000480-GPOS-00229</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92147r1_rule" severity="high" weight="10.0"><version>SLES-12-030150</version><title>The SUSE operating system must not allow unattended or automatic logon via SSH.</title><description>&lt;VulnDiscussion&gt;Failure to restrict system access via SSH to authenticated users negatively impacts SUSE operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84091r1_fix">Configure the SUSE operating system disables unattended or automatic logon via SSH.
+
+Add or edit the following lines in the "/etc/ssh/sshd_config" file:
+
+PermitEmptyPasswords no
+PermitUserEnvironment no</fixtext><fix id="F-84091r1_fix" /><check system="C-77009r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system disables unattended or automatic logon via SSH.
+
+Check that unattended or automatic logon via SSH is disabled with the following command:
+
+# sudo egrep '(Permit(.*?)(Passwords|Environment))' /etc/ssh/sshd_config
+
+PermitEmptyPasswords no
+PermitUserEnvironment no
+
+If "PermitEmptyPasswords" or "PermitUserEnvironment" keywords are not set to "no", are missing completely, or are commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77455"><title>SRG-OS-000033-GPOS-00014</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92151r2_rule" severity="medium" weight="10.0"><version>SLES-12-030170</version><title>The SUSE operating system must implement DoD-approved encryption to protect the confidentiality of SSH remote connections.</title><description>&lt;VulnDiscussion&gt;Without confidentiality protection mechanisms, unauthorized individuals may gain access to sensitive information via a remote access session.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, nonorganization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Encryption provides a means to secure the remote connection to prevent unauthorized access to the data traversing the remote access connection (e.g., RDP), thereby providing a degree of confidentiality. The encryption strength of a mechanism is selected based on the security categorization of the information.
+
+Satisfies: SRG-OS-000033-GPOS-00014, SRG-OS-000120-GPOS-00061, SRG-OS-000125-GPOS-00065, SRG-OS-000250-GPOS-00093, SRG-OS-000393-GPOS-00173&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000068</ident><ident system="http://iase.disa.mil/cci">CCI-000366</ident><ident system="http://iase.disa.mil/cci">CCI-000803</ident><ident system="http://iase.disa.mil/cci">CCI-002890</ident><fixtext fixref="F-84095r1_fix">Edit the SSH daemon configuration (/etc/ssh/sshd_config) and remove any ciphers not starting with "aes" and remove any ciphers ending with "cbc". If necessary, add a "Ciphers" line:
+
+Ciphers aes128-ctr,aes192-ctr,aes256-ctr
+
+Restart the SSH daemon:
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-84095r1_fix" /><check system="C-77013r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system implements DoD-approved encryption to protect the confidentiality of SSH remote connections.
+
+Check the SSH daemon configuration for allowed ciphers with the following command:
+
+# sudo grep -i ciphers /etc/ssh/sshd_config | grep -v '^#'
+
+Ciphers aes128-ctr,aes192-ctr,aes256-ctr
+
+If any ciphers other than "aes128-ctr", "aes192-ctr", or "aes256-ctr" are listed, the "Ciphers" keyword is missing, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77457"><title>SRG-OS-000125-GPOS-00065</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92153r2_rule" severity="medium" weight="10.0"><version>SLES-12-030180</version><title>The SUSE operating system SSH daemon must be configured to only use Message Authentication Codes (MACs) employing FIPS 140-2 approved cryptographic hash algorithms.</title><description>&lt;VulnDiscussion&gt;Without cryptographic integrity protections, information can be altered by unauthorized users without detection.
+
+Remote access (e.g., RDP) is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, nonorganization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Cryptographic mechanisms used for protecting the integrity of information include, for example, signed hash functions using asymmetric cryptography enabling distribution of the public key to verify the hash information while maintaining the confidentiality of the secret key used to generate the hash.
+
+Satisfies: SRG-OS-000125-GPOS-00065, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000877</ident><ident system="http://iase.disa.mil/cci">CCI-001453</ident><ident system="http://iase.disa.mil/cci">CCI-003123</ident><fixtext fixref="F-84097r1_fix">Configure the SUSE operating system SSH daemon to only use MACs that employ FIPS 140-2 approved ciphers.
+
+Edit the "/etc/ssh/sshd_config" file to uncomment or add the line for the "MACs" keyword and set its value to "hmac-sha2-256" and/or "hmac-sha2-512" (The file might be named differently or be in a different location):
+
+MACs hmac-sha2-256,hmac-sha2-512</fixtext><fix id="F-84097r1_fix" /><check system="C-77015r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon is configured to only use MACs that employ FIPS 140-2 approved ciphers.
+
+Check that the SSH daemon is configured to only use MACs that employ FIPS 140-2 approved ciphers with the following command:
+
+# sudo grep -i macs /etc/ssh/sshd_config
+MACs hmac-sha2-256,hmac-sha2-512
+
+If any ciphers other than "hmac-sha2-256" or "hmac-sha2-512" are listed or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77459"><title>SRG-OS-000126-GPOS-00066</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92155r1_rule" severity="medium" weight="10.0"><version>SLES-12-030190</version><title>The SUSE operating system SSH daemon must be configured with a timeout interval.</title><description>&lt;VulnDiscussion&gt;Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element. 
+
+Terminating network connections associated with communications sessions includes, for example, deallocating associated TCP/IP address/port pairs at the SUSE operating system level, and deallocating networking assignments at the application level if multiple application sessions are using a single SUSE operating system-level network connection. This does not mean that the SUSE operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session.
+
+Satisfies: SRG-OS-000126-GPOS-00066, SRG-OS-000163-GPOS-00072, SRG-OS-000279-GPOS-00109&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000879</ident><ident system="http://iase.disa.mil/cci">CCI-001133</ident><ident system="http://iase.disa.mil/cci">CCI-002361</ident><fixtext fixref="F-84099r1_fix">Configure the SUSE operating system SSH daemon to timeout idle sessions.
+
+Add or modify (to match exactly) the following line in the "/etc/ssh/sshd_config" file:
+
+ClientAliveInterval 600
+
+The SSH daemon must be restarted in order for any changes to take effect.</fixtext><fix id="F-84099r1_fix" /><check system="C-77017r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon is configured to timeout idle sessions.
+
+Check that the "ClientAliveInterval" parameter is set to a value of "600" with the following command:
+
+# sudo grep -i clientalive /etc/ssh/sshd_config
+ClientAliveInterval 600
+
+If "ClientAliveInterval" is not set to "600" in "/etc/ssh/sshd_config", this is a finding.</check-content></check></Rule></Group><Group id="V-77461"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92157r1_rule" severity="medium" weight="10.0"><version>SLES-12-030200</version><title>The SUSE operating system SSH daemon must be configured to not allow authentication using known hosts authentication.</title><description>&lt;VulnDiscussion&gt;Configuring this setting for the SSH daemon provides additional assurance that remote logon via SSH will require a password, even in the event of misconfiguration elsewhere.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84101r1_fix">Configure the SUSE operating system SSH daemon to not allow authentication using known hosts authentication.
+
+Add the following line in "/etc/ssh/sshd_config", or uncomment the line and set the value to "yes":
+
+IgnoreUserKnownHosts yes</fixtext><fix id="F-84101r1_fix" /><check system="C-77019r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon is configured to not allow authentication using known hosts authentication.
+
+To determine how the SSH daemon's "IgnoreUserKnownHosts" option is set, run the following command:
+
+# sudo grep -i IgnoreUserKnownHosts /etc/ssh/sshd_config
+
+IgnoreUserKnownHosts yes
+
+If the value is returned as "no", the returned line is commented out, or no output is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-77463"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92159r2_rule" severity="medium" weight="10.0"><version>SLES-12-030210</version><title>The SUSE operating system SSH daemon public host key files must have mode 0644 or less permissive.</title><description>&lt;VulnDiscussion&gt;If a public host key file is modified by an unauthorized user, the SSH service may be compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84103r1_fix">Configure the SUSE operating system SSH daemon public host key files have mode "0644" or less permissive.
+
+Note: SSH public key files may be found in other directories on the system depending on the installation. 
+
+Change the mode of public host key files under "/etc/ssh" to "0644" with the following command:
+
+# chmod 0644 /etc/ssh/*.key.pub</fixtext><fix id="F-84103r1_fix" /><check system="C-77021r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon public host key files have mode "0644" or less permissive.
+
+Note: SSH public key files may be found in other directories on the system depending on the installation.
+
+The following command will find all SSH public key files on the system:
+
+# sudo find /etc/ssh -name '*.pub' -exec ls -lL {} \;
+
+-rw-r--r--  1 root  wheel  618 Nov 28 06:43 ssh_host_dsa_key.pub
+-rw-r--r--  1 root  wheel  347 Nov 28 06:43 ssh_host_key.pub
+-rw-r--r--  1 root  wheel  238 Nov 28 06:43 ssh_host_rsa_key.pub
+
+If any file has a mode more permissive than "0644", this is a finding.</check-content></check></Rule></Group><Group id="V-77465"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92161r2_rule" severity="medium" weight="10.0"><version>SLES-12-030220</version><title>The SUSE operating system SSH daemon private host key files must have mode 0600 or less permissive.</title><description>&lt;VulnDiscussion&gt;If an unauthorized user obtains the private SSH host key file, the host could be impersonated.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84107r1_fix">Configure the mode of the SUSE operating system SSH daemon private host key files under "/etc/ssh" to "0600" with the following command:
+
+# chmod 0600 /etc/ssh/ssh_host*key</fixtext><fix id="F-84107r1_fix" /><check system="C-77025r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon private host key files have mode "0600" or less permissive.
+
+The following command will find all SSH private key files on the system:
+
+# sudo find / -name '*ssh_host*key' -exec ls -lL {} \;
+
+Check the mode of the private host key files under "/etc/ssh" file with the following command:
+
+# ls -lL /etc/ssh/*key
+-rw-------  1 root  wheel  668 Nov 28 06:43 ssh_host_dsa_key
+-rw-------  1 root  wheel  582 Nov 28 06:43 ssh_host_key
+-rw-------  1 root  wheel  887 Nov 28 06:43 ssh_host_rsa_key
+
+If any file has a mode more permissive than "0600", this is a finding.</check-content></check></Rule></Group><Group id="V-77467"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92163r2_rule" severity="medium" weight="10.0"><version>SLES-12-030230</version><title>The SUSE operating system SSH daemon must perform strict mode checking of home directory configuration files.</title><description>&lt;VulnDiscussion&gt;If other users have access to modify user-specific SSH configuration files, they may be able to log on to the system as another user.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84109r1_fix">Configure the SUSE operating system SSH daemon performs strict mode checking of home directory configuration files.
+
+Uncomment the "StrictModes" keyword in "/etc/ssh/sshd_config" and set the value to "yes":
+
+StrictModes yes</fixtext><fix id="F-84109r1_fix" /><check system="C-77027r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon performs strict mode checking of home directory configuration files.
+
+Check that the SSH daemon performs strict mode checking of home directory configuration files with the following command:
+
+# sudo grep -i strictmodes /etc/ssh/sshd_config
+
+StrictModes yes
+
+If "StrictModes" is set to "no", is missing, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77469"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92165r2_rule" severity="medium" weight="10.0"><version>SLES-12-030240</version><title>The SUSE operating system SSH daemon must use privilege separation.</title><description>&lt;VulnDiscussion&gt;SSH daemon privilege separation causes the SSH process to drop root privileges when not needed, which would decrease the impact of software vulnerabilities in the unprivileged section.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84111r1_fix">Configure the SUSE operating system SSH daemon is configured to use privilege separation.
+
+Uncomment the "UsePrivilegeSeparation" keyword in "/etc/ssh/sshd_config" and set the value to "yes":
+
+UsePrivilegeSeparation yes</fixtext><fix id="F-84111r1_fix" /><check system="C-77029r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon is configured to use privilege separation.
+
+Check that the SUSE operating system SSH daemon performs privilege separation with the following command:
+
+# sudo grep -i usepriv /etc/ssh/sshd_config 
+
+UsePrivilegeSeparation yes
+
+If the "UsePrivilegeSeparation" keyword is set to "no", is missing, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77471"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92167r2_rule" severity="medium" weight="10.0"><version>SLES-12-030250</version><title>The SUSE operating system SSH daemon must not allow compression or must only allow compression after successful authentication.</title><description>&lt;VulnDiscussion&gt;If compression is allowed in an SSH connection prior to authentication, vulnerabilities in the compression software could result in compromise of the system from an unauthenticated connection, potentially with root privileges.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84113r1_fix">Configure the SUSE operating system SSH daemon performs compression after a user successfully authenticates.
+
+Uncomment the "Compression" keyword in "/etc/ssh/sshd_config" on the system and set the value to "delayed" or "no":
+
+Compression no</fixtext><fix id="F-84113r1_fix" /><check system="C-77031r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon performs compression after a user successfully authenticates.
+
+Check that the SSH daemon performs compression after a user successfully authenticates with the following command:
+
+# sudo grep -i compression /etc/ssh/sshd_config
+Compression delayed
+
+If the "Compression" keyword is set to "yes", is missing, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77473"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92169r1_rule" severity="high" weight="10.0"><version>SLES-12-030260</version><title>The SUSE operating system SSH daemon must encrypt forwarded remote X connections for interactive users.</title><description>&lt;VulnDiscussion&gt;Open X displays allow an attacker to capture keystrokes and execute commands remotely.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84115r1_fix">Configure the SUSE operating system SSH daemon to encrypt forwarded X connections for interactive users.
+
+Edit the "/etc/ssh/sshd_config" file to uncomment or add the line for the "X11Forwarding" keyword and set its value to "yes" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor):
+
+X11Forwarding yes</fixtext><fix id="F-84115r1_fix" /><check system="C-77033r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system SSH daemon remote X forwarded connections for interactive users are encrypted.
+
+Check that SSH remote X forwarded connections are encrypted with the following command:
+
+# sudo grep -i x11forwarding /etc/ssh/sshd_config
+X11Forwarding yes
+
+If the "X11Forwarding" keyword is set to "no", is missing, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-77475"><title>SRG-OS-000355-GPOS-00143</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92171r1_rule" severity="medium" weight="10.0"><version>SLES-12-030300</version><title>The SUSE operating system clock must, for networked systems, be synchronized to an authoritative DoD time source at least every 24 hours.</title><description>&lt;VulnDiscussion&gt;Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events. Sources outside the configured acceptable allowance (drift) may be inaccurate.
+
+Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
+
+Organizations should consider endpoints that may not have regular access to the authoritative time server (e.g., mobile, teleworking, and tactical endpoints).
+
+Satisfies: SRG-OS-000355-GPOS-00143, SRG-OS-000356-GPOS-00144&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001891</ident><ident system="http://iase.disa.mil/cci">CCI-002046</ident><fixtext fixref="F-84117r1_fix">Configure the SUSE operating system clock must be configured to synchronize to an authoritative DoD time source when the time difference is greater than one second. 
+
+To configure the system clock to synchronize to an authoritative DoD time source at least every 24 hours, edit the file "/etc/ntp.conf". Add or correct the following lines by replacing "[time_source]" with an authoritative DoD time source:
+
+server [time_source] maxpoll 17</fixtext><fix id="F-84117r1_fix" /><check system="C-77035r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system clock must be configured to synchronize to an authoritative DoD time source when the time difference is greater than one second. 
+
+Check that the SUSE operating system clock must be configured to synchronize to an authoritative DoD time source when the time difference is greater than one second with the following command:
+
+# sudo grep maxpoll /etc/ntp.conf
+
+server 0.us.pool.ntp.mil maxpoll 17
+
+If nothing is returned or "maxpoll" is greater than "17", this is a finding.
+
+Verify the "ntp.conf" file is configured to an authoritative DoD time source by running the following command:
+
+# sudo grep -i server /etc/ntp.conf
+server 0.us.pool.ntp.mil 
+
+If the parameter "server" is not set or is not set to an authoritative DoD time source, this is a finding.</check-content></check></Rule></Group><Group id="V-77477"><title>SRG-OS-000359-GPOS-00146</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92173r1_rule" severity="low" weight="10.0"><version>SLES-12-030310</version><title>The SUSE operating system must be configured to use Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT).</title><description>&lt;VulnDiscussion&gt;If time stamps are not consistently applied and there is no common time reference, it is difficult to perform forensic analysis.
+
+Time stamps generated by the SUSE operating system include date and time. Time is commonly expressed in UTC, a modern continuation of GMT, or local time with an offset from UTC.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001890</ident><fixtext fixref="F-84119r1_fix">Configure the SUSE operating system is configured to use UTC or GMT.
+
+To configure the system time zone to use UTC or GMT, run the following command, replacing [ZONE] with "UTC" or "GMT".
+
+# sudo timedatectl set-timezone [ZONE]</fixtext><fix id="F-84119r1_fix" /><check system="C-77037r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system is configured to use UTC or GMT.
+
+Check that the SUSE operating system is configured to use UTC or GMT with the following command:
+
+# timedatectl status | grep -i timezone
+Timezone: UTC (UTC, +0000)
+
+If "Timezone" is not set to UTC or GMT, this is a finding.</check-content></check></Rule></Group><Group id="V-77479"><title>SRG-OS-000433-GPOS-00192</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92175r2_rule" severity="medium" weight="10.0"><version>SLES-12-030320</version><title>The SUSE operating system must implement kptr-restrict to prevent the leaking of internal kernel addresses.</title><description>&lt;VulnDiscussion&gt;Some adversaries launch attacks with the intent of executing code in nonexecutable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced, with hardware providing the greater strength of mechanism.
+
+Examples of attacks are buffer overflow attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002824</ident><fixtext fixref="F-84121r2_fix">Configure the SUSE operating system to prevent leaking of internal kernel addresses by running the following command: 
+
+# sudo echo 1 &gt;&gt; /proc/sys/kernel/kptr_restrict
+
+After the line has been added, the kernel settings from all system configuration files must be reloaded before any of the changes will take effect. Run the following command to reload all of the kernel system configuration files:
+
+# sudo sysctl --system</fixtext><fix id="F-84121r2_fix" /><check system="C-77039r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system prevents leaking of internal kernel addresses.
+
+Check that the SUSE operating system prevents leaking of internal kernel addresses by running the following command:
+
+# cat /proc/sys/kernel/kptr_restrict
+1
+
+If the above output does not return "1", this is a finding.</check-content></check></Rule></Group><Group id="V-77481"><title>SRG-OS-000433-GPOS-00193</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92177r1_rule" severity="medium" weight="10.0"><version>SLES-12-030330</version><title>Address space layout randomization (ASLR) must be implemented by the SUSE operating system to protect memory from unauthorized code execution.</title><description>&lt;VulnDiscussion&gt;Some adversaries launch attacks with the intent of executing code in nonexecutable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced, with hardware providing the greater strength of mechanism.
+
+Examples of attacks are buffer overflow attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002824</ident><fixtext fixref="F-84123r1_fix">Configure the SUSE operating system implements address space layout randomization (ASLR).
+
+Remove the "kernel.randomize_va_space" entry found in the "/etc/sysctl.conf" file.
+
+After the line has been removed, the kernel settings from all system configuration files must be reloaded before any of the changes will take effect. Run the following command to reload all of the kernel system configuration files:
+
+# sudo sysctl --system
+
+To check that "kernel.randomize_va_space" has been properly set to "2" after reloading the settings, run the following command:
+
+# cat /proc/sys/kernel/randomize_va_space</fixtext><fix id="F-84123r1_fix" /><check system="C-77041r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system implements address space layout randomization (ASLR).
+
+Check that the SUSE operating system implements ASLR by running the following command:
+
+# sudo sysctl kernel.randomize_va_space
+
+kernel.randomize_va_space = 2
+
+If nothing is returned, verify the kernel parameter "randomize_va_space" is equal to "2" in the current process by running the following command:
+
+# cat /proc/sys/kernel/randomize_va_space
+
+2
+
+If "kernel.randomize_va_space" is not set to "2", this is a finding.</check-content></check></Rule></Group><Group id="V-77483"><title>SRG-OS-000479-GPOS-00224</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92179r1_rule" severity="medium" weight="10.0"><version>SLES-12-030340</version><title>The SUSE operating system must off-load rsyslog messages for networked systems in real time and off-load standalone systems at least weekly.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001851</ident><fixtext fixref="F-84125r1_fix">Configure the SUSE operating system to off-load rsyslog messages for networked systems in real time.
+
+For stand-alone systems establish a procedure to off-load log messages at least once a week.
+
+For networked systems add a "@[Log_Server_IP_Address]" option to every active message label in "/etc/rsyslog.conf" that does not have one. Some examples are listed below:
+
+*.*;mail.none;news.none -/var/log/messages
+*.*;mail.none;news.none @192.168.1.101:514
+
+An additional option is to capture all of the log messages and send them to a remote log host:
+
+*.* @@loghost:514</fixtext><fix id="F-84125r1_fix" /><check system="C-77043r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system must off-load rsyslog messages for networked systems in real time and off-load standalone systems at least weekly.
+
+For stand-alone hosts, verify with the System Administrator that the log files are off-loaded at least weekly.
+
+For networked systems, check that rsyslog is sending log messages to a remote server with the following command:
+
+# sudo grep "\*.\*" /etc/rsyslog.conf | grep "@" | grep -v "^#"
+
+*.*;mail.none;news.none @192.168.1.101:514
+
+If any active message labels in the file do not have a line to send log messages to a remote server, this is a finding.</check-content></check></Rule></Group><Group id="V-77485"><title>SRG-OS-000142-GPOS-00071</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92181r1_rule" severity="medium" weight="10.0"><version>SLES-12-030350</version><title>The SUSE operating system must be configured to use TCP syncookies.</title><description>&lt;VulnDiscussion&gt;Denial of Service (DoS) is a condition when a resource is not available for legitimate users. When this occurs, the organization either cannot accomplish its mission or must operate at degraded capacity. 
+
+Managing excess capacity ensures that sufficient capacity is available to counter flooding attacks. Employing increased capacity and service redundancy may reduce the susceptibility to some DoS attacks. Managing excess capacity may include, for example, establishing selected usage priorities, quotas, or partitioning.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001095</ident><fixtext fixref="F-84127r1_fix">Configure the SUSE operating system to use TCP syncookies by running the following command as an administrator:
+
+# sudo sysctl -w net.ipv4.tcp_syncookies=1
+
+If "1" is not the system's default value, add or update the following line in "/etc/sysctl.conf":
+
+net.ipv4.tcp_syncookies = 1</fixtext><fix id="F-84127r1_fix" /><check system="C-77045r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is configured to use TCP syncookies.
+
+Check to see if syncookies are used with the following command:
+
+# sudo sysctl net.ipv4.tcp_syncookies
+
+net.ipv4.tcp_syncookies = 1
+
+If the value is not set to "1", this is a finding.</check-content></check></Rule></Group><Group id="V-77487"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92183r1_rule" severity="medium" weight="10.0"><version>SLES-12-030360</version><title>The SUSE operating system must not forward Internet Protocol version 4 (IPv4) source-routed packets.</title><description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when IPv4 forwarding is enabled and the system is functioning as a router.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84129r1_fix">Configure the SUSE operating system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.conf.all.accept_source_route = 0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84129r1_fix" /><check system="C-77047r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not accept IPv4 source-routed packets.
+
+Check the value of the accept source route variable with the following command:
+
+# sysctl net.ipv4.conf.all.accept_source_route
+net.ipv4.conf.all.accept_source_route = 0
+
+If the returned line does not have a value of "0" this is a finding.</check-content></check></Rule></Group><Group id="V-77489"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92185r3_rule" severity="medium" weight="10.0"><version>SLES-12-030370</version><title>The SUSE operating system must not forward Internet Protocol version 4 (IPv4) source-routed packets by default.</title><description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when IPv4 forwarding is enabled and the system is functioning as a router.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84131r3_fix">Configure the SUSE operating system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.conf.default.accept_source_route = 0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84131r3_fix" /><check system="C-77049r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not accept IPv4 source-routed packets by default.
+
+Check the value of the default accept source route variable with the following command:
+
+# sysctl net.ipv4.conf.default.accept_source_route
+net.ipv4.conf.default.accept_source_route = 0
+
+If the returned line does not have a value of "0" this is a finding.</check-content></check></Rule></Group><Group id="V-77491"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92187r1_rule" severity="medium" weight="10.0"><version>SLES-12-030380</version><title>The SUSE operating system must not respond to Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) echoes sent to a broadcast address.</title><description>&lt;VulnDiscussion&gt;Responding to broadcast (ICMP) echoes facilitates network mapping and provides a vector for amplification attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84133r1_fix">Configure the SUSE operating system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.conf.all.accept_source_route = 0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84133r1_fix" /><check system="C-77051r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not accept IPv4 source-routed packets.
+
+Check the value of the accept source route variable with the following command:
+
+# sysctl net.ipv4.conf.all.accept_source_route
+net.ipv4.conf.all.accept_source_route = 0
+
+If the returned line does not have a value of "0" this is a finding.</check-content></check></Rule></Group><Group id="V-77493"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92189r3_rule" severity="medium" weight="10.0"><version>SLES-12-030390</version><title>The SUSE operating system must prevent Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirect messages from being accepted.</title><description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84135r3_fix">Configure the SUSE operating system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.icmp_echo_ignore_broadcasts=1
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84135r3_fix" /><check system="C-77053r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not respond to IPv4 ICMP echoes sent to a broadcast address.
+
+Check the value of the "icmp_echo_ignore_broadcasts" variable with the following command:
+
+# sysctl net.ipv4.icmp_echo_ignore_broadcasts
+net.ipv4.icmp_echo_ignore_broadcasts=1
+
+If the returned line does not have a value of "1" this is a finding.</check-content></check></Rule></Group><Group id="V-77495"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92191r4_rule" severity="medium" weight="10.0"><version>SLES-12-030400</version><title>The SUSE operating system must not allow interfaces to accept Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirect messages by default.</title><description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84137r3_fix">Configure the SUSE operating system ignores IPv4 ICMP redirect messages by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.conf.all.accept_redirects = 0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84137r3_fix" /><check system="C-77055r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system ignores IPv4 ICMP redirect messages.
+
+Check the value of the "accept_redirects" variables with the following command:
+
+# sysctl net.ipv4.conf.all.accept_redirects
+net.ipv4.conf.all.accept_redirects = 0
+
+If the returned line does not have a value of "0" this is a finding.</check-content></check></Rule></Group><Group id="V-77497"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92193r4_rule" severity="medium" weight="10.0"><version>SLES-12-030410</version><title>The SUSE operating system must not allow interfaces to send Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirect messages by default.</title><description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages contain information from the system's route table, possibly revealing portions of the network topology.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84139r3_fix">Configure the SUSE operating system to not allow interfaces to perform IPv4 ICMP redirects by default. 
+
+Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.conf.default.send_redirects=0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84139r3_fix" /><check system="C-77057r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not allow interfaces to perform IPv4 ICMP redirects by default.
+
+Check the value of the "default send_redirects" variables with the following command:
+
+# sysctl net.ipv4.conf.default.send_redirects
+net.ipv4.conf.default.send_redirects = 0
+
+If the returned line does not have a value of "0” this is a finding.</check-content></check></Rule></Group><Group id="V-77499"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92195r3_rule" severity="medium" weight="10.0"><version>SLES-12-030420</version><title>The SUSE operating system must not send Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirects.</title><description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages contain information from the system's route table, possibly revealing portions of the network topology.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84141r3_fix">Configure the SUSE operating system to not allow interfaces to perform IPv4 ICMP redirects. 
+
+Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.conf.all.send_redirects=0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84141r3_fix" /><check system="C-77059r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not send IPv4 ICMP redirect messages.
+
+Check the value of the "all send_redirects" variables with the following command:
+
+# sysctl net.ipv4.conf.default.send_redirects
+net.ipv4.conf.default.send_redirects = 0
+
+If the returned line does not have a value of "0” this is a finding.</check-content></check></Rule></Group><Group id="V-77501"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92197r3_rule" severity="medium" weight="10.0"><version>SLES-12-030430</version><title>The SUSE operating system must not be performing packet forwarding unless the system is a router.</title><description>&lt;VulnDiscussion&gt;Routing protocol daemons are typically used on routers to exchange network topology information with other routers. If this software is used when not required, system network information may be unnecessarily transmitted across the network.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84143r3_fix">Configure the SUSE operating system to the required kernel parameter upon boot by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv4.ip_forward=0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-84143r3_fix" /><check system="C-77061r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system is not performing packet forwarding, unless the system is a router.
+
+Check to see if IP forwarding is enabled using the following command:
+
+# sysctl net.ipv4.ip_forward
+net.ipv4.ip_forward = 0
+
+If IP forwarding value is "1" and the system is hosting any application, database, or web servers, this is a finding.</check-content></check></Rule></Group><Group id="V-77503"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92199r2_rule" severity="medium" weight="10.0"><version>SLES-12-030440</version><title>The SUSE operating system must not have network interfaces in promiscuous mode unless approved and documented.</title><description>&lt;VulnDiscussion&gt;Network interfaces in promiscuous mode allow for the capture of all network traffic visible to the system. If unauthorized individuals can access these applications, it may allow then to collect information such as logon IDs, passwords, and key exchanges between systems.
+
+If the system is being used to perform a network troubleshooting function, the use of these tools must be documented with the Information System Security Officer (ISSO) and restricted to only authorized personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-84145r2_fix">Configure the SUSE operating system network interfaces to turn off promiscuous mode unless approved by the ISSO and documented.
+
+Set the promiscuous mode of an interface to off with the following command:
+
+# ip link set dev &lt;devicename&gt; promisc off</fixtext><fix id="F-84145r2_fix" /><check system="C-77063r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system network interfaces are not in promiscuous mode unless approved by the ISSO and documented.
+
+Check for the status with the following command:
+
+# ip link | grep -i promisc
+
+If network interfaces are found on the system in promiscuous mode and their use has not been approved by the ISSO and documented, this is a finding.</check-content></check></Rule></Group><Group id="V-77505"><title>SRG-OS-000299-GPOS-00117</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92201r1_rule" severity="medium" weight="10.0"><version>SLES-12-030450</version><title>The SUSE operating system wireless network adapters must be disabled unless approved and documented.</title><description>&lt;VulnDiscussion&gt;Without protection of communications with wireless peripherals, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read, altered, or used to compromise the SUSE operating system.
+
+This requirement applies to wireless peripheral technologies (e.g., wireless mice, keyboards, displays, etc.) used with A SUSE operating system. Wireless peripherals (e.g., Wi-Fi/Bluetooth/IR Keyboards, Mice, and Pointing Devices and Near Field Communications [NFC]) present a unique challenge by creating an open, unsecured port on a computer. Wireless peripherals must meet DoD requirements for wireless data transmission and be approved for use by the AO. Even though some wireless peripherals, such as mice and pointing devices, do not ordinarily carry information that need to be protected, modification of communications with these wireless peripherals may be used to compromise the SUSE operating system. Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.
+
+Protecting the confidentiality and integrity of communications with wireless peripherals can be accomplished by physical means (e.g., employing physical barriers to wireless radio frequencies) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa. If the wireless peripheral is only passing telemetry data, encryption of the data may not be required.
+
+Satisfies: SRG-OS-000299-GPOS-00117, SRG-OS-000300-GPOS-00118, SRG-OS-000481-GPOS-000481&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001443</ident><ident system="http://iase.disa.mil/cci">CCI-001444</ident><ident system="http://iase.disa.mil/cci">CCI-002418</ident><fixtext fixref="F-84147r1_fix">Configure the SUSE operating system to disable all wireless network interfaces with the following command:
+
+For each interface of type wireless, bring the interface into "down" state:
+
+# wicked ifdown wlan0
+
+For each interface of type wireless with a configuration of type "compat:suse:", remove the associated file:
+
+# rm /etc/sysconfig/network/ifcfg-wlan0
+
+For each interface of type wireless, for each configuration of type "wicked:xml:", remove the associated file or remove the interface configuration from the file.
+
+# rm /etc/wicked/ifconfig/wlan0.xml</fixtext><fix id="F-84147r1_fix" /><check system="C-77065r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that the SUSE operating system has no wireless network adapters enabled.
+
+Check that there are no wireless interfaces configured on the system with the following command:
+
+# wicked show all
+
+lo up
+link: #1, state up
+type: loopback
+config: compat:suse:/etc/sysconfig/network/ifcfg-lo
+leases: ipv4 static granted
+leases: ipv6 static granted
+addr: ipv4 127.0.0.1/8 [static]
+addr: ipv6 ::1/128 [static]
+
+eth0 up
+link: #2, state up, mtu 1500
+type: ethernet, hwaddr 06:00:00:00:00:01
+config: compat:suse:/etc/sysconfig/network/ifcfg-eth0
+leases: ipv4 dhcp granted
+leases: ipv6 dhcp granted, ipv6 auto granted
+addr: ipv4 10.0.0.100/16 [dhcp]
+route: ipv4 default via 10.0.0.1 proto dhcp
+
+wlan0 up
+link: #3, state up, mtu 1500
+type: wireless, hwaddr 06:00:00:00:00:02
+config: wicked:xml:/etc/wicked/ifconfig/wlan0.xml
+leases: ipv4 dhcp granted
+addr: ipv4 10.0.0.101/16 [dhcp]
+route: ipv4 default via 10.0.0.1 proto dhcp
+
+If a wireless interface is configured it must be documented and approved by the local Authorizing Official.
+
+If a wireless interface is configured and has not been documented and approved, this is a finding.</check-content></check></Rule></Group><Group id="V-77507"><title>SRG-OS-000375-GPOS-00160</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92203r3_rule" severity="medium" weight="10.0"><version>SLES-12-030500</version><title>The SUSE operating system must have the packages required for multifactor authentication to be installed.</title><description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device.
+
+Multifactor solutions that require devices separate from information systems gaining access include, for example, hardware tokens providing time-based or challenge-response authenticators and smart cards such as the U.S. Government Personal Identity Verification card and the DoD Common Access Card.
+
+A privileged account is defined as an information system account with authorizations of a privileged user.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+This requirement only applies to components where this is specific to the function of the device or has the concept of an organizational user (e.g., VPN, proxy capability). This does not apply to authentication for the purpose of configuring the device itself (management).
+
+Satisfies: SRG-OS-000375-GPOS-00160, SRG-OS-000376-GPOS-00161, SRG-OS-000377-GPOS-00162&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001948</ident><ident system="http://iase.disa.mil/cci">CCI-001953</ident><ident system="http://iase.disa.mil/cci">CCI-001954</ident><fixtext fixref="F-84149r1_fix">Configure the SUSE operating system to implement multifactor authentication by installing the required packages.
+
+Install the packages required to support multifactor authentication with the following commands:
+
+#zypper install pam_pkcs11
+
+#zypper install mozilla-nss
+
+#zypper install mozilla-nss-tools
+
+#zypper install pcsc-ccid
+
+#zypper install pcsc-lite
+
+#zypper install pcsc-tools
+
+#zypper install opensc
+
+#zypper install coolkey
+
+Additional information on the configuration of multifactor authentication on the SUSE operating system can be found at https://www.suse.com/communities/blog/configuring-smart-card-authentication-suse-linux-enterprise/</fixtext><fix id="F-84149r1_fix" /><check system="C-77067r2_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system has the packages required for multifactor authentication installed.
+
+Check for the presence of the packages required to support multifactor authentication with the following commands:
+
+# zypper se pam_pkcs11
+
+i | pam_pkcs11 | PKCS #11 PAM Module | package
+
+# zypper se mozilla-nss
+
+i | mozilla-nss | Network Security Services | package
+i | mozilla-nss-tools | Tools for developing, debugging, and managing applications t-&gt; | package
+
+# zypper se pcsc
+
+i | pcsc-ccid | PCSC Driver for CCID Based Smart Card Readers and GemPC Twin -&gt; | package
+i | pcsc-lite | PCSC Smart Cards Library | package
+i | pcsc-tools | PCSC Tools | package
+
+# zypper se opensc
+
+i | opensc | Smart Card Utilities | package
+
+# zypper info coolkey | grep -i installed
+
+Installed: Yes
+
+If any of the packages required for multifactor authentication are not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-77509"><title>SRG-OS-000375-GPOS-00160</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92205r2_rule" severity="medium" weight="10.0"><version>SLES-12-030510</version><title>The SUSE operating system must implement certificate status checking for multifactor authentication.</title><description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device.
+
+Multifactor solutions that require devices separate from information systems gaining access include, for example, hardware tokens providing time-based or challenge-response authenticators and smart cards such as the U.S. Government Personal Identity Verification card and the DoD Common Access Card.
+
+A privileged account is defined as an information system account with authorizations of a privileged user.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+This requirement only applies to components where this is specific to the function of the device or has the concept of an organizational user (e.g., VPN, proxy capability). This does not apply to authentication for the purpose of configuring the device itself (management).
+
+Requires further clarification from NIST.
+
+Satisfies: SRG-OS-000375-GPOS-00160, SRG-OS-000376-GPOS-00161, SRG-OS-000377-GPOS-00162&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001948</ident><ident system="http://iase.disa.mil/cci">CCI-001953</ident><ident system="http://iase.disa.mil/cci">CCI-001954</ident><fixtext fixref="F-84151r1_fix">Configure the SUSE operating system to certificate status checking for PKI authentication.
+
+Modify all of the cert_policy lines in "/etc/pam_pkcs11/pam_pkcs11.conf" to include "ocsp_on".
+
+Note: OSCP allows sending request for certificate status information. Additional certificate validation polices are permitted.
+
+Additional information on the configuration of multifactor authentication on the SUSE operating system can be found at https://www.suse.com/communities/blog/configuring-smart-card-authentication-suse-linux-enterprise/</fixtext><fix id="F-84151r1_fix" /><check system="C-77069r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system implements certificate status checking for multifactor authentication.
+
+Check that certificate status checking for multifactor authentication is implemented with the following command:
+
+# grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module coolkey {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy
+
+cert_policy = ca,oscp_on,signature,crl_auto;
+
+If "cert_policy" is not set to include "ocsp", this is a finding.</check-content></check></Rule></Group><Group id="V-77511"><title>SRG-OS-000068-GPOS-00036</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92207r3_rule" severity="medium" weight="10.0"><version>SLES-12-030520</version><title>The SUSE operating system must implement multifactor authentication for access to privileged accounts via pluggable authentication modules (PAM).</title><description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device.
+
+Multifactor solutions that require devices separate from information systems gaining access include, for example, hardware tokens providing time-based or challenge-response authenticators and smart cards such as the U.S. Government Personal Identity Verification card and the DoD Common Access Card.
+
+A privileged account is defined as an information system account with authorizations of a privileged user.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+This requirement only applies to components where this is specific to the function of the device or has the concept of an organizational user (e.g., VPN, proxy capability). This does not apply to authentication for the purpose of configuring the device itself (management).
+
+Satisfies: SRG-OS-000068-GPOS-00036, SRG-OS-000105-GPOS-00052, SRG-OS-000106-GPOS-00053, SRG-OS-000107-GPOS-00054, SRG-OS-000108-GPOS-00055, SRG-OS-000375-GPOS-00160, SRG-OS-000375-GPOS-00161, SRG-OS-000375-GPOS-00162&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000187</ident><ident system="http://iase.disa.mil/cci">CCI-000765</ident><ident system="http://iase.disa.mil/cci">CCI-000766</ident><ident system="http://iase.disa.mil/cci">CCI-000767</ident><ident system="http://iase.disa.mil/cci">CCI-000768</ident><ident system="http://iase.disa.mil/cci">CCI-001948</ident><ident system="http://iase.disa.mil/cci">CCI-001953</ident><ident system="http://iase.disa.mil/cci">CCI-001954</ident><fixtext fixref="F-84153r2_fix">Configure the SUSE operating system to implement multifactor authentication for remote access to privileged accounts via PAM.
+
+Add or update "pam_pkcs11.so" in "/etc/pam.d/common-auth" to match the following line:
+
+auth  sufficient pam_pkcs11.so</fixtext><fix id="F-84153r2_fix" /><check system="C-77071r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system implements multifactor authentication for remote access to privileged accounts via pluggable authentication modules (PAM).
+
+Check that the "pam_pkcs11.so" option is configured in the "/etc/pam.d/common-auth" file with the following command:
+
+# grep pam_pkcs11.so /etc/pam.d/common-auth
+
+auth sufficient pam_pkcs11.so
+
+If "pam_pkcs11.so" is not set in "/etc/pam.d/common-auth", this is a finding.</check-content></check></Rule></Group><Group id="V-77513"><title>SRG-OS-000066-GPOS-00034</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-92209r1_rule" severity="medium" weight="10.0"><version>SLES-12-030530</version><title>The SUSE operating system, for PKI-based authentication, must validate certificates by constructing a certification path (which includes status information) to an accepted trust anchor.</title><description>&lt;VulnDiscussion&gt;Without path validation, an informed trust decision by the relying party cannot be made when presented with any certificate not already explicitly trusted.
+
+A trust anchor is an authoritative entity represented via a public key and associated data. It is used in the context of public key infrastructures, X.509 digital certificates, and DNSSEC.
+
+When there is a chain of trust, usually the top entity to be trusted becomes the trust anchor; it can be, for example, a Certification Authority (CA). A certification path starts with the subject certificate and proceeds through a number of intermediate certificates up to a trusted root certificate, typically issued by a trusted CA.
+
+This requirement verifies that a certification path to an accepted trust anchor is used for certificate validation and that the path includes status information. Path validation is necessary for a relying party to make an informed trust decision when presented with any certificate not already explicitly trusted. Status information for certification paths includes certificate revocation lists or online certificate status protocol responses. Validation of the certificate status information is out of scope for this requirement.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000384-GPOS-00167&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000185</ident><ident system="http://iase.disa.mil/cci">CCI-001991</ident><fixtext fixref="F-84155r1_fix">Configure the SUSE operating system, for PKI-based authentication, to validate certificates by constructing a certification path (which includes status information) to an accepted trust anchor.
+
+Modify all of the cert_policy lines in "/etc/pam_pkcs11/pam_pkcs11.conf" to include "ca":
+
+cert_policy = ca,signature,oscp_on;
+
+Note: Additional certificate validation polices are permitted.
+
+Additional information on the configuration of multifactor authentication on the SUSE operating system can be found at https://www.suse.com/communities/blog/configuring-smart-card-authentication-suse-linux-enterprise/</fixtext><fix id="F-84155r1_fix" /><check system="C-77073r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system, for PKI-based authentication, had valid certificates by constructing a certification path (which includes status information) to an accepted trust anchor.
+
+Check that the certification path to an accepted trust anchor for multifactor authentication is implemented with the following command:
+
+# grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module coolkey {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy
+
+cert_policy = ca,oscp_on,signature,crl_auto;
+
+If "cert_policy" is not set to include "ca", this is a finding.</check-content></check></Rule></Group><Group id="V-81709"><title>SRG-OS-000329-GPOS-00128</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-96423r2_rule" severity="medium" weight="10.0"><version>SLES-12-010131</version><title>Accounts on the SUSE operating system that are subject to three unsuccessful logon attempts within 15 minutes must be locked for the maximum configurable period.</title><description>&lt;VulnDiscussion&gt;By limiting the number of failed logon attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-forcing, is reduced. Limits are imposed by locking the account.
+
+Satisfies: SRG-OS-000329-GPOS-00128, SRG-OS-000021-GPOS-00005
+&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-002238</ident><fixtext fixref="F-88557r1_fix">Configure the operating system to lock an account for the maximum period when three unsuccessful logon attempts in 15 minutes are made.
+
+Modify the first three lines of the auth section and the first line of the account section of the "/etc/pam.d/system-auth" and "/etc/pam.d/password-auth" files to match the following lines:
+
+auth required pam_faillock.so preauth silent audit deny=3 even_deny_root fail_interval=900 unlock_time=900
+auth sufficient pam_unix.so try_first_pass
+auth [default=die] pam_faillock.so authfail audit deny=3 even_deny_root fail_interval=900 unlock_time=900
+account required pam_faillock.so 
+
+Note: Manual changes to the listed files may be overwritten by the "authconfig" program. The "authconfig" program should not be used to update the configurations listed in this requirement.</fixtext><fix id="F-88557r1_fix" /><check system="C-81489r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the operating system automatically locks an account for the maximum period for which the system can be configured.
+
+Check that the system locks an account for the maximum period after three unsuccessful logon attempts within a period of 15 minutes with the following command:
+
+# grep pam_faillock.so /etc/pam.d/password-auth
+auth required pam_faillock.so preauth silent audit deny=3 even_deny_root fail_interval=900 unlock_time=900
+auth [default=die] pam_faillock.so authfail audit deny=3 even_deny_root fail_interval=900 unlock_time=900
+account required pam_faillock.so 
+
+If the "unlock_time" parameter is not set to "0", "never", or is set to a value less than "900" on both "auth" lines with the "pam_faillock.so" module, or is missing from these lines, this is a finding.
+Note: The maximum configurable value for "unlock_time" is "604800".</check-content></check></Rule></Group><Group id="V-81785"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-96499r1_rule" severity="medium" weight="10.0"><version>SLES-12-010231</version><title>The SUSE operating system must not be configured to allow blank or null passwords.</title><description>&lt;VulnDiscussion&gt; Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-88635r1_fix">Configure the SUSE operating system to not allow blank or null passwords.
+
+Remove any instances of the "nullok" option in "/etc/pam.d/system-auth" and "/etc/pam.d/password-auth" to prevent logons with empty passwords.</fixtext><fix id="F-88635r1_fix" /><check system="C-81569r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating is not configured to allow blank or null passwords.
+
+Check that blank or null passwords cannot be used by running the following command:
+
+# grep pam_unix.so /etc/pam.d/* | grep nullok
+If this produces any output, it may be possible to log on with accounts with empty passwords.
+
+If null passwords can be used, this is a finding.</check-content></check></Rule></Group><Group id="V-81801"><title>SRG-OS-000163-GPOS-00072</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-96515r1_rule" severity="medium" weight="10.0"><version>SLES-12-030191</version><title>The SUSE operating system for all network connections associated with SSH traffic must immediately terminate at the end of the session or after 10 minutes of inactivity.</title><description>&lt;VulnDiscussion&gt;Automatic session termination addresses the termination of user-initiated logical sessions in contrast to the termination of network connections that are associated with communications sessions (i.e., network disconnect). A logical session (for local, network, and remote access) is initiated whenever a user (or process acting on behalf of a user) accesses an organizational information system. Such user sessions can be terminated (and thus terminate user access) without terminating network sessions.
+
+Session termination terminates all processes associated with a user's logical session except those processes that are specifically created by the user (i.e., session owner) to continue after the session is terminated.
+
+Conditions or trigger events requiring automatic session termination can include, for example, organization-defined periods of user inactivity, targeted responses to certain types of incidents, and time-of-day restrictions on information system use.
+
+This capability is typically reserved for specific Ubuntu operating system functionality where the system owner, data owner, or organization requires additional assurance.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000879</ident><ident system="http://iase.disa.mil/cci">CCI-001133</ident><ident system="http://iase.disa.mil/cci">CCI-002361</ident><fixtext fixref="F-88651r1_fix">Configure the SUSE operating system to automatically terminate all network connections associated with SSH traffic at the end of a session or after a "10" minute period of inactivity.
+
+Modify or append the following lines in the "/etc/ssh/sshd_config" file:
+
+ClientAliveCountMax 1
+
+In order for the changes to take effect, the SSH daemon must be restarted.
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-88651r1_fix" /><check system="C-81589r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify that all network connections associated with SSH traffic are automatically terminated at the end of the session or after "10" minutes of inactivity.
+
+Check that the "ClientAliveInterval" variable is set to a value of "600" or less by performing the following command:
+
+# sudo grep -i clientalive /etc/ssh/sshd_config
+
+ClientAliveInterval 600
+
+ClientAliveCountMax 1
+
+If  "ClientAliveCountMax" does not exist or "ClientAliveCountMax" is not set to a value of "1" or greater in "/etc/ssh/sshd_config", or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-81803"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-96517r1_rule" severity="medium" weight="10.0"><version>SLES-12-030361</version><title>The SUSE operating system must not forward Internet Protocol version 6 (IPv6) source-routed packets.</title><description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when IPv4 forwarding is enabled and the system is functioning as a router.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-88653r1_fix">Configure the SUSE operating system to not accept IPv6 source-routed packets by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv6.conf.all.accept_source_route = 0
+
+Run the following command to apply this value:
+
+# sysctl --system</fixtext><fix id="F-88653r1_fix" /><check system="C-81593r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not accept IPv6 source-routed packets.
+
+Check the value of the accept source route variable with the following command:
+
+# sudo sysctl net.ipv6.conf.all.accept_source_route
+net.ipv6.conf.all.accept_source_route = 0
+
+If the returned line does not have a value of "0", this is a finding.</check-content></check></Rule></Group><Group id="V-81805"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-96519r1_rule" severity="medium" weight="10.0"><version>SLES-12-030401</version><title>The SUSE operating system must not allow interfaces to accept Internet Protocol version 6 (IPv6) Internet Control Message Protocol (ICMP) redirect messages by default.</title><description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-000366</ident><fixtext fixref="F-88657r1_fix">Configure the SUSE operating system to not allow IPv6 ICMP redirect messages by default. 
+
+Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" (or modify the line to have the required value):
+
+net.ipv6.conf.default.accept_redirects=0
+
+Run the following command to apply this value:
+
+# sysctl –system</fixtext><fix id="F-88657r1_fix" /><check system="C-81599r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Verify the SUSE operating system does not allow IPv6 ICMP redirect messages by default.
+
+Check the value of the "default accept_redirects" variables with the following command:
+
+# sudo sysctl net.ipv6.conf.default.accept_redirects
+net.ipv6.conf.default.accept_redirects = 0
+
+If the returned line does not have a value of "0", this is a finding.</check-content></check></Rule></Group><Group id="V-92249"><title>SRG-OS-000196</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-102351r1_rule" severity="medium" weight="10.0"><version>SLES-12-010599</version><title>The SUSE operating system must have a host-based intrusion detection tool installed.</title><description>&lt;VulnDiscussion&gt;Adding host-based intrusion detection tools can provide the capability to automatically take actions in response to malicious behavior, which can provide additional agility in reacting to network threats. These tools also often include a reporting capability to provide network awareness of the system, which may not otherwise exist in an organization's systems management regime.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target SLES 12</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>SLES 12</dc:subject><dc:identifier>2903</dc:identifier></reference><ident system="http://iase.disa.mil/cci">CCI-001263</ident><fixtext fixref="F-98457r1_fix">Install and enable the latest McAfee HIPS package, available from USCYBERCOM.
+
+Note: If the system does not support the McAfee HIPS package, install and enable a supported intrusion detection system application and document its use with the Authorizing Official.</fixtext><fix id="F-98457r1_fix" /><check system="C-91415r1_chk"><check-content-ref name="M" href="DPMS_XCCDF_Benchmark_SLES_12_STIG.xml" /><check-content>Ask the SA or ISSO if a host-based intrusion detection application is loaded on the system. Per OPORD 16-0080, the preferred intrusion detection system is McAfee HBSS available through the U.S. Cyber Command (USCYBERCOM).
+
+If another host-based intrusion detection application is in use, such as AppArmor, this must be documented and approved by the local Authorizing Official.
+
+Procedure:
+Examine the system to see if the Host Intrusion Prevention System (HIPS) is installed:
+
+# rpm -qa | grep MFEhiplsm
+
+Verify that the McAfee HIPS module is active on the system:
+
+# ps -ef | grep -i “hipclient”
+
+If the MFEhiplsm package is not installed, check for another intrusion detection system:
+
+# find / -name &lt;daemon name&gt;
+
+Where &lt;daemon name&gt; is the name of the primary application daemon to determine if the application is loaded on the system.
+
+Determine if the application is active on the system:
+
+# ps -ef | grep -i &lt;daemon name&gt;
+
+If the MFEhiplsm package is not installed and an alternate host-based intrusion detection application has not been documented for use, this is a finding.
+
+If no host-based intrusion detection system is installed and running on the system, this is a finding.
+</check-content></check></Rule></Group></Benchmark>

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -1,0 +1,10 @@
+documentation_complete: true
+
+title: 'DISA STIG for SUSE Linux Enterprise 12'
+
+description: |-
+    This profile contains configuration checks that align to the
+    DISA STIG for SUSE Linux Enterprise 12 V1R2.
+
+selections:
+    - installed_OS_is_vendor_supported

--- a/sle12/transforms/constants.xslt
+++ b/sle12/transforms/constants.xslt
@@ -3,15 +3,14 @@
 <xsl:include href="../../shared/transforms/shared_constants.xslt"/>
 
 <xsl:variable name="product_long_name">SUSE Linux Enterprise 12</xsl:variable>
-<xsl:variable name="product_short_name">SUSE 12</xsl:variable>
-<xsl:variable name="product_stig_id_name">SUSE_12_STIG</xsl:variable>
-<xsl:variable name="product_guide_id_name">SUSE-12</xsl:variable>
+<xsl:variable name="product_short_name">SLE 12</xsl:variable>
+<xsl:variable name="product_stig_id_name">SUSE_Linux_Enterprise_12_STIG</xsl:variable>
+<xsl:variable name="product_guide_id_name">SLE-12</xsl:variable>
 <xsl:variable name="prod_type">sle12</xsl:variable>
 
-<!-- Define URI of official CIS Red Hat Enterprise Linux 7 Benchmark -->
-<xsl:variable name="cisuri"></xsl:variable>
+<xsl:variable name="cisuri">empty</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
-<xsl:variable name="os-stigid-concat"></xsl:variable>
+<xsl:variable name="os-stigid-concat">SLES-12-</xsl:variable>
 
 <!-- Define URI for custom CCE identifier which can be used for mapping to corporate policy -->
 <!--xsl:variable name="custom-cce-uri">https://www.example.org</xsl:variable-->

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -243,6 +243,7 @@ STIG_PLATFORM_ID_MAP = {
     "rhel6": "RHEL-06",
     "rhel7": "RHEL-07",
     "rhel8": "RHEL-08",
+    "sle12": "SLES-12",
 }
 
 # see xccdf-addremediations.xslt <- shared_constants.xslt <- shared_shorthand2xccdf.xslt


### PR DESCRIPTION
#### Description:

This is an initial PR to add a STIG profile for SUSE Linux Enterprise Server 12.

The PR adds the official manual SLES 12 DISA STIG benchmark in version 1 release 2 and then extends the SLE 12 profiles with ```stig.profile``` and the first rule ```installed_OS_is_vendor_supported```.