### PR TITLE
PermitUserEnvironment Checks For Incorrect Setting

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
@@ -40,7 +40,7 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
     cis-csc: 11,3,9
 
-ocil_clause: 'PermitUserEnvironment is not disabled'
+ocil_clause: 'PermitUserEnvironment is disabled'
 
 ocil: |-
     To ensure users are not able to send environment variables, run the following command:
@@ -54,4 +54,4 @@ template:
         missing_parameter_pass: 'false'
         parameter: PermitUserEnvironment
         rule_id: sshd_do_not_permit_user_env
-        value: 'yes'
+        value: 'no'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
@@ -40,7 +40,7 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
     cis-csc: 11,3,9
 
-ocil_clause: 'PermitUserEnvironment is disabled'
+ocil_clause: 'PermitUserEnvironment is not disabled'
 
 ocil: |-
     To ensure users are not able to send environment variables, run the following command:


### PR DESCRIPTION
The `PermitUserEnvironment` setting in `/etc/ssh/sshd_config` should be `no` but is currently written to be `yes`.

This fix updates the template to correctly scan for `PermitUserEnvironment no`

- Fixes #5086
