### PR TITLE
Generate OCIL check for cramfs kernel module

### DIFF
--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -30,6 +30,8 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4,A.9.1.2
     cis-csc: 11,14,3,9
 
+{{{ complete_ocil_entry_module_disable(module="cramfs") }}}
+
 platform: machine
 
 template:


### PR DESCRIPTION
#### Description:

- Generate OCIL check for cramfs kernel module
