### PR TITLE
SSGTS: Use wildcards instead of matching substring

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -246,9 +246,9 @@ Example usage:
 
 ### Rule-based testing
 
-In this mode, you specify the `rule` command and you supply part of the rule
-title as a positional argument. Unlike the profile mode, here each rule from
-the matching rule set is addressed independently, one-by-one.
+In this mode, you specify the `rule` command and you supply one or more rule
+IDs or wildcards as positional arguments. Unlike the profile mode, here each
+rule from the matching rule set is addressed independently, one-by-one.
 
 Rule-based testing enables to perform two kinds of tests:
 
@@ -262,26 +262,27 @@ Rule-based testing enables to perform two kinds of tests:
 - Remediation tests: The system is set up into a non-compliant state, and
   remediation is performed.
 
-If you would like to evaluate the rule `rule_sysctl_net_ipv4_conf_default_secure_redirects`:
+If you would like to evaluate the rule `sshd_disable_kerb_auth`:
 
 Using Libvirt:
 ```
-./test_suite.py rule --libvirt qemu:///system ssg-test-suite-rhel7 --datastream ../build/ssg-rhel7-ds.xml ipv4_conf_default_secure_redirects
+./test_suite.py rule --libvirt qemu:///system ssg-test-suite-rhel7 --datastream ../build/ssg-rhel7-ds.xml sshd_disable_kerb_auth
 ```
 
 Using Podman:
 ```
-./test_suite.py rule --container ssg_test_suite --datastream ../build/ssg-rhel7-ds.xml rule_sshd_disable_kerb_auth
+./test_suite.py rule --container ssg_test_suite --datastream ../build/ssg-rhel7-ds.xml sshd_disable_kerb_auth
 ```
 
 Using Docker:
 ```
-./test_suite.py rule --docker ssg_test_suite --datastream ../build/ssg-rhel7-ds.xml rule_sshd_disable_kerb_auth
+./test_suite.py rule --docker ssg_test_suite --datastream ../build/ssg-rhel7-ds.xml sshd_disable_kerb_auth
 ```
 
-Notice we didn't use full rule name on the command line.
-Test suite runs every rule, which contains given substring in the name.
-So all that is needed is to use unique substring.
+Notice we didn't use full rule name on the command line. The prefix `xccdf_org.ssgproject.content_rule_` is added if not provided.
+
+It is possible to use wildcards, eg `accounts_passwords*` will run test scenarios for all
+rules which ID starts with `accounts_passwords`.
 
 #### Debug mode
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -8,8 +8,9 @@ import re
 import subprocess
 import collections
 import json
+import fnmatch
 
-from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID
+from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID, OSCAP_RULE
 from ssg_test_suite import oscap
 from ssg_test_suite import xml_operations
 from ssg_test_suite import test_env
@@ -190,7 +191,11 @@ class RuleChecker(oscap.Checker):
         else:
             for rule_to_be_tested in rules_to_be_tested:
                 # we check for a substring
-                if rule_to_be_tested in rule_id:
+                if rule_to_be_tested.startswith(OSCAP_RULE):
+                    pattern = rule_to_be_tested
+                else:
+                    pattern = OSCAP_RULE + rule_to_be_tested
+                if fnmatch.fnmatch(rule_id, pattern):
                     return True
             return False
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -116,15 +116,17 @@ def parse_args():
                                               "by openscap!"),
                                         parents=[common_parser])
     parser_rule.set_defaults(func=ssg_test_suite.rule.perform_rule_check)
-    parser_rule.add_argument("target",
-                             nargs="+",
-                             metavar="RULE",
-                             help=("Rule to be tested, 'ALL' means every "
-                                   "rule-testing scenario will be evaluated. Each "
-                                   "target is handled as a substring - so you can "
-                                   "ask for subset of all rules this way. (If you "
-                                   "type ipv6 as a target, all rules containing "
-                                   "ipv6 within id will be performed."))
+    parser_rule.add_argument(
+        "target",
+        nargs="+",
+        metavar="RULE",
+        help=(
+            "Rule or rules to be tested. Special value 'ALL' means every "
+            "rule-testing scenario will be evaluated. The SSG rule ID prefix "
+            "is appended automatically if not provided. Wildcards to match "
+            "multiple rules are accepted."
+            )
+        )
     parser_rule.add_argument("--debug",
                              dest="manual_debug",
                              action="store_true",


### PR DESCRIPTION

#### Description:

This commit changes the way test suite users specify rules to be tested
in rule mode. Instead of matching a substring in rule ID, we will accept
wildcards as rule mode arguments. The wildcards are similar to shell
globs, and use Python fnmatch library. For example, argument
accounts_passwords_pam_faillock_deny will run test scenarios for a
single rule and accounts_passwords* will run test scenarios for all
rules which ID starts with accounts_passwords.

The rule ID prefix (xccdf_org.ssgproject.content_rule_) does not need to
be provided by the user because it will be added automatically.



#### Rationale:


Using substring match to find rules to be tested caused problems in
situation when we have 2 rule IDs and one of them is a substring of
another. For example, when an user requested to run test scenarios for
rule accounts_passwords_pam_faillock_deny, the test suite run tests also
for rule accounts_passwords_pam_faillock_deny_root. That was annoying
because testing the latter takes some time.
