### PR TITLE
PCI-DSS profile should install audispd plugins

### DIFF
--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -23,6 +23,7 @@ selections:
     - auditd_data_retention_space_left_action
     - auditd_data_retention_admin_space_left_action
     - auditd_data_retention_action_mail_acct
+    - package_audispd-plugins_installed
     - auditd_audispd_syslog_plugin_activated
     - audit_rules_time_adjtimex
     - audit_rules_time_settimeofday


### PR DESCRIPTION

#### Description:

- Add rule that install `audispd-plugins`.

#### Rationale:
- If the profile wants to configure `audispd-plugins`, it should also install the package.

