### PR TITLE
Updated the e8 profile for RHEL8.

### DIFF
--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -123,13 +123,15 @@ selections:
   - sshd_print_last_log
   - sshd_use_priv_separation
   - sshd_do_not_permit_user_env
-  - sshd_disable_rhosts_rsa
   - sshd_disable_rhosts
-  - sshd_allow_only_protocol2
   - sshd_set_loglevel_info
   - sshd_disable_empty_passwords
   - sshd_disable_user_known_hosts
   - sshd_enable_strictmodes
+
+  - var_system_crypto_policy=default
+  - configure_crypto_policy
+  - configure_ssh_crypto_policy
 
   ### Application whitelisting
   - package_fapolicyd_installed

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -129,7 +129,10 @@ selections:
   - sshd_disable_user_known_hosts
   - sshd_enable_strictmodes
 
-  - var_system_crypto_policy=default
+  # The E8 profile bans usage of SHA-1, and as of 11/2019 the FUTURE crypto policy is the only one that ensures this.
+  # TODO: Re-evaluate after another crypto policies become available.
+  # See also: https://www.cyber.gov.au/ism/guidelines-using-cryptography
+  - var_system_crypto_policy=future
   - configure_crypto_policy
   - configure_ssh_crypto_policy
 


### PR DESCRIPTION
- removed obsolete `sshd` settings.
- added rules for crypto policies to set up strong ciphers + MACs for `sshd`.