### PR TITLE
Don't check for path length of logs directory

### DIFF
--- a/tests/ensure_paths_are_short.py
+++ b/tests/ensure_paths_are_short.py
@@ -15,7 +15,8 @@ def main():
     for dir_, _, files in os.walk(ssg_root):
         # Don't check for path len of log files
         # They are not shipped nor used during build
-        if "tests/logs/" in dir_:
+        current_relative_path = os.path.relpath(dir_, ssg_root)
+        if current_relative_path.startswith("tests/logs/"):
             continue
         for file_ in files:
             path = os.path.relpath(os.path.join(dir_, file_), ssg_root)

--- a/tests/ensure_paths_are_short.py
+++ b/tests/ensure_paths_are_short.py
@@ -13,6 +13,10 @@ def main():
     ssg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     max_path = ""
     for dir_, _, files in os.walk(ssg_root):
+        # Don't check for path len of log files
+        # They are not shipped nor used during build
+        if "tests/logs/" in dir_:
+            continue
         for file_ in files:
             path = os.path.relpath(os.path.join(dir_, file_), ssg_root)
             if len(path) > len(max_path):


### PR DESCRIPTION
#### Description:

- Don't check for path length of logs directory

#### Rationale:

- The logs are not part of the tarball, nor used to build the content.