### PR TITLE
Add rules to generate OVAL dependencies

### DIFF
--- a/linux_os/guide/services/avahi/package_avahi_installed/rule.yml
+++ b/linux_os/guide/services/avahi/package_avahi_installed/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: Install avahi Package
+
+description: |-
+    {{{ describe_package_install(package="avahi") }}}
+
+rationale: |-
+    Avahi is a system which facilitates service discovery on
+    a local network -- this means that you can plug your laptop or
+    computer into a network and instantly be able to view other people who
+    you can chat with, find printers to print to or find files being
+    shared.
+
+severity: medium
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="avahi") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: avahi

--- a/linux_os/guide/services/ldap/openldap_client/package_pam_ldap_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_pam_ldap_removed/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+prodtype: rhel6
+
+title: Remove pam_ldap Package
+
+description: |-
+    {{{ describe_package_remove(package="pam_ldap") }}}
+
+rationale: |-
+    The pam_ldap module is a Pluggable Authentication Module (PAM) which provides authentication, authorization and password changing against LDAP servers.
+
+severity: medium
+
+ocil_clause: 'the package is installed'
+
+ocil: '{{{ ocil_package(package="pam_ldap") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: pam_ldap

--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -1,0 +1,17 @@
+documentation_complete: true
+
+title: 'Enable the chronyd Daemon'
+
+description: '{{{ describe_service_enable(service="chronyd") }}}'
+
+rationale: |-
+    chronyd is a daemon for synchronisation of the system clock.
+
+severity: medium
+
+ocil: '{{{ ocil_service_enabled(service="chronyd") }}}'
+
+template:
+    name: service_enabled
+    vars:
+        servicename: chronyd

--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -15,3 +15,4 @@ template:
     name: service_enabled
     vars:
         servicename: chronyd
+        packagename: chrony

--- a/linux_os/guide/services/smb/disabling_samba/package_samba-common_removed/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/package_samba-common_removed/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: Remove samba-common Package
+
+description: |-
+    {{{ describe_package_remove(package="samba-common") }}}
+
+rationale: |-
+
+severity: medium
+
+ocil_clause: 'the package is installed'
+
+ocil: '{{{ ocil_package(package="samba-common") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: samba-common

--- a/linux_os/guide/services/sssd/service_sssd_disabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_disabled/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+prodtype: rhel6,rhel7,rhel8,ol7,ol8
+
+title: 'Disable the SSSD Service'
+
+description: |-
+    The SSSD service should be disabled.
+    {{{ describe_service_disable(service="sssd") }}}
+
+rationale: ""
+
+severity: medium
+
+ocil_clause: 'the service is not disabled'
+
+ocil: '{{{ ocil_service_disabled(service="sssd") }}}'
+
+template:
+    name: service_disabled
+    vars:
+        servicename: sssd

--- a/linux_os/guide/services/sssd/service_sssd_disabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,ol7,ol8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8,fedora,rhv4
 
 title: 'Disable the SSSD Service'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_esc_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_esc_installed/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: Install esc Package
+
+description: |-
+    {{{ describe_package_install(package="esc") }}}
+
+rationale: |-
+    Enterprise Security Client allows the user to enroll and manage their cryptographic smartcards.
+
+severity: medium
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="esc") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: esc

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pam_pkcs11_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pam_pkcs11_installed/rule.yml
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: Install pam_pkcs11 Package
+
+description: |-
+    {{{ describe_package_install(package="pam_pkcs11") }}}
+
+rationale: |-
+
+severity: medium
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="pam_pkcs11") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: pam_pkcs11

--- a/linux_os/guide/system/software/gnome/package_GConf2_installed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_GConf2_installed/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: Install GConf2 Package
+
+description: |-
+    {{{ describe_package_install(package="GConf2") }}}
+
+rationale: |-
+    GConf is a process-transparent configuration database API used to
+    store user preferences. It has pluggable backends and features to
+    support workgroup administration.
+
+severity: medium
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="GConf2") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: GConf2

--- a/linux_os/guide/system/software/gnome/package_dconf_installed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_dconf_installed/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: Install dconf Package
+
+description: |-
+    {{{ describe_package_install(package="dconf") }}}
+
+rationale: |-
+    dconf is a low-level configuration system. Its main purpose is to provide a
+    backend to the GSettings API in GLib.
+
+severity: medium
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="dconf") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: dconf

--- a/linux_os/guide/system/software/gnome/package_gdm_installed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_gdm_installed/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: Install gdm Package
+
+description: |-
+    {{{ describe_package_install(package="gdm") }}}
+
+rationale: |-
+    GDM, the GNOME Display Manager, handles authentication-related backend
+    functionality for logging in a user and unlocking the user's session after
+    it's been locked. GDM also provides functionality for initiating user-switching,
+    so more than one user can be logged in at the same time. It handles
+    graphical session registration with the system for both local and remote
+    sessions (in the latter case, via the XDMCP protocol).  In cases where the
+    session doesn't provide it's own display server, GDM can start the display
+    server on behalf of the session.
+
+severity: medium
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="gdm") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: gdm

--- a/linux_os/guide/system/software/integrity/package_prelink_removed/rule.yml
+++ b/linux_os/guide/system/software/integrity/package_prelink_removed/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: Remove prelink Package
+
+description: |-
+    {{{ describe_package_remove(package="prelink") }}}
+
+rationale: |-
+    prelink is a program that modifies ELF shared libraries and ELF dynamically linked binaries in such a way that the time needed for the dynamic linker to perform relocations at startup significantly decreases.
+
+severity: medium
+
+ocil_clause: 'the package is installed'
+
+ocil: '{{{ ocil_package(package="prelink") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: prelink


### PR DESCRIPTION


#### Description:

Add new rules that will not be used in any profile for now but they are used to generate OVALs which are used in other rules.

#### Rationale:
Some of the rules depend on content which was generated from CSVs but no
corresponding rule exists. This is not possible in the new templating
system.  Since the new templating system is rule-based, we need a
rule.yml that contains a `template:` key to generate templated content.
