### PR TITLE
Remove openshift api_server_profiling check

### DIFF
--- a/ocp3/profiles/opencis-master.profile
+++ b/ocp3/profiles/opencis-master.profile
@@ -95,7 +95,6 @@ selections:
     - api_server_kubelet_client_cert
     - api_server_kubelet_client_key
     - api_server_kubelet_https
-    - api_server_profiling
     - api_server_request_timeout
     - api_server_secure_port
     - api_server_service_account_ca


### PR DESCRIPTION
The ocp3 opencis-master profile has a check that expects profiling
for the API server to be explicitly disabled.  Red Hat has changed
their guidance in this area, as API server profiling is protected
via RBAC and can be left enabled or disabled as desired.  From a
security perspective, we only want to make sure that the web
interface for profiling is disabled for the controller.  We already
have the controller_disable_profiling check for this.

This patch removes the api_server_profiling check.

- Fixes #4943 
