### PR TITLE
Extend SSH session to timeout while stilll allowing session to disconnect

### DIFF
--- a/linux_os/guide/services/ssh/sshd_idle_timeout_value.var
+++ b/linux_os/guide/services/ssh/sshd_idle_timeout_value.var
@@ -13,6 +13,7 @@ interactive: false
 options:
     10_minutes: 600
     120_minutes: 7200
+    14_minutes: 840
     15_minutes: 900
     30_minutes: 1800
     5_minutes: 300

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -289,7 +289,8 @@ selections:
 
     ## Set Screen Lock Timeout Period to 30 Minutes or Less
     ## AC-11(a) / FMT_MOF_EXT.1
-    - sshd_idle_timeout_value=10_minutes
+    ## We deliberately set sshd timeout to 1 minute before tmux lock timeout
+    - sshd_idle_timeout_value=14_minutes
     - sshd_set_idle_timeout
 
     ## Disable Unauthenticated Login (such as Guest Accounts)


### PR DESCRIPTION
#### Description:

- Bring remote session timeout closer to screen locking timeout, but not exactly the same.
  - Add selector for 14 minutes (840 seconds) SSHD idle timeout
  - Select 14 minutes as idle timeout for SSHD in RHEL8 OSPP profile

#### Rationale:

- Reasons for not making the timeout value not exactly the same:
  - When tmux is screen locked (vlock), it prevents the SSH session from timing out.
  - By timing out the SSH session before tmux screen lock times out, the SSH session terminates when idle.
