### PR TITLE
Fix: Yield empty table columns explicitly

### DIFF
--- a/shared/transforms/shared_table-srgmap.xslt
+++ b/shared/transforms/shared_table-srgmap.xslt
@@ -101,6 +101,10 @@
 				</xsl:if>
 			</xsl:for-each>
 		</xsl:for-each>
+		<xsl:if test="$flat">
+			<!-- there is no Rule matching the SRG. Let's output empty fields. -->
+			<td/><td/><td/><td/><td/><td/><td/><td/><td/>
+		</xsl:if>
 	  </td>
 	  </tr>
 	</xsl:template>


### PR DESCRIPTION
Ommiting table fields leads these fields do not have background color.

See second row in [this image](https://user-images.githubusercontent.com/6666052/72068901-efc44500-32dd-11ea-8367-dbfa37872421.jpg). Grey background disappears in the middle of the row.