### PR TITLE
Double quote value when setting runtime sysctl configuration.

### DIFF
--- a/shared/templates/template_BASH_sysctl
+++ b/shared/templates/template_BASH_sysctl
@@ -10,7 +10,7 @@ populate sysctl_{{{ SYSCTLID }}}_value
 #
 # Set runtime for {{{ SYSCTLVAR }}}
 #
-/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}=$sysctl_{{{ SYSCTLID }}}_value
+/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="$sysctl_{{{ SYSCTLID }}}_value"
 
 #
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to appropriate value
@@ -22,7 +22,7 @@ replace_or_append '/etc/sysctl.conf' '^{{{ SYSCTLVAR }}}' "$sysctl_{{{ SYSCTLID 
 #
 # Set runtime for {{{ SYSCTLVAR }}}
 #
-/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}={{{ SYSCTLVAL }}}
+/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="{{{ SYSCTLVAL }}}"
 
 #
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to "{{{ SYSCTLVAL }}}"


### PR DESCRIPTION
#### Description:

- Double quote value when setting runtime sysctl configuration, ensuring that they will be applied correctly.

#### Rationale:

- When using values such as `|/bin/false`, it needs to be quoted otherwise `/sbin/sysctl` will fail to apply the runtime configuration.
