### PR TITLE
Fail when the rule provided by --rule-id doesn't exist

### DIFF
--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -212,6 +212,8 @@ def get_rules_to_compare(benchmark, rule_id):
             rule_id = ssg.constants.OSCAP_RULE + rule_id
         rules = benchmark.findall(
             ".//xccdf:Rule[@id='%s']" % (rule_id), ns)
+        if len(rules) == 0:
+            raise ValueError("Can't find rule %s" % (rule_id))
     else:
         rules = benchmark.findall(".//xccdf:Rule", ns)
     return rules


### PR DESCRIPTION

#### Description:
When an user wants to compare only 1 rule, and the rule isn't present in the datastream, for example the user makes a typo in --rule-id value, the script will fail.


#### Rationale:
