### PR TITLE
Fix missing content in datastreams generated by new templating system

### DIFF
--- a/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/rule.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel6,rhel7,rhel8,rhv4
+prodtype: fedora,sle12,wrlinux1019,rhel6,rhel7,rhel8,rhv4
 
 title: 'Uninstall vsftpd Package'
 

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
+prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Uninstall net-snmp Package'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,rhv4,ol7,ol8
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Enable the pcscd Service'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
@@ -11,10 +11,10 @@
     </metadata>
     <criteria operator="AND">
       <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_rmdir" />
-      <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_unlink" />
-      <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_unlinkat" />
-      <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_rename" />
-      <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_renameat" />
+      <extend_definition comment="audit unlink" definition_ref="audit_rules_file_deletion_events_unlink" />
+      <extend_definition comment="audit unlinkat" definition_ref="audit_rules_file_deletion_events_unlinkat" />
+      <extend_definition comment="audit rename" definition_ref="audit_rules_file_deletion_events_rename" />
+      <extend_definition comment="audit renameat" definition_ref="audit_rules_file_deletion_events_renameat" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
-
 title: 'Ensure auditd Collects File Deletion Events by User - rename'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
-
 title: 'Ensure auditd Collects File Deletion Events by User - renameat'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
-
 title: 'Ensure auditd Collects File Deletion Events by User - rmdir'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
-
 title: 'Ensure auditd Collects File Deletion Events by User - unlink'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
-
 title: 'Ensure auditd Collects File Deletion Events by User - unlinkat'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
+prodtype: rhel6,wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
 title: 'Record Attempts to Alter Logon and Logout Events - faillock'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
+prodtype: rhel6,wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
 title: 'Record Attempts to Alter Logon and Logout Events - lastlog'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
 title: 'Record Attempts to Alter Logon and Logout Events - tallylog'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -47,4 +47,5 @@ template:
         type@rhel7: tmpfs
         type@rhel8: tmpfs
     backends:
-        anaconda: 'off'
+        anaconda@rhel7: 'off'
+        anaconda@rhel8: 'off'

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -50,4 +50,5 @@ template:
         type@rhel7: tmpfs
         type@rhel8: tmpfs
     backends:
-        anaconda: 'off'
+        anaconda@rhel7: 'off'
+        anaconda@rhel8: 'off'

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -47,4 +47,5 @@ template:
         type@rhel7: tmpfs
         type@rhel8: tmpfs
     backends:
-        anaconda: 'off'
+        anaconda@rhel7: 'off'
+        anaconda@rhel8: 'off'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
+prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 
 title: 'Install AIDE'
 


### PR DESCRIPTION
#### Description:

The missing OVALs were caused mostly by a mismatch in `prodtype` tag in the rule and the rule that generates the dependent content. This is solved by adding the prodtypes from the dependent rule to its dependency. However, a fix for 4 missing OVALs in OCP3  datastream will be submitted in a separate PR.

There was a mistake in port of CSV data for mount options, which caused that Anaconda remediation was disabled on all platforms. But according to CSVs it should be disabled only on RHEL 7  and 8.

For more details please read the commit messages of each commit. 


#### Rationale:

This prevents missing OVALs and Anaconda remediations in comparison of datatstreams generated by old and new templating.
