### PR TITLE
Add missing prodtypes for apt rules

### DIFF
--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: debian8,ubuntu1404,ubuntu1604,ubuntu1804
+
 title: 'Disable unauthenticated repositories in APT configuration'
 
 description: 'Unauthenticated repositories should not be used for updates.'

--- a/linux_os/guide/services/apt/apt_sources_list_official/rule.yml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: debian8
+
 title: 'Ensure that official distribution repositories are used'
 
 description: 'Check that official Debian repositories, including security repository, are configured in apt.'


### PR DESCRIPTION
#### Description:

- The rules `apt_conf_disallow_unauthenticated` and `apt_sources_list_official`
were missing prodtype. This commit adds prodtypes for these rules based on
products where these rules are selected.