### PR TITLE
Remove slash from audit rules login failock

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
@@ -8,8 +8,8 @@
 fix_audit_watch_rule "auditctl" "/var/log/tallylog" "wa" "logins"
 fix_audit_watch_rule "augenrules" "/var/log/tallylog" "wa" "logins"
 
-fix_audit_watch_rule "auditctl" "/var/run/faillock/" "wa" "logins"
-fix_audit_watch_rule "augenrules" "/var/run/faillock/" "wa" "logins"
+fix_audit_watch_rule "auditctl" "/var/run/faillock" "wa" "logins"
+fix_audit_watch_rule "augenrules" "/var/run/faillock" "wa" "logins"
 
 fix_audit_watch_rule "auditctl" "/var/log/lastlog" "wa" "logins"
 fix_audit_watch_rule "augenrules" "/var/log/lastlog" "wa" "logins"


### PR DESCRIPTION

#### Description:

- There shouldn't be slash for `/var/run/faillock`
- Follows 0e83474ea75d762c77f78630448ad5a72b58d211
