### PR TITLE
Improve rule and group ordering

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -513,8 +513,20 @@ class Benchmark(object):
             root.append(value.to_xml_element())
         if self.bash_remediation_fns_group is not None:
             root.append(self.bash_remediation_fns_group)
-        for group in self.groups.values():
-            root.append(group.to_xml_element())
+
+        groups_in_bench = list(self.groups.keys())
+        # Make system group the first, followed by services group
+        group_priority_order = ["system", "services"]
+        for group_id in group_priority_order:
+            group = self.groups.get(group_id)
+            # Products using application benchmark don't have system or services group
+            if group is not None:
+                root.append(group.to_xml_element())
+                groups_in_bench.remove(group_id)
+        # Add any remaining top level groups
+        for group_id in groups_in_bench:
+            root.append(self.groups.get(group_id).to_xml_element())
+
         for rule in self.rules.values():
             root.append(rule.to_xml_element())
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -638,11 +638,17 @@ class Group(object):
         for _group in self.groups.values():
             group.append(_group.to_xml_element())
 
+        # Rules that install or remove packages affect remediation
+        # of other rules.
+        # When packages installed/removed rules come first:
+        # The Rules are ordered in more logical way, and
+        # remediation order is natural, first the package is installed, then configured.
         rules_in_group = list(self.rules.keys())
         regex = re.compile(r'(package_.*_(installed|removed))|(service_.*_(enabled|disabled))$')
         priority_rules = list(filter(regex.match, rules_in_group))
         priority_order = ["installed", "removed", "enabled", "disabled"]
-        # Add priority rules first in order
+        # Add priority rules in priority order, first all packages installed, then removed,
+        # followed by services enabled, then disabled
         for priority_type in priority_order:
             for priority_rule_id in priority_rules:
                 if priority_type in priority_rule_id:


### PR DESCRIPTION
#### Description:

- Simple approach for ordering of rules in a Group
  - package_installed
  - package_removed
  - service_enabled
  - service_disabled
- Simple ordering of top level Groups (the ones directly under the Benchmark), inspired by old [shared_guide.xslt](https://github.com/ComplianceAsCode/content/blob/6c8c3fe734bec785dbd3de4421a05a5d2027b99b/shared/xccdf/shared_guide.xslt)
  - system
  - service

#### Rationale:

- Rules for packages instlaled/removed should always come first in the group, so that following rules configuring this package can fix or `pass` evaluation with package state already defined.
- Similar for services disabled/removed
- Bonus: By ordering the system group before service group, rules like `service_fapolicyd_enabled` are evaluated/fixed later, reducing chances of problems during remediation.
