### PR TITLE
STIG overlay XCCDF shall include Benchmark/@id

### DIFF
--- a/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
+++ b/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
@@ -10,6 +10,10 @@
 
   <xsl:template match="xccdf:Benchmark">
     <xsl:copy>
+      <xsl:attribute name="id">
+        <xsl:value-of select="@id"/>
+      </xsl:attribute>
+
     <title>DISA STIG for <xsl:value-of select="$product_long_name" /></title>
 
   	<xsl:variable name="rules" select="//xccdf:Rule"/>


### PR DESCRIPTION
otherwise we produce invalid XCCDF.

Addressing:
```
File 'rhel7/unlinked-stig-xccdf.xml' line 2: Element '{http://checklists.nist.gov/xccdf/1.1}Benchmark': The attribute 'id' is required but missing.
```