### PR TITLE
Firefox content fixes

### DIFF
--- a/firefox/guide/firefox/firefox_preferences-home_page/bash/firefox.sh
+++ b/firefox/guide/firefox/firefox_preferences-home_page/bash/firefox.sh
@@ -1,4 +1,8 @@
 # platform = Mozilla Firefox
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
 populate var_default_home_page
 
-{{{ bash_firefox_cfg_setting("stig.cfg", "browser.startup.homepage", "\"${var_default_home_page}\"") }}}
+{{{ bash_firefox_cfg_setting("stig.cfg", "browser.startup.homepage", quoted_value="${var_default_home_page}") }}}

--- a/firefox/guide/firefox/firefox_preferences-lock_settings/firefox_preferences-lock_settings_config_file/bash/firefox.sh
+++ b/firefox/guide/firefox/firefox_preferences-lock_settings/firefox_preferences-lock_settings_config_file/bash/firefox.sh
@@ -1,3 +1,3 @@
 # platform = Mozilla Firefox
 
-{{{ bash_firefox_js_setting("stig_settings.js", "general.config.filename", "\"stig.cfg\"") }}}
+{{{ bash_firefox_js_setting("stig_settings.js", "general.config.filename", quoted_value="stig.cfg") }}}

--- a/firefox/guide/firefox/firefox_preferences-lock_settings/firefox_preferences-lock_settings_config_file/oval/firefox.xml
+++ b/firefox/guide/firefox/firefox_preferences-lock_settings/firefox_preferences-lock_settings_config_file/oval/firefox.xml
@@ -13,11 +13,11 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="Check for configuration filename" id="test_firefox_preferences-config_filename" version="1">
+  <ind:textfilecontent54_test check="all" comment="Check for configuration filename" id="test_firefox_preferences-config_filename" version="2">
     <ind:object object_ref="object_firefox_preferences-config_filename" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_firefox_preferences-config_filename" version="1">
-    <ind:path operation="pattern match">^\/usr\/(|local\/)lib(|64)\/firefox\/defaults\/preferences</ind:path>
+    <ind:path operation="pattern match">^\/usr\/(|local\/)lib(|64)\/firefox\/defaults\/(preferences|pref)</ind:path>
     <ind:filename operation="pattern match">^.*\.js$</ind:filename>
     <ind:pattern operation="pattern match">^pref\("general.config.filename",[\s]+"(\S+)\.cfg"\);$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/firefox/guide/firefox/firefox_preferences-lock_settings/firefox_preferences-lock_settings_obscure/oval/firefox.xml
+++ b/firefox/guide/firefox/firefox_preferences-lock_settings/firefox_preferences-lock_settings_obscure/oval/firefox.xml
@@ -17,7 +17,7 @@
     <ind:object object_ref="object_firefox_preferences-obscure_value" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_firefox_preferences-obscure_value" version="1">
-    <ind:path operation="pattern match">^\/usr\/(|local\/)lib(|64)\/firefox\/defaults\/preferences</ind:path>
+    <ind:path operation="pattern match">^\/usr\/(|local\/)lib(|64)\/firefox\/defaults\/(preferences|pref)</ind:path>
     <ind:filename operation="pattern match">^.*\.js$</ind:filename>
     <ind:pattern operation="pattern match">^pref\("general.config.obscure_value",[\s]+0\);$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/firefox/guide/firefox/firefox_preferences-open_confirmation/bash/firefox.sh
+++ b/firefox/guide/firefox/firefox_preferences-open_confirmation/bash/firefox.sh
@@ -1,4 +1,8 @@
 # platform = Mozilla Firefox
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
 populate var_required_file_types
 
-{{{ bash_firefox_cfg_setting("stig.cfg", "plugin.disable_full_page_plugin_for_types", "\"${var_required_file_types}\"") }}}
+{{{ bash_firefox_cfg_setting("stig.cfg", "plugin.disable_full_page_plugin_for_types", quoted_value="${var_required_file_types}", sed_separator="|") }}}

--- a/firefox/guide/firefox/firefox_preferences-verification/bash/firefox.sh
+++ b/firefox/guide/firefox/firefox_preferences-verification/bash/firefox.sh
@@ -1,3 +1,3 @@
 # platform = Mozilla Firefox
 
-{{{ bash_firefox_cfg_setting("stig.cfg", "security.default_personal_cert", "\"Ask Every Time\"") }}}
+{{{ bash_firefox_cfg_setting("stig.cfg", "security.default_personal_cert", quoted_value="Ask Every Time") }}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -200,6 +200,28 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
 {{%- endif -%}}
 {{%- endmacro -%}}
 
+
+{{%- macro _put_into_firefox_cfg(config_item, key, value_varname, where, sed_separator) -%}}
+# If the key exists, change it. Otherwise, add it to the config_file.
+if LC_ALL=C grep -m 1 -q '^{{{ config_item }}}("{{{ key }}}", ' "{{{ where }}}"; then
+  sed -i 's{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}".*{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}})"';{{{ sed_separator }}}g' "{{{ where }}}"
+else
+  echo '{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}}"');' >> "{{{ where }}}"
+fi
+{{%- endmacro -%}}
+
+
+{{%- macro _make_bash_variable_assignment(varname, value="", quoted_value="") -%}}
+{{% if value -%}}
+	{{{ varname }}}="{{{ value }}}"
+{{%- elif quoted_value -%}}
+	{{{ varname }}}="\"{{{ quoted_value }}}\""
+{{%- else %}}
+	{{{ raise("Specify either 'value' or 'quoted_value' as macro arguments.") }}}
+{{%- endif -%}}
+{{%- endmacro -%}}
+
+
 {{#
 # bash_firefox_js_setting expects three arguments:
 #
@@ -213,15 +235,14 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
 #     bash_firefox_js_setting("stig_settings.js", "general.config.obscure_value", "0")
 #
 #     With a fixed string value:
-#     bash_firefox_js_setting("stig_settings.js", "general.config.filename", "\"stig.cfg\"")
+#     bash_firefox_js_setting("stig_settings.js", "general.config.filename", quoted_value="stig.cfg")
 #
 #     With a string variable:
-#     bash_firefox_js_setting("stig_settings.js", "general.config.filename", "\"$var_config_file_name\"")
+#     bash_firefox_js_setting("stig_settings.js", "general.config.filename", quoted_value="$var_config_file_name")
 #}}
-{{%- macro bash_firefox_js_setting(config_file, key, value) -%}}
+{{%- macro bash_firefox_js_setting(config_file, key, value="", quoted_value="", sed_separator="/") %}}
+  {{{ _make_bash_variable_assignment(varname="value", value=value, quoted_value=quoted_value) }}}
   firefox_js="{{{ config_file }}}"
-  key="{{{ key }}}"
-  value="{{{ value }}}"
   firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
   firefox_pref="/defaults/pref"
   firefox_preferences="/defaults/preferences"
@@ -246,12 +267,7 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
         chmod 644 "${firefox_pref_dir}/${firefox_js}"
       fi
 
-      # If the key exists, change it. Otherwise, add it to the config_file.
-      if LC_ALL=C grep -m 1 -q "^pref(\"${key}\", " "${firefox_pref_dir}/${firefox_js}"; then
-        sed -i "s/pref(\"${key}\".*/pref(\"${key}\", ${value});/g" "${firefox_pref_dir}/${firefox_js}"
-      else
-        echo "pref(\"${key}\", ${value});" >> "${firefox_pref_dir}/${firefox_js}"
-      fi
+      {{{ _put_into_firefox_cfg(config_item="pref", key=key, value_varname="value", where="${firefox_pref_dir}/${firefox_js}", sed_separator=sed_separator) | indent(2 * 3) }}}
     fi
   done
 {{%- endmacro -%}}
@@ -270,18 +286,17 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
 # Example Call(s):
 #
 #     Without string or variable:
-#     firefox_cfg_setting "stig.cfg" "extensions.update.enabled" "false"
+#     bash_firefox_cfg_setting("stig.cfg" "extensions.update.enabled" value="false")
 #
 #     With string:
-#     firefox_cfg_setting "stig.cfg" "security.default_personal_cert" "\"Ask Every Time\""
+#     bash_firefox_cfg_setting("stig.cfg" "security.default_personal_cert" quoted_value="Ask Every Time")
 #
 #     With a string variable:
-#     firefox_cfg_setting "stig.cfg" "browser.startup.homepage\" "\"${var_default_home_page}\""
+#     bash_firefox_cfg_setting("stig.cfg" "browser.startup.homepage" quoted_value="${var_default_home_page}")
 #}}
-{{%- macro bash_firefox_cfg_setting(config_file, key, value) -%}}
+{{%- macro bash_firefox_cfg_setting(config_file, key, value="", quoted_value="", sed_separator="/") %}}
   firefox_cfg="{{{ config_file }}}"
-  key="{{{ key }}}"
-  value="{{{ value }}}"
+  {{{ _make_bash_variable_assignment(varname="value", value=value, quoted_value=quoted_value) }}}
   firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
 
   # Check the possible Firefox install directories
@@ -294,12 +309,7 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
         chmod 644 "${firefox_dir}/${firefox_cfg}"
       fi
 
-      # If the key exists, change it. Otherwise, add it to the config_file.
-      if LC_ALL=C grep -m 1 -q "^lockPref(\"${key}\", " "${firefox_dir}/${firefox_cfg}"; then
-        sed -i "s/lockPref(\"${key}\".*/lockPref(\"${key}\", ${value});/g" "${firefox_dir}/${firefox_cfg}"
-      else
-        echo "lockPref(\"${key}\", ${value});" >> "${firefox_dir}/${firefox_cfg}"
-      fi
+      {{{ _put_into_firefox_cfg(config_item="lockPref", key=key, value_varname="value", where="${firefox_dir}/${firefox_cfg}", sed_separator=sed_separator) | indent(2 * 3) }}}
     fi
   done
 {{%- endmacro -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -192,11 +192,11 @@ dconf update
 
 {{%- if xinetd != "" -%}}
 grep -qi disable "/etc/xinetd.d/$xinetd" && \
-  {{%- if service_state == "disable" -%}}
+    {{%- if service_state == "disable" -%}}
 sed -i "s/disable.*/disable         = no/gI" "/etc/xinetd.d/$xinetd"
-  {{%- else -%}}
+    {{%- else -%}}
 sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
-  {{%- endif -%}}
+    {{%- endif -%}}
 {{%- endif -%}}
 {{%- endmacro -%}}
 
@@ -204,9 +204,9 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
 {{%- macro _put_into_firefox_cfg(config_item, key, value_varname, where, sed_separator) -%}}
 # If the key exists, change it. Otherwise, add it to the config_file.
 if LC_ALL=C grep -m 1 -q '^{{{ config_item }}}("{{{ key }}}", ' "{{{ where }}}"; then
-  sed -i 's{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}".*{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}})"';{{{ sed_separator }}}g' "{{{ where }}}"
+    sed -i 's{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}".*{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}})"';{{{ sed_separator }}}g' "{{{ where }}}"
 else
-  echo '{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}}"');' >> "{{{ where }}}"
+    echo '{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}}"');' >> "{{{ where }}}"
 fi
 {{%- endmacro -%}}
 
@@ -241,35 +241,35 @@ fi
 #     bash_firefox_js_setting("stig_settings.js", "general.config.filename", quoted_value="$var_config_file_name")
 #}}
 {{%- macro bash_firefox_js_setting(config_file, key, value="", quoted_value="", sed_separator="/") %}}
-  {{{ _make_bash_variable_assignment(varname="value", value=value, quoted_value=quoted_value) }}}
-  firefox_js="{{{ config_file }}}"
-  firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
-  firefox_pref="/defaults/pref"
-  firefox_preferences="/defaults/preferences"
+{{{ _make_bash_variable_assignment(varname="value", value=value, quoted_value=quoted_value) }}}
+firefox_js="{{{ config_file }}}"
+firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
+firefox_pref="/defaults/pref"
+firefox_preferences="/defaults/preferences"
 
-  # Check the possible Firefox install directories
-  for firefox_dir in ${firefox_dirs}; do
+# Check the possible Firefox install directories
+for firefox_dir in ${firefox_dirs}; do
     # If the Firefox directory exists, then Firefox is installed
     if [ -d "${firefox_dir}" ]; then
-      # Different versions of Firefox have different preferences directories, check for them and set the right one
-      if [ -d "${firefox_dir}/${firefox_pref}" ] ; then
-        firefox_pref_dir="${firefox_dir}/${firefox_pref}"
-      elif [ -d "${firefox_dir}/${firefox_preferences}" ] ; then
-        firefox_pref_dir="${firefox_dir}/${firefox_preferences}"
-      else
-        mkdir -m 755 -p "${firefox_dir}/${firefox_preferences}"
-        firefox_pref_dir="${firefox_dir}/${firefox_preferences}"
-      fi
+        # Different versions of Firefox have different preferences directories, check for them and set the right one
+        if [ -d "${firefox_dir}/${firefox_pref}" ] ; then
+            firefox_pref_dir="${firefox_dir}/${firefox_pref}"
+        elif [ -d "${firefox_dir}/${firefox_preferences}" ] ; then
+            firefox_pref_dir="${firefox_dir}/${firefox_preferences}"
+        else
+            mkdir -m 755 -p "${firefox_dir}/${firefox_preferences}"
+            firefox_pref_dir="${firefox_dir}/${firefox_preferences}"
+        fi
 
-      # Make sure the Firefox .js file exists and has the appropriate permissions
-      if ! [ -f "${firefox_pref_dir}/${firefox_js}" ] ; then
-        touch "${firefox_pref_dir}/${firefox_js}"
-        chmod 644 "${firefox_pref_dir}/${firefox_js}"
-      fi
+        # Make sure the Firefox .js file exists and has the appropriate permissions
+        if ! [ -f "${firefox_pref_dir}/${firefox_js}" ] ; then
+            touch "${firefox_pref_dir}/${firefox_js}"
+            chmod 644 "${firefox_pref_dir}/${firefox_js}"
+        fi
 
-      {{{ _put_into_firefox_cfg(config_item="pref", key=key, value_varname="value", where="${firefox_pref_dir}/${firefox_js}", sed_separator=sed_separator) | indent(2 * 3) }}}
+        {{{ _put_into_firefox_cfg(config_item="pref", key=key, value_varname="value", where="${firefox_pref_dir}/${firefox_js}", sed_separator=sed_separator) | indent(4 * 2) }}}
     fi
-  done
+done
 {{%- endmacro -%}}
 
 {{#
@@ -295,23 +295,23 @@ fi
 #     bash_firefox_cfg_setting("stig.cfg" "browser.startup.homepage" quoted_value="${var_default_home_page}")
 #}}
 {{%- macro bash_firefox_cfg_setting(config_file, key, value="", quoted_value="", sed_separator="/") %}}
-  firefox_cfg="{{{ config_file }}}"
-  {{{ _make_bash_variable_assignment(varname="value", value=value, quoted_value=quoted_value) }}}
-  firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
+firefox_cfg="{{{ config_file }}}"
+{{{ _make_bash_variable_assignment(varname="value", value=value, quoted_value=quoted_value) }}}
+firefox_dirs="/usr/lib/firefox /usr/lib64/firefox /usr/local/lib/firefox /usr/local/lib64/firefox"
 
-  # Check the possible Firefox install directories
-  for firefox_dir in ${firefox_dirs}; do
+# Check the possible Firefox install directories
+for firefox_dir in ${firefox_dirs}; do
     # If the Firefox directory exists, then Firefox is installed
     if [ -d "${firefox_dir}" ]; then
-      # Make sure the Firefox .cfg file exists and has the appropriate permissions
-      if ! [ -f "${firefox_dir}/${firefox_cfg}" ] ; then
-        touch "${firefox_dir}/${firefox_cfg}"
-        chmod 644 "${firefox_dir}/${firefox_cfg}"
-      fi
+        # Make sure the Firefox .cfg file exists and has the appropriate permissions
+        if ! [ -f "${firefox_dir}/${firefox_cfg}" ] ; then
+            touch "${firefox_dir}/${firefox_cfg}"
+            chmod 644 "${firefox_dir}/${firefox_cfg}"
+        fi
 
-      {{{ _put_into_firefox_cfg(config_item="lockPref", key=key, value_varname="value", where="${firefox_dir}/${firefox_cfg}", sed_separator=sed_separator) | indent(2 * 3) }}}
+        {{{ _put_into_firefox_cfg(config_item="lockPref", key=key, value_varname="value", where="${firefox_dir}/${firefox_cfg}", sed_separator=sed_separator) | indent(4 * 2) }}}
     fi
-  done
+done
 {{%- endmacro -%}}
 
 {{#

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -13,6 +13,10 @@ from .constants import (JINJA_MACROS_BASE_DEFINITIONS,
 from .utils import required_key, prodtype_to_name, name_to_platform, prodtype_to_platform
 
 
+class MacroError(RuntimeError):
+    pass
+
+
 class AbsolutePathFileSystemLoader(jinja2.BaseLoader):
     """Loads templates from the file system. This loader insists on absolute
     paths and fails if a relative path is provided.
@@ -74,6 +78,10 @@ def _get_jinja_environment(substitutions_dict):
 _get_jinja_environment.env = None
 
 
+def raise_exception(message):
+    raise MacroError(message)
+
+
 def update_substitutions_dict(filename, substitutions_dict):
     """
     Treat the given filename as a jinja2 file containing macro definitions,
@@ -104,6 +112,7 @@ def add_python_functions(substitutions_dict):
     substitutions_dict['prodtype_to_name'] = prodtype_to_name
     substitutions_dict['name_to_platform'] = name_to_platform
     substitutions_dict['prodtype_to_platform'] = prodtype_to_platform
+    substitutions_dict['raise'] = raise_exception
 
 
 def load_macros(substitutions_dict=None):


### PR DESCRIPTION
- Fixed Firefox remediation regressions caused by porting bash shared remediations to jinja.
- Fixed OVALs that have not been passing on RHEL7
- Added a possibility to raise exceptions from inside Jinja macros at expand-time.

As the test suite doesn't pick the Firefox product directories, one can test the PR by running profile-mode test run with the `stig` profile.

Note: Inclusion of ` . /usr/share/scap-security-guide/remediation_functions` is needed in order to populate variables.