### PR TITLE
fix grub2_argument bash remediation

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/arg_not_there.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/arg_not_there.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 8
+
+# Removes pti argument from kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*pti=.*'  "$file" ; then
+	sed -i 's/\(^.*\)pti=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
+fi

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 8
+
+grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) pti=on"

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/wrong_value.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 8
+
+# Break the pti argument in kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*pti=.*'  "$file" ; then
+	# modify the GRUB command-line if an pti= arg already exists
+	sed -i 's/\(^.*\)pti=[^[:space:]]*\(.*\)/\1 pti=off \2/'  "$file"
+else
+	# no pti=arg is present, append it
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 pti=off/'  "$file"
+fi

--- a/shared/templates/template_BASH_grub2_bootloader_argument
+++ b/shared/templates/template_BASH_grub2_bootloader_argument
@@ -14,5 +14,5 @@ fi
 grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"
 {{% else %}}
 #in later versions of rhel grub2-editenv is used
-grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) audit=1"
+grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) {{{ ARG_NAME_VALUE }}}"
 {{% endif %}}


### PR DESCRIPTION
#### Description:

Fixed the bash remediation for grub2_argument template by removing "audit=1" and replacing it with proper Jinja macro.

Also wrote tests for the grub2_pti_argument rule.

#### Rationale:

It was found that in the Bash remediation for the grub2_argument template specifically for rhel8, there was hardcoded "audit=1" instead of proper Jinja macro. This caused wrong remediations for templated rules other than grub2_audit_argument.