### PR TITLE
Fix OVAL applicability for RHV4

### DIFF
--- a/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/oval/shared.xml
+++ b/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Restrict Kerberos operation by removing keytab files</title>
       <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
         <platform>Oracle Linux 8</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_fedora</platform>
       </affected>
       <description>Check that there is no Kerberos keytab file present in /etc</description>
     </metadata>

--- a/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_rhv</platform>
       </affected>
       <description>Enable LDAP in authconfig.</description>
     </metadata>

--- a/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhv4
 
 title: 'Enable the LDAP Client For Use in Authconfig'
 

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Configure LDAP to Use TLS for All Transactions</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>Require the use of TLS for ldap clients.</description>

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Ensure root has a mail alias</title>
       <affected family="unix">
+          <platform>Red Hat Virtualization 4</platform>
           <platform>multi_platform_sle</platform>
       </affected>
       <description>Check if root has the correct mail alias.</description>

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/oval/shared.xml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_ol</platform>
       </affected>
       <description>Using Kerberos Security allows to cryptography authenticate a

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Configure Time Service Maxpoll Interval</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Configure the maxpoll setting in /etc/ntp.conf or chrony.conf
       to continuously poll the time source servers.</description>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Specify Multiple Remote ntpd NTP Server for Time Data</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Multiple ntpd NTP Servers for time synchronization should be specified.</description>
     </metadata>

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Specify a Remote ntpd NTP Server for Time Data</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>A remote ntpd NTP Server for time synchronization should be
       specified (and dependencies are met)</description>

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>No shosts.equiv file deployed on the system</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_sle</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>There should not be any shosts.equiv files on the system.</description>
     </metadata>

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>No Legacy .rhosts Or hosts.equiv Files</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>There should not be any .rhosts or hosts.equiv files on the system.</description>
     </metadata>

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>No .shosts file deployed on the system</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_sle</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>There should not be any .shosts files on the system.</description>
     </metadata>

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>TFTP Daemon Uses Secure Mode</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>The TFTP daemon should use secure mode.</description>
     </metadata>

--- a/linux_os/guide/services/smb/configuring_samba/package_samba-common_installed/rule.yml
+++ b/linux_os/guide/services/smb/configuring_samba/package_samba-common_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8
+prodtype: rhel6,rhel7,rhel8,rhv4
 
 title: 'Install the Samba Common Package'
 

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8
+prodtype: debian9,wrlinux1019,rhel6,rhel7,rhel8,rhv4,fedora,ol7,ol8
 
 title: 'Uninstall net-snmp Package'
 

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Allow inbound firewall access to the SSH Server port</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>If inbound SSH access is needed, the firewall should allow access to
       the SSH port (22).</description>

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
       </affected>
       <description>SSSD should be configured to run SSSD PAM services.
       </description>

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Configure SSSD's Memory Cache to Expire</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>SSSD's memory cache should be configured to set to expire records after 1 day.</description>
     </metadata>

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Configure SSSD to Expire Offline Credentials</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>SSSD should be configured to expire offline credentials after 1 day.</description>
     </metadata>

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Configure SSSD to Expire SSH Known Hosts</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>SSSD should be configured to expire keys from known SSH hosts after 1 day.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Set Last Login/Access Notification</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Configure the system to notify users of last login/access using pam_lastlog.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Set Password retry Requirements</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>The password retry should meet minimum requirements</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_ol</platform>
       </affected>
       <description>Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
@@ -6,10 +6,11 @@
     <metadata>
       <title>Disable Ctrl-Alt-Del Reboot Activation</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>By default, the system will reboot when the
       Ctrl-Alt-Del key sequence is pressed.</description>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>All GIDs Are Present In /etc/group</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>All GIDs referenced in /etc/passwd must be defined in /etc/group.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Ensure new users receive home directories</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>CREATE_HOME should be enabled</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Set Maximum Number of Concurrent Login Sessions Per User</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_ol</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
       </affected>
       <description>The maximum number of concurrent login sessions per user should meet
       minimum requirements.</description>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Set Interactive Session Timeout</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Checks interactive shell timeout</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Ensure that No Dangerous Directories Exist in Root's Path</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_ol</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
       </affected>
       <description>The environment variable PATH should be set correctly for
       the root user.</description>

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Ensure that Users Have Sensible Umask Values in /etc/login.defs</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
       </affected>

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Ensure that Users Have Sensible Umask Values in /etc/profile</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
       </affected>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Audit File Deletion Events</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Audit files deletion events.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful)</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Audit Kernel Module Loading and Unloading</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Attempts to Alter Login and Logout Events</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Audit rules should be configured to log successful and unsuccessful login and logout events.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Make Audit Configuration Immutable</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Force a reboot to change audit rules is enabled</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Events that Modify the System's Mandatory Access Controls</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Audit rules that detect changes to the system's mandatory access controls (SELinux) are enabled.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Events that Modify the System's Network Environment</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>The network environment should not be modified by anything other than
       administrator action. Any change to network parameters should be audited.</description>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Attempts to Alter Process and Session Initiation Information</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Audit rules should capture information about session initiation.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Audit User/Group Modification</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Audit rules should detect modification to system files that hold information about users and groups.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Attempts to Alter Time Through Adjtimex</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Record attempts to alter time through adjtimex.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Attempts to Alter Time Through Clock_settime</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Record attempts to alter time through clock_settime.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Attempts to Alter Time Through Settimeofday</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Record attempts to alter time through settimeofday.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Attempts to Alter Time Through Stime</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Record attempts to alter time through stime. Note that on
       64-bit architectures the stime system call is not defined in the audit

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Record Attempts to Alter Time Through the Localtime File</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Record attempts to alter time through /etc/localtime.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Verify /var/log/audit Directory Permissions</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>Checks for correct permissions for /var/log/audit.</description>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Auditd priority for flushing data to disk</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>The setting for flush in /etc/audit/auditd.conf</description>
     </metadata>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
@@ -4,10 +4,11 @@
     <metadata>
       <title>Verify Cron is Logging to Rsyslog</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Rsyslog should be configured to capture cron messages.</description>
     </metadata>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
@@ -3,11 +3,12 @@
     <metadata>
       <title>Confirm Existence and Permissions of System Log Files</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_debian</platform>
-        <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ubuntu</platform>
       </affected>
       <description>All syslog log files should be owned by the appropriate group.</description>
     </metadata>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
@@ -3,11 +3,12 @@
     <metadata>
       <title>Confirm Existence and Permissions of System Log Files</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_debian</platform>
-        <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ubuntu</platform>
       </affected>
       <description>All syslog log files should be owned by the appropriate user.</description>
     </metadata>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -3,11 +3,12 @@
     <metadata>
       <title>Confirm Existence and Permissions of System Log Files</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_debian</platform>
-        <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ubuntu</platform>
       </affected>
       <description>File permissions for all syslog log files should be set correctly.</description>
     </metadata>

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/oval/shared.xml
@@ -4,8 +4,9 @@
       <title>Disable Rsyslogd from Accepting Remote Messages on Loghosts
       Only</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>rsyslogd should reject remote messages</description>
     </metadata>

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
@@ -3,12 +3,13 @@
     <metadata>
       <title>Send Logs to a Remote Loghost</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_debian</platform>
-        <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Syslog logs should be sent to a remote loghost</description>
     </metadata>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Configure the Firewalld Ports</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Configure the firewalld ports to allow approved
       services to have access to the system.</description>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/oval/shared.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/oval/shared.xml
@@ -4,8 +4,9 @@
     <metadata>
       <title>Enable Privacy Extensions for IPv6</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Enable privacy extensions for IPv6</description>
     </metadata>

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/oval/shared.xml
@@ -4,6 +4,7 @@
     <metadata>
       <title>Disable Support for RPC IPv6</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>Disable ipv6 based rpc services</description>

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Deactivate Wireless Interfaces</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>All wireless interfaces should be disabled.</description>

--- a/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
+++ b/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Configure Multiple DNS Servers in /etc/resolv.conf</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Multiple Domain Name System (DNS) Servers should be configured
       in /etc/resolv.conf.</description>

--- a/linux_os/guide/system/network/network_sniffer_disabled/oval/shared.xml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Disable the network sniffer</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Disable the network sniffer</description>
     </metadata>

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Verify that All World-Writable Directories Have Sticky Bits Set</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>The sticky bit should be set for all world-writable directories.</description>
     </metadata>

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Find world writable directories not owned by a system account</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>All world writable directories should be owned by a system user.</description>
     </metadata>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Find Unauthorized World-Writable Files</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_ol</platform>
+        <platform>multi_platform_opensuse</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_opensuse</platform>
-        <platform>multi_platform_ol</platform>
       </affected>
       <description>The world-write permission should be disabled for all files.</description>
     </metadata>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Find files unowned by a group</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>All files should be owned by a group</description>
     </metadata>

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Find files unowned by a user</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>All files should be owned by a user</description>
     </metadata>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Verify that System Executables Have Root Ownership</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>
         Checks that /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Verify that Shared Library Files Have Root Ownership</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>
         Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Verify that System Executables Have Restrictive Permissions</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>
         Checks that binary files under /bin, /sbin, /usr/bin, /usr/sbin,

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Verify that Shared Library Files Have Restrictive Permissions</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>
         Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/oval/shared.xml
@@ -4,6 +4,7 @@
       <title>Package kernel-PAE Installed</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
       </affected>
       <description>The RPM package kernel-PAE should be installed on 32-bit

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
@@ -3,12 +3,13 @@
     <metadata>
       <title>Device Files Have Proper SELinux Context</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
         <platform>Red Hat Enterprise Linux 6</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>All device files in /dev should be assigned an SELinux security context other than 'device_t'.</description>
     </metadata>

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/oval/shared.xml
@@ -134,10 +134,11 @@
     <metadata>
       <title>Harden SSH client Crypto Policy</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Look for specific parameters in /etc/ssh/ssh_config.d/02-ospp.conf</description>
     </metadata>

--- a/linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Disable Prelinking</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>The prelinking feature can interfere with the operation of
       checksum integrity tools (e.g. AIDE), mitigates the protection provided

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/oval/shared.xml
@@ -4,8 +4,9 @@
     <metadata>
       <title>Install Intrusion Detection Software</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Intrusion detection software or SELinux should be installed and enabled.</description>
     </metadata>

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
@@ -10,6 +10,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>Oracle Linux 7</platform>
       </affected>
       <description>The RPM package dracut-fips-aesni should be installed.</description>

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
@@ -10,6 +10,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 6</platform>
         <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>Oracle Linux 7</platform>
       </affected>
       <description>The RPM package dracut-fips should be installed.</description>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Aide Database Must Exist</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>The aide database must be initialized.</description>
     </metadata>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
@@ -3,10 +3,11 @@
     <metadata>
       <title>Configure Periodic Execution of AIDE</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>By default, AIDE does not install itself for periodic
       execution. Periodically running AIDE is necessary to reveal

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Configure Notification of Post-AIDE Scan Details</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>AIDE should notify appropriate personnel of the details
       of a scan after the scan has been run.</description>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Configure AIDE to Use FIPS 140-2 for Validating Hashes</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>AIDE should be configured to use the FIPS 140-2 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Configure AIDE to Verify Access Control Lists (ACLs)</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>AIDE should be configured to verify Access Control Lists (ACLs).</description>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
@@ -3,6 +3,7 @@
     <metadata>
       <title>Configure AIDE to Verify Extended Attributes</title>
       <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
       </affected>
       <description>AIDE should be configured to verify extended file attributes.</description>

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/oval/shared.xml
@@ -3,11 +3,12 @@
     <metadata>
       <title>Ensure !authenticate Is Not Used in Sudo</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_debian</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Checks sudo usage without authentication</description>
     </metadata>

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/oval/shared.xml
@@ -3,11 +3,12 @@
     <metadata>
       <title>Ensure NOPASSWD Is Not Used in Sudo</title>
       <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_debian</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Checks sudo usage without password</description>
     </metadata>

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
@@ -3,9 +3,10 @@
     <metadata>
       <title>Ensure Users Re-Authenticate for Privilege Escalation - sudo</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_debian</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ubuntu</platform>
       </affected>
       <description>Checks sudo usage without password</description>

--- a/linux_os/guide/system/software/sudo/sudo_vdsm_nopasswd/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_vdsm_nopasswd/oval/shared.xml
@@ -3,8 +3,9 @@
     <metadata>
       <title>Ensure NOPASSWD Is Used Only for the VDSM User in Sudo</title>
       <affected family="unix">
-        <platform>multi_platform_rhel</platform>
+        <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhel</platform>
       </affected>
       <description>Checks sudo usage for the vdsm user without a password</description>
     </metadata>

--- a/shared/checks/oval/accounts_password_pam_pwquality.xml
+++ b/shared/checks/oval/accounts_password_pam_pwquality.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/audit_rules_auditctl.xml
+++ b/shared/checks/oval/audit_rules_auditctl.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_wrlinux</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_wrlinux</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/audit_rules_networkconfig_modification_domainname.xml
+++ b/shared/checks/oval/audit_rules_networkconfig_modification_domainname.xml
@@ -4,6 +4,7 @@
       <title>Record Events that Modify the System's Network Environment</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/audit_rules_networkconfig_modification_hostname.xml
+++ b/shared/checks/oval/audit_rules_networkconfig_modification_hostname.xml
@@ -4,6 +4,7 @@
       <title>Record Events that Modify the System's Network Environment</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/bootloader_disable_recovery_set_to_true.xml
+++ b/shared/checks/oval/bootloader_disable_recovery_set_to_true.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/chronyd_specify_multiple_servers.xml
+++ b/shared/checks/oval/chronyd_specify_multiple_servers.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/chronyd_specify_remote_server.xml
+++ b/shared/checks/oval/chronyd_specify_remote_server.xml
@@ -5,6 +5,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_ol</platform>
       </affected>

--- a/shared/checks/oval/no_cd_dvd_drive_in_etc_fstab.xml
+++ b/shared/checks/oval/no_cd_dvd_drive_in_etc_fstab.xml
@@ -4,6 +4,7 @@
       <title>No CD/DVD drive is configured to automount in /etc/fstab</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_wrlinux</platform>
       </affected>

--- a/shared/checks/oval/removable_partition_doesnt_exist.xml
+++ b/shared/checks/oval/removable_partition_doesnt_exist.xml
@@ -4,6 +4,7 @@
       <title>Device Files for Removable Media Partitions Does Not Exist on the System</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_wrlinux</platform>
       </affected>

--- a/shared/checks/oval/var_accounts_user_umask_as_number.xml
+++ b/shared/checks/oval/var_accounts_user_umask_as_number.xml
@@ -4,6 +4,7 @@
       <title>Value of 'var_accounts_user_umask' variable represented as octal number</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Value of 'var_accounts_user_umask' variable represented as octal number</description>

--- a/shared/checks/oval/var_removable_partition_is_cd_dvd_drive.xml
+++ b/shared/checks/oval/var_removable_partition_is_cd_dvd_drive.xml
@@ -4,6 +4,7 @@
       <title>Value of 'var_removable_partition' variable is set to '/dev/cdrom'</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_wrlinux</platform>
       </affected>

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -53,7 +53,7 @@ def walk_products(root, all_products):
         for cur_dir in [guide_dir] + add_content_dirs:
             if cur_dir not in visited_dirs:
                 for rule_id, rule_dir in collect_rule_ids_and_dirs(cur_dir):
-                    all_rule_dirs.append((rule_id, rule_dir, guide_dir, product))
+                    all_rule_dirs.append((rule_id, rule_dir, cur_dir, product))
                 visited_dirs.add(cur_dir)
 
     return all_rule_dirs, product_yamls

--- a/utils/rule_dir_stats.py
+++ b/utils/rule_dir_stats.py
@@ -12,6 +12,7 @@ import pprint
 import ssg.build_yaml
 import ssg.oval
 import ssg.build_remediations
+import ssg.products
 import ssg.rule_dir_stats as rds
 import ssg.rules
 import ssg.yaml


### PR DESCRIPTION
#### Description:

- Make OVAL checks for rules which already have `prodtype: rhv4` applicable to `rhv4`
- Add a few rules necessary to generate templated OVAL checks.

#### Rationale:

- Rule with `prodtype: rhv4` just enables part of the content. A lot of rules are evaluating to `notchecked`.

#### Notes:
Most of the `<platform>Red Hat Virtualization 4</platform>` was added via `utils/mod_checks.py`.
The process was as follows:
```
 . .pyenv.sh
python3 ./utils/rule_dir_json.py # generates build/rule_dirs.json
python3 ./utils/rule_dir_stats.py -p rhv4 -o -q rhv4 > rhv_oval.txt
# process rhv_oval.txt to contain list of one rule per line (the processed file is attached)

cat rhv_oval.txt | xargs -I {} python3 ./utils/mod_checks.py {} add "Red Hat Virtualization 4"
```
Processed [rhv_oval.txt](https://github.com/ComplianceAsCode/content/files/3922961/rhv_oval.txt) attached.
