### PR TITLE
Set rule service_timesyncd_enabled prodtype to ubuntu 16.04 and 18.04

### DIFF
--- a/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ubuntu1604,ubuntu1804
+
 title: 'Enable systemd_timesyncd Service'
 
 description: '{{{ describe_service_enable(service="systemd_timesyncd") }}}'
@@ -30,3 +32,9 @@ references:
     cis-csc: 1,14,15,16,3,5,6
 
 ocil: '{{{ ocil_service_enabled(service="systemd_timesyncd") }}}'
+
+template:
+    name: service_enabled
+    vars:
+        servicename: systemd-timesyncd
+        packagename: systemd


### PR DESCRIPTION
#### Description:

- This rule enables service which is not in RHEL and the rule is only
selected in profiles for ubuntu1604 and ubuntu1804 products.
- Also added missing `service_enabled` template.