### PR TITLE
Fixed the remediation for rsyslog_files_permissions

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -73,7 +73,7 @@
          * the chunk was retrieved from a row not starting with space, '#',
            or '$' characters
     -->
-    <ind:pattern operation="pattern match">^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[^\s#\$]+[\s]+.*[\s]+-?(/+[^:;\s]+);*.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0600.pass.sh
@@ -9,10 +9,13 @@ source $SHARED/rsyslog_log_utils.sh
 PERMS=0600
 
 # setup test data
-create_rsyslog_test_logs 1
+create_rsyslog_test_logs 4
 
-# setup test log file and permissions
-chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+# setup all files with incorrect permission
+chmod 0601 "${RSYSLOG_TEST_LOGS[@]}"
+
+# setup the real logfile with correct permissions
+chmod $PERMS "${RSYSLOG_TEST_LOGS[0]}"
 
 # add rule with 0600 permissions log file
 cat << EOF > $RSYSLOG_CONF
@@ -21,5 +24,13 @@ cat << EOF > $RSYSLOG_CONF
 #### RULES ####
 
 *.*        ${RSYSLOG_TEST_LOGS[0]}
+
+ *.*        ${RSYSLOG_TEST_LOGS[1]}
+
+authpriv.*        /nonexistent_file
+
+# *.*        /irrelevant_file
+
+\$something /irrelevant_file
 
 EOF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0601.fail.sh
@@ -9,7 +9,7 @@ source $SHARED/rsyslog_log_utils.sh
 PERMS=0601
 
 # setup test data
-create_rsyslog_test_logs 1
+create_rsyslog_test_logs 3
 
 # setup test log file and permissions
 chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
@@ -21,4 +21,15 @@ cat << EOF > $RSYSLOG_CONF
 #### RULES ####
 
 *.*     ${RSYSLOG_TEST_LOGS[0]}
+
+cron.*        /nonexistent_file
+
+ authpriv.*        /irrelevant_file
+
+# *.*        /irrelevant_file
+
+\$something /irrelevant_file
+
+something.*	${RSYSLOG_TEST_LOGS[2]}
+
 EOF


### PR DESCRIPTION
- Stripped quotes and brackets from extracted paths.
- Dropped apparent config files from extracted list of logfile paths.

The old remediation shows errors on a fresh RHEL8 install.