### PR TITLE
Removed stray whitespace discard directive.

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -181,7 +181,7 @@ dconf update
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.
 # Service should be 'inactive', not 'failed' after reboot though.
-/usr/bin/systemctl reset-failed "$service"
+/usr/bin/systemctl reset-failed "{{{ service }}}"
 {{%- elif init_system == "upstart" -%}}
   {{%- if service_state == "disable" -%}}
 /sbin/service "{{{ service }}}" disable

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -177,8 +177,7 @@ dconf update
   {{%- else -%}}
 /usr/bin/systemctl enable "{{{ service }}}"
 /usr/bin/systemctl start "{{{ service }}}"
-  {{%- endif -%}}
-
+  {{%- endif %}}
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.
 # Service should be 'inactive', not 'failed' after reboot though.


### PR DESCRIPTION
The previous state led the '# The service may ...' to be glued
directly to the service name in the systemctl command, ruining the check.