### PR TITLE
Mark rules as platform: machine.

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/group.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/group.yml
@@ -12,3 +12,5 @@ warnings:
         The steps in this section will prevent a system
         from operating as either an NFS client or an NFS server. Only perform these
         steps on systems which do not need NFS at all.
+
+platform: machine

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/group.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/group.yml
@@ -15,3 +15,5 @@ description: |-
     be executed from remote servers is particularly risky, both for this reason and
     because it requires the clients to extend root-level trust to the NFS
     server.
+
+platform: machine

--- a/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing/rule.yml
+++ b/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing/rule.yml
@@ -34,3 +34,5 @@ ocil: |-
     To verify that Samba clients using mount.cifs must use packet signing, run the following command:
     <pre>$ grep sec /etc/fstab</pre>
     The output should show either <tt>krb5i</tt> or <tt>ntlmv2i</tt> in use.
+
+platform: machine

--- a/linux_os/guide/system/entropy/group.yml
+++ b/linux_os/guide/system/entropy/group.yml
@@ -7,3 +7,5 @@ description: |-
     unpredictable execution times have been traditionally considered as a reliable
     source to contribute to random-number entropy pool of the Linux kernel. This
     has changed with introduction of solid-state storage devices (SSDs) though.
+
+platform: machine

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
@@ -35,3 +35,5 @@ template:
     vars:
         servicename: ip6tables
         packagename: iptables-ipv6
+
+platform: machine

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
@@ -31,3 +31,5 @@ template:
     name: service_enabled
     vars:
         servicename: iptables
+
+platform: machine

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     lines in all files in <tt>/etc/modprobe.d</tt> and the deprecated
     <tt>/etc/modprobe.conf</tt>:
     <pre xml:space="preserve">$ grep -r ipv6 /etc/modprobe.conf /etc/modprobe.d</pre>
+
+platform: machine

--- a/linux_os/guide/system/network/network-uncommon/group.yml
+++ b/linux_os/guide/system/network/network-uncommon/group.yml
@@ -13,3 +13,5 @@ warnings:
         Although these protocols are not commonly used, avoid disruption
         in your network environment by ensuring they are not needed
         prior to disabling them.
+
+platform: machine

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/rule.yml
@@ -27,8 +27,6 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="atm") }}}
 
-platform: machine
-
 template:
     name: kernel_module_disabled
     vars:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/rule.yml
@@ -27,8 +27,6 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="can") }}}
 
-platform: machine
-
 template:
     name: kernel_module_disabled
     vars:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -40,8 +40,6 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="dccp") }}}
 
-platform: machine
-
 template:
     name: kernel_module_disabled
     vars:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/rule.yml
@@ -25,8 +25,6 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="firewire-core") }}}
 
-platform: machine
-
 template:
     name: kernel_module_disabled
     vars:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
@@ -40,8 +40,6 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="sctp") }}}
 
-platform: machine
-
 template:
     name: kernel_module_disabled
     vars:

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
@@ -31,3 +31,5 @@ template:
         sysctlvar: fs.protected_hardlinks
         sysctlval: '1'
         datatype: int
+
+platform: machine

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
@@ -33,3 +33,5 @@ template:
         sysctlvar: fs.protected_symlinks
         sysctlval: '1'
         datatype: int
+
+platform: machine


### PR DESCRIPTION
#### Description:

- Mark rules as platform: machine. Some entries were removed in favor of specifying it into respective `group.yml` file.

#### Rationale:

- These rules should not be applicable to containers
