### PR TITLE
Use correct function to handle wrong args in build_product.

### DIFF
--- a/build_product
+++ b/build_product
@@ -314,7 +314,7 @@ for chosen_product in "${_arg_product[@]}"; do
 	if is_product "$chosen_product"; then
 		cmake_enable_args+=("$(opt_product_in "$chosen_product")")
 	else
-		handle_wrong_argument "$chosen_product"
+		handle_wrong_products "$chosen_product"
 	fi
 done
 


### PR DESCRIPTION
#### Description:

- Fix build product tool when using nonexistent product names

#### Rationale:

- The function's name is `handle_wrong_products` instead of `handle_wrong_argument` therefore there was a syntax error.
