### PR TITLE
Fix XML "parsing" of the remediation functions file.

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -56,11 +56,11 @@ def get_available_functions(build_dir):
     remediation_functions = []
     with codecs.open(xmlfilepath, "r", encoding="utf-8") as xmlfile:
         filestring = xmlfile.read()
-        # This regex looks implementation dependent but we can rely on
-        # ElementTree sorting XML attrs alphabetically. Hidden is guaranteed
-        # to be the first attr and ID is guaranteed to be second.
+        # This regex looks implementation dependent but we can rely on the element attributes
+        # being present on one line.
+        # We can't rely on ElementTree sorting XML attrs in any way since Python 3.7.
         remediation_functions = re.findall(
-            r'<Value hidden=\"true\" id=\"function_(\S+)\"',
+            r'<Value.*id=\"function_(\S+)\"',
             filestring, re.DOTALL
         )
 


### PR DESCRIPTION
A proper fix is not worth the effort, as we aim to kill shared Bash remediation
with Jinja2 macros.

This fixes the build for Python>=3.7 that saves XMLs slightly differently - attributes have different ordering.