### PR TITLE
Fixed incorrect fips=1 comment in test_grub2_enable_force_iommu_default

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/oval/shared.xml
@@ -30,7 +30,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test id="test_grub2_enable_force_iommu_default"
-  comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
+  comment="check for iommu=force in /etc/default/grub via GRUB_CMDLINE_LINUX_DEFAULT"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_grub2_enable_force_iommu_default" />
     <ind:state state_ref="state_grub2_enable_force_iommu" />


### PR DESCRIPTION
#### Description:

This fixes an incorrect comment, which stated the test is looking for "fips=1" when the test is actually looking for "iommu=force".

#### Rationale:

The "fips=1" comment is out of place. Fixing the comment clears up any confusion there might be as to how to correctly remediate.

