### PR TITLE
Make the srg_group.xml work again

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1045,12 +1045,21 @@ macro(ssg_build_html_srgmap_tables PRODUCT PROFILE_ID DISA_SRG_TYPE)
     # we have to encode spaces in paths before passing them as stringparams to xsltproc
     string(REPLACE " " "%20" CMAKE_CURRENT_BINARY_DIR_NO_SPACES "${CMAKE_CURRENT_BINARY_DIR}")
     add_custom_command(
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked-srg-overlay.xml"
+      COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam profileId ${PROFILE_ID} --stringparam productXccdf ${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml --stringparam overlay ${CMAKE_CURRENT_SOURCE_DIR}/overlays/srg_support.xml --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked-srg-overlay.xml" "${CMAKE_SOURCE_DIR}/shared/transforms/srg-overlay.xslt" ${DISA_SRG_REF}
+      DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
+      DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+      DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/overlays/srg_support.xml"
+      DEPENDS "${CMAKE_SOURCE_DIR}/shared/transforms/srg-overlay.xslt"
+      DEPENDS "${DISA_SRG_REF}"
+      COMMENT "[${PRODUCT}-tables] Adding custom SRG overrides to XCCDF"
+    )
+    add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        # We need to use xccdf-linked.xml because ssg-${PRODUCT}-xccdf.xml has the srg_support Group removed
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam profileId "${PROFILE_ID}" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --stringparam ocil-document "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ocil-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${DISA_SRG_REF}"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked-srg-overlay.xml" --stringparam ocil-document "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ocil-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${DISA_SRG_REF}"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked-srg-overlay.xml"
         DEPENDS "${DISA_SRG_REF}"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML SRG map table (flat=no)"
@@ -1058,10 +1067,9 @@ macro(ssg_build_html_srgmap_tables PRODUCT PROFILE_ID DISA_SRG_TYPE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        # We need to use xccdf-linked.xml because ssg-${PRODUCT}-xccdf.xml has the srg_support Group removed
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam profileId "${PROFILE_ID}" --stringparam flat "y" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked.xml" --stringparam ocil-document "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ocil-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${DISA_SRG_REF}"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam flat "y" --stringparam map-to-items "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/xccdf-linked-srg-overlay.xml" --stringparam ocil-document "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ocil-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-srgmap-flat.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt" "${DISA_SRG_REF}"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked-srg-overlay.xml"
         DEPENDS "${DISA_SRG_REF}"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/table-srgmap.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML SRG map table (flat=yes)"

--- a/rhel8/overlays/srg_support.xml
+++ b/rhel8/overlays/srg_support.xml
@@ -1,0 +1,173 @@
+<Group id="srg_support" hidden="true">
+<title>Documentation to Support DISA OS SRG Mapping</title>
+<description>These groups exist to document how the Red Hat Enterprise Linux
+product meets (or does not meet) requirements listed in the DISA OS SRG, for
+those cases where Groups or Rules elsewhere in scap-security-guide do
+not clearly relate.
+</description>
+
+
+<!-- The CCI/SRG items referenced here are:
+     - satisfied (through design and implementation)
+     - selected in DoD baseline (per CNSS 1253) -->
+<Rule id="met_inherently_generic">
+<title>Product Meets this Requirement</title>
+<rationale>
+Red Hat Enterprise Linux meets this requirement through design and implementation.
+</rationale>
+<ocil>RHEL8 supports this requirement and cannot be configured to be out of
+compliance. This is a permanent not a finding.
+</ocil>
+<description>
+This requirement is a permanent not a finding. No fix is required.
+</description>
+<!-- Note: This XCCDF rule is used to group DISA requirements. As such,
+          it should not have CCE association -->
+<ref disa="42,56,206,1084,66,85,86,185,223,171,172,1694,770,804,162,163,164,345,346,1096,1111,1291,386,156,186,1083,1082,1090,804,1127,1128,1129,1248,1265,1314,1362,1368,1310,1311,1328,1399,1400,1404,1405,1427,1499,1632,1693,1665,1674" />
+</Rule>
+
+
+<!-- The CCI/SRG items referenced here relate to auditing, and are:
+     - satisfied (through design and implementation)
+     - selected in DoD baseline (per CNSS 1253) -->
+<Rule id="met_inherently_auditing">
+<title>Product Meets this Requirement</title>
+<rationale>
+The Red Hat Enterprise Linux audit system meets this requirement through design and implementation.
+</rationale>
+<ocil>The RHEL8 auditing system supports this requirement and cannot be configured to be out of
+compliance. Every audit record in RHEL includes a timestamp, the operation attempted,
+success or failure of the operation, the subject involved (executable/process),
+the object involved (file/path), and security labels for the subject and object.
+It also includes the ability to label events with custom key labels.  The auditing system
+centralizes the recording of audit events for the entire system and includes
+reduction (<tt>ausearch</tt>), reporting (<tt>aureport</tt>), and real-time
+response (<tt>audispd</tt>) facilities.
+This is a permanent not a finding.
+</ocil>
+<description>
+This requirement is a permanent not a finding. No fix is required.
+</description>
+<!-- Note: This XCCDF rule is used to group DISA requirements. As such,
+          it should not have CCE association -->
+<ref disa="130,157,131,132,133,134,135,159,174" />
+</Rule>
+
+
+<!-- The CCI/SRG item referenced here are:
+     - satisfied (through design and implementation)
+     - not selected in a DoD baseline -->
+<Rule id="met_inherently_nonselected">
+<title>Product Meets this Requirement</title>
+<rationale>
+Red Hat Enterprise Linux meets this requirement through design and implementation.
+</rationale>
+<ocil>RHEL8 supports this requirement and cannot be configured to be out of
+compliance. This is a permanent not a finding.
+</ocil>
+<description>
+This requirement is a permanent not a finding. No fix is required.
+</description>
+<!-- Note: This XCCDF rule is used to group DISA requirements. As such,
+          it should not have CCE association -->
+<ref disa="34,35,99,154,226,802,872,1086,1087,1089,1091,1424,1426,1428,1209,1214,1237,1269,1338,1425,1670" />
+</Rule>
+
+
+<!-- The CCI/SRG item listed here are:
+     - satisfied (by Rules in the guidance, which include the reference)
+     - not selected in DoD baseline -->
+<!-- disa="26,32,771,772,831,884,888,1095,1115,1117,1250,1348,1353,1464,1496" -->
+
+
+<!-- The CCI/SRG item referenced here are:
+     - not satisfied
+     - not selected in a DoD baseline
+     - considered out of scope -->
+<Rule id="unmet_nonfinding_nonselected_scope">
+<title>Guidance Does Not Meet this Requirement Due to Impracticality or Scope</title>
+<rationale>
+The guidance does not meet this requirement.
+The requirement is impractical or out of scope.
+</rationale>
+<ocil>
+RHEL8 cannot support this requirement without assistance from an external
+application, policy, or service. This requirement is NA.
+</ocil>
+<description>
+This requirement is NA. No fix is required.
+</description>
+<!-- Note: This XCCDF rule is used to group DISA requirements. As such,
+          it should not have CCE association -->
+<ref disa="21,25,28,29,30,165,221,354,553,779,780,781,1009,1094,1123,1124,1125,1132,1135,1140,1141,1142,1143,1145,1147,1148,1166,1339,1340,1341,1350,1356,1373,1374,1383,1391,1392,1395,1662" />
+</Rule>
+
+
+<!-- The CCI/SRG items referenced here are:
+     - not satisfied
+     - not selected in a DoD baseline
+     - considered permanent findings -->
+<Rule id="unmet_finding_nonselected">
+<title>Implementation of the Requirement is Not Supported</title>
+<rationale>
+RHEL8 does not support this requirement.
+</rationale>
+<ocil>
+This is a permanent finding.
+</ocil>
+<description>
+This requirement is a permanent finding and cannot be fixed. An appropriate
+mitigation for the system must be implemented but this finding cannot be
+considered fixed.
+</description>
+<ref disa="20,31,52,144,1158,1294,1295,1500" />
+<!-- Note: CCI 52 supported for text login, but not graphical -->
+</Rule>
+
+
+<!-- The CCI/SRG items referenced here are:
+     - not satisfied
+     - selected in a DoD baseline
+     - considered NA -->
+<Rule id="unmet_nonfinding_scope">
+<title>Guidance Does Not Meet this Requirement Due to Impracticality or Scope</title>
+<rationale>
+The guidance does not meet this requirement.
+The requirement is impractical or out of scope.
+</rationale>
+<ocil>
+RHEL8 cannot support this requirement without assistance from an external
+application, policy, or service. This requirement is NA.
+</ocil>
+<description>
+This requirement is NA. No fix is required.
+</description>
+<!-- Note: This XCCDF rule is used to group DISA requirements. As such,
+     it should not have CCE association -->
+<ref disa="15,27,218,219,371,372,535,537,539,1682,370,37,24,1112,1126,1143,1149,1157,1159,1210,1211,1274,1372,1376,1377,1352,1401,1555,1556,1150" />
+</Rule>
+
+<Rule id="update_process">
+<title>A process for prompt installation of OS updates must exist.</title>
+<rationale>
+This is a manual inquiry about update procedure.
+</rationale>
+<ocil>
+Ask an administrator if a process exists to promptly and automatically apply OS
+software updates.  If such a process does not exist, this is a finding.
+<br /><br />
+If the OS update process limits automatic updates of software packages, where
+such updates would impede normal system operation, to scheduled maintenance
+windows, but still within IAVM-dictated timeframes, this is not a finding.
+</ocil>
+<description>
+Procedures to promptly apply software updates must be established and
+executed. The Red Hat operating system provides support for automating such a
+process, by running the yum program through a cron job or by managing the
+system and its packages through the Red Hat Network or a Satellite Server.
+</description>
+<ref disa="1232" />
+<!-- Note: This is a process, as such, will not receive a CCE -->
+</Rule>
+
+</Group>

--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -130,6 +130,7 @@
 						<td> <xsl:apply-templates select="$item/cdf:description"/></td>					<!-- VulDiscussion -->
 						<td>												<!-- Status -->
 							<xsl:choose>
+								<xsl:when test="contains($item/@id, 'met_inherently_')">Applicable - Inherently Meets</xsl:when>
 								<xsl:when test="contains($item/@id, '-overlay-')">N/A</xsl:when>
 								<xsl:otherwise>Applicable - Configurable</xsl:otherwise>
 							</xsl:choose>

--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -7,9 +7,7 @@
      "flat", then it will output a separate row for every Rule which satisfies an SRG requirement. -->
 
 <xsl:param name="flat" select="''"/>
-<xsl:param name="profileId" select="'stig'"/>
 <xsl:param name="ocil-document" select="''"/>
-<xsl:variable name="profile" select="document($map-to-items)/cdf:Benchmark/cdf:Profile[@id=$profileId]"/>
 <xsl:variable name="ocil" select="document($ocil-document)/ocil2:ocil"/>
 
 	<xsl:template match="/">
@@ -90,20 +88,18 @@
 		<td>
 		<xsl:for-each select="$items">
 			<xsl:variable name="item" select="."/>
-			<xsl:if test="$profile/cdf:select[@selected='true' and @idref=$item/@id]">
-				<xsl:for-each select="cdf:reference[@href=$disa-srguri]">
-					<xsl:variable name="ssg_srg" select='self::node()[text()]' />
-					<xsl:variable name="disa_srg" select="$rule/cdf:version"  />
-					<xsl:if test="$ssg_srg=$disa_srg" >
-						<table>
-						<tr>
-						<td> <xsl:value-of select="$item/cdf:title"/> </td>
-						<td> <xsl:apply-templates select="$item/cdf:description"/> </td>
-						</tr>
-						</table>
-					</xsl:if>
-				</xsl:for-each>
-			</xsl:if>
+			<xsl:for-each select="cdf:reference[@href=$disa-srguri]">
+				<xsl:variable name="ssg_srg" select='self::node()[text()]' />
+				<xsl:variable name="disa_srg" select="$rule/cdf:version"  />
+				<xsl:if test="$ssg_srg=$disa_srg" >
+					<table>
+					<tr>
+					<td> <xsl:value-of select="$item/cdf:title"/> </td>
+					<td> <xsl:apply-templates select="$item/cdf:description"/> </td>
+					</tr>
+					</table>
+				</xsl:if>
+			</xsl:for-each>
 		</xsl:for-each>
 	  </td>
 	  </tr>
@@ -114,36 +110,34 @@
 		<!-- iterate over the items (everything with references) in the (externally-provided) XCCDF document -->
 		<xsl:for-each select="$items">
 			<xsl:variable name="item" select="."/>
-			<xsl:if test="$profile/cdf:select[@selected='true' and @idref=$item/@id]">
-				<xsl:for-each select="cdf:reference[@href=$disa-srguri]">
-				  <xsl:variable name="ssg_srg" select='self::node()[text()]' />
-				  <xsl:variable name="disa_srg" select="$rule/cdf:version"  />
-					<xsl:if test="$ssg_srg=$disa_srg" >
-						<tr>
-							<td><xsl:value-of select="$rule/cdf:ident" /></td> 								<!-- CCI -->
-							<td><xsl:value-of select="$rule/cdf:version" /></td> 							<!-- SRGID -->
-							<td><i>TBD - Assigned by DISA after STIG release</i></td> 						<!-- STIGID -->
-							<td><xsl:value-of select="$rule/cdf:title"/> </td>								<!-- SRG Requirement -->
-							<td><xsl:value-of select="$item/cdf:ident"/>: <xsl:value-of select="$item/cdf:title"/> </td>		<!-- Requirement -->
-							<td><xsl:call-template name="extract-vulndiscussion">							<!-- SRG VulDiscussion -->
-									<xsl:with-param name="desc" select="$rule/cdf:description"/>
-								</xsl:call-template>
-							</td>
-							<td> <xsl:apply-templates select="$item/cdf:description"/></td>					<!-- VulDiscussion -->
-							<td>Applicable - Configurable</td>												<!-- Status -->
-							<td><xsl:apply-templates select="$rule/cdf:check/cdf:check-content"/></td>		<!-- SRG Check -->
-							<td><xsl:apply-templates select="$item/cdf:check[@system='http://scap.nist.gov/schema/ocil/2']"/></td>	<!-- Check -->
-							<td><xsl:apply-templates select="$rule/cdf:fixtext"/></td>						<!-- SRG Fix -->
-							<td><xsl:value-of select="$item/cdf:description"/></td>							<!-- Fix -->
-							<td><xsl:value-of select="$item/@severity"/></td>								<!-- Severity -->
-							<td></td>																		<!-- Mitigation -->
-							<td></td>																		<!-- Artifact Description -->
-							<td></td>																		<!-- Status Justification -->
-						
-						</tr>
-					</xsl:if>
-				</xsl:for-each>
-			</xsl:if>
+			<xsl:for-each select="cdf:reference[@href=$disa-srguri]">
+			  <xsl:variable name="ssg_srg" select='self::node()[text()]' />
+			  <xsl:variable name="disa_srg" select="$rule/cdf:version"  />
+				<xsl:if test="$ssg_srg=$disa_srg" >
+					<tr>
+						<td><xsl:value-of select="$rule/cdf:ident" /></td> 								<!-- CCI -->
+						<td><xsl:value-of select="$rule/cdf:version" /></td> 							<!-- SRGID -->
+						<td><i>TBD - Assigned by DISA after STIG release</i></td> 						<!-- STIGID -->
+						<td><xsl:value-of select="$rule/cdf:title"/> </td>								<!-- SRG Requirement -->
+						<td><xsl:value-of select="$item/cdf:ident"/>: <xsl:value-of select="$item/cdf:title"/> </td>		<!-- Requirement -->
+						<td><xsl:call-template name="extract-vulndiscussion">							<!-- SRG VulDiscussion -->
+								<xsl:with-param name="desc" select="$rule/cdf:description"/>
+							</xsl:call-template>
+						</td>
+						<td> <xsl:apply-templates select="$item/cdf:description"/></td>					<!-- VulDiscussion -->
+						<td>Applicable - Configurable</td>												<!-- Status -->
+						<td><xsl:apply-templates select="$rule/cdf:check/cdf:check-content"/></td>		<!-- SRG Check -->
+						<td><xsl:apply-templates select="$item/cdf:check[@system='http://scap.nist.gov/schema/ocil/2']"/></td>	<!-- Check -->
+						<td><xsl:apply-templates select="$rule/cdf:fixtext"/></td>						<!-- SRG Fix -->
+						<td><xsl:value-of select="$item/cdf:description"/></td>							<!-- Fix -->
+						<td><xsl:value-of select="$item/@severity"/></td>								<!-- Severity -->
+						<td></td>																		<!-- Mitigation -->
+						<td></td>																		<!-- Artifact Description -->
+						<td></td>																		<!-- Status Justification -->
+
+					</tr>
+				</xsl:if>
+			</xsl:for-each>
 		</xsl:for-each>
 	</xsl:template>
 

--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -119,7 +119,10 @@
 						<td><xsl:value-of select="$rule/cdf:version" /></td> 							<!-- SRGID -->
 						<td><i>TBD - Assigned by DISA after STIG release</i></td> 						<!-- STIGID -->
 						<td><xsl:value-of select="$rule/cdf:title"/> </td>								<!-- SRG Requirement -->
-						<td><xsl:value-of select="$item/cdf:ident"/>: <xsl:value-of select="$item/cdf:title"/> </td>		<!-- Requirement -->
+						<td>													<!-- Requirement -->
+							<xsl:if test="$item/cdf:ident"><xsl:value-of select="$item/cdf:ident"/>:</xsl:if>
+							<xsl:value-of select="$item/cdf:title"/>
+						</td>
 						<td><xsl:call-template name="extract-vulndiscussion">							<!-- SRG VulDiscussion -->
 								<xsl:with-param name="desc" select="$rule/cdf:description"/>
 							</xsl:call-template>

--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -125,7 +125,12 @@
 							</xsl:call-template>
 						</td>
 						<td> <xsl:apply-templates select="$item/cdf:description"/></td>					<!-- VulDiscussion -->
-						<td>Applicable - Configurable</td>												<!-- Status -->
+						<td>												<!-- Status -->
+							<xsl:choose>
+								<xsl:when test="contains($item/@id, '-overlay-')">N/A</xsl:when>
+								<xsl:otherwise>Applicable - Configurable</xsl:otherwise>
+							</xsl:choose>
+						</td>
 						<td><xsl:apply-templates select="$rule/cdf:check/cdf:check-content"/></td>		<!-- SRG Check -->
 						<td><xsl:apply-templates select="$item/cdf:check[@system='http://scap.nist.gov/schema/ocil/2']"/></td>	<!-- Check -->
 						<td><xsl:apply-templates select="$rule/cdf:fixtext"/></td>						<!-- SRG Fix -->

--- a/shared/transforms/srg-overlay.xslt
+++ b/shared/transforms/srg-overlay.xslt
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" exclude-result-prefixes="xccdf">
+  <xsl:output method="xml" indent="yes"/>
+  <!--
+  This stylesheet takes
+   - Product XCCDF from ComplianceAsCode
+   - relevant DISA STIG XCCDF
+   - and overlay file information
+   and outputs unified XCCDF that serves as a response to DISA STIG SRGs; overlaying information from these three sources.
+  -->
+
+  <xsl:param name="productXccdf"/>
+  <xsl:param name="profileId" select="'stig'"/>
+  <xsl:param name="overlay"/>
+
+  <xsl:variable name="disaOssrgUri">https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os</xsl:variable>
+  <xsl:variable name="disaSrgUri" select="$disaOssrgUri"/>
+
+  <xsl:variable name="title" select="document($productXccdf)/xccdf:Benchmark/xccdf:title" />
+  <xsl:variable name="profile" select="document($productXccdf)/xccdf:Benchmark/xccdf:Profile[@id=$profileId]"/>
+  <xsl:variable name="selectedRules" select="document($productXccdf)//*[xccdf:reference and @id = $profile/xccdf:select[@selected='true']/@idref]"/>
+  <xsl:variable name="overlayRules" select="document($overlay)//Rule"/>
+
+  <xsl:template match="/xccdf:Benchmark">
+    <xsl:copy>
+      <xsl:attribute name="id">benchmark-with-overlays-for-srg</xsl:attribute>
+      <xccdf:status>draft</xccdf:status>
+      <xsl:copy-of select="$profile/xccdf:title"/>
+      <xsl:apply-templates select=".//xccdf:Rule"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="xccdf:Rule">
+    <xsl:variable name="disaRule" select="."/>
+	  <xsl:variable name="currSrg" select="xccdf:version"/>
+    <xsl:variable name="relevantRules" select="$selectedRules[xccdf:reference[@href=$disaSrgUri and text()=$currSrg]]"/>
+    <xsl:choose>
+      <xsl:when test="$relevantRules">
+        <xsl:for-each select="$relevantRules">
+          <xsl:call-template name="copyProductRule">
+            <xsl:with-param name="rule" select="."/>
+            <xsl:with-param name="cci" select="$disaRule/xccdf:ident/text()"/>
+          </xsl:call-template>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+
+        <xsl:variable name="override-rtf">
+          <xsl:call-template name="findOverlay">
+            <xsl:with-param name="cci" select="$disaRule/xccdf:ident/text()"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="override" select="exsl:node-set($override-rtf)//Rule[1]" xmlns:exsl="http://exslt.org/common"/>
+
+        <xsl:if test="$override">
+          <xsl:element name="Rule" namespace="http://checklists.nist.gov/xccdf/1.1">
+            <xsl:attribute name="id">
+              <xsl:value-of select="concat($override/@id, '-overlay-', $disaRule/xccdf:ident/text())"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:value-of select="$disaRule/@severity"/>
+            </xsl:attribute>
+            <xsl:element name="title">
+              <xsl:value-of select="$override/title"/>
+            </xsl:element>
+            <xsl:element name="description">
+              <xsl:value-of select="$override/description"/>
+            </xsl:element>
+            <xsl:element name="reference">
+              <xsl:attribute name="href">
+                <xsl:value-of select="$disaSrgUri"/>
+              </xsl:attribute>
+              <xsl:value-of select="$disaRule/xccdf:version"/>
+            </xsl:element>
+            <xsl:element name="check">
+              <xsl:attribute name="system">http://scap.nist.gov/schema/ocil/2</xsl:attribute>
+              <xsl:value-of select="$override/ocil"/>
+            </xsl:element>
+          </xsl:element>
+        </xsl:if>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="copyProductRule">
+    <xsl:param name="rule"/>
+    <xsl:param name="cci"/>
+    <xsl:copy-of select="$rule"/>
+  </xsl:template>
+
+  <xsl:template name="findOverlay">
+    <xsl:param name="cci"/>
+
+    <xsl:variable name="cciNumber" select="concat(',', number(substring-after($cci, 'CCI-')), ',')"/>
+    <xsl:variable name="result">
+      <xsl:for-each select="$overlayRules">
+        <xsl:variable name="relevantCcis" select="concat(',', ./ref/@disa, ',')"/>
+        <xsl:if test="contains($relevantCcis, $cciNumber)">
+          <xsl:copy-of select="."/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:if test="count($result) > 1">
+      <xsl:message terminate="yes">Error: multiple overlays match <xsl:value-of select="$cci"/></xsl:message>
+    </xsl:if>
+
+    <xsl:copy-of select="$result"/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
# A picture is worth 1000 words
![scrot](https://user-images.githubusercontent.com/6666052/72068901-efc44500-32dd-11ea-8367-dbfa37872421.jpg)

See also `tables/table-rhel7-srgmap-flat.html`.

# Overview

This re-implements SRG overlay.

SRG overlays have been broken since the repo was converted from the shorthand
format. This brings the support for `overlays/srg_support.xml` back to the game.

Overlay is used to generate more complete SRG Mapping table. The mapping tables
provides overview how the SRG requirements are implemented in scope of the
product.


