### PR TITLE
Remove extraneous *.* from description and check of rule 'rsyslog_remote_tls_cacert'

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/oval/shared.xml
@@ -22,7 +22,7 @@
 
   <ind:textfilecontent54_object id="obj_rsyslog_remote_tls_cacert" version="1">
     <ind:filepath operation="pattern match">^/etc/rsyslog\.(conf|d/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*global\(DefaultNetstreamDriverCAFile="(.+?)"\) +\*\.\*\s*\n</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*global\(DefaultNetstreamDriverCAFile="(.+?)"\)\s*\n</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">0</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
@@ -9,7 +9,7 @@ description: |-
     to remote server using Transport Layer Security (TLS)
     using correct path for the <tt>DefaultNetstreamDriverCAFile</tt>
     global option in <tt>/etc/rsyslog.conf</tt>, for example with the following command:
-    <pre>echo 'global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*' >> /etc/rsyslog.conf</pre>
+    <pre>echo 'global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem")' >> /etc/rsyslog.conf</pre>
     Replace the <tt>/etc/pki/tls/cert.pem</tt> in the above command with the path to the file with CA certificate generated for the purpose of remote logging.
 
 rationale: |-
@@ -32,5 +32,5 @@ ocil: |-
     configured for its TLS connections to remote server, run the following command:
     <pre>$ grep DefaultNetstreamDriverCAFile /etc/rsyslog.conf /etc/rsyslog.d/*.conf</pre>
     The output should include record similar to
-    <pre>global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*</pre>
+    <pre>global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem")</pre>
     where the path to the CA file (<tt>/etc/pki/tls/cert.pem</tt> in case above) must point to the correct CA certificate.

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/cacert_configured.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/cacert_configured.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo 'global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem")' >> /etc/rsyslog.conf

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/syntax_error.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/syntax_error.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
+
+echo 'global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*' >> /etc/rsyslog.conf


### PR DESCRIPTION
#### Description:

- Rule `rsyslog_remote_tls_cacert`: remove extra `*.*`from rule description and check 
- Add simple test scenario for this
