### PR TITLE
[object_api_server_experimental_encryption_provider_cipher] Fix unclosed capture group & subexpression

### DIFF
--- a/applications/openshift/api-server/api_server_experimental_encryption_provider_cipher/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_experimental_encryption_provider_cipher/oval/shared.xml
@@ -28,11 +28,11 @@
 
   <ind:textfilecontent54_object id="object_api_server_experimental_encryption_provider_cipher" version="1">
     <ind:filepath>/etc/origin/master/encryption-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*resources\:(?:[^\n]*\n+)+?[\s]*providers\:([\s]*[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*resources\:(?:[^\n]*\n+)+?[\s]*providers\:[\s]*[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_api_server_experimental_encryption_provider_cipher" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^aescbc$</ind:subexpression>
+    <ind:subexpression datatype="string" operation="pattern match">^aescbc:$</ind:subexpression>
   </ind:textfilecontent54_state>
 </def-group>


### PR DESCRIPTION
#### Description

Regex was not working due to an unclosed capture group +  Character ':' is matched in the capture group as it is not a whitespace, but was not matched in the subexpression regex.