### PR TITLE
Add security autoupdates to the RHEL8 E8 profile.

### DIFF
--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -36,6 +36,7 @@ selections:
   - ensure_gpgcheck_local_packages
   - ensure_gpgcheck_globally_activated
   - security_patches_up_to_date
+  - dnf-automatic_security_updates_only
 
   ### System security settings
   - sysctl_kernel_randomize_va_space


### PR DESCRIPTION
The E8 requires that systems are continuously updated, so a rule that ensures so should be part of the profile.