### PR TITLE
Add basic test scenarios for a few audit rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/correct_rules.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/rules_not_there.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+true
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/correct_rules.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-a always,exit -F arch=b32 -S rename -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a always,exit -F arch=b64 -S rename -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/rules_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+true

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-a always,exit -F arch=b32 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b64 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/default.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules
+echo "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/rules_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+true

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/correct_rules.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/issue -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/hosts -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/rules_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules
+true


### PR DESCRIPTION
#### Description:

Basic test scenarios for following rules:
- audit_rules_dac_modification_fchown
- audit_rules_file_deletion_events_rename
- audit_rules_kernel_module_loading_init
- audit_rules_media_export
- audit_rules_networkconfig_modification


Basic test scenario means, no rules configured, and correct rules
are there (in single -S arg)