### PR TITLE
utils: Remove unused variable

### DIFF
--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -78,8 +78,7 @@ def getkey(elem):
     return elem.get("ownerid")
 
 
-def new_stig_overlay(xccdftree, ssgtree, outfile,
-                     overlayfile=False):
+def new_stig_overlay(xccdftree, ssgtree, outfile):
     if not ssgtree:
         ssg_mapping = False
     else:


### PR DESCRIPTION
 Unused since beginning in 71dc9eec3b80984cc3be43dd8d05343555213382.