### PR TITLE
Update test scenarios for chronyd_or_ntpd_set_maxpoll for RHEL8

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
@@ -5,7 +5,9 @@
 yum install -y chrony
 yum remove -y ntp
 
-if ! grep "^server.*maxpoll 10" /etc/chrony.conf; then
+if ! grep "^server" /etc/chrony.conf ; then
+    echo "server foo.example.net iburst maxpoll 10" >> /etc/chrony.conf
+elif ! grep "^server.*maxpoll 10" /etc/chrony.conf; then
     sed -i "s/^server.*/& maxpoll 10/" /etc/chrony.conf
 fi
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_nothing_done.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_nothing_done.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Red Hat Enterprise Linux 7
 
 yum install -y chrony
 yum remove -y ntp

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Red Hat Enterprise Linux 7
 
 yum install -y ntp
 yum remove -y chrony

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_wrong_maxpoll.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_wrong_maxpoll.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Red Hat Enterprise Linux 7
 
 yum install -y ntp
 yum remove -y chrony


### PR DESCRIPTION
The rule chronyd_or_ntpd_set_maxpoll checks both ntp and chronyd
configuration. The test scenarios have been developed on RHEL7, but the
rule is also applicable to RHEL8. But on RHEL8, there is no ntp, only
chronyd. Therefore the scenarios that test ntp configuration should not
be applicable to RHEL8.

Also, the rule checks `maxpoll` parameters only on `server` keys, but
`server` keys are not the only way to configure time source, there can
be also `pool` and other keys. On RHEL8, the default `/etc/chrony.conf`
does not contain `server` but it contains `pool`.  That means to test
the `server` key we cannot rely on its default presence but we need to
insert a line if it is not present.