### PR TITLE
Update remetiation of mount_option_tmp rules, /tmp is not tmpfs in RHEL

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -40,12 +40,4 @@ template:
         mountpoint: /tmp
         mountoption: nodev
         mount_has_to_exist: 'yes'
-        mount_has_to_exist@rhel7: 'no'
-        mount_has_to_exist@rhel8: 'no'
-        filesystem@rhel7: tmpfs
-        filesystem@rhel8: tmpfs
-        type@rhel7: tmpfs
-        type@rhel8: tmpfs
-    backends:
-        anaconda@rhel7: 'off'
-        anaconda@rhel8: 'off'
+# Note that /tmp on RHEL systems is not tmpfs

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -43,12 +43,4 @@ template:
         mountpoint: /tmp
         mountoption: noexec
         mount_has_to_exist: 'yes'
-        mount_has_to_exist@rhel7: 'no'
-        mount_has_to_exist@rhel8: 'no'
-        filesystem@rhel7: tmpfs
-        filesystem@rhel8: tmpfs
-        type@rhel7: tmpfs
-        type@rhel8: tmpfs
-    backends:
-        anaconda@rhel7: 'off'
-        anaconda@rhel8: 'off'
+# Note that /tmp on RHEL systems is not tmpfs

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -40,12 +40,4 @@ template:
         mountpoint: /tmp
         mountoption: nosuid
         mount_has_to_exist: 'yes'
-        mount_has_to_exist@rhel7: 'no'
-        mount_has_to_exist@rhel8: 'no'
-        filesystem@rhel7: tmpfs
-        filesystem@rhel8: tmpfs
-        type@rhel7: tmpfs
-        type@rhel8: tmpfs
-    backends:
-        anaconda@rhel7: 'off'
-        anaconda@rhel8: 'off'
+# Note that /tmp on RHEL systems is not tmpfs

--- a/rhel7/templates/csv/mount_options.csv
+++ b/rhel7/templates/csv/mount_options.csv
@@ -13,10 +13,10 @@
 /dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
-# /tmp is mounted as tmpfs by default by systemd (and thus not in fstab)
-/tmp,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
-/tmp,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
-/tmp,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+# By default /tmp is not mounted as tmpfs by systemd
+/tmp,nodev
+/tmp,noexec
+/tmp,nosuid
 /home,nosuid
 /home,nodev
 /var/tmp,nodev

--- a/rhel8/templates/csv/mount_options.csv
+++ b/rhel8/templates/csv/mount_options.csv
@@ -11,10 +11,10 @@
 /dev/shm,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
 /dev/shm,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
-# /tmp is mounted as tmpfs by default by systemd (and thus not in fstab)
-/tmp,nodev,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
-/tmp,noexec,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
-/tmp,nosuid,create_fstab_entry_if_needed,tmpfs,tmpfs #except-for:anaconda
+# By default /tmp is not mounted as tmpfs by systemd
+/tmp,nodev
+/tmp,noexec
+/tmp,nosuid
 /home,nosuid
 /home,nodev
 /var,nodev


### PR DESCRIPTION
#### Description:

- In RHEL systems, do not create `/tmp` entry in `/etc/fstab` as a `tmpfs`
  - By default RHEL creates `/tmp` as normal filesystem.
- Enable Anaconda remediations so that partition existence is checked during installation
  - Remediation can only add the mount options, it cannot create the partition.
![anaconda_tmp_warning](https://user-images.githubusercontent.com/7460169/66419403-606c7480-ea04-11e9-8232-f821a073317c.png)

#### Rationale:
- Align with RHEL filesystem.



