### PR TITLE
Update references of USBGuard rules

### DIFF
--- a/linux_os/guide/services/usbguard/package_usbguard_installed/rule.yml
+++ b/linux_os/guide/services/usbguard/package_usbguard_installed/rule.yml
@@ -20,7 +20,8 @@ identifiers:
     cce@rhel8: 82959-8
 
 references:
-    srg: SRG-OS-000378-GPOS-00163
+    ospp: FMT_SMF_EXT.1
+    srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 
 references:
     ospp: FMT_SMF_EXT.1
-    srg: SRG-OS-000378-GPOS-00163
+    srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163
 
 ocil_clause: 'the service is not enabled'
 

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid/rule.yml
@@ -24,10 +24,6 @@ severity: medium
 identifiers:
     cce@rhel8: 82274-2
 
-references:
-    ospp: FMT_SMF_EXT.1
-    srg: SRG-OS-000114-GPOS-00059
-
 ocil_clause: 'USB devices of class 3 are not authorized'
 
 ocil: |-

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
@@ -25,10 +25,6 @@ severity: medium
 identifiers:
     cce@rhel8: 82368-2
 
-references:
-    ospp: FMT_SMF_EXT.1
-    srg: SRG-OS-000114-GPOS-00059
-
 ocil_clause: 'USB devices of class 3 and 9:00 are not authorized'
 
 ocil: |-

--- a/linux_os/guide/services/usbguard/usbguard_allow_hub/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hub/rule.yml
@@ -23,10 +23,6 @@ severity: medium
 identifiers:
     cce@rhel8: 82273-4
 
-references:
-    ospp: FMT_SMF_EXT.1
-    srg: SRG-OS-000114-GPOS-00059
-
 ocil_clause: 'USB devices of class 9 are not authorized'
 
 ocil: |-


### PR DESCRIPTION
As there is effectively only one security related rule -
`service_usbguard_enabled`, correct OSPP and SRG references should be
there. `package_usbguard_installed` is prerequisite for the service rule.

Other rules, `usbguard_allow_*` are convenience and usability
and as such should not be linked to security requirements.