### PR TITLE
Prevent an exception when processing empty derived profiles

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -101,7 +101,8 @@ class Profile(object):
         del yaml_contents["description"]
         profile.extends = yaml_contents.pop("extends", None)
         selection_entries = required_key(yaml_contents, "selections")
-        profile._parse_selections(selection_entries)
+        if selection_entries:
+            profile._parse_selections(selection_entries)
         del yaml_contents["selections"]
 
         if yaml_contents:


### PR DESCRIPTION
#### Description:

- Prevent an exception by ensuring that only non-empty selections are parsed

#### Rationale:

- When a profile is derived from another but adds no additional rules then the `selections` key returns `None` instead of an empty list, this an exception is thrown what that gets iterated over.  This ensures that the selections are only iterated over when it's a non-empty list, skipping `None` and empty lists.
