### PR TITLE
Fix sourcing of shared functions in test scenarios for gui_login_banner group

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_ncp
 
-. ../../../../group_software/group_gnome/dconf_test_functions.sh
+source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_ncp
 
-. ../../../../group_software/group_gnome/dconf_test_functions.sh
+source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_ncp
 
-. ../../../../group_software/group_gnome/dconf_test_functions.sh
+source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig.pass.sh
@@ -2,7 +2,7 @@
 # platform = Red Hat Enterprise Linux 7
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-. ../../../../group_software/group_gnome/dconf_test_functions.sh
+source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/missing_value_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/missing_value_stig.fail.sh
@@ -2,7 +2,7 @@
 # platform = Red Hat Enterprise Linux 7
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-. ../../../../group_software/group_gnome/dconf_test_functions.sh
+source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_ncp
 
-. ../../../../group_software/group_gnome/dconf_test_functions.sh
+source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value_stig.fail.sh
@@ -2,7 +2,7 @@
 # platform = Red Hat Enterprise Linux 7
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-. ../../../../group_software/group_gnome/dconf_test_functions.sh
+source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 


### PR DESCRIPTION
#### Description:

Test scenarios in `linux_os/guide/system/accounts/accounts-banners/gui_login_banner`
have been fixed to source shared functions from the variable `$SHARED` exported by
the SSG Test Suite. Also some test scenarios profile selection has been updated
from the `ospp` to the `ncp` as the original `ospp` profile has been renamed to `ncp`.