### PR TITLE
Remove installation of packages from RHEL8 kickstarts as it is handled by rules

### DIFF
--- a/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
@@ -136,13 +136,6 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 # Require @Base
 @Base
 
-# Install selected additional packages (required by profile)
-# CCE-27024-9: Install AIDE
-aide
-
-# Install libreswan package
-libreswan
-
 %end # End of %packages section
 
 # Reboot after the installation is complete (optional)

--- a/rhel7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
@@ -124,13 +124,6 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 # Require 'Server with GUI' package environment to be installed
 @^Server with GUI
 
-# Install selected additional packages (required by PCI-DSS profile)
-# CCE-27024-9: Install AIDE
-aide
-
-# Install libreswan package
-libreswan
-
 %end # End of %packages section
 
 # Reboot after the installation is complete (optional)

--- a/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
@@ -160,13 +160,6 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 # Require @Base
 @Base
 
-# Install selected additional packages (required by profile)
-# CCE-27024-9: Install AIDE
-aide
-
-# Install libreswan package
-libreswan
-
 %end # End of %packages section
 
 # Reboot after the installation is complete (optional)

--- a/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
@@ -150,14 +150,6 @@ logvol swap --name=lv_swap --vgname=VolGroup --size=2016
 
 # Packages selection (%packages section is required)
 %packages
-
-# Install selected additional packages (required by PCI-DSS profile)
-# CCE-27024-9: Install AIDE
-aide
-
-# Install libreswan package
-libreswan
-
 %end # End of %packages section
 
 # Reboot after the installation is complete (optional)


### PR DESCRIPTION
#### Description:

- `aide` is handled by the rule `package_aide_installed`
* `libreswan` is handled by the rule `package_libreswan_installed` + it has been removed from the `ospp` profile

#### Rationale:

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1751681
