### PR TITLE
make aide_periodic_cron_checking accepting broader array of time specs

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/shared.sh
@@ -4,4 +4,7 @@
 
 if ! grep -q "/usr/sbin/aide --check" /etc/crontab ; then
     echo "05 4 * * * root /usr/sbin/aide --check" >> /etc/crontab
+else
+    sed -i '/^.*\/usr\/sbin\/aide --check.*$/d' /etc/crontab
+    echo "05 4 * * * root /usr/sbin/aide --check" >> /etc/crontab
 fi

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
@@ -29,7 +29,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide with cron" id="object_test_aide_periodic_cron_checking" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
-    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*[\*,0-9])|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
@@ -29,7 +29,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide with cron" id="object_test_aide_periodic_cron_checking" version="1">
     <ind:filepath>/etc/crontab</ind:filepath>
-    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*[\*,0-9])|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*(\*|([0-7]|mon|tue|wed|thu|fri|sat|sun)|[0-7]-[0-7]))|@(hourly|daily|weekly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
@@ -39,7 +39,7 @@
   <ind:textfilecontent54_object comment="run aide with cron" id="object_test_aide_crond_checking" version="1">
     <ind:path>/etc/cron.d</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*(\*|([0-7]|mon|tue|wed|thu|fri|sat|sun)|[0-7]-[0-7]))|@(hourly|daily|weekly))[\s]*root[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -48,7 +48,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide with cron" id="object_aide_var_cron_checking" version="1">
     <ind:filepath>/var/spool/cron/root</ind:filepath>
-    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*\*)|@(hourly|daily|weekly|monthly))([\s]*root)?[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(([0-9]*[\s]*[0-9]*[\s]*\*[\s]*\*[\s]*(\*|([0-7]|mon|tue|wed|thu|fri|sat|sun)|[0-7]-[0-7]))|@(hourly|daily|weekly))[\s]*(root)?[\s]*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -56,7 +56,7 @@
     <ind:object object_ref="object_aide_crontabs_checking" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="run aide with cron.(daily|weekly|monthly)" id="object_aide_crontabs_checking" version="1">
-    <ind:path operation="pattern match">^/etc/cron.(daily|weekly|monthly)$</ind:path>
+    <ind:path operation="pattern match">^/etc/cron.(daily|weekly)$</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^\s*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
@@ -19,7 +19,7 @@
         <criterion comment="run aide with cron" test_ref="test_aide_periodic_cron_checking" />
         <criterion comment="run aide with cron" test_ref="test_aide_crond_checking" />
         <criterion comment="run aide with cron" test_ref="test_aide_var_cron_checking" />
-        <criterion comment="run aide with cron.(daily|weekly|monthly)" test_ref="test_aide_crontabs_checking" />
+        <criterion comment="run aide with cron.(daily|weekly)" test_ref="test_aide_crontabs_checking" />
       </criteria>
     </criteria>
   </definition>
@@ -52,10 +52,10 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide with cron.(daily|weekly|monthly)" id="test_aide_crontabs_checking" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="run aide with cron.(daily|weekly)" id="test_aide_crontabs_checking" version="2">
     <ind:object object_ref="object_aide_crontabs_checking" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="run aide with cron.(daily|weekly|monthly)" id="object_aide_crontabs_checking" version="1">
+  <ind:textfilecontent54_object comment="run aide with cron.(daily|weekly)" id="object_aide_crontabs_checking" version="1">
     <ind:path operation="pattern match">^/etc/cron.(daily|weekly)$</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^\s*/usr/sbin/aide[\s]*\-\-check.*$</ind:pattern>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -5,7 +5,7 @@ prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
 title: 'Configure Periodic Execution of AIDE'
 
 description: |-
-    At a minimum, AIDE should be configured to run a weekly scan. At most, AIDE should be run daily.
+    At a minimum, AIDE should be configured to run a weekly scan.
     To implement a daily execution of AIDE at 4:05am using cron, add the following line to <tt>/etc/crontab</tt>:
     <pre>05 4 * * * root /usr/sbin/aide --check</pre>
     To implement a weekly execution of AIDE at 4:05am using cron, add the following line to <tt>/etc/crontab</tt>:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '@daily    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '21    21    1    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '21    21    *    *    1-2    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
-echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    *    *    3    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
-echo '21    21    *    *    @weekly    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '@weekly    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '21    21    *    *    @weekly    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '21    21    *    *    mon    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo '21    21    1    2    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab


### PR DESCRIPTION
#### Description:

Modified the oval so that more ways of specifying the desired periodicity are passing.
- specifying weekdays by name
- ranges of weekdays
- asterisk in weekday column

Changed regexes for all crontab locations.
Removed acceptance of `@monthly` because it violates the rule description.
Modified remediation so that it removes invalid crontab entries pertaining to this rule.
Extended tests.


#### Rationale:

The rule specifies that the check should be run at least weekly and at most daily. However, the rule didn't accept for example
21 21 * * 6 ...
But this is valid specification of a weekly job.

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1658036
