### PR TITLE
Enable file permissions templates in new templating system

### DIFF
--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_cni_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_cni_conf/rule.yml
@@ -29,6 +29,6 @@ ocil: |-
 template:
     name: file_regex_permissions
     vars:
-        filemode: '0644'
+        path: /etc/cni/net.d
         filename: ^.*$
-        filepath: /etc/cni/net.d
+        filemode: '0644'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
@@ -31,6 +31,6 @@ ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") 
 template:
     name: file_regex_permissions
     vars:
-        filemode: '0640'
+        path: /etc/httpd/conf.d
         filename: ^.*$
-        filepath: /etc/httpd/conf.d
+        filemode: '0640'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
@@ -32,6 +32,6 @@ ocil: '{{{ ocil_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}
 template:
     name: file_regex_permissions
     vars:
-        filemode: '0640'
+        path: /etc/httpd/conf
         filename: ^.*$
-        filepath: /etc/httpd/conf
+        filemode: '0640'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -39,7 +39,7 @@ ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
 template:
     name: file_regex_permissions
     vars:
+        path: /etc/ssh
+        filename: ^.*_key$
         filemode: '0640'
         filemode@sle12: '0600'
-        filename: ^.*_key$
-        filepath: /etc/ssh

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -34,6 +34,6 @@ ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'
 template:
     name: file_regex_permissions
     vars:
-        filemode: '0644'
+        path: /etc/ssh
         filename: ^.*.pub$
-        filepath: /etc/ssh
+        filemode: '0644'

--- a/shared/templates/template_OVAL_file_groupowner
+++ b/shared/templates/template_OVAL_file_groupowner
@@ -23,7 +23,12 @@
     {{{ UNIX_DIR }}}
     {{{ UNIX_FILENAME }}}
   {{%- else -%}}
-    <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+    {{%- if IS_DIRECTORY -%}}
+      <unix:path>{{{ FILEPATH }}}</unix:path>
+      <unix:filename xsi:nil="true" />
+    {{%- else -%}}
+      <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+    {{%- endif -%}}
   {{%- endif %}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_groupowner
+++ b/shared/templates/template_OVAL_file_groupowner
@@ -19,7 +19,11 @@
     <unix:group_id datatype="int">{{{ FILEGID }}}</unix:group_id>
   </unix:file_state>
   <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_groupowner{{{ FILEID }}}" version="1">
+  {{% if UNIX_DIR and UNIX_FILENAME -%}}
     {{{ UNIX_DIR }}}
     {{{ UNIX_FILENAME }}}
+  {{%- else -%}}
+    <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+  {{%- endif %}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_owner
+++ b/shared/templates/template_OVAL_file_owner
@@ -23,7 +23,12 @@
     {{{ UNIX_DIR }}}
     {{{ UNIX_FILENAME }}}
   {{%- else -%}}
-    <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+    {{%- if IS_DIRECTORY -%}}
+      <unix:path>{{{ FILEPATH }}}</unix:path>
+      <unix:filename xsi:nil="true" />
+    {{%- else -%}}
+      <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+    {{%- endif -%}}
   {{%- endif %}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_owner
+++ b/shared/templates/template_OVAL_file_owner
@@ -19,7 +19,11 @@
     <unix:user_id datatype="int">{{{ FILEUID }}}</unix:user_id>
   </unix:file_state>
   <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_owner{{{ FILEID }}}" version="1">
+  {{% if UNIX_DIR and UNIX_FILENAME -%}}
     {{{ UNIX_DIR }}}
     {{{ UNIX_FILENAME }}}
+  {{%- else -%}}
+    <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+  {{%- endif %}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_permissions
+++ b/shared/templates/template_OVAL_file_permissions
@@ -25,7 +25,12 @@
     {{{ UNIX_DIR }}}
     {{{ UNIX_FILENAME }}}
   {{%- else -%}}
-    <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+    {{%- if IS_DIRECTORY -%}}
+      <unix:path>{{{ FILEPATH }}}</unix:path>
+      <unix:filename xsi:nil="true" />
+    {{%- else -%}}
+      <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+    {{%- endif -%}}
   {{%- endif %}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_permissions
+++ b/shared/templates/template_OVAL_file_permissions
@@ -21,7 +21,11 @@
     {{{ STATEMODE }}}
   </unix:file_state>
   <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_permissions{{{ FILEID }}}" version="1">
+  {{% if UNIX_DIR and UNIX_FILENAME -%}}
     {{{ UNIX_DIR }}}
     {{{ UNIX_FILENAME }}}
+  {{%- else -%}}
+    <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+  {{%- endif %}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_regex_permissions
+++ b/shared/templates/template_OVAL_file_regex_permissions
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+    <metadata>
+      <title>Verify {{{ FILEPATH }}} Mode Permissions</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>This test makes sure that {{{ FILEPATH }}} has mode {{{ FILEMODE }}}.
+      If the target file or directory has an extended ACL, then it will fail the mode check.
+      </description>
+    </metadata>
+    <criteria>
+      <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_{{{ _RULE_ID }}}" />
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing mode of {{{ FILEPATH }}}" id="test_{{{ _RULE_ID }}}" version="1">
+    <unix:object object_ref="object_{{{ _RULE_ID }}}" />
+    <unix:state state_ref="state_{{{ _RULE_ID }}}_mode_{{{ FILEMODE }}}" />
+  </unix:file_test>
+  <unix:file_state id="state_{{{ _RULE_ID }}}_mode_{{{ FILEMODE }}}" version="1">
+    {{{ STATEMODE }}}
+  </unix:file_state>
+  <unix:file_object comment="{{{ FILEPATH }}}" id="object_{{{ _RULE_ID }}}" version="1">
+    <unix:path>{{{ PATH }}}</unix:path>
+    <unix:filename operation="pattern match">{{{ FILENAME }}}</unix:filename>
+  </unix:file_object>
+</def-group>

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -90,18 +90,21 @@ def audit_rules_usergroup_modification(data, lang):
 def file_groupowner(data, lang):
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_groupowner", "")
+        data["is_directory"] = data["filepath"].endswith("/")
     return data
 
 
 def file_owner(data, lang):
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_owner", "")
+        data["is_directory"] = data["filepath"].endswith("/")
     return data
 
 
 def file_permissions(data, lang):
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_permissions", "")
+        data["is_directory"] = data["filepath"].endswith("/")
 
         # build the state that describes our mode
         # mode_str maps to STATEMODE in the template
@@ -126,7 +129,6 @@ def file_permissions(data, lang):
 
 
 def file_regex_permissions(data, lang):
-    print(data)
     if lang == "ansible":
         data["filepath"] = data["path"]
     elif lang == "bash":

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -87,6 +87,63 @@ def audit_rules_usergroup_modification(data, lang):
     return data
 
 
+def file_groupowner(data, lang):
+    if lang == "oval":
+        data["fileid"] = data["_rule_id"].replace("file_groupowner", "")
+    return data
+
+
+def file_owner(data, lang):
+    if lang == "oval":
+        data["fileid"] = data["_rule_id"].replace("file_owner", "")
+    return data
+
+
+def file_permissions(data, lang):
+    if lang == "oval":
+        data["fileid"] = data["_rule_id"].replace("file_permissions", "")
+
+        # build the state that describes our mode
+        # mode_str maps to STATEMODE in the template
+        mode = data["filemode"]
+        fields = [
+            'oexec', 'owrite', 'oread', 'gexec', 'gwrite', 'gread',
+            'uexec', 'uwrite', 'uread', 'sticky', 'sgid', 'suid']
+        mode_int = int(mode, 8)
+        mode_str = ""
+        for field in fields:
+            if mode_int & 0x01 == 1:
+                mode_str = (
+                    "	<unix:" + field + " datatype=\"boolean\">true</unix:"
+                    + field + ">\n" + mode_str)
+            else:
+                mode_str = (
+                    "	<unix:" + field + " datatype=\"boolean\">false</unix:"
+                    + field + ">\n" + mode_str)
+            mode_int = mode_int >> 1
+        data["statemode"] = mode_str
+    return data
+
+
+def file_regex_permissions(data, lang):
+    print(data)
+    if lang == "ansible":
+        data["filepath"] = data["path"]
+    elif lang == "bash":
+        data["filepath"] = data["path"]
+        data["filename"] = re.sub(r"^\^", "", data["filename"])
+    elif lang == "oval":
+        # build a string that contains the full path to the file
+        path = data["path"]
+        filename = data["filename"]
+        if filename == '[NULL]' or filename == '':
+            filepath = path
+        else:
+            filepath = path + '/' + filename
+        data["filepath"] = filepath
+    return data
+
+
 def grub2_bootloader_argument(data, lang):
     data["arg_name_value"] = data["arg_name"] + "=" + data["arg_value"]
     return data
@@ -168,10 +225,10 @@ templates = {
     "audit_rules_unsuccessful_file_modification_rule_order":
         audit_rules_unsuccessful_file_modification_rule_order,
     "audit_rules_usergroup_modification": audit_rules_usergroup_modification,
-    "file_groupowner": None,
-    "file_owner": None,
-    "file_permissions": None,
-    "file_regex_permissions": None,
+    "file_groupowner": file_groupowner,
+    "file_owner": file_owner,
+    "file_permissions": file_permissions,
+    "file_regex_permissions": file_regex_permissions,
     "grub2_bootloader_argument": grub2_bootloader_argument,
     "kernel_module_disabled": kernel_module_disabled,
     "mount": mount,
@@ -182,7 +239,6 @@ templates = {
     "ocp_service_runtime_config": None,
     "package_installed": package_installed,
     "package_removed": package_removed,
-    "permissions": None,
     "sebool": None,
     "sebool_var": None,
     "service_disabled": service_disabled,
@@ -230,9 +286,9 @@ class Builder(object):
         """
         template_func = templates[template]
         if template_func is not None:
-            parameters = template_func(raw_parameters, lang)
+            parameters = template_func(raw_parameters.copy(), lang)
         else:
-            parameters = raw_parameters
+            parameters = raw_parameters.copy()
         # TODO: Remove this right after the variables in templates are renamed
         # to lowercase
         parameters = {k.upper(): v for k, v in parameters.items()}


### PR DESCRIPTION
Ports `shared/templates/create_permissions.py`. This script populated
multiple templates at once, generating content for up to 3 rules.  In
the new system there is a different approach - the `rule.yml`s contain
specifically in their template `name` key the type of check to be
generated: file_owner, file_groupowner, file_permissions.

Files template_BASH_permissions and template_OVAL_permissions are never
used and no content was generated from them, so we can remove them.

In the old system, there were special Bash and Ansible templates used
(template_ANSIBLE_file_regex_permissions and
template_BASH_file_regex_permissions) if the file name was specified
using a regular expression. However, OVAL template was shared, meaning
there was no special OVAL template for regular expressions.
Unfortunately, the new system doesn't allow sharing templates between
multiple templates. This problem is solved by creating a new special
OVAL template for template file_regex_permissions.

To disambiguate filepath, path, and filename among these templates the
variable `filepath` has been renamed to `path` in template
`file_regex_permissions`, because it is in line with name of OVAL
`<unix:path>` element which also specifies directory paths. This way
we prevent people confusing it with OVAL `<unix:filepath>` element,
which specifies the full path instead.

