### PR TITLE
Add waiting for RUNNING state of virtual machine

### DIFF
--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -107,6 +107,14 @@ def determine_ip(domain):
                        "          state='connected'/>"
                        "</channel>")
 
+    # wait for machine until it gets to RUNNING state,
+    # because it isn't possible to determine IP in e.g. PAUSED state
+    must_end = time.time() + 30  # wait max. 30 seconds
+    while time.time() < must_end:
+        if domain.state()[0] == libvirt.VIR_DOMAIN_RUNNING:
+            break
+        time.sleep(1)
+
     domain_xml = ET.fromstring(domain.XMLDesc())
     for mac_node in domain_xml.iter('mac'):
         domain_mac = mac_node.attrib['address']


### PR DESCRIPTION
#### Description:
Add 30sec waiting for virtual machine.

#### Rationale:
When running SSGTS multiple times in row, it can happen that virtual machine is in PAUSED state (and it's reverting snapshot to previous machine state) longer than expected. But a new run can be started (previous SSGTS process is finished) and it will crash, because it can't determine machine IP when machine is in PAUSED state.

If the state isn't still RUNNING after 30sec., then just try get IP and throw error, if it's not possible.