### PR TITLE
Fix grub2 enable fips mode rule

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/anaconda/shared.anaconda
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/anaconda/shared.anaconda
@@ -1,3 +1,3 @@
 # platform = Red Hat Enterprise Linux 7,Oracle Linux 7
 
-package --add=dracut-fips
+package --add=dracut-fips --add=dracut-fips-aesni

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -89,21 +89,19 @@ apt-get remove -y "{{{ package }}}"
 
 {{%- macro bash_disable_prelink() -%}}
 # prelink not installed
-if test ! -e /etc/sysconfig/prelink -a ! -e /usr/sbin/prelink; then
-    return 0
-fi
+if test -e /etc/sysconfig/prelink -o -e /usr/sbin/prelink; then
+    if grep -q ^PRELINKING /etc/sysconfig/prelink
+    then
+        sed -i 's/^PRELINKING[:blank:]*=[:blank:]*[:alpha:]*/PRELINKING=no/' /etc/sysconfig/prelink
+    else
+        printf '\n' >> /etc/sysconfig/prelink
+        printf '%s\n' '# Set PRELINKING=no per security requirements' 'PRELINKING=no' >> /etc/sysconfig/prelink
+    fi
 
-if grep -q ^PRELINKING /etc/sysconfig/prelink
-then
-    sed -i 's/^PRELINKING[:blank:]*=[:blank:]*[:alpha:]*/PRELINKING=no/' /etc/sysconfig/prelink
-else
-    printf '\n' >> /etc/sysconfig/prelink
-    printf '%s\n' '# Set PRELINKING=no per security requirements' 'PRELINKING=no' >> /etc/sysconfig/prelink
-fi
-
-# Undo previous prelink changes to binaries if prelink is available.
-if test -x /usr/sbin/prelink; then
-    /usr/sbin/prelink -ua
+    # Undo previous prelink changes to binaries if prelink is available.
+    if test -x /usr/sbin/prelink; then
+        /usr/sbin/prelink -ua
+    fi
 fi
 {{%- endmacro -%}}
 


### PR DESCRIPTION
#### Description:

The problem was that it may happen that bash remediation phase when doing a fresh installation, some functions may require installing package, but it can happen that the machine is not registered to any repository yet, so the package installation should happen during the package installation phase via anaconda.

- Add `dracut-fips-aesni` to anaconda remediation for grub2_enable_fips_mode rule.
- Fix log of disable_prelink to detect the presence of prelink package as we changed the bash code to be a macro and it is not a function anymore, so we cannot use neither `return` statement nor `exit`, now it skips correctly when the package is not installed.

#### Rationale:

- grub2_enable_fips_mode passes during fresh installation when using oscap-anaconda-addon profiles.

- Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1754532
