### PR TITLE
Fix regexes in template_oval_service_disabled and template_oval_service_enabled

### DIFF
--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
+
+yum -y install at
+systemctl disable atd.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
+# profiles = xccdf_org.ssgproject.content_profile_standard
 
 yum -y install at
 systemctl disable atd.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
+# profiles = xccdf_org.ssgproject.content_profile_standard
 
 # this tesst ensures that only the atd.service is matched, not for example the service rpc-statd
 

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
+
+# this tesst ensures that only the atd.service is matched, not for example the service rpc-statd
+
+yum -y install nfs-utils at
+systemctl disable atd.service
+systemctl add-wants default.target rpc-statd.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
+# profiles = xccdf_org.ssgproject.content_profile_standard
 
 yum -y install at
 systemctl enable atd.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_standard
+
+yum -y install at
+systemctl enable atd.service

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -54,7 +54,7 @@
     <linux:state state_ref="state_service_not_running_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
   <linux:systemdunitproperty_object id="obj_service_not_running_{{{ SERVICENAME }}}" comment="Retrieve the ActiveState property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_not_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is not running">
@@ -66,7 +66,7 @@
     <linux:state state_ref="state_service_loadstate_is_masked_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
   <linux:systemdunitproperty_object id="obj_service_loadstate_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the LoadState property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
     <linux:property>LoadState</linux:property>
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_loadstate_is_masked_{{{ SERVICENAME }}}" version="1" comment="LoadState is set to masked">
@@ -78,7 +78,7 @@
     <linux:state state_ref="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
   <linux:systemdunitproperty_object id="obj_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" comment="Retrieve the FragmentPath property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
     <linux:property>FragmentPath</linux:property>
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" version="1" comment="FragmentPath is set to /dev/null">

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -54,7 +54,7 @@
     <linux:state state_ref="state_service_not_running_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
   <linux:systemdunitproperty_object id="obj_service_not_running_{{{ SERVICENAME }}}" comment="Retrieve the ActiveState property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)$</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_not_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is not running">
@@ -66,7 +66,7 @@
     <linux:state state_ref="state_service_loadstate_is_masked_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
   <linux:systemdunitproperty_object id="obj_service_loadstate_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the LoadState property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)$</linux:unit>
     <linux:property>LoadState</linux:property>
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_loadstate_is_masked_{{{ SERVICENAME }}}" version="1" comment="LoadState is set to masked">
@@ -78,7 +78,7 @@
     <linux:state state_ref="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
   <linux:systemdunitproperty_object id="obj_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" comment="Retrieve the FragmentPath property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)</linux:unit>
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)$</linux:unit>
     <linux:property>FragmentPath</linux:property>
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" version="1" comment="FragmentPath is set to /dev/null">

--- a/shared/templates/template_OVAL_service_enabled
+++ b/shared/templates/template_OVAL_service_enabled
@@ -49,7 +49,7 @@
     <linux:state state_ref="state_service_running_{{{ SERVICENAME }}}"/>
   </linux:systemdunitproperty_test>
   <linux:systemdunitproperty_object id="obj_service_running_{{{ SERVICENAME }}}" comment="Retrieve the ActiveState property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">{{{ SERVICENAME }}}\.(socket|service)</linux:unit>
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(socket|service)$</linux:unit>
     <linux:property>ActiveState</linux:property>
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is running">


### PR DESCRIPTION

#### Description:

The regex used to find the unit files in the above mentioned template was lacking the ^ character, I added it.

I also created tests for the service_atd_disabled rule to verify it.

#### Rationale:

therefore in some cases it matched incorrect services as seen here:

https://bugzilla.redhat.com/show_bug.cgi?id=1662627