### PR TITLE
SRG Mapping: Do not flip CCI and SRGID when we do not have content

### DIFF
--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -35,9 +35,9 @@
 				<td>SRGID</td>
 				<td>STIGID</td>
 				<td>SRG Requirement</td>
+				<td>Requirement</td> <!-- XCCDF RULE Title -->
 				<xsl:choose>
 					<xsl:when test="$flat">
-						<td>Requirement</td> <!-- XCCDF RULE ID -->
 						<td>SRG VulDiscussion</td>
 						<td>VulDiscussion</td> <!-- XCCDF RATIONALE -->
 						<td>Status</td>

--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -75,8 +75,8 @@
 	<xsl:template name="output-row-nested">
 		<xsl:param name="rule" />
 		<tr>
-		<td> <xsl:value-of select="$rule/cdf:version"/> </td>
 		<td> <xsl:value-of select="$rule/cdf:ident"/> </td>
+		<td> <xsl:value-of select="$rule/cdf:version"/> </td>
 		<td> <xsl:value-of select="$rule/cdf:title"/> </td>
 		<td> <xsl:call-template name="extract-vulndiscussion">
 				<xsl:with-param name="desc" select="$rule/cdf:description"/>

--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -77,6 +77,7 @@
 		<tr>
 		<td> <xsl:value-of select="$rule/cdf:ident"/> </td>
 		<td> <xsl:value-of select="$rule/cdf:version"/> </td>
+		<td><i>TBD - Assigned by DISA after STIG release</i></td>
 		<td> <xsl:value-of select="$rule/cdf:title"/> </td>
 		<td> <xsl:call-template name="extract-vulndiscussion">
 				<xsl:with-param name="desc" select="$rule/cdf:description"/>


### PR DESCRIPTION
This is follow-up on V1R6 changes.

Kudos to @tedbrunell for noticing this.

See the flip in the collumns 1 and 2 below.

![image](https://user-images.githubusercontent.com/6666052/69981316-054d8e80-152a-11ea-8d41-ba6da31f5e72.png)
