### PR TITLE
Fix mod fixes script

### DIFF
--- a/ssg/fixes.py
+++ b/ssg/fixes.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import os
 import re
 
-from .build_remediations import parse_from_file_with_jinja
+from .build_remediations import parse_from_file_without_jinja
 from .constants import XCCDF11_NS
 from .rule_yaml import parse_prodtype
 from .utils import read_file_list
@@ -45,7 +45,7 @@ def get_fix_contents(rule_obj, lang, fix_id):
 
 
 def applicable_platforms(fix_path):
-    _, config = parse_from_file_with_jinja(fix_path, {})
+    _, config = parse_from_file_without_jinja(fix_path)
 
     if 'platform' not in config:
         raise ValueError("Malformed fix: missing platform" % fix_path)

--- a/utils/mod_checks.py
+++ b/utils/mod_checks.py
@@ -60,6 +60,10 @@ def list_platforms(rule_obj):
 def add_platforms(rule_obj, platforms):
     oval_file, oval_contents = ssg.checks.get_oval_contents(rule_obj, 'shared')
     current_platforms = ssg.oval.applicable_platforms(oval_file)
+
+    if "multi_platform_all" in current_platforms:
+        return
+
     new_platforms = set(current_platforms)
     new_platforms.update(platforms)
 

--- a/utils/mod_fixes.py
+++ b/utils/mod_fixes.py
@@ -63,6 +63,9 @@ def add_platforms(rule_obj, lang, platforms):
     fix_file, fix_contents = ssg.fixes.get_fix_contents(rule_obj, lang, 'shared')
     current_platforms = ssg.fixes.applicable_platforms(fix_file)
 
+    if "multi_platform_all" in current_platforms:
+        return
+
     new_platforms = set(current_platforms)
     new_platforms.update(platforms)
 

--- a/utils/mod_fixes.py
+++ b/utils/mod_fixes.py
@@ -62,6 +62,7 @@ def list_platforms(rule_obj, lang):
 def add_platforms(rule_obj, lang, platforms):
     fix_file, fix_contents = ssg.fixes.get_fix_contents(rule_obj, lang, 'shared')
     current_platforms = ssg.fixes.applicable_platforms(fix_file)
+
     new_platforms = set(current_platforms)
     new_platforms.update(platforms)
 
@@ -94,7 +95,7 @@ def replace_platforms(rule_obj, lang, platforms):
     for platform in platforms:
         parsed_platform = platform.split('~')
         if not len(parsed_platform) == 2:
-            print("Invalid platform replacement description: %s" % product,
+            print("Invalid platform replacement description: %s" % platform,
                   file=sys.stderr)
             sys.exit(1)
 


### PR DESCRIPTION
#### Description:

- Parse files without expanding jinja macros as it doesn't contain the correct environment to expand macros.
- Do not add platform if remediation already contains `multi_platform_all` to avoid redundancy.

#### Rationale:

- Some files were being skipped and they shouldn't.
