### PR TITLE
Various minor fixes

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/bash/shared.sh
@@ -10,7 +10,7 @@ echo "options ipv6 disable=1" > /etc/modprobe.d/ipv6.conf
 
 declare -a IPV6_SETTINGS=("net.ipv6.conf.all.disable_ipv6" "net.ipv6.conf.default.disable_ipv6")
 
-for setting in ${IPV6_SETTINGS[@]}
+for setting in "${IPV6_SETTINGS[@]}"
 do
 	# Set runtime =1 for setting
 	/sbin/sysctl -q -n -w "$setting=1"

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,fedora,ol8
+prodtype: rhel8,fedora,ol8
 
 title: 'Disable Access to Network bpf() Syscall From Unprivileged Processes'
 


### PR DESCRIPTION
- Removed incorrect prodtype from a rule (the `unprivileged_bpf_disabled` kernel param doesn't work on RHEL7)
- Added proper quoting to bash array.