### PR TITLE
Bugfix overlay XSLT to include original SRG rule title

### DIFF
--- a/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
+++ b/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
@@ -19,7 +19,7 @@
       <xsl:variable name="overlay_rule" select="@ruleid"/>
       <xsl:variable name="overlay_severity" select="@severity"/>
       <xsl:variable name="overlay_ref" select="@disa"/>
-      <xsl:variable name="overlay_title" select="xccdf:title/text()"/>
+      <xsl:variable name="overlay_title" select="xccdf:title/@text"/>
 
       <xsl:for-each select="$rules">
         <xsl:if test="@id=$overlay_rule">


### PR DESCRIPTION
Previously, title was empty:
```
    <title/>
```

After this, we have tile filled in; like:
```
      <title>The Red Hat Enterprise Linux operating system must be configured so that the file permissions, 
ownership, and group membership of system files and commands match the vendor values.</title>
```