### PR TITLE
Fix ansible lint issues

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -302,20 +302,20 @@ macro(ssg_build_remediations PRODUCT)
     if (ANSIBLE_PLAYBOOK_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
         add_test(
             NAME "ansible-playbook-syntax-check-${PRODUCT}"
-            COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_PLAYBOOK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${PRODUCT}"
+            COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_PLAYBOOK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all"
         )
     endif()
     if (ANSIBLE_CHECKS)
         if (ANSIBLE_LINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
             add_test(
                 NAME "ansible-playbook-ansible-lint-check-${PRODUCT}"
-                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${PRODUCT}"
+                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all"
             )
         endif()
         if (YAMLLINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
             add_test(
                 NAME "ansible-playbook-yamllint-check-${PRODUCT}"
-                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${PRODUCT}" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
+                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
             )
         endif()
     endif()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -302,20 +302,20 @@ macro(ssg_build_remediations PRODUCT)
     if (ANSIBLE_PLAYBOOK_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
         add_test(
             NAME "ansible-playbook-syntax-check-${PRODUCT}"
-            COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_PLAYBOOK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all"
+            COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_PLAYBOOK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${PRODUCT}"
         )
     endif()
     if (ANSIBLE_CHECKS)
         if (ANSIBLE_LINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
             add_test(
                 NAME "ansible-playbook-ansible-lint-check-${PRODUCT}"
-                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all"
+                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks" "${CMAKE_SOURCE_DIR}/tests/ansible-lint_config.yml"
             )
         endif()
         if (YAMLLINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
             add_test(
                 NAME "ansible-playbook-yamllint-check-${PRODUCT}"
-                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
+                COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
             )
         endif()
     endif()

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml
@@ -14,11 +14,11 @@
       dest: /etc/sysconfig/prelink
       regexp: ^#?PRELINKING
       line: "PRELINKING=no"
-  when: prelink_exists.stat.exists == True
+  when: prelink_exists.stat.exists
 
 - name: revert prelinking binaries
   command: /usr/sbin/prelink -ua
-  when: prelink_exists.stat.exists == True
+  when: prelink_exists.stat.exists
 
 - name: Check if system supports AES-NI
   command: grep -q -m1 -o aes /proc/cpuinfo

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -9,7 +9,6 @@
   register: service_file_exists
   changed_when: False
   ignore_errors: True
-
 - name: Disable service {{{ SERVICENAME }}}
   systemd:
     name: "{{{ DAEMONNAME }}}.service"
@@ -19,13 +18,11 @@
     masked: "yes"
 {{%- endif %}}
   when: '"{{{ DAEMONNAME }}}.service" in service_file_exists.stdout_lines[1]'
-
 - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
   command: systemctl list-unit-files {{{ DAEMONNAME }}}.socket
   register: socket_file_exists
   changed_when: False
   ignore_errors: True
-
 - name: Disable socket {{{ SERVICENAME }}}
   systemd:
     name: "{{{ DAEMONNAME }}}.socket"
@@ -35,14 +32,11 @@
     masked: "yes"
 {{%- endif %}}
   when: '"{{{ DAEMONNAME }}}.socket" in socket_file_exists.stdout_lines[1]'
-
 {{% elif init_system == "upstart" %}}
 - name: Stop {{{ SERVICENAME }}}
   command: /sbin/service '{{{ DAEMONNAME }}}' stop
 - name: Switch off {{{ SERVICENAME }}}
   command: /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
-
 {{%- else %}}
-
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}

--- a/tests/ansible-lint_config.yml
+++ b/tests/ansible-lint_config.yml
@@ -1,0 +1,5 @@
+skip_list:
+  - '204' # Lines should be no longer than 160 chars
+  - '301' # Commands should not change things if nothing needs doing
+  - '303' # Using command rather than module
+  - '403' # Package installs should not use latest

--- a/tests/ansible_playbook_check.sh
+++ b/tests/ansible_playbook_check.sh
@@ -6,7 +6,7 @@ if [[ $1 =~ ansible-playbook ]]; then
 	$1 --syntax-check $3-playbook-*.yml
 	ret=$?
 elif [[ $1 =~ ansible-lint ]]; then
-	$1 -p $3-playbook-*.yml
+	$1 -x 303,204 -p $3-playbook-*.yml
 	ret=$?
 elif [[ $1 =~ yamllint ]]; then
 	$1 -c $4 $3-playbook-*.yml

--- a/tests/ansible_playbook_check.sh
+++ b/tests/ansible_playbook_check.sh
@@ -1,21 +1,32 @@
 #!/bin/bash
 
-FILES=$(ls $2/*.yml 2> /dev/null | wc -l)
-if [ "$FILES" -eq "0" ]; then
+pushd "$2" > /dev/null
+
+DIRS="" # directories which might contain playbooks
+for dir in `find . -type d`
+do
+	# tries to find which directories contain valid playbooks
+	FILES=$(ls $dir/*.yml 2> /dev/null | wc -l)
+	if [ ! "$FILES" -eq "0" ]; then
+		CONTAINS_VALID_FILES=1
+		DIRS="$DIRS $dir/*.yml"
+	fi
+done
+
+if [ -z "$CONTAINS_VALID_FILES" ]; then
 	echo "$2 does not contain any valid YAML files. Skipping the test."
+	popd > /dev/null
 	exit 0
 fi
 
-pushd "$2" > /dev/null
-
 if [[ $1 =~ ansible-playbook ]]; then
-	$1 --syntax-check *.yml
+	$1 --syntax-check $3-playbook-*.yml
 	ret=$?
 elif [[ $1 =~ ansible-lint ]]; then
-	$1 -x 303,204,301,403 -p *.yml
+	$1 -c $3 -p $DIRS
 	ret=$?
 elif [[ $1 =~ yamllint ]]; then
-	$1 -c $3 *.yml
+	$1 -c $3 $DIRS
 	ret=$?
 else
 	echo "Error: '$1' is not expected executable" 1>&2

--- a/tests/ansible_playbook_check.sh
+++ b/tests/ansible_playbook_check.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
+FILES=$(ls $2/*.yml 2> /dev/null | wc -l)
+if [ "$FILES" -eq "0" ]; then
+	echo "$2 does not contain any valid YAML files. Skipping the test."
+	exit 0
+fi
+
 pushd "$2" > /dev/null
 
 if [[ $1 =~ ansible-playbook ]]; then
-	$1 --syntax-check $3-playbook-*.yml
+	$1 --syntax-check *.yml
 	ret=$?
 elif [[ $1 =~ ansible-lint ]]; then
-	$1 -x 303,204,301 -p $3-playbook-*.yml
+	$1 -x 303,204,301,403 -p *.yml
 	ret=$?
 elif [[ $1 =~ yamllint ]]; then
-	$1 -c $4 $3-playbook-*.yml
+	$1 -c $3 *.yml
 	ret=$?
 else
 	echo "Error: '$1' is not expected executable" 1>&2

--- a/tests/ansible_playbook_check.sh
+++ b/tests/ansible_playbook_check.sh
@@ -6,7 +6,7 @@ if [[ $1 =~ ansible-playbook ]]; then
 	$1 --syntax-check $3-playbook-*.yml
 	ret=$?
 elif [[ $1 =~ ansible-lint ]]; then
-	$1 -x 303,204 -p $3-playbook-*.yml
+	$1 -x 303,204,301 -p $3-playbook-*.yml
 	ret=$?
 elif [[ $1 =~ yamllint ]]; then
 	$1 -c $4 $3-playbook-*.yml

--- a/tests/yamllint_config.yml
+++ b/tests/yamllint_config.yml
@@ -12,3 +12,4 @@ rules:
   empty-lines:
     level: warning
   truthy: disable
+  document-start: {present: false}

--- a/tests/yamllint_config.yml
+++ b/tests/yamllint_config.yml
@@ -4,7 +4,7 @@ extends: default
 rules:
   line-length:
     level: warning
-    max: 180
+    max: 160
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true
   comments: disable

--- a/tests/yamllint_config.yml
+++ b/tests/yamllint_config.yml
@@ -4,7 +4,7 @@ extends: default
 rules:
   line-length:
     level: warning
-    max: 160
+    max: 180
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true
   comments: disable


### PR DESCRIPTION
#### Description:

- This pull request fixes linting issues and ignore some expected issues. Also changes the behavior to go through all generated playbook for given product, which means testing playbooks for each rule individually based on current product.

The rules ignored are: 204,301,303,403
Here you can find more details on their meaning:
https://docs.ansible.com/ansible-lint/rules/default_rules.html

#### Rationale:

- Makes the lint check all green so it can be enabled on All Green Jenkins view tab.

Note1: The ansible --syntax-check uses the same bash script and I tried to keep the original behavior which checks the syntax for each profile ansible playbook.
Note2: Considering how long the test takes to run, it is not feasible to enable it into PR gating.

The jenkins job which actually tests the build is this one, this job had the cmake variable ANSIBLE_CHECKS ON by default, so it triggered the ansible linting tests:
https://jenkins.complianceascode.io/job/scap-security-guide-pull-requests/2171

But as we are not going to enable by default, I'm removing the commit which had enabled by default.