### PR TITLE
Check EKU in rsyslog remote configuration

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/oval/shared.xml
@@ -29,6 +29,6 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_rsyslog_remote_tls" comment="value of omfwd action" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">(?=[\S\s]*\sprotocol="tcp")(?=[\S\s]*\sTarget="[^"]+?")(?=[\S\s]*\sport="6514")(?=[\S\s]*\sStreamDriver="gtls")(?=[\S\s]*\sStreamDriverMode="1")(?=[\S\s]*\sStreamDriverAuthMode="x509/name")</ind:subexpression>
+    <ind:subexpression datatype="string" operation="pattern match">(?=[\S\s]*\sprotocol="tcp")(?=[\S\s]*\sTarget="[^"]+?")(?=[\S\s]*\sport="6514")(?=[\S\s]*\sStreamDriver="gtls")(?=[\S\s]*\sStreamDriverMode="1")(?=[\S\s]*\sStreamDriverAuthMode="x509/name")(?=[\S\s]*\sstreamdriver\.CheckExtendedKeyPurpose="on")</ind:subexpression>
   </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
@@ -10,7 +10,7 @@ description: |-
     for the Forwarding Output Module in <tt>/etc/rsyslog.conf</tt>
     using action. You can use the following command:
     <pre>echo 'action(type="omfwd" protocol="tcp" Target="&lt;remote system>" port="6514"
-        StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")' >> /etc/rsyslog.conf
+        StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")' >> /etc/rsyslog.conf
     </pre>
     Replace the <tt>&lt;remote system></tt> in the above command with an IP address or a host name of the remote logging server.
 
@@ -36,6 +36,6 @@ ocil: |-
     <pre>$ grep omfwd /etc/rsyslog.conf /etc/rsyslog.d/*.conf</pre>
     The output should include record similar to
     <pre>action(type="omfwd" protocol="tcp" Target="&lt;remote system>" port="6514"
-        StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")
+        StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")
     </pre>
     where the <tt>&lt;remote system></tt> present in the configuration line above must be a valid IP address or a host name of the remote logging server.

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_multiline.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_multiline.pass.sh
@@ -7,5 +7,6 @@ action(type="omfwd"
        port="6514"
        StreamDriver="gtls"
        StreamDriverMode="1"
-       StreamDriverAuthMode="x509/name")
+       StreamDriverAuthMode="x509/name"
+       streamdriver.CheckExtendedKeyPurpose="on")
 EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cat >> /etc/rsyslog.conf <<EOF
-action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name")
+action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")
 EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_EKU.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_EKU.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 cat >> /etc/rsyslog.conf <<EOF
 action(type="omfwd"

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_EKU.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_EKU.fail.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
-# remediation = none
 
 cat >> /etc/rsyslog.conf <<EOF
 action(type="omfwd"
        protocol="tcp"
        Target="remote.system.com"
        port="6514"
-       StreamDriver="ptcp"
+       StreamDriver="gtls"
        StreamDriverMode="1"
-       StreamDriverAuthMode="x509/name"
-       streamdriver.CheckExtendedKeyPurpose="on")
+       StreamDriverAuthMode="x509/name")
 EOF


### PR DESCRIPTION
This patch adds option "streamdriver.CheckExtendedKeyPurpose" to the
list of mandatory settings in rule rsyslog_remote_tls and requires this
option to be set to "on".  This option configures rsyslog to check for
the ExtendedKeyUsage field of the certificate.  This is a new feature in
rsyslog introduced in https://github.com/rsyslog/rsyslog/pull/3845

Fixes: #5098

