### PR TITLE
Fix applicability of disable_ctrl_altdel_reboot

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 {{%- if init_system == "systemd" -%}}
 {{% if product in ["rhel7", "rhel8"] %}}
 # The process to disable ctrl+alt+del has changed in RHEL7. 


### PR DESCRIPTION

#### Description:

- Fix typo in applicability by accident

#### Rationale:

- Issue introduced in https://github.com/ComplianceAsCode/content/commit/634e948fced882c05e2d2eb3202f827a89c4b34b#diff-5a37d40853f1938feda29bf8d76a8d0fR1
- Thank you @ggbecker for this amazing catch

