### PR TITLE
SRG Map: move main text column to the right

### DIFF
--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -78,6 +78,7 @@
 		<td> <xsl:value-of select="$rule/cdf:version"/> </td>
 		<td> <xsl:value-of select="$rule/cdf:ident"/> </td>
 		<td> <xsl:value-of select="$rule/cdf:title"/> </td>
+		<xsl:if test="$flat"><td></td></xsl:if>
 		<td> <xsl:call-template name="extract-vulndiscussion">
 				<xsl:with-param name="desc" select="$rule/cdf:description"/>
 			 </xsl:call-template>


### PR DESCRIPTION
Kudos to @tedbrunell for noticing this.

Moving the higlighted text to the right to right to align well with the other items.

![image](https://user-images.githubusercontent.com/6666052/70055677-f15d6780-15d1-11ea-80c4-892bbb09f1d0.png)