### PR TITLE
Use the DEFAULT:NO-SHA1 Crypto Policy for the E8 profile.

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_nosha1_set.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_nosha1_set.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_e8
+
+update-crypto-policies --set "DEFAULT:NO-SHA1"

--- a/linux_os/guide/system/software/integrity/crypto/var_system_crypto_policy.var
+++ b/linux_os/guide/system/software/integrity/crypto/var_system_crypto_policy.var
@@ -13,6 +13,7 @@ interactive: false
 
 options:
     default: DEFAULT
+    default_nosha1: "DEFAULT:NO-SHA1"
     fips: FIPS
     legacy: LEGACY
     future: FUTURE

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -129,10 +129,8 @@ selections:
   - sshd_disable_user_known_hosts
   - sshd_enable_strictmodes
 
-  # The E8 profile bans usage of SHA-1, and as of 11/2019 the FUTURE crypto policy is the only one that ensures this.
-  # TODO: Re-evaluate after another crypto policies become available.
   # See also: https://www.cyber.gov.au/ism/guidelines-using-cryptography
-  - var_system_crypto_policy=future
+  - var_system_crypto_policy=default_nosha1
   - configure_crypto_policy
   - configure_ssh_crypto_policy
 


### PR DESCRIPTION
DEFAULT + NO-SHA1 is a good fit for the profile. FIPS isn't really required, and FUTURE is too strict (it may prevent downloads from some HTTPS servers that are actually safe).