### PR TITLE
Added machine-only CPEs to rules relevant only to non-virtualized systems

### DIFF
--- a/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_disable_plaintext_auth/rule.yml
+++ b/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_disable_plaintext_auth/rule.yml
@@ -16,6 +16,8 @@ rationale: |-
 
 severity: unknown
 
+platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+
 identifiers:
     cce@rhel6: 27144-5
     cce@rhel7: 80299-1

--- a/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_enable_ssl/rule.yml
+++ b/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_enable_ssl/rule.yml
@@ -19,6 +19,8 @@ rationale: |-
 
 severity: unknown
 
+platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+
 identifiers:
     cce@rhel6: 27571-9
     cce@rhel7: 80296-7

--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/rule.yml
@@ -17,6 +17,8 @@ rationale: |-
 
 severity: medium
 
+platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+
 identifiers:
     cce@rhel6: 26780-7
     cce@rhel7: 80289-2

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
@@ -15,6 +15,8 @@ rationale: |-
 
 severity: medium
 
+platform: machine  # The oscap password probe doesn't support offline mode
+
 identifiers:
     cce@rhel6: 26476-2
     cce@rhel7: 27352-4

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -21,6 +21,8 @@ rationale: |-
 
 severity: medium
 
+platform: machine  # The oscap password probe doesn't support offline mode
+
 identifiers:
     cce@rhel6: 27032-2
     cce@rhel7: 80134-0


### PR DESCRIPTION
This update ensures that rules that container/chrooted scanning is free from noise caused by notapplicable rules.