### PR TITLE
Fix grub2 enable fips mode rule

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
@@ -3,8 +3,6 @@
 # include remediation functions library
 . /usr/share/scap-security-guide/remediation_functions
 
-{{{ bash_disable_prelink() }}}
-
 if grep -q -m1 -o aes /proc/cpuinfo; then
 	{{{ bash_package_install("dracut-fips-aesni") }}}
 fi

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -90,7 +90,7 @@ apt-get remove -y "{{{ package }}}"
 {{%- macro bash_disable_prelink() -%}}
 # prelink not installed
 if test ! -e /etc/sysconfig/prelink -a ! -e /usr/sbin/prelink; then
-    return 0
+    exit 0
 fi
 
 if grep -q ^PRELINKING /etc/sysconfig/prelink


### PR DESCRIPTION
#### Description:

- Fix bash remediation of grub2_enable_fips_mode rule

#### Additional Info:

`{{{ bash_disable_prelink() }}}` macro doesn't seem to be in the right place and it is there for the whole time.