### PR TITLE
Fix remediation applicability for RHV4

### DIFF
--- a/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/bash/shared.sh
+++ b/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora
 
 rm -f /etc/*.keytab

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_sle
 . /usr/share/scap-security-guide/remediation_functions
 populate var_postfix_root_mail_alias
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_time_service_set_maxpoll
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_multiple_time_servers
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 . /usr/share/scap-security-guide/remediation_functions
 populate var_multiple_time_servers
 

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_sle,multi_platform_wrlinux
 
 # Identify local mounts
 MOUNT_LIST=$(df --local | awk '{ print $6 }')

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 find /home -maxdepth 2 -type f -name .rhosts -exec rm -f '{}' \;
 
 if [ -f /etc/hosts.equiv ]; then

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_sle,multi_platform_wrlinux
 
 # Identify local mounts
 MOUNT_LIST=$(df --local | awk '{ print $6 }')

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # complexity = low
 # strategy = configure

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 
 {{%- if product == "rhel6" -%}}
 sed -i --follow-symlinks '/pam_limits.so/a session\t    required\t  pam_lastlog.so showfailed' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_password_pam_retry
 

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 {{%- if init_system == "systemd" -%}}
 {{% if product in ["rhel7", "rhel8"] %}}
 # The process to disable ctrl+alt+del has changed in RHEL7. 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora
 
 tmux_conf="/etc/tmux.conf"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 declare var_accounts_password_minlen_login_defs
 populate var_accounts_password_minlen_login_defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_password_warn_age_login_defs
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_wrlinux
 
 if ! grep -q ^CREATE_HOME /etc/login.defs; then
 	echo "CREATE_HOME     yes" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 # disruption = low
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_wrlinux,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_max_concurrent_login_sessions
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_tmout
 

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_user_umask
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_user_umask
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_user_umask
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_accounts_user_umask
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 #
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Traverse all of:
 #

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 
 if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_audispd_remote_server
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4
 # reboot = false
 # complexity = low
 # disruption = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_disk_error_action
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_action_mail_acct
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 
 populate var_auditd_admin_space_left_action

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_flush
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_max_log_file
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_max_log_file_action
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_space_left
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 . /usr/share/scap-security-guide/remediation_functions
 populate var_auditd_space_left_action
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 
 if ! grep -s "^\s*cron\.\*\s*/var/log/cron$" /etc/rsyslog.conf /etc/rsyslog.d/*.conf; then
 	mkdir -p /etc/rsyslog.d

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 # List of log file paths to be inspected for correct permissions
 # * Primarily inspect log file paths listed in /etc/rsyslog.conf

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
@@ -1,2 +1,2 @@
-# platform = Red Hat Enterprise Linux 6
+# platform = Red Hat Enterprise Linux 6,Red Hat Virtualization 4
 sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/sysconfig/ip6tables

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/bash/shared.sh
@@ -1,2 +1,2 @@
-# platform = Red Hat Enterprise Linux 6
+# platform = Red Hat Enterprise Linux 6,Red Hat Virtualization 4
 sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/sysconfig/iptables

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule_forward/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule_forward/bash/shared.sh
@@ -1,2 +1,2 @@
-# platform = Red Hat Enterprise Linux 6
+# platform = Red Hat Enterprise Linux 6,Red Hat Virtualization 4
 sed -i 's/^:FORWARD ACCEPT.*/:FORWARD DROP [0:0]/g' /etc/sysconfig/iptables

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 
 # enable randomness in ipv6 address generation
 for interface in /etc/sysconfig/network-scripts/ifcfg-*

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 
 # Drop 'tcp6' and 'udp6' entries from /etc/netconfig to prevent RPC
 # services for NFSv4 from attempting to start IPv6 network listeners

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 df --local -P | awk '{if (NR!=1) print $6}' \
 | xargs -I '{}' find '{}' -xdev -type d \
 \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null \

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform=multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 find /bin/ \
 /usr/bin/ \
 /usr/local/bin/ \

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform=multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 for LIBDIR in /usr/lib /usr/lib64 /lib /lib64
 do
   if [ -d $LIBDIR ]

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform=multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 DIRS="/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -exec chmod go-w '{}' \;

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = high

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -type f -exec chmod go-w '{}' \;

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel
 SECURITY_LIMITS_FILE="/etc/security/limits.conf"
 
 if grep -qE '\*\s+hard\s+core' $SECURITY_LIMITS_FILE; then

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora
 
 #the file starts with 02 so that it is loaded before the 05-redhat.conf which activates configuration provided by system vide crypto policy
 file="/etc/ssh/ssh_config.d/02-ospp.conf"

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora
 
 
 cp="CRYPTO_POLICY='-oCiphers=aes128-ctr,aes256-ctr,aes128-cbc,aes256-cbc -oMACs=hmac-sha2-256,hmac-sha2-512 -oGSSAPIKeyExchange=no -oKexAlgorithms=diffie-hellman-group14-sha1,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521 -oHostKeyAlgorithms=ssh-rsa,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384 -oPubkeyAcceptedKeyTypes=ssh-rsa,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384'"

--- a/linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_rhv
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,multi_platform_rhv
 # reboot = true
 # strategy = restrict
 # complexity = high

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_rhv
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_rhv
 # reboot = true
 # strategy = restrict
 # complexity = high

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Oracle Linux 7
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Virtualization 4
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Oracle Linux 7
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Virtualization 4
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 # reboot = true
 # strategy = patch
 # complexity = low


### PR DESCRIPTION
#### Description:

- Make remediations for rules which already have `prodtype: rhv4` applicable to `rhv4`

#### Rationale:

- Rule with `prodtype: rhv4` just enables part of the content. This PR adds the remediations to the DS.

#### Notes:
Most of the `<platform>Red Hat Virtualization 4</platform>` was added via `utils/mod_fixes.py`.
The process was as follows:
```
 . .pyenv.sh
python3 ./utils/rule_dir_json.py # generates build/rule_dirs.json
python3 ./utils/rule_dir_stats.py -p rhv4 -f > rhv_fixes.txt
# process rhv_fixes.txt to contain list of one rule per line (the processed file is attached)

cat rhv_fixes.txt | xargs -I {} python3 ./utils/mod_fixes.py {} bash add "Red Hat Virtualization 4"
cat rhv_fixes.txt | xargs -I {} python3 ./utils/mod_fixes.py {} ansible add "Red Hat Virtualization 4"
```

Processed [rhv_fixes.txt](https://github.com/ComplianceAsCode/content/files/3927895/rhv_fixes.txt) attached.

