### PR TITLE
Add sshd_lineinfile and auditd_lineinfile to new templating system

### DIFF
--- a/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,ol7,ol8,rhv4
+prodtype: debian8,fedora,ol7,ol8,rhel6,rhel7,rhel8,rhv4,ubuntu1404,ubuntu1604,ubuntu1804,wrlinux8,wrlinux1019
 
 title: 'Install the OpenSSH Server Package'
 

--- a/linux_os/guide/services/ssh/package_openssh-server_removed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_removed/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
 
 severity: medium
 
-ocil_clause: 'the package is removed'
+ocil_clause: 'the package is installed'
 
 ocil: '{{{ ocil_package(package="openssh-server") }}}'
 

--- a/linux_os/guide/services/ssh/package_openssh-server_removed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_removed/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: debian8,fedora,ol7,ol8,rhel6,rhel7,rhel8,rhv4,ubuntu1404,ubuntu1604,ubuntu1804,wrlinux8,wrlinux1019
+
+title: 'Remove the OpenSSH Server Package'
+
+description: |-
+    The <tt>openssh-server</tt> package should be removed.
+    {{{ describe_package_remove(package="openssh-server") }}}
+
+rationale: |-
+    Without protection of the transmitted information, confidentiality, and
+    integrity may be compromised because unprotected communications can be
+    intercepted and either read or altered.
+
+severity: medium
+
+ocil_clause: 'the package is removed'
+
+ocil: '{{{ ocil_package(package="openssh-server") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: openssh-server

--- a/linux_os/guide/services/ssh/package_openssh_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12
+prodtype: opensuse,sle11,sle12
 
 title: 'Install the OpenSSH Client and Server Package'
 

--- a/linux_os/guide/services/ssh/package_openssh_removed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh_removed/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: opensuse,sle11,sle12
+
+title: 'Remove the OpenSSH Client and Server Package'
+
+description: |-
+    The <tt>openssh</tt> package should be removed.
+    {{{ describe_package_remove(package="openssh") }}}
+
+rationale: |-
+    Without protection of the transmitted information, confidentiality, and
+    integrity may be compromised because unprotected communications can be
+    intercepted and either read or altered.
+
+severity: medium
+
+ocil_clause: 'the package is installed'
+
+ocil: '{{{ ocil_package(package="openssh") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: openssh

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
@@ -47,7 +47,7 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="yes", option="HostbasedAuthentication", value="no") }}}
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: HostbasedAuthentication

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
@@ -68,7 +68,7 @@ warnings:
         <tt>/etc/ssh/sshd_config</tt> is not necessary.
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: Protocol

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
@@ -49,7 +49,7 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="yes", option="PermitEmptyPasswords", value="no") }}}
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: PermitEmptyPasswords

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/rule.yml
@@ -44,7 +44,7 @@ ocil: |-
     If configured properly, output should be <pre>no</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: GSSAPIAuthentication

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
@@ -45,7 +45,7 @@ ocil: |-
     If configured properly, output should be <pre>no</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: KerberosAuthentication

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/rule.yml
@@ -45,7 +45,7 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="yes", option="IgnoreRhosts", value="yes") }}}
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: IgnoreRhosts

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -50,7 +50,7 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="no", option="PermitRootLogin", value="no") }}}
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: PermitRootLogin

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/rule.yml
@@ -40,7 +40,7 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="no", option="IgnoreUserKnownHosts", value="yes") }}}
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: IgnoreUserKnownHosts

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
     <pre>PermitUserEnvironment no</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: PermitUserEnvironment

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
@@ -44,7 +44,7 @@ ocil: |-
     If configured properly, output should be <pre>yes</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: StrictModes

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
@@ -46,7 +46,7 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue") }}}
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: Banner

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/rule.yml
@@ -38,7 +38,7 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="no", option="X11Forwarding", value="yes") }}}
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: X11Forwarding

--- a/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_print_last_log/rule.yml
@@ -43,7 +43,7 @@ ocil: |-
     If configured properly, output should be <pre>yes</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: PrintLastLog

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/rule.yml
@@ -32,7 +32,7 @@ ocil: |-
     <pre>RekeyLimit 512M 1h</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: RekeyLimit

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/rule.yml
@@ -35,7 +35,7 @@ ocil: |-
     If configured properly, output should be <pre>LogLevel INFO</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: LogLevel

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/rule.yml
@@ -34,7 +34,7 @@ ocil: |-
     If configured properly, output should be <pre>LogLevel VERBOSE</pre>
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: LogLevel

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/rule.yml
@@ -43,7 +43,7 @@ ocil: |-
     If configured properly, output should be <tt><sub idref="var_sshd_priv_separation" /></tt>.
 
 template:
-    name: auditd_lineinfile
+    name: sshd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: UsePrivilegeSeparation

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
@@ -30,7 +30,7 @@ ocil: |-
     <pre>freq = 50</pre>
 
 template:
-    name: sshd_lineinfile
+    name: auditd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: freq

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/rule.yml
@@ -29,7 +29,7 @@ ocil: |-
     <pre>local_events = yes</pre>
 
 template:
-    name: sshd_lineinfile
+    name: auditd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: local_events

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/rule.yml
@@ -31,7 +31,7 @@ ocil: |-
     <pre>log_format = ENRICHED</pre>
 
 template:
-    name: sshd_lineinfile
+    name: auditd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: log_format

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
@@ -31,7 +31,7 @@ ocil: |-
     <pre>name_format = hostname</pre>
 
 template:
-    name: sshd_lineinfile
+    name: auditd_lineinfile
     vars:
         missing_parameter_pass: 'false'
         parameter: name_format

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/rule.yml
@@ -29,7 +29,7 @@ ocil: |-
     <pre>write_logs = yes</pre>
 
 template:
-    name: sshd_lineinfile
+    name: auditd_lineinfile
     vars:
         missing_parameter_pass: 'true'
         parameter: write_logs

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -25,6 +25,16 @@ def accounts_password(data, lang):
     return data
 
 
+def auditd_lineinfile(data, lang):
+    missing_parameter_pass = data["missing_parameter_pass"]
+    if missing_parameter_pass == "true":
+        missing_parameter_pass = True
+    elif missing_parameter_pass == "false":
+        missing_parameter_pass = False
+    data["missing_parameter_pass"] = missing_parameter_pass
+    return data
+
+
 def audit_rules_dac_modification(data, lang):
     return data
 
@@ -145,6 +155,16 @@ def service_enabled(data, lang):
     return data
 
 
+def sshd_lineinfile(data, lang):
+    missing_parameter_pass = data["missing_parameter_pass"]
+    if missing_parameter_pass == "true":
+        missing_parameter_pass = True
+    elif missing_parameter_pass == "false":
+        missing_parameter_pass = False
+    data["missing_parameter_pass"] = missing_parameter_pass
+    return data
+
+
 def timer_enabled(data, lang):
     if "packagename" not in data:
         data["packagename"] = data["timername"]
@@ -153,7 +173,7 @@ def timer_enabled(data, lang):
 
 templates = {
     "accounts_password": accounts_password,
-    "auditd_lineinfile": None,
+    "auditd_lineinfile": auditd_lineinfile,
     "audit_rules_dac_modification": audit_rules_dac_modification,
     "audit_rules_file_deletion_events": audit_rules_file_deletion_events,
     "audit_rules_login_events": audit_rules_login_events,
@@ -187,7 +207,7 @@ templates = {
     "sebool_var": None,
     "service_disabled": service_disabled,
     "service_enabled": service_enabled,
-    "sshd_lineinfile": None,
+    "sshd_lineinfile": sshd_lineinfile,
     "sysctl": sysctl,
     "timer_enabled": timer_enabled,
 }


### PR DESCRIPTION
#### Description:
This PR adds templates sshd_lineinfile and auditd_lineinfe to new templating system.

First, I had to fix wrong template names in some `rule.yml`s. Some rules that use templates have a wrong template name, which was probably a mistake during the mass conversion of CSVs.

Second, when we process the Jinja macros in OVALs or remediations which are defined in rule directories we add variables (eg. rule title, platforms) to the Jinja environment. The Jinja macros that are used in templates for auditd_lineinfile and templates for sshd_lineinfile require that these variables are defined. If they aren't defined they silently generate an invalid OVAL which is then dropped later in the build process.  Therefore we need to define these variables also in the env_yaml that is used in the templating engine to get a similar environment for generating content from templates as when processing not templated content.  This is similar to code in checks() in
ssg/build_ovals.py. Accidentaly, it fixes the weird task names in Ansible remediations for the affected rules.

Third, we had to add a rule which generates OVAL from template for check if OpenSSH isn't present. The rule package_openssh_removed is for SUSE, the rule
package_openssh-server_removed is for other operating systems.

The new callbacks in `templates.py` are very simple, but I don't like that they are working around the fact that we don't support boolean values in YAML.

~Needs to be rebased on master after #4820 is merged.~

#### Rationale:

Part of the "new templating system" effort.
