### PR TITLE
Set sshd private key permission to 0600 for Ubuntu 18.04

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Verify Permissions on SSH Server Private *_key Key Files'
 
 description: |-
-    {{% if product in ['opensuse', 'sle11', 'sle12'] %}}
+    {{% if product in ['ubuntu1804','opensuse', 'sle11', 'sle12'] %}}
     {{{ describe_file_permissions(file="/etc/ssh/*_key", perms="0600") }}}
     {{% else %}}
     {{{ describe_file_permissions(file="/etc/ssh/*_key", perms="0640") }}}
@@ -46,3 +46,4 @@ template:
         file_regex: ^.*_key$
         filemode: '0640'
         filemode@sle12: '0600'
+        filemode@ubuntu1804: '0600'


### PR DESCRIPTION
#### Description:
This PR addresses the fact that the OpenSSH server will ignore all private key files if they have permissions less strict than `0600` on Ubuntu 18.04. This appears to also have been the case for openSUSE, and I have updated the rule file to include Ubuntu 18.04 to this scenario.

- Fixes #5088 
