### PR TITLE
Fix NTP-Chrony remediation + check.

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
@@ -4,7 +4,7 @@ if rpm -q --quiet chrony ; then
     if ! /usr/sbin/pidof ntpd ; then
         {{{ bash_service_command("enable", "chronyd") | indent(8) }}}
     fi
-elif rpm -q --quiet ntp- ; then
+elif rpm -q --quiet ntp ; then
     {{{ bash_service_command("enable", "ntpd") | indent(4) }}}
 else
     {{{ bash_package_install("chrony") | indent(4) }}}

--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -47,6 +47,7 @@ service_chronyd_enabled:
   name: service_enabled
   vars:
     servicename: chronyd
+    packagename: chrony
 
 service_sssd_disabled:
   name: service_disabled

--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -53,3 +53,4 @@ service_sssd_disabled:
   name: service_disabled
   vars:
     servicename: sssd
+    packagename: sssd-common


### PR DESCRIPTION
- Remove the trailing dash when checking for the ntp package in the remediation.
- Add the correct package name to the Chrony(d) OVAL.