### PR TITLE
Improve ordering of rules: Add sub groups after any current level group rules

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -636,8 +636,6 @@ class Group(object):
 
         for _value in self.values.values():
             group.append(_value.to_xml_element())
-        for _group in self.groups.values():
-            group.append(_group.to_xml_element())
 
         # Rules that install or remove packages affect remediation
         # of other rules.
@@ -658,6 +656,13 @@ class Group(object):
         # Add remaining rules in the group
         for rule_id in rules_in_group:
             group.append(self.rules.get(rule_id).to_xml_element())
+
+        # Add the sub groups after any current level group rules.
+        # As package installed/removed and service enabled/disabled rules are usuallly in
+        # top level group, this ensures groups that further configure a package or service
+        # are after rules that install or remove it.
+        for _group in self.groups.values():
+            group.append(_group.to_xml_element())
 
         return group
 


### PR DESCRIPTION
#### Description:

- Add sub groups after any current level group rules
- This will better position rules package installed/removed, service enabled/disabled withing the Benchmark when a group has such rules and subgroups for configuring the package/service.
- Thanks @matusmarhefka for noticing this

#### Rationale:

- As package installed/removed and service enabled/disabled rules are usually
in top level group, this ensures groups that further configure a package or
service are after rules that install or remove it.

#### Notes
To get raw order of rules in Benchmark: `grep -R "Rule.*id=" ./ssg-rhel8-ds.xml | tr -d " " > new.txt`
Order of rules before patch: [old.txt](https://github.com/ComplianceAsCode/content/files/3751148/old.txt)
Order of rules after patch: [new.txt](https://github.com/ComplianceAsCode/content/files/3751146/new.txt)
