### PR TITLE
Remove directory_access_var_log_audit from RHEL 7 OSPP

### DIFF
--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -285,13 +285,11 @@ selections:
     ## AU-2(a) / FAU_GEN.1.1.c
     ## Audit Kernel Module Loading and Unloading Events (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
-    - audit_rules_for_ospp
-
     ## Audit All Audit and Log Data Accesses (Success/Failure)
     ##  CNSSI 1253 Value or DoD-specific Values:
     ##      - Audit and log data access (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
-    - directory_access_var_log_audit
+    - audit_rules_for_ospp
 
 
     ###  SELinux Configuration

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -278,16 +278,16 @@ selections:
     ##  CNSSI 1253 Value or DoD-specific Values:
     ##      - Privilege/Role escalation (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
+    ## Audit All Audit and Log Data Accesses (Success/Failure)
+    ##  CNSSI 1253 Value or DoD-specific Values:
+    ##      - Audit and log data access (Success/Failure)
+    ## AU-2(a) / FAU_GEN.1.1.c
     ## Audit Cryptographic Verification of Software (Success/Failure)
     ##  CNSSI 1253 Value or DoD-specific Values:
     ##      - Applications (e.g. Firefox, Internet Explorer, MS Office Suite,
     ##        etc) initialization (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
     ## Audit Kernel Module Loading and Unloading Events (Success/Failure)
-    ## AU-2(a) / FAU_GEN.1.1.c
-    ## Audit All Audit and Log Data Accesses (Success/Failure)
-    ##  CNSSI 1253 Value or DoD-specific Values:
-    ##      - Audit and log data access (Success/Failure)
     ## AU-2(a) / FAU_GEN.1.1.c
     - audit_rules_for_ospp
 


### PR DESCRIPTION
#### Description:
Remove directory_access_var_log_audit from RHEL 7 OSPP

#### Rationale:

The audit rule `-a always,exit -F dir=/var/log/audit/
-F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail`
is present in `/usr/share/doc/audit-2.8.5/rules/30-ospp-v42.rules`
(checked on audit-2.8.5-4.el7.x86_64). That means this audit rule
is already checked and remediated by rule `audit_rules_for_ospp`.

