### PR TITLE
Use replace module in gpgcheck ansible

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -16,4 +16,4 @@
   replace:
     dest: "{{ item.path }}"
     regexp: '^gpgcheck.+'
-    replace: 'gpgcheck = 1'
+    replace: 'gpgcheck=1'

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -15,5 +15,5 @@
   with_items: "{{ yum_find.files }}"
   replace:
     dest: "{{ item.path }}"
-    regexp: '^(gpgcheck.+)'
-    replace: '# \1'
+    regexp: '^gpgcheck.+'
+    replace: 'gpgcheck = 1'

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -13,8 +13,7 @@
 
 - name: Ensure gpgcheck Enabled For All {{{ pkg_manager }}} Package Repositories
   with_items: "{{ yum_find.files }}"
-  lineinfile:
-    create: yes
+  replace:
     dest: "{{ item.path }}"
-    regexp: '^gpgcheck'
-    line: 'gpgcheck=1'
+    regexp: '^(gpgcheck.+)'
+    replace: '# \1'

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -1,19 +1,20 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_rhv
 # reboot = false
-# strategy = unknown
+# strategy = enable
 # complexity = low
 # disruption = medium
-#
-- name: Find All {{{ pkg_manager }}} Repositories
-  find:
-    paths: "/etc/yum.repos.d/"
-    patterns: "*.repo"
-    contains: ^\[.+]$
-  register: yum_find
+- name: Grep for {{{ pkg_manager }}} repo section names
+  shell: grep -HEr '^\[.+\]' -r ./etc/yum.repos.d/
+  register: repo_grep_results
+  ignore_errors: True
+  changed_when: False
 
-- name: Ensure gpgcheck Enabled For All {{{ pkg_manager }}} Package Repositories
-  with_items: "{{ yum_find.files }}"
-  replace:
-    dest: "{{ item.path }}"
-    regexp: '^gpgcheck.+'
-    replace: 'gpgcheck=1'
+- name: Set gpgcheck=1 for each {{{ pkg_manager }}} repo
+  ini_file:
+    path: "{{item[0]}}"
+    section: "{{item[1]}}"
+    option: gpgcheck
+    value: '1'
+    no_extra_spaces: True
+  # regex filters grep output for files ending in .repo and matching section names.
+  loop: "{{ repo_grep_results.stdout | regex_findall( '(.+\\.repo):\\[(.+)\\]\\n?' ) }}"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 - name: Grep for {{{ pkg_manager }}} repo section names
-  shell: grep -HEr '^\[.+\]' -r ./etc/yum.repos.d/
+  shell: grep -HEr '^\[.+\]' -r /etc/yum.repos.d/
   register: repo_grep_results
   ignore_errors: True
   changed_when: False


### PR DESCRIPTION
Closes #3810

This will comment out all lines beginning with 'gpgcheck'
instead of only changing the final instance as lineinfile
does.

#### Description:

- This change modifies the play to use the [Ansible replace module](https://docs.ansible.com/ansible/latest/modules/replace_module.html#replace-module) instead which will address each line in each file.
- The original ensure_gpgcheck_never_disabled ansible remediation play uses the [Ansible lineinfile module](https://docs.ansible.com/ansible/latest/modules/lineinfile_module.html) which only affects one line at a time.
- One change in behaviour is that this play now comments out the entire line instead of replacing it with `gpgcheck=1`. Happy to modify this to replace the line with `gpgcheck=1` instead.

#### Rationale:

- This change will address a faulty playbook which did not fix all gpgcheck configurations.
- Fixes #3810
