### PR TITLE
Ocp3 audit config

### DIFF
--- a/applications/openshift/api-server/api_server_audit_log_maxage/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxage/oval/shared.xml
@@ -19,7 +19,7 @@
 
   <ind:textfilecontent54_object id="object_api_server_audit_log_maxage" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*maximumFileRetentionDays\:[\s]+(\d+)[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*maximumFileRetentionDays:[\s]+(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/oval/shared.xml
@@ -19,7 +19,7 @@
 
   <ind:textfilecontent54_object id="object_api_server_audit_log_maxbackup" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*auditConfig:\:(?:[^\n]*\n+)+?[\s]*maximumRetainedFiles\:[\s]+(\d+)[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*maximumRetainedFiles:[\s]+(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/oval/shared.xml
@@ -19,7 +19,7 @@
 
   <ind:textfilecontent54_object id="object_api_server_audit_log_maxsize" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*auditConfig:\:(?:[^\n]*\n+)+?[\s]*maximumFileSizeMegabytes\:[\s]+(\d+)[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*maximumFileSizeMegabytes:[\s]+(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/applications/openshift/api-server/api_server_audit_log_path/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_path/oval/shared.xml
@@ -20,7 +20,7 @@
 
   <ind:textfilecontent54_object id="object_api_server_audit_log_path" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*auditFilePath:[\s]+(\S+)[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*auditFilePath:[\s"']+([^\s"']+)[\s"']*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/applications/openshift/api-server/api_server_audit_log_path/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_path/oval/shared.xml
@@ -20,7 +20,7 @@
 
   <ind:textfilecontent54_object id="object_api_server_audit_log_path" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*auditConfig:\:(?:[^\n]*\n+)+?[\s]*auditFilePath\:[\s]+(\S+)[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*auditFilePath:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- This fixes an issue with the expected configuration format for the OpenShift API server audit log checks being incorrect in our regexes.  Specifically, we were expecting an extra ':' character in a few checks, and the audit log file check was not tolerant of quoted paths.

#### Rationale:

- These patches correct the above described issues.

- Fixes #4941
