### PR TITLE
Fix templates file_owner, file_groupowner and merge templates file_permissions and file_regex_permissions

### DIFF
--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_cni_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_cni_conf/rule.yml
@@ -23,3 +23,10 @@ references:
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 
 ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/cni/net.d/
+        file_regex: ^.*$
+        filegid: '0'

--- a/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_openvswitch/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_groupowner_master_openvswitch/rule.yml
@@ -23,3 +23,10 @@ references:
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/origin/openvswitch/*", group="root") }}}'
 
 ocil: '{{{ ocil_file_group_owner(file="/etc/origin/openvswitch/*", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/origin/openvswitch/
+        file_regex: ^.*$
+        filegid: '0'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_cni_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_cni_conf/rule.yml
@@ -23,3 +23,10 @@ references:
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 
 ocil: '{{{ ocil_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/cni/net.d/
+        file_regex: ^.*$
+        fileuid: '0'

--- a/applications/openshift/ocp-permissions/ocp-files/file_owner_master_openvswitch/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_owner_master_openvswitch/rule.yml
@@ -23,3 +23,10 @@ references:
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/origin/openvswitch/*", owner="root") }}}'
 
 ocil: '{{{ ocil_file_owner(file="/etc/origin/openvswitch/*", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/origin/openvswitch/
+        file_regex: ^.*$
+        fileuid: '0'

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_cni_conf/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_cni_conf/rule.yml
@@ -27,8 +27,8 @@ ocil: |-
     {{{ ocil_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}
 
 template:
-    name: file_regex_permissions
+    name: file_permissions
     vars:
-        path: /etc/cni/net.d
-        filename: ^.*$
+        filepath: /etc/cni/net.d/
+        file_regex: ^.*$
         filemode: '0644'

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
@@ -27,8 +27,8 @@ ocil: |-
     {{{ ocil_file_permissions(file="/etc/origin/openvswitch/*", perms="-rw-r--r--") }}}
 
 template:
-    name: file_regex_permissions
+    name: file_permissions
     vars:
-        path: /etc/origin/openvswitch
-        filename: ^.*$
+        filepath: /etc/origin/openvswitch/
+        file_regex: ^.*$
         filemode: '0644'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
@@ -29,8 +29,8 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf.d/*", perms=
 ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}'
 
 template:
-    name: file_regex_permissions
+    name: file_permissions
     vars:
-        path: /etc/httpd/conf.d
-        filename: ^.*$
+        filepath: /etc/httpd/conf.d/
+        file_regex: ^.*$
         filemode: '0640'

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
@@ -30,8 +30,8 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf/*", perms="-
 ocil: '{{{ ocil_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}'
 
 template:
-    name: file_regex_permissions
+    name: file_permissions
     vars:
-        path: /etc/httpd/conf
-        filename: ^.*$
+        filepath: /etc/httpd/conf/
+        file_regex: ^.*$
         filemode: '0640'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -37,9 +37,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*_key", perms="-rw
 ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
 
 template:
-    name: file_regex_permissions
+    name: file_permissions
     vars:
-        path: /etc/ssh
-        filename: ^.*_key$
+        filepath: /etc/ssh/
+        file_regex: ^.*_key$
         filemode: '0640'
         filemode@sle12: '0600'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -32,8 +32,8 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*.pub", perms="-rw
 ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'
 
 template:
-    name: file_regex_permissions
+    name: file_permissions
     vars:
-        path: /etc/ssh
-        filename: ^.*.pub$
+        filepath: /etc/ssh/
+        file_regex: ^.*.pub$
         filemode: '0644'

--- a/shared/templates/template_ANSIBLE_file_groupowner
+++ b/shared/templates/template_ANSIBLE_file_groupowner
@@ -3,6 +3,25 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+
+{{% if IS_DIRECTORY and FILE_REGEX %}}
+
+- name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
+  find:
+    paths: "{{{ FILEPATH }}}"
+    patterns: "{{{ FILE_REGEX }}}"
+    use_regex: yes
+  register: files_found
+
+- name: Ensure group owner on {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
+  file:
+    path: "{{ item.path }}"
+    group: "{{{ FILEGID }}}"
+  with_items:
+    - "{{ files_found.files }}"
+
+{{% else %}}
+
 - name: Test for existence {{{ FILEPATH }}}
   stat:
     path: "{{{ FILEPATH }}}"
@@ -13,3 +32,5 @@
     path: "{{{ FILEPATH }}}"
     group: "{{{ FILEGID }}}"
   when: file_exists.stat is defined and file_exists.stat.exists
+
+{{% endif %}}

--- a/shared/templates/template_ANSIBLE_file_owner
+++ b/shared/templates/template_ANSIBLE_file_owner
@@ -3,6 +3,25 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+
+{{% if IS_DIRECTORY and FILE_REGEX %}}
+
+- name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
+  find:
+    paths: "{{{ FILEPATH }}}"
+    patterns: "{{{ FILE_REGEX }}}"
+    use_regex: yes
+  register: files_found
+
+- name: Ensure group owner on {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
+  file:
+    path: "{{ item.path }}"
+    owner: "{{{ FILEUID }}}"
+  with_items:
+    - "{{ files_found.files }}"
+
+{{% else %}}
+
 - name: Test for existence {{{ FILEPATH }}}
   stat:
     path: "{{{ FILEPATH }}}"
@@ -13,3 +32,5 @@
     path: "{{{ FILEPATH }}}"
     owner: "{{{ FILEUID }}}"
   when: file_exists.stat is defined and file_exists.stat.exists
+
+{{% endif %}}

--- a/shared/templates/template_ANSIBLE_file_permissions
+++ b/shared/templates/template_ANSIBLE_file_permissions
@@ -3,6 +3,24 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+{{% if IS_DIRECTORY and FILE_REGEX %}}
+
+- name: Find {{{ FILEPATH }}} file(s)
+  find:
+    paths: "{{{ FILEPATH }}}"
+    patterns: "{{{ FILE_REGEX }}}"
+    use_regex: yes
+  register: files_found
+
+- name: Set permissions for {{{ FILEPATH }}} file(s)
+  file:
+    path: "{{ item.path }}"
+    mode: "{{{ FILEMODE }}}"
+  with_items:
+    - "{{ files_found.files }}"
+
+{{% else %}}
+
 - name: Test for existence {{{ FILEPATH }}}
   stat:
     path: "{{{ FILEPATH }}}"
@@ -13,3 +31,5 @@
     path: "{{{ FILEPATH }}}"
     mode: "{{{ FILEMODE }}}"
   when: file_exists.stat is defined and file_exists.stat.exists
+
+{{% endif %}}

--- a/shared/templates/template_BASH_file_groupowner
+++ b/shared/templates/template_BASH_file_groupowner
@@ -4,4 +4,8 @@
 # complexity = low
 # disruption = low
 
+{{% if IS_DIRECTORY and FILE_REGEX %}}
+find {{{ FILEPATH }}} -regex '{{{ FILE_REGEX }}}' -exec chgrp {{{ FILEGID }}} {} \;
+{{% else %}}
 chgrp {{{ FILEGID }}} {{{ FILEPATH }}}
+{{% endif %}}

--- a/shared/templates/template_BASH_file_owner
+++ b/shared/templates/template_BASH_file_owner
@@ -4,4 +4,8 @@
 # complexity = low
 # disruption = low
 
+{{% if IS_DIRECTORY and FILE_REGEX %}}
+find {{{ FILEPATH }}} -regex '{{{ FILE_REGEX }}}' -exec chown {{{ FILEUID }}} {} \;
+{{% else %}}
 chown {{{ FILEUID }}} {{{ FILEPATH }}}
+{{% endif %}}

--- a/shared/templates/template_BASH_file_permissions
+++ b/shared/templates/template_BASH_file_permissions
@@ -3,5 +3,8 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-
+{{% if IS_DIRECTORY and FILE_REGEX %}}
+find {{{ FILEPATH }}} -regex '{{{ FILE_REGEX }}}' -exec chmod {{{ FILEMODE }}} {} \;
+{{% else %}}
 chmod {{{ FILEMODE }}} {{{ FILEPATH }}}
+{{% endif %}}

--- a/shared/templates/template_OVAL_file_groupowner
+++ b/shared/templates/template_OVAL_file_groupowner
@@ -25,7 +25,11 @@
   {{%- else -%}}
     {{%- if IS_DIRECTORY -%}}
       <unix:path>{{{ FILEPATH }}}</unix:path>
-      <unix:filename xsi:nil="true" />
+      {{%- if FILE_REGEX -%}}
+        <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else -%}}
+        <unix:filename xsi:nil="true" />
+      {{%- endif -%}}
     {{%- else -%}}
       <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
     {{%- endif -%}}

--- a/shared/templates/template_OVAL_file_owner
+++ b/shared/templates/template_OVAL_file_owner
@@ -25,7 +25,11 @@
   {{%- else -%}}
     {{%- if IS_DIRECTORY -%}}
       <unix:path>{{{ FILEPATH }}}</unix:path>
-      <unix:filename xsi:nil="true" />
+      {{%- if FILE_REGEX -%}}
+        <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else -%}}
+        <unix:filename xsi:nil="true" />
+      {{%- endif -%}}
     {{%- else -%}}
       <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
     {{%- endif -%}}

--- a/shared/templates/template_OVAL_file_permissions
+++ b/shared/templates/template_OVAL_file_permissions
@@ -27,7 +27,11 @@
   {{%- else -%}}
     {{%- if IS_DIRECTORY -%}}
       <unix:path>{{{ FILEPATH }}}</unix:path>
-      <unix:filename xsi:nil="true" />
+      {{%- if FILE_REGEX -%}}
+        <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else -%}}
+        <unix:filename xsi:nil="true" />
+      {{%- endif -%}}
     {{%- else -%}}
       <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
     {{%- endif -%}}

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -97,17 +97,26 @@ def audit_rules_usergroup_modification(data, lang):
     return data
 
 
+def _file_owner_groupowner_regex(data):
+    data["is_directory"] = data["filepath"].endswith("/")
+    if "file_regex" in data and not data["is_directory"]:
+        raise ValueError(
+            "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
+            "specify a directory. Append '/' to the filepath or remove the "
+            "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+
+
 def file_groupowner(data, lang):
+    _file_owner_groupowner_regex(data)
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_groupowner", "")
-        data["is_directory"] = data["filepath"].endswith("/")
     return data
 
 
 def file_owner(data, lang):
+    _file_owner_groupowner_regex(data)
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_owner", "")
-        data["is_directory"] = data["filepath"].endswith("/")
     return data
 
 

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -97,7 +97,7 @@ def audit_rules_usergroup_modification(data, lang):
     return data
 
 
-def _file_owner_groupowner_regex(data):
+def _file_owner_groupowner_permissions_regex(data):
     data["is_directory"] = data["filepath"].endswith("/")
     if "file_regex" in data and not data["is_directory"]:
         raise ValueError(
@@ -107,24 +107,23 @@ def _file_owner_groupowner_regex(data):
 
 
 def file_groupowner(data, lang):
-    _file_owner_groupowner_regex(data)
+    _file_owner_groupowner_permissions_regex(data)
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_groupowner", "")
     return data
 
 
 def file_owner(data, lang):
-    _file_owner_groupowner_regex(data)
+    _file_owner_groupowner_permissions_regex(data)
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_owner", "")
     return data
 
 
 def file_permissions(data, lang):
+    _file_owner_groupowner_permissions_regex(data)
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_permissions", "")
-        data["is_directory"] = data["filepath"].endswith("/")
-
         # build the state that describes our mode
         # mode_str maps to STATEMODE in the template
         mode = data["filemode"]
@@ -144,24 +143,6 @@ def file_permissions(data, lang):
                     + field + ">\n" + mode_str)
             mode_int = mode_int >> 1
         data["statemode"] = mode_str
-    return data
-
-
-def file_regex_permissions(data, lang):
-    if lang == "ansible":
-        data["filepath"] = data["path"]
-    elif lang == "bash":
-        data["filepath"] = data["path"]
-        data["filename"] = re.sub(r"^\^", "", data["filename"])
-    elif lang == "oval":
-        # build a string that contains the full path to the file
-        path = data["path"]
-        filename = data["filename"]
-        if filename == '[NULL]' or filename == '':
-            filepath = path
-        else:
-            filepath = path + '/' + filename
-        data["filepath"] = filepath
     return data
 
 
@@ -277,7 +258,6 @@ templates = {
     "file_groupowner": file_groupowner,
     "file_owner": file_owner,
     "file_permissions": file_permissions,
-    "file_regex_permissions": file_regex_permissions,
     "grub2_bootloader_argument": grub2_bootloader_argument,
     "kernel_module_disabled": kernel_module_disabled,
     "mount": mount,


### PR DESCRIPTION
#### Description:
During the port of template data to CSVs we have forgotten about 4 rules in OCP3 benchmark which check for owner and group owner of files specified by a wild card. The result was that we haven't port the feature that enabled generating this type of check as we incorrectly thought it isn't used. To avoid regression in OCP3 Benchmark after the new templating system is switched on, we need to reintroduce this feature in templates `file_owner` and `file_groupowner`. During the migration of the data the base name and directory path has been merged. So we propose an alternative way: there will be a new optional variable `file_regex` in the template which can contain a regular expression describing files in a given directory.  If `file_regex` is set the `filepath` must describe a directory, which we recognize by the trailing backslash.

#### Rationale:

Prevents breaking of OCP3 rules if we switch to the new templating system. `file_owner_master_openvswitch`, `file_owner_master_cni_conf`, `file_groupowner_master_openvswitch`, `file_groupowner_master_cni_conf`
The potentially missing OVALs were revealed by `utils/compare_ds.py`.
