### PR TITLE
Run tmux only right after sshd/login

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/bash/shared.sh
@@ -1,7 +1,11 @@
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
 
-LINE='[ -n "$PS1" -a -z "$TMUX" ] && exec tmux'
-if ! tail -1 /etc/bashrc | grep -x "$LINE" ; then
-    echo "$LINE" >> /etc/bashrc
+if ! grep -x '  case "$name" in sshd|login) exec tmux ;; esac' /etc/bashrc; then
+    cat >> /etc/bashrc <<'EOF'
+if [ "$PS1" ]; then
+  parent=$(ps -o ppid= -p $$)
+  name=$(ps -o comm= -p $parent)
+  case "$name" in sshd|login) exec tmux ;; esac
 fi
-
+EOF
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/oval/shared.xml
@@ -23,10 +23,10 @@
   <ind:textfilecontent54_object id="obj_configure_bashrc_exec_tmux" version="1">
     <ind:behaviors singleline="true" multiline="false" />
     <ind:filepath>/etc/bashrc</ind:filepath>
-    <ind:pattern operation="pattern match">([^\n]+)\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_configure_bashrc_exec_tmux" version="1">
-    <ind:subexpression datatype="string" operation="equals">[ -n "$PS1" -a -z "$TMUX" ] &amp;&amp; exec tmux</ind:subexpression>
+    <ind:subexpression datatype="string" operation="pattern match">if \[ "\$PS1" \]; then\n\s+parent=\$\(ps -o ppid= -p \$\$\)\n\s+name=\$\(ps -o comm= -p \$parent\)\n\s+case "\$name" in sshd\|login\) exec tmux ;; esac\nfi</ind:subexpression>
   </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
@@ -26,8 +26,12 @@ ocil_clause: 'exec tmux is not present at the end of bashrc'
 ocil: |-
     To verify that tmux is configured to execute,
     run the following command:
-    <pre>$ tail -1 /etc/bashrc</pre>
+    <pre>$ grep -A1 -B3 "case ..name. in sshd|login) exec tmux ;; esac" /etc/bashrc</pre>
     The output should return the following:
-    <pre>[ -n "$PS1" -a -z "$TMUX" ] &amp;&amp; exec tmux</pre>
+    <pre>if [ "$PS1" ]; then
+      parent=$(ps -o ppid= -p $$)
+      name=$(ps -o comm= -p $parent)
+      case "$name" in sshd|login) exec tmux ;; esac
+    fi</pre>
 
 platform: machine


### PR DESCRIPTION
This prevents tmux-inside-tmux for common use cases like `su -`.

I'm not quite sure how the OVAL should look like or whether the `tail -5` is valid, hence I'm submitting this as a draft. Any opinions?

Thanks.