### PR TITLE
Remove overly restrictive FIPS checks

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
@@ -11,24 +11,21 @@
       </affected>
       <description>Limit the ciphers to those which are FIPS-approved.</description>
     </metadata>
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="SSH is configured correctly or is not installed"
-      operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-          definition_ref="sshd_not_required_or_unset" />
-          <extend_definition comment="rpm package openssh-server removed"
-          definition_ref="package_openssh-server_removed" />
-        </criteria>
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-          definition_ref="sshd_required_or_unset" />
-          <extend_definition comment="rpm package openssh-server installed"
-          definition_ref="package_openssh-server_installed" />
-          <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
-          test_ref="test_sshd_use_approved_ciphers" />
-        </criteria>
+    <criteria comment="SSH is configured correctly or is not installed"
+    operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server removed"
+        definition_ref="package_openssh-server_removed" />
+      </criteria>
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+        <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_approved_ciphers" />
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -12,34 +12,31 @@
       </affected>
       <description>Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.</description>
     </metadata>
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="SSH is configured correctly or is not installed"
-      operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-          definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
-          <extend_definition comment="rpm package openssh removed"
-          definition_ref="package_openssh_removed" />
-          {{% else %}}
-          <extend_definition comment="rpm package openssh-server removed"
-          definition_ref="package_openssh-server_removed" />
-          {{% endif %}}
-        </criteria>
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-          definition_ref="sshd_required_or_unset" />
-          {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
-          <extend_definition comment="rpm package openssh installed"
-          definition_ref="package_openssh_installed" />
-          {{% else %}}
-          <extend_definition comment="rpm package openssh-server installed"
-          definition_ref="package_openssh-server_installed" />
-          {{% endif %}}
-          <criterion comment="Check MACs in /etc/ssh/sshd_config"
-          test_ref="test_sshd_use_approved_macs" />
-        </criteria>
+    <criteria comment="SSH is configured correctly or is not installed"
+    operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
+        <extend_definition comment="rpm package openssh removed"
+        definition_ref="package_openssh_removed" />
+        {{% else %}}
+        <extend_definition comment="rpm package openssh-server removed"
+        definition_ref="package_openssh-server_removed" />
+        {{% endif %}}
+      </criteria>
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
+        <extend_definition comment="rpm package openssh installed"
+        definition_ref="package_openssh_installed" />
+        {{% else %}}
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+        {{% endif %}}
+        <criterion comment="Check MACs in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_approved_macs" />
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -14,7 +14,6 @@
       <extend_definition comment="check sysctl crypto.fips_enabled = 1" definition_ref="sysctl_crypto_fips_enabled" />
       <extend_definition comment="Dracut FIPS module is enabled" definition_ref="enable_dracut_fips_module" />
       <extend_definition comment="system cryptography policy is configured" definition_ref="configure_crypto_policy" />
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criterion comment="check if system crypto policy selection in var_system_crypto_policy in the profile is set to FIPS" test_ref="test_system_crypto_policy_value" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
@@ -11,7 +11,6 @@
       <description>Look for argument fips=1 in the kernel line in /etc/default/grub.</description>
     </metadata>
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <extend_definition comment="prelink disabled" definition_ref="disable_prelink" />
       <extend_definition comment="package dracut-fips installed" definition_ref="package_dracut-fips_installed" />
       <extend_definition comment="package dracut-fips-aesni installed" definition_ref="package_dracut-fips-aesni_installed" />

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
@@ -16,11 +16,8 @@
     </metadata>
     <criteria operator="OR">
       <criterion comment="System does not support AES instruction set" test_ref="test_processor_aes_instruction" />
-      <criteria operator="AND">
-        <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-        <criterion comment="package dracut-fips-aesni is installed"
-        test_ref="test_package_dracut-fips-aesni_installed" />
-      </criteria>
+      <criterion comment="package dracut-fips-aesni is installed"
+      test_ref="test_package_dracut-fips-aesni_installed" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
@@ -14,11 +14,8 @@
       </affected>
       <description>The RPM package dracut-fips should be installed.</description>
     </metadata>
-    <criteria>
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criterion comment="package dracut-fips is installed"
-      test_ref="test_package_dracut-fips_installed" />
-    </criteria>
+    <criterion comment="package dracut-fips is installed"
+    test_ref="test_package_dracut-fips_installed" />
   </definition>
   <linux:rpminfo_test check="all" check_existence="all_exist"
   id="test_package_dracut-fips_installed" version="1"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
@@ -9,7 +9,6 @@
       cryptographic hashes.</description>
     </metadata>
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criterion comment="non-FIPS hashes are not configured" test_ref="test_aide_non_fips_hashes" />
       <criterion comment="FIPS hashes are configured" test_ref="test_aide_use_fips_hashes" />


### PR DESCRIPTION
#### Description:

- This removes the OS FIPS certification check from testing the FIPS related configuration of various individual components.

#### Rationale:

- Whether or not a package is configured to use FIPS approved crypto algorithms and hashes or fips-related packages are installed is orthogonal to whether or not the installed operating system is FIPS certified.   Whether or not the OS is FIPS certified still remains a stand alone rule by itself and should continue to be used in environments where necessary.

- Fixes #4917
