### PR TITLE
E8: ensure there is a single account with uid zero

### DIFF
--- a/rhel7/profiles/e8.profile
+++ b/rhel7/profiles/e8.profile
@@ -78,6 +78,7 @@ selections:
   - network_sniffer_disabled
 
   ### Admin privileges
+  - accounts_no_uid_except_zero
   - sudo_remove_nopasswd
   - sudo_remove_no_authenticate
   - sudo_require_authentication

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -80,6 +80,7 @@ selections:
   - network_sniffer_disabled
 
   ### Admin privileges
+  - accounts_no_uid_except_zero
   - sudo_remove_nopasswd
   - sudo_remove_no_authenticate
   - sudo_require_authentication


### PR DESCRIPTION
The [Essential 8 in Linux Environments guide](https://www.cyber.gov.au/publications/essential-eight-in-linux-environments) specifically mentions organisations should check for multiple accounts with UID zero. 

This PR adds the `accounts_no_uid_except_zero` check to the E8 profiles.
