### PR TITLE
Add check to set /etc/motd similar to /etc/issue

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
@@ -1,0 +1,13 @@
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+. /usr/share/scap-security-guide/remediation_functions
+populate login_banner_text
+
+# There was a regular-expression matching various banners, needs to be expanded
+expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/[^-]- /\n\n-/g;s/(n)\**//g')
+formatted=$(echo "$expanded" | fold -sw 80)
+
+cat <<EOF >/etc/motd
+$formatted
+EOF
+
+printf "\n" >> /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="banner_etc_motd" version="2">
+    <metadata>
+      <title>System Login Banner Compliance</title>
+      <affected family="unix">
+        <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>The system login banner text should be set correctly.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="/etc/motd is set appropriately" test_ref="test_banner_etc_motd" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="correct banner in /etc/motd" id="test_banner_etc_motd" version="1">
+    <ind:object object_ref="object_banner_etc_motd" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_banner_etc_motd" version="1">
+    <ind:filepath>/etc/motd</ind:filepath>
+    <ind:pattern var_ref="login_banner_text" operation="pattern match" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <external_variable comment="warning banner text variable" datatype="string" id="login_banner_text" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
@@ -1,0 +1,56 @@
+documentation_complete: true
+
+prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
+
+title: 'Modify the System Message of the Day Banner'
+
+description: |-
+    To configure the system message banner edit <tt>/etc/motd</tt>. Replace the
+    default text with a message compliant with the local site policy or a legal
+    disclaimer.
+
+    The DoD required text is either:
+    <br /><br />
+    <tt>You are accessing a U.S. Government (USG) Information System (IS) that
+    is provided for USG-authorized use only. By using this IS (which includes
+    any device attached to this IS), you consent to the following conditions:
+    <br />-The USG routinely intercepts and monitors communications on this IS
+    for purposes including, but not limited to, penetration testing, COMSEC
+    monitoring, network operations and defense, personnel misconduct (PM), law
+    enforcement (LE), and counterintelligence (CI) investigations.
+    <br />-At any time, the USG may inspect and seize data stored on this IS.
+    <br />-Communications using, or data stored on, this IS are not private,
+    are subject to routine monitoring, interception, and search, and may be
+    disclosed or used for any USG-authorized purpose.
+    <br />-This IS includes security measures (e.g., authentication and access
+    controls) to protect USG interests -- not for your personal benefit or
+    privacy.
+    <br />-Notwithstanding the above, using this IS does not constitute consent
+    to PM, LE or CI investigative searching or monitoring of the content of
+    privileged communications, or work product, related to personal
+    representation or services by attorneys, psychotherapists, or clergy, and
+    their assistants. Such communications and work product are private and
+    confidential. See User Agreement for details.</tt>
+    <br /><br />
+    OR:
+    <br /><br />
+    <tt>I've read &amp; consent to terms in IS user agreem't.</tt>
+
+rationale: |-
+    Display of a standardized and approved use notification before granting
+    access to the operating system ensures privacy and security notification
+    verbiage used is consistent with applicable federal laws, Executive Orders,
+    directives, policies, regulations, standards, and guidance.
+    <br /><br />
+    System use notifications are required only for access via login interfaces
+    with human users and are not required when such human interfaces do not
+    exist.
+
+severity: medium
+
+ocil_clause: 'it does not display the required banner'
+
+ocil: |-
+    To check if the system login banner is compliant,
+    run the following command:
+    <pre>$ cat /etc/motd</pre>

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_dod_default_banner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_dod_default_banner.pass.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_default banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is 
+provided for USG-authorized use only. By using this IS (which includes any 
+device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for 
+purposes including, but not limited to, penetration testing, COMSEC monitoring, 
+network operations and defense, personnel misconduct (PM), law enforcement 
+(LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject 
+to routine monitoring, interception, and search, and may be disclosed or used 
+for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) 
+to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE 
+or CI investigative searching or monitoring of the content of privileged 
+communications, or work product, related to personal representation or services 
+by attorneys, psychotherapists, or clergy, and their assistants. Such 
+communications and work product are private and confidential. See User 
+Agreement for details." > /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_dod_short.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_dod_short.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_short banner
+echo "I've read & consent to terms in IS user agreem't." > /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_double_banner.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_double_banner.fail.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_default|dod_short banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is 
+provided for USG-authorized use only. By using this IS (which includes any 
+device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for 
+purposes including, but not limited to, penetration testing, COMSEC monitoring, 
+network operations and defense, personnel misconduct (PM), law enforcement 
+(LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject 
+to routine monitoring, interception, and search, and may be disclosed or used 
+for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) 
+to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE 
+or CI investigative searching or monitoring of the content of privileged 
+communications, or work product, related to personal representation or services 
+by attorneys, psychotherapists, or clergy, and their assistants. Such 
+communications and work product are private and confidential. See User 
+Agreement for details. I've read & consent to terms in IS user agreem't." > /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_usgcb_banner.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_disa_usgcb_banner.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# usgcb_default banner
+echo "-- WARNING -- This system is for the use of authorized users only. Individuals 
+using this computer system without authority or in excess of their authority 
+are subject to having all their activities on this system monitored and 
+recorded by system personnel. Anyone using this system expressly consents to 
+such monitoring and is advised that if such monitoring reveals possible 
+evidence of criminal activity system personal may provide the evidence of such 
+monitoring to law enforcement officials." > /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_ospp_usbcg_banner.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_ospp_usbcg_banner.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+echo "This is not the expected banner" > /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_ospp_usbcg_banner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_ospp_usbcg_banner.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# usgcb_default banner
+echo "-- WARNING -- This system is for the use of authorized users only. Individuals 
+using this computer system without authority or in excess of their authority 
+are subject to having all their activities on this system monitored and 
+recorded by system personnel. Anyone using this system expressly consents to 
+such monitoring and is advised that if such monitoring reveals possible 
+evidence of criminal activity system personal may provide the evidence of such 
+monitoring to law enforcement officials." > /etc/motd


### PR DESCRIPTION
#### Description:

Add setting to permit setting /etc/motd in a similar way as /etc/issue.

#### Rationale:

Sites may want the "short" message for `/etc/motd` and the "long" one for `/etc/issue` so that the user notifications are highly visible in multiple places.
