### PR TITLE
Allow incomplete rules.

### DIFF
--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -7,7 +7,7 @@ import sys
 from copy import deepcopy
 import collections
 
-from .build_yaml import Rule
+from .build_yaml import Rule, DocumentationNotComplete
 from .constants import oval_namespace as oval_ns
 from .constants import oval_footer
 from .constants import oval_header
@@ -276,7 +276,11 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
         rule_id = get_rule_dir_id(_dir_path)
 
         rule_path = os.path.join(_dir_path, "rule.yml")
-        rule = Rule.from_yaml(rule_path, env_yaml)
+        try:
+            rule = Rule.from_yaml(rule_path, env_yaml)
+        except DocumentationNotComplete:
+            # Happens on non-debug build when a rule is "documentation-incomplete"
+            continue
         prodtypes = parse_prodtype(rule.prodtype)
 
         local_env_yaml['rule_id'] = rule.id_

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -353,7 +353,11 @@ class AnsibleRemediation(Remediation):
     def from_snippet_and_rule(cls, snippet_fname, rule_fname):
         if os.path.isfile(snippet_fname) and os.path.isfile(rule_fname):
             result = cls(snippet_fname)
-            result.load_rule_from(rule_fname)
+            try:
+                result.load_rule_from(rule_fname)
+            except ssg.yaml.DocumentationNotComplete:
+                # Happens on non-debug build when a rule is "documentation-incomplete"
+                return None
             return result
 
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -464,6 +464,10 @@ class Benchmark(object):
                 new_profile = Profile.from_yaml(dir_item_path, env_yaml)
             except DocumentationNotComplete:
                 continue
+            except Exception as exc:
+                msg = ("Error building profile from '{fname}': '{error}'"
+                       .format(fname=dir_item_path, error=str(exc)))
+                raise RuntimeError(msg)
             if new_profile is None:
                 continue
 
@@ -1155,7 +1159,11 @@ class BuildLoader(DirectoryLoader):
 
     def _process_rules(self):
         for rule_yaml in self.rule_files:
-            rule = Rule.from_yaml(rule_yaml, self.env_yaml)
+            try:
+                rule = Rule.from_yaml(rule_yaml, self.env_yaml)
+            except DocumentationNotComplete:
+                # Happens on non-debug build when a rule is "documentation-incomplete"
+                continue
             prodtypes = parse_prodtype(rule.prodtype)
             if "all" not in prodtypes and self.product not in prodtypes:
                 continue

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -436,7 +436,11 @@ class Builder(object):
     def build_all_rules(self):
         for rule_file in os.listdir(self.resolved_rules_dir):
             rule_path = os.path.join(self.resolved_rules_dir, rule_file)
-            rule = ssg.build_yaml.Rule.from_yaml(rule_path, self.env_yaml)
+            try:
+                rule = ssg.build_yaml.Rule.from_yaml(rule_path, self.env_yaml)
+            except ssg.build_yaml.DocumentationNotComplete:
+                # Happens on non-debug build when a rule is "documentation-incomplete"
+                continue
             if rule.template is None:
                 # rule is not templated, skipping
                 continue

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -167,7 +167,12 @@ def main():
         if 'linux_os' not in guide_dir:
             product_list = [given_product]
 
-        rule_obj = handle_rule_yaml(product_list, product_yamls, rule_id, rule_dir, guide_dir)
+        try:
+            rule_obj = handle_rule_yaml(product_list, product_yamls, rule_id, rule_dir, guide_dir)
+        except ssg.yaml.DocumentationNotComplete:
+            # Happens on non-debug build when a rule is "documentation-incomplete"
+            continue
+
         rule_obj['ovals'], oval_products = handle_ovals(product_list, product_yamls, rule_obj)
         rule_obj['remediations'], r_products = handle_remediations(product_list, product_yamls, rule_obj)
 


### PR DESCRIPTION
If a rule is marked as not `documentation_complete`, skip it on non-debug builds, like we do with "incomplete" profiles.