### PR TITLE
Wrap dconf login banner in single quotes

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/shared.sh
@@ -4,5 +4,5 @@ populate login_banner_text
 
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
 
-{{{ bash_dconf_settings("org/gnome/login-screen", "banner-message-text", "${expanded}", "gdm.d", "00-security-settings") }}}
+{{{ bash_dconf_settings("org/gnome/login-screen", "banner-message-text", "'${expanded}'", "gdm.d", "00-security-settings") }}}
 {{{ bash_dconf_lock("org/gnome/login-screen", "banner-message-text", "gdm.d", "00-security-settings-lock") }}}


### PR DESCRIPTION
#### Description:

- The banner is expected to be wrapped in single quotes:
  `banner-message-text='My banner text'`

#### Rationale:

- During conversion of [dconf bash remediation to dconf macro](https://github.com/ComplianceAsCode/content/commit/107397559b3b3d678ef8e767d91b7c6ef6abd0af#diff-7848fbffe0fa30d8e9cf9601f702f6f2R7), the single quotes were dropped.


