### PR TITLE
audit package on ubuntu* is auditd.

### DIFF
--- a/linux_os/guide/system/auditing/package_audit_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audit_installed/rule.yml
@@ -24,3 +24,6 @@ template:
     name: package_installed
     vars:
         pkgname: audit
+        pkgname@ubuntu1404: auditd
+        pkgname@ubuntu1604: auditd
+        pkgname@ubuntu1804: auditd


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

#### Description:

`xccdf_org.ssgproject.content_rule_package_audit_installed` and `xccdf_org.ssgproject.content_rule_service_auditd_enabled` fails on Ubuntu.

#### Rationale:

On Ubuntu the package name is `auditd`.
