### PR TITLE
Extend installed_OS_is_rhel8.xml to include test_rhvh4_version.

### DIFF
--- a/shared/checks/oval/installed_OS_is_rhel7.xml
+++ b/shared/checks/oval/installed_OS_is_rhel7.xml
@@ -19,9 +19,9 @@
         <criterion comment="RHEL 7 Workstation is installed" test_ref="test_rhel7_workstation" />
         <criterion comment="RHEL 7 Server is installed" test_ref="test_rhel7_server" />
         <criterion comment="RHEL 7 Compute Node is installed" test_ref="test_rhel7_computenode" />
-        <criteria operator="AND" comment="Red Hat Enterpise Virtualization Host is installed">
-          <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="test_redhat_release_virtualization_host_rpm" />
-          <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="test_rhev_rhel_version" />
+        <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
+          <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
+          <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 7" test_ref="test_rhevh_rhel7_version" />
         </criteria>
       </criteria>
     </criteria>
@@ -80,23 +80,16 @@
     <linux:name>redhat-release-computenode</linux:name>
   </linux:rpminfo_object>
 
-  <linux:rpminfo_test check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="test_redhat_release_virtualization_host_rpm" version="1">
-    <linux:object object_ref="obj_redhat_release_virtualization_host_rpm" />
-  </linux:rpminfo_test>
-  <linux:rpminfo_object id="obj_redhat_release_virtualization_host_rpm" version="1">
-    <linux:name>redhat-release-virtualization-host</linux:name>
-  </linux:rpminfo_object>
-
-  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 7" id="test_rhev_rhel_version" version="1">
-    <ind:object object_ref="obj_rhevh_rhel_version" />
-    <ind:state state_ref="state_rhevh_rhel_version" />
+  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 7" id="test_rhevh_rhel7_version" version="1">
+    <ind:object object_ref="obj_rhevh_rhel7_version" />
+    <ind:state state_ref="state_rhevh_rhel7_version" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_rhevh_rhel_version" version="1">
+  <ind:textfilecontent54_object id="obj_rhevh_rhel7_version" version="1">
     <ind:filepath>/etc/redhat-release</ind:filepath>
     <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_rhevh_rhel_version" version="1">
+  <ind:textfilecontent54_state id="state_rhevh_rhel7_version" version="1">
     <ind:subexpression operation="pattern match">7</ind:subexpression>
   </ind:textfilecontent54_state>
 

--- a/shared/checks/oval/installed_OS_is_rhel8.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8.xml
@@ -17,6 +17,10 @@
       <criteria operator="OR">
         <criterion comment="RHEL 8 is installed" test_ref="test_rhel8" />
         <criterion comment="RHEL 8 CoreOS is installed" test_ref="test_rhel8_coreos" />
+        <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
+          <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
+          <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 8" test_ref="test_rhevh_rhel8_version" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>
@@ -51,6 +55,19 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_rhel8_coreos" version="1">
+    <ind:subexpression operation="pattern match">8</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 8" id="test_rhevh_rhel8_version" version="1">
+    <ind:object object_ref="obj_rhevh_rhel8_version" />
+    <ind:state state_ref="state_rhevh_rhel8_version" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhevh_rhel8_version" version="1">
+    <ind:filepath>/etc/redhat-release</ind:filepath>
+    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhevh_rhel8_version" version="1">
     <ind:subexpression operation="pattern match">8</ind:subexpression>
   </ind:textfilecontent54_state>
 </def-group>

--- a/shared/checks/oval/installed_OS_is_rhv4.xml
+++ b/shared/checks/oval/installed_OS_is_rhv4.xml
@@ -28,4 +28,3 @@
   </linux:rpminfo_state>
 
 </def-group>
-


### PR DESCRIPTION
#### Description:

- Extend installed_OS_is_rhel8.xml to include test_rhvh4_version.

#### Rationale:

- RHV 4.4 will be proper recognised as RHEL8 as well.
