### PR TITLE
Add postfix relayhost check

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_relayhost/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_relayhost/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Configure System to Forward All Mail through a specific host'
+
+description: |-
+    Set up a relay host that will act as a gateway for all outbound email.
+    Edit the file <tt>/etc/postfix/main.cf</tt> to ensure that only the following
+    <tt>relayhost</tt> line appears:
+    <pre>relayhost = <sub idref="var_postfix_relayhost" /></pre>
+
+rationale: |-
+    A central outbound email location ensures messages sent from any network host
+    can be audited for potential unexpected content.  Tooling on the central server
+    may help prevent spam or viruses from being delivered.
+
+severity: medium
+
+ocil_clause: 'it is not'
+
+ocil: |-
+    Run the following command to ensure postfix routes mail to this system:
+    <pre>$ grep relayhost /etc/postfix/main.cf</pre>
+    If properly configured, the output should show only <tt><sub idref="var_postfix_relayhost" /></tt>.

--- a/linux_os/guide/services/mail/postfix_client/var_postfix_relayhost.var
+++ b/linux_os/guide/services/mail/postfix_client/var_postfix_relayhost.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Postfix relayhost'
+
+description: 'Specify the host all outbound email should be routed into.'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: smtp.$mydomain


### PR DESCRIPTION
#### Description:

This adds a check to permit restricting how postfix will relay outbound email.

#### Rationale:

The `relayhost` can have a central place to check for virus content or spam being sent out by a compromised host.  This rate limiting and scanning can help limit the spread problems from one host to other sites.