### PR TITLE
Set default to match syslog default

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
@@ -15,9 +15,8 @@ description: |-
 {{%- endif -%}}
     </pre>
     with an IP address or hostname of the system that the audispd plugin should
-    send audit records to. For example replacing <i>REMOTE_SYSTEM</i> with an IP
-    address or hostname:
-    <pre>remote_server = <i>REMOTE_SYSTEM</i></pre>
+    send audit records to. For example
+    <pre>remote_server = <i><sub idref="var_audispd_remote_server" /></i></pre>
 
 rationale: |-
     Information stored in one location is vulnerable to accidental or incidental
@@ -47,7 +46,6 @@ ocil: |-
 {{% else %}}
     <pre>$ sudo grep -i remote_server /etc/audisp/audisp-remote.conf</pre>
 {{% endif %}}
-    The output should return something similar to where <i>REMOTE_SYSTEM</i>
-    is an IP address or hostname:
-    <pre>remote_server = <i>REMOTE_SYSTEM</i></pre>
+    The output should return something similar to
+    <pre>remote_server = <i><sub idref="var_audispd_remote_server" /></i></pre>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audisp_remote_server_hostname.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audisp_remote_server_hostname.pass.sh
@@ -4,4 +4,4 @@
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment
-set_parameters_value /etc/audisp/audisp-remote.conf "remote_server" "myhost.mydomain.com"
+set_parameters_value /etc/audisp/audisp-remote.conf "remote_server" "logcollector"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audit_remote_server_hostname.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audit_remote_server_hostname.pass.sh
@@ -4,4 +4,4 @@
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment
-set_parameters_value /etc/audit/audisp-remote.conf "remote_server" "myhost.mydomain.com"
+set_parameters_value /etc/audit/audisp-remote.conf "remote_server" "logcollector"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_remote_server.var
@@ -14,4 +14,4 @@ type: string
 interactive: true
 
 options:
-    default: myhost.mydomain.com
+    default: logcollector


### PR DESCRIPTION
#### Description:

The auditsp log can have a more useful default.

#### Rationale:

The rsyslog default points to `logcollector` this patch brings the audit default into sync so that folks using this alias can "just work" with the default audit rules.