### PR TITLE
Add rule for sshd_pubkey

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: 'Disable PubkeyAuthentication Authentication'
+
+description: |-
+    Unless needed, SSH should not permit extraneous or unnecessary
+    authentication mechanisms. To disable PubkeyAuthentication authentication, add or
+    correct the following line in the <tt>/etc/ssh/sshd_config</tt> file:
+    <pre>PubkeyAuthentication no</pre>
+
+rationale: |-
+    PubkeyAuthentication authentication is used to provide additional authentication mechanisms to
+    applications. Allowing PubkeyAuthentication authentication through SSH allows users to
+    generate their own authentication tokens, increasing the attack surface of the system.
+
+severity: medium
+
+ocil_clause: 'it is not disabled'
+
+ocil: |-
+    To check if PubkeyAuthentication is disabled or set correctly, run the following
+    command:
+    <pre>$ sudo grep PubkeyAuthentication /etc/ssh/sshd_config</pre>
+    If configured properly, output should be <pre>no</pre>
+
+template:
+    name: sshd_lineinfile
+    vars:
+        missing_parameter_pass: 'false'
+        parameter: PubkeyAuthentication
+        rule_id: sshd_disable_pubkey_auth
+        value: 'no'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^PubkeyAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^PubkeyAuthentication.*/PubkeyAuthentication no/" /etc/ssh/sshd_config
+else
+	echo "PubkeyAuthentication no" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/missing_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/missing_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^PubkeyAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^PubkeyAuthentication.*/#PubkeyAuthentication yes/" /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -q "^PubkeyAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^PubkeyAuthentication.*/PubkeyAuthentication yes/" /etc/ssh/sshd_config
+else
+	echo "PubkeyAuthentication yes" >> /etc/ssh/sshd_config
+fi


### PR DESCRIPTION
#### Description:

This begins the process for building a scap rule to remove PubkeyAuthentication from sshd.

#### Rationale:

- Fixes #3224

#### Help Required
Alas I need help with a fair bit....

I'm not sure how to build remediation scripts or documentation....

I'm sure in one of the various hardening specs someone recommends this, but I can't find it for references.  It is inconceivable to me that some of the higher security specs would leave this option on....

Strictly speaking, the `sshd_config` `Match` parameter can flip options on and off per match.  What would be the best way to ensure this is checking the Default (un`Match`ed) case?