### PR TITLE
Updated reference URL for gconf

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
@@ -10,7 +10,7 @@ description: |-
     <br /><br />
     {{% if product == "rhel6" %}}
     For more information about enforcing preferences in the GNOME environment using the GConf
-    configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
+    configuration system, see <b>{{{ weblink(link="http://developer.gnome.org/gconf") }}}</b> and
     the man page <tt>gconftool-2(1)</tt>.
     {{% elif product in ["ol7", "ol8"] %}}
     For more information about enforcing preferences in the GNOME3 environment using the DConf

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/group.yml
@@ -29,7 +29,7 @@ description: |-
     For more information about configuring GNOME screensaver, see
     <b>{{{ weblink(link="http://live.gnome.org/GnomeScreensaver") }}}</b>. For more information about
     enforcing preferences in the GNOME environment using the GConf
-    configuration system, see <b>{{{ weblink(link="http://projects.gnome.org/gconf") }}}</b> and
+    configuration system, see <b>{{{ weblink(link="http://developer.gnome.org/gconf") }}}</b> and
     the man page <tt>gconftool-2(1)</tt>.
 {{% else %}}
     In the default GNOME3 desktop, the screen can be locked


### PR DESCRIPTION
#### Description:

- Updated reference URL for gconf

#### Rationale:

- The previous URL when 404.
  Contents are not the same, but this is the closest thing available.
- It's been failing on Jenkins test for a few days:
  https://jenkins.complianceascode.io/view/SCAP%20Security%20Guide/job/scap-security-guide-linkcheck/
