### PR TITLE
Enable copr builds and add packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,7 @@ jobs:
     - fedora-all-x86_64
 - job: propose_downstream
   metadata:
-  dist-git-branch: fedora-all
+    dist-git-branch: fedora-all
   trigger: release
 - job: sync_from_downstream
   trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,16 +1,18 @@
+upstream_package_name: content
 downstream_package_name: scap-security-guide
-jobs:
-- job: copr_build
-  metadata:
-    targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
-  trigger: pull_request
 specfile_path: scap-security-guide.spec
 synced_files:
-- scap-security-guide.spec
-- .packit.yaml
-upstream_package_name: content
-actions:
-  post-upstream-clone: wget -N https://src.fedoraproject.org/rpms/scap-security-guide/raw/master/f/scap-security-guide.spec
+  - scap-security-guide.spec
+  - .packit.yaml
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-all-x86_64
+- job: propose_downstream
+  metadata:
+  dist-git-branch: fedora-all
+  trigger: release
+- job: sync_from_downstream
+  trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,9 +1,8 @@
-upstream_package_name: content
 downstream_package_name: scap-security-guide
 specfile_path: scap-security-guide.spec
-synced_files:
-  - scap-security-guide.spec
-  - .packit.yaml
+actions:
+  post-upstream-clone:
+    - wget -N https://src.fedoraproject.org/rpms/scap-security-guide/raw/master/f/scap-security-guide-0.1.48-xml_parsing.patch
 jobs:
 - job: copr_build
   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,16 @@
+downstream_package_name: scap-security-guide
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-30-x86_64
+    - fedora-31-x86_64
+    - fedora-rawhide-x86_64
+  trigger: pull_request
+specfile_path: scap-security-guide.spec
+synced_files:
+- scap-security-guide.spec
+- .packit.yaml
+upstream_package_name: content
+actions:
+  post-upstream-clone: wget -N https://src.fedoraproject.org/rpms/scap-security-guide/raw/master/f/scap-security-guide.spec

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -1,0 +1,66 @@
+Name:		scap-security-guide
+Version:	0.1.47
+Release:	2%{?dist}
+Summary:	Security guidance and baselines in SCAP formats
+License:	BSD-3-Clause
+URL:		https://github.com/ComplianceAsCode/content/
+Source0:	https://github.com/ComplianceAsCode/content/releases/download/v%{version}/scap-security-guide-%{version}.tar.bz2
+BuildArch:	noarch
+
+Patch0:		scap-security-guide-0.1.48-xml_parsing.patch
+
+BuildRequires:	libxslt, expat, python3, openscap-scanner >= 1.2.5, cmake >= 3.8, python3-jinja2, python3-PyYAML
+Requires:	xml-common, openscap-scanner >= 1.2.5
+Obsoletes:	openscap-content < 0:0.9.13
+Provides:	openscap-content
+
+%description
+The scap-security-guide project provides a guide for configuration of the
+system from the final system's security point of view. The guidance is specified
+in the Security Content Automation Protocol (SCAP) format and constitutes
+a catalog of practical hardening advice, linked to government requirements
+where applicable. The project bridges the gap between generalized policy
+requirements and specific implementation guidelines. The Fedora system
+administrator can use the oscap CLI tool from openscap-scanner package, or the
+scap-workbench GUI tool from scap-workbench package to verify that the system
+conforms to provided guideline. Refer to scap-security-guide(8) manual page for
+further information.
+
+%package	doc
+Summary:	HTML formatted security guides generated from XCCDF benchmarks
+Requires:	%{name} = %{version}-%{release}
+
+%description	doc
+The %{name}-doc package contains HTML formatted documents containing
+hardening guidances that have been generated from XCCDF benchmarks
+present in %{name} package.
+
+%prep
+%setup -q
+%patch0 -p1
+mkdir build
+
+%build
+cd build
+%cmake ../
+%make_build
+
+%install
+cd build
+%make_install
+
+%files
+%{_datadir}/xml/scap/ssg/content
+%{_datadir}/%{name}/kickstart
+%{_datadir}/%{name}/ansible
+%{_datadir}/%{name}/bash
+%lang(en) %{_mandir}/man8/scap-security-guide.8.*
+%doc %{_docdir}/%{name}/LICENSE
+%doc %{_docdir}/%{name}/README.md
+%doc %{_docdir}/%{name}/Contributors.md
+
+%files doc
+%doc %{_docdir}/%{name}/guides/*.html
+%doc %{_docdir}/%{name}/tables/*.html
+
+%changelog

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -38,7 +38,7 @@ present in %{name} package.
 %prep
 %setup -q
 %patch0 -p1
-mkdir build
+mkdir -p build
 
 %build
 cd build


### PR DESCRIPTION

Let us introduce [packit service](https://packit.dev) to you - the automation to integrate upstream open source projects into Fedora operating system.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

But there is more. By using packit, you can for example enable adding new releases into Fedora Rawhide.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact @packit-service

The spec you see in this PR was fetched from your package's Fedora dist-git.
