### PR TITLE
Add WRLinux 10.19 to prodtype

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
+prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4,wrlinux1019
 
 title: 'Disable IPv6 Networking Support Automatic Loading'
 


### PR DESCRIPTION
#### Description:
Brings a dependency of shared/checks/oval/sysctl_kernel_ipv6_disable.xml
to the new templating system.


#### Rationale:
Addressing:
```
$ oscap ds sds-validate ssg-wrlinux1019-ds.xml
File 'ssg-wrlinux1019-ds.xml' line 11554: Element '{http://oval.mitre.org/XMLSchema/oval-definitions-5}extend_definition': No match found for key-sequence ['oval:ssg-sysctl_kernel_ipv6_disable:def:1'] of keyref
'{http://oval.mitre.org/XMLSchema/oval-definitions-5}extendKeyRef'.
OpenSCAP Error: Invalid SCAP Source Datastream (1.3) content in ssg-wrlinux1019-ds.xml. [/builddir/build/BUILD/openscap-1.3.1/src/source/oscap_source.c:346]
```