### PR TITLE
Use only first occurence from /etc/mtab

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/multiple_entries_in_mtab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/multiple_entries_in_mtab.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+cat /etc/mtab > /etc/mtab.old
+# destroy symlink
+rm -f /etc/mtab
+cp /etc/mtab.old /etc/mtab
+echo "tmpfs /dev/shm tmpfs rw,seclabel,relatime 0 0" >> /etc/mtab
+echo "tmpfs /dev/shm tmpfs rw,seclabel,relatime 0 0" >> /etc/mtab

--- a/shared/bash_remediation_functions/include_mount_options_functions.sh
+++ b/shared/bash_remediation_functions/include_mount_options_functions.sh
@@ -27,7 +27,7 @@ function ensure_mount_option_in_fstab {
 
 	if [ "$(grep -c "$_mount_point_match_regexp" /etc/fstab)" -eq 0 ]; then
 		# runtime opts without some automatic kernel/userspace-added defaults
-		_previous_mount_opts=$(grep "$_mount_point_match_regexp" /etc/mtab | awk '{print $4}' \
+		_previous_mount_opts=$(grep "$_mount_point_match_regexp" /etc/mtab | head -1 |  awk '{print $4}' \
 					| sed -E "s/(rw|defaults|seclabel|${_new_opt})(,|$)//g;s/,$//")
 		[ "$_previous_mount_opts" ] && _previous_mount_opts+=","
 		echo "${_device} ${_mount_point} ${_type} defaults,${_previous_mount_opts}${_new_opt} 0 0" >> /etc/fstab


### PR DESCRIPTION
#### Description:
The mount options of the first entry will be used. 

#### Rationale:
If there are multiple lines in `/etc/mtab` that match the same mount point, the variable `_previous_mount_opts` contained newline characters. These newlines were propagated to `/etc/fstab`. As a result, an invalid entry in `/etc/fstab` was created, `mount` command hasn't been successful and the oscap scan after remediation returned false.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1754553