### PR TITLE
Update configure_crypto_policy test scenarios

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/dropin_file_and_symlink_exist.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/dropin_file_and_symlink_exist.fail.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # using example of opensshserver
 DROPIN_FILE="/etc/crypto-policies/local.d/opensshserver-test.config"
 
-update-crypto-policies --set FIPS
+update-crypto-policies --set "FIPS:OSPP"
 
 echo "" > "$DROPIN_FILE"
 echo "CRYPTO_POLICY=" >> "$DROPIN_FILE"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/file_exists_but_no_file_in_local_d.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/file_exists_but_no_file_in_local_d.fail.sh
@@ -5,7 +5,7 @@
 #using example of openssh server
 CRYPTO_POLICY_FILE="/etc/crypto-policies/back-ends/opensshserver.config"
 
-update-crypto-policies --set "FIPS"
+update-crypto-policies --set "FIPS:OSPP"
 
 rm -f /etc/crypto-policies/local.d/opensshserver-*.config
 rm -f "$CRYPTO_POLICY_FILE"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_nss_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_nss_config.fail.sh
@@ -2,6 +2,6 @@
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-update-crypto-policies --set "FIPS"
+update-crypto-policies --set "FIPS:OSPP"
 
 rm -f "/etc/crypto-policies/back-ends/nss.config"


### PR DESCRIPTION
#### Description:

- Update test scenarios for OSPP profile, 
#### Rationale:

- It selects 'FIPS:OSPP' crypto policy, not 'FIPS'