### PR TITLE
New templating - generate OVAL definitions without creating rules 

### DIFF
--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -1,0 +1,54 @@
+package_avahi_installed:
+  name: package_installed
+  vars:
+    pkgname: avahi
+
+package_esc_installed:
+  name: package_installed
+  vars:
+    pkgname: esc
+
+package_pam_pkcs11_installed:
+  name: package_installed
+  vars:
+    pkgname: pam_pkcs11
+
+package_GConf2_installed:
+  name: package_installed
+  vars:
+    pkgname: GConf2
+
+package_dconf_installed:
+  name: package_installed
+  vars:
+    pkgname: dconf
+
+package_gdm_installed:
+  name: package_installed
+  vars:
+    pkgname: gdm
+
+package_pam_ldap_removed:
+  name: package_removed
+  vars:
+    pkgname: pam_ldap
+
+package_samba-common_removed:
+  name: package_removed
+  vars:
+    pkgname: samba-common
+
+package_prelink_removed:
+  name: package_removed
+  vars:
+    pkgname: prelink
+
+service_chronyd_enabled:
+  name: service_enabled
+  vars:
+    servicename: chronyd
+
+service_sssd_disabled:
+  name: service_disabled
+  vars:
+    servicename: sssd

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -424,6 +424,12 @@ class Builder(object):
             self.build_lang(
                 rule_id, template_name, template_vars, lang, local_env_yaml)
 
+    def build_all_rules(self):
+        for rule_file in os.listdir(self.resolved_rules_dir):
+            rule_path = os.path.join(self.resolved_rules_dir, rule_file)
+            rule = ssg.build_yaml.Rule.from_yaml(rule_path, self.env_yaml)
+            self.build_rule(rule)
+
     def build(self):
         """
         Builds all templated content for all languages, writing
@@ -434,7 +440,4 @@ class Builder(object):
             if not os.path.exists(dir_):
                 os.makedirs(dir_)
 
-        for rule_file in os.listdir(self.resolved_rules_dir):
-            rule_path = os.path.join(self.resolved_rules_dir, rule_file)
-            rule = ssg.build_yaml.Rule.from_yaml(rule_path, self.env_yaml)
-            self.build_rule(rule)
+        self.build_all_rules()

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -420,10 +420,13 @@ class Builder(object):
     def build_extra_ovals(self):
         declaration_path = os.path.join(self.templates_dir, "extra_ovals.yml")
         declaration = ssg.yaml.open_raw(declaration_path)
-        for fake_rule_id, template in declaration.items():
+        for oval_def_id, template in declaration.items():
             langs_to_generate = ["oval"]
+            # Since OVAL definition ID in shorthand format is always the same
+            # as rule ID, we can use it instead of the rule ID even if no rule
+            # with that ID exists
             self.build_rule(
-                fake_rule_id, fake_rule_id, template, langs_to_generate)
+                oval_def_id, oval_def_id, template, langs_to_generate)
 
     def build_all_rules(self):
         for rule_file in os.listdir(self.resolved_rules_dir):

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -385,41 +385,44 @@ class Builder(object):
         if rule.template is None:
             # rule is not templated, skipping
             return
+        template = rule.template
+        rule_title = rule.title
+        rule_id = rule.id_
+        langs_to_generate = self.get_langs_to_generate(rule)
         try:
-            template_name = rule.template["name"]
+            template_name = template["name"]
         except KeyError:
             raise ValueError(
                 "Rule {0} is missing template name under template key".format(
-                    rule.id_))
+                    rule_id))
         if template_name not in templates:
             raise ValueError(
                 "Rule {0} uses template {1} which does not exist.".format(
-                    rule.id_, template_name))
+                    rule_id, template_name))
         if templates[template_name] is None:
             sys.stderr.write(
                 "The template {0} has not been completely implemented, no "
                 "content will be generated for rule {1}.\n".format(
-                    template_name, rule.id_))
+                    template_name, rule_id))
             return
         try:
-            template_vars = rule.template["vars"]
+            template_vars = template["vars"]
         except KeyError:
             raise ValueError(
                 "Rule {0} does not contain mandatory 'vars:' key under "
-                "'template:' key.".format(rule.id_))
+                "'template:' key.".format(rule_id))
         # Add the rule ID which will be reused in OVAL templates as OVAL
         # definition ID so that the build system matches the generated
         # check with the rule.
-        template_vars["_rule_id"] = rule.id_
-        langs_to_generate = self.get_langs_to_generate(rule)
+        template_vars["_rule_id"] = rule_id
         # checks and remediations are processed with a custom YAML dict
         local_env_yaml = self.env_yaml.copy()
-        local_env_yaml["rule_id"] = rule.id_
-        local_env_yaml["rule_title"] = rule.title
+        local_env_yaml["rule_id"] = rule_id
+        local_env_yaml["rule_title"] = rule_title
         local_env_yaml["products"] = self.env_yaml["product"]
         for lang in langs_to_generate:
             self.build_lang(
-                rule.id_, template_name, template_vars, lang, local_env_yaml)
+                rule_id, template_name, template_vars, lang, local_env_yaml)
 
     def build(self):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -332,7 +332,7 @@ class Builder(object):
         return parameters
 
     def build_lang(
-            self, rule, template_name, template_vars, lang, local_env_yaml):
+            self, rule_id, template_name, template_vars, lang, local_env_yaml):
         """
         Builds templated content for a given rule for a given language.
         Writes the output to the correct build directories.
@@ -344,7 +344,7 @@ class Builder(object):
         if not os.path.exists(template_file_path):
             return
         ext = lang_to_ext_map[lang]
-        output_file_name = rule.id_ + ext
+        output_file_name = rule_id + ext
         output_filepath = os.path.join(
             self.output_dirs[lang], output_file_name)
         template_parameters = self.preprocess_data(
@@ -419,7 +419,7 @@ class Builder(object):
         local_env_yaml["products"] = self.env_yaml["product"]
         for lang in langs_to_generate:
             self.build_lang(
-                rule, template_name, template_vars, lang, local_env_yaml)
+                rule.id_, template_name, template_vars, lang, local_env_yaml)
 
     def build(self):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -424,11 +424,9 @@ class Builder(object):
             if rule.template is None:
                 # rule is not templated, skipping
                 continue
-            template = rule.template
-            rule_title = rule.title
-            rule_id = rule.id_
             langs_to_generate = self.get_langs_to_generate(rule)
-            self.build_rule(rule_id, rule_title, template, langs_to_generate)
+            self.build_rule(
+                rule.id_, rule.title, rule.template, langs_to_generate)
 
     def build(self):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -417,6 +417,14 @@ class Builder(object):
             self.build_lang(
                 rule_id, template_name, template_vars, lang, local_env_yaml)
 
+    def build_extra_ovals(self):
+        declaration_path = os.path.join(self.templates_dir, "extra_ovals.yml")
+        declaration = ssg.yaml.open_raw(declaration_path)
+        for fake_rule_id, template in declaration.items():
+            langs_to_generate = ["oval"]
+            self.build_rule(
+                fake_rule_id, fake_rule_id, template, langs_to_generate)
+
     def build_all_rules(self):
         for rule_file in os.listdir(self.resolved_rules_dir):
             rule_path = os.path.join(self.resolved_rules_dir, rule_file)
@@ -438,4 +446,5 @@ class Builder(object):
             if not os.path.exists(dir_):
                 os.makedirs(dir_)
 
+        self.build_extra_ovals()
         self.build_all_rules()

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -377,18 +377,11 @@ class Builder(object):
         else:
             return languages
 
-    def build_rule(self, rule):
+    def build_rule(self, rule_id, rule_title, template, langs_to_generate):
         """
-        Builds templated content for a given rule for all languages, writing
-        the output to the correct build directories.
+        Builds templated content for a given rule for selected languages,
+        writing the output to the correct build directories.
         """
-        if rule.template is None:
-            # rule is not templated, skipping
-            return
-        template = rule.template
-        rule_title = rule.title
-        rule_id = rule.id_
-        langs_to_generate = self.get_langs_to_generate(rule)
         try:
             template_name = template["name"]
         except KeyError:
@@ -428,7 +421,14 @@ class Builder(object):
         for rule_file in os.listdir(self.resolved_rules_dir):
             rule_path = os.path.join(self.resolved_rules_dir, rule_file)
             rule = ssg.build_yaml.Rule.from_yaml(rule_path, self.env_yaml)
-            self.build_rule(rule)
+            if rule.template is None:
+                # rule is not templated, skipping
+                continue
+            template = rule.template
+            rule_title = rule.title
+            rule_id = rule.id_
+            langs_to_generate = self.get_langs_to_generate(rule)
+            self.build_rule(rule_id, rule_title, template, langs_to_generate)
 
     def build(self):
         """


### PR DESCRIPTION
#### Description:

This PR introduces a way to generate templated OVALs that aren't "owned" by any rule into the new templating system.

For more details, please see the commit messages of each commit.

#### Rationale:

Some templated OVALs are needed as dependency in other OVALs referenced by extend_definition. The new templating system is based on rules, so to generate an OVAL definition a rule should be created. But for some OVALs it isn't acceptable to have a special rule in the benchmark.

This is a temporary solution until applicability of all rules is handled by using CPE applicability checks.

See #4874