### PR TITLE
Fix typo in installed_OS_is_rhv4.xml file.

### DIFF
--- a/shared/checks/oval/installed_OS_is_rhv4.xml
+++ b/shared/checks/oval/installed_OS_is_rhv4.xml
@@ -44,5 +44,5 @@
     <ind:subexpression operation="pattern match">7</ind:subexpression>
   </ind:textfilecontent54_state>
 
-</def-group>N
+</def-group>
 


### PR DESCRIPTION
#### Description:

- Fix typo in installed_OS_is_rhv4.xml file.
