### PR TITLE
Enable ansible template for service_fapolicyd_enable rule.

### DIFF
--- a/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/rule.yml
+++ b/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/rule.yml
@@ -30,5 +30,3 @@ template:
     name: service_enabled
     vars:
         servicename: fapolicyd
-    backends:
-        ansible: 'off'


### PR DESCRIPTION
#### Description:

- Enable ansible template for service_fapolicyd_enable rule.

#### Rationale:

- Since newer version of fapolicyd does not block ansible execution anymore by default, we should enable ansible remediation for this rule again.

See: 
https://github.com/linux-application-whitelisting/fapolicyd/blob/86ed0abcf4c1e03cf4e719d6771e9efefa138123/init/fapolicyd.rules#L30
https://github.com/linux-application-whitelisting/fapolicyd/blob/1b16fdcb3469175ec2ba1bbd66747471b353156a/ChangeLog#L7