### PR TITLE
remove rule package_telnet_removed from profiles in rhel7, rhel8, rhv4

### DIFF
--- a/rhel7/profiles/C2S.profile
+++ b/rhel7/profiles/C2S.profile
@@ -101,7 +101,6 @@ selections:
     - package_ypbind_removed
     - package_rsh_removed
     - package_talk_removed
-    - package_telnet_removed
     - sysctl_net_ipv4_ip_forward
     - sysctl_net_ipv4_conf_all_send_redirects
     - sysctl_net_ipv4_conf_default_send_redirects

--- a/rhel7/profiles/e8.profile
+++ b/rhel7/profiles/e8.profile
@@ -19,7 +19,6 @@ selections:
   - package_xinetd_removed
   - service_xinetd_disabled
   - package_ypbind_removed
-  - package_telnet_removed
   - service_telnet_disabled
   - package_telnet-server_removed
   - package_rsh_removed

--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -39,7 +39,6 @@ selections:
     - package_rsh-server_removed
     - package_talk_removed
     - package_talk-server_removed
-    - package_telnet_removed
     - package_telnet-server_removed
     - package_xinetd_removed
     - package_ypbind_removed

--- a/rhel7/profiles/ncp.profile
+++ b/rhel7/profiles/ncp.profile
@@ -156,7 +156,6 @@ selections:
     - package_rsh-server_removed
     - package_talk_removed
     - package_talk-server_removed
-    - package_telnet_removed
     - package_telnet-server_removed
     - package_xinetd_removed
     - package_ypbind_removed

--- a/rhel7/profiles/rhelh-stig.profile
+++ b/rhel7/profiles/rhelh-stig.profile
@@ -186,7 +186,6 @@ selections:
     - package_rsh-server_removed
     - package_talk_removed
     - package_talk-server_removed
-    - package_telnet_removed
     - package_telnet-server_removed
     - package_xinetd_removed
     - package_ypbind_removed

--- a/rhel7/profiles/rht-ccp.profile
+++ b/rhel7/profiles/rht-ccp.profile
@@ -86,7 +86,6 @@ selections:
     - service_abrtd_disabled
     - service_telnet_disabled
     - package_telnet-server_removed
-    - package_telnet_removed
     - sshd_allow_only_protocol2
     - sshd_set_idle_timeout
     - sshd_set_keepalive

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -19,7 +19,6 @@ selections:
   - package_xinetd_removed
   - service_xinetd_disabled
   - package_ypbind_removed
-  - package_telnet_removed
   - service_telnet_disabled
   - package_telnet-server_removed
   - package_rsh_removed

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -38,7 +38,6 @@ selections:
     - package_rsh-server_removed
     - package_talk_removed
     - package_talk-server_removed
-    - package_telnet_removed
     - package_telnet-server_removed
     - package_xinetd_removed
     - service_crond_enabled

--- a/rhel8/profiles/rht-ccp.profile
+++ b/rhel8/profiles/rht-ccp.profile
@@ -86,7 +86,6 @@ selections:
     - service_abrtd_disabled
     - service_telnet_disabled
     - package_telnet-server_removed
-    - package_telnet_removed
     - sshd_allow_only_protocol2
     - sshd_set_idle_timeout
     - sshd_set_keepalive

--- a/rhv4/profiles/rhvh-stig.profile
+++ b/rhv4/profiles/rhvh-stig.profile
@@ -185,7 +185,6 @@ selections:
     - package_rsh-server_removed
     - package_talk_removed
     - package_talk-server_removed
-    - package_telnet_removed
     - package_telnet-server_removed
     - package_xinetd_removed
     - package_ypbind_removed


### PR DESCRIPTION
#### Description:

The rule package_telnet_removed was removet from all profiles shipped with rhel7, rhel8 and rhv4

#### Rationale:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1729222

The rule package_telnet_removed removes Telnet client which is needed by some installations, especially fence agents. The Telnet server, which introduces much bigger security problem, is removed by a different rule. It should be fine to keep the Telnet client as it does not introduce direct security risk.