### PR TITLE
Small Bash style fixes.

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/bash/shared.sh
@@ -4,7 +4,7 @@
 # services for NFSv4 from attempting to start IPv6 network listeners
 declare -a IPV6_RPC_ENTRIES=("tcp6" "udp6")
 
-for rpc_entry in ${IPV6_RPC_ENTRIES[@]}
+for rpc_entry in "${IPV6_RPC_ENTRIES[@]}"
 do
-	sed -i "/^$rpc_entry[[:space:]]\+tpi\_.*inet6.*/d" /etc/netconfig
+	sed -i "/^${rpc_entry}[[:space:]]\\+tpi\\_.*inet6.*/d" /etc/netconfig
 done

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -19,7 +19,7 @@ if [ "$(getconf LONG_BIT)" = "64" ] ; then
   if grep --silent noexec /boot/grub2/grub*.cfg ; then 
         sed -i "s/noexec.*//g" /etc/default/grub
         sed -i "s/noexec.*//g" /etc/grub.d/*
-        GRUBCFG=`ls | grep '.cfg$'`
-        grub2-mkconfig -o "/boot/grub2/$GRUBCFG"
+        GRUBCFG=/boot/grub2/*.cfg
+        grub2-mkconfig -o "$GRUBCFG"
   fi
 fi


### PR DESCRIPTION
- Use explicit curly braces when deferencing a variable when it is followed by square brackets.
- Removed ls | grep pattern in favor of wildcard expression, fixing the remediation in the process.
- Added robust [backslash quoting](https://www.gnu.org/software/bash/manual/bash.html#Double-Quotes) inside of double quotes.