### PR TITLE
Fix RHEL7 rules sshd_use_strong_macs and sshd_use_strong_ciphers.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_all
 
-{{{ bash_sshd_config_set(parameter="Ciphers", value="aes128-ctr,aes192-ctr,aes256-ctr,chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr") }}}
+{{{ bash_sshd_config_set(parameter="Ciphers", value="aes128-ctr,aes192-ctr,aes256-ctr,chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_all
+
+{{{ bash_sshd_config_set(parameter="Ciphers", value="aes128-ctr,aes192-ctr,aes256-ctr,chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
@@ -1,1 +1,1 @@
-{{{ oval_sshd_config(parameter="Ciphers", value="((aes128-ctr|aes192-ctr|aes256-ctr|chacha20-poly1305@openssh\.com|aes256-gcm@openssh\.com|aes128-gcm@openssh\.com|aes256-ctr|aes128-ctr),?)") }}}
+{{{ oval_sshd_config(parameter="Ciphers", value="((aes128-ctr|aes192-ctr|aes256-ctr|chacha20-poly1305@openssh\.com|aes256-gcm@openssh\.com|aes128-gcm@openssh\.com),?)+") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
@@ -1,1 +1,1 @@
-{{{ oval_sshd_config(parameter="Ciphers", value="((chacha20-poly1305@openssh\.com|aes256-gcm@openssh\.com|aes128-gcm@openssh\.com|aes256-ctr|aes128-ctr),?)") }}}
+{{{ oval_sshd_config(parameter="Ciphers", value="((aes128-ctr|aes192-ctr|aes256-ctr|chacha20-poly1305@openssh\.com|aes256-gcm@openssh\.com|aes128-gcm@openssh\.com|aes256-ctr|aes128-ctr),?)") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
@@ -9,8 +9,7 @@ description: |-
     Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
     The following line in <tt>/etc/ssh/sshd_config</tt>
     demonstrates use of those ciphers:
-    <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr</pre>
-    <pre>chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr</pre>
+    <pre>Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
 
 rationale: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/good_cipher.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/good_cipher.pass.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+# profiles = e8
+
+sed -i 's/^\s*Ciphers\s.*//i' /etc/ssh/sshd_config
+echo "Ciphers aes256-ctr" >> /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/no_ciphers.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/no_ciphers.fail.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+# profiles = e8
+
+sed -i 's/^\s*Ciphers\s/# &/i' /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/bash/shared.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_all
+
+{{{ bash_sshd_config_set(parameter="MACs", value="hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160") }}}
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+# profiles = e8
+
+sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config
+echo "MACs hmac-sha2-512" >> /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/no_macs.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/no_macs.fail.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+# profiles = e8
+
+sed -i 's/^\s*MACs\s/# &/i' /etc/ssh/sshd_config


### PR DESCRIPTION
- Implemented Bash remediations according to rule description.
- Synced sshd_use_strong_ciphers OVAL according with the rule description.