### PR TITLE
Use defaults/main.yml and not vars/main.yml

### DIFF
--- a/utils/ansible_galaxy_readme_template.md
+++ b/utils/ansible_galaxy_readme_template.md
@@ -17,7 +17,7 @@ Requirements
 Role Variables
 --------------
 
-To customize the role to your liking, check out the [list of variables](vars/main.yml).
+To customize the role to your liking, check out the [list of variables](defaults/main.yml).
 
 Dependencies
 ------------


### PR DESCRIPTION
Ansible roles prefer `defaults/main.yml` over `vars/main.yml`