### PR TITLE
create new rule for ipv4 tcp rate limiting through sysctl

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+- name: "Configure rate limiting direct rule for firewalld"
+  command: "firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES"

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+# platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES
 firewall-cmd --reload

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/bash/shared.sh
@@ -1,0 +1,4 @@
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+
+firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES
+firewall-cmd --reload

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
@@ -30,4 +30,4 @@
   <ind:xmlfilecontent_state id="state_firewalld_rate_limiting" version="1">
     <ind:value_of datatype="string" entity_check="at least one">-p tcp -m limit --limit 25/minute --limit-burst 100 -j INPUT_ZONES</ind:value_of>
   </ind:xmlfilecontent_state>
-</def-group>def-group>
+</def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
@@ -4,7 +4,9 @@
       <title>Configure firewalld To Rate Limit Connections</title>
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
+        <!--  there is problem with remediation on rhel8 -->
         <platform>Red Hat Enterprise Linux 8</platform>
+        -->
         <platform>multi_platform_wrlinux</platform>
       </affected>
       <description>Create a direct firewall rule to protect against DoS attacks by rate limiting incoming connections.</description>
@@ -26,6 +28,6 @@
   </ind:xmlfilecontent_object>
 
   <ind:xmlfilecontent_state id="state_firewalld_rate_limiting" version="1">
-    <ind:value_of datatype="string">-p tcp -m limit --limit 25/minute --limit-burst 100 -j INPUT_ZONES</ind:value_of>
+    <ind:value_of datatype="string" entity_check="at least one">-p tcp -m limit --limit 25/minute --limit-burst 100 -j INPUT_ZONES</ind:value_of>
   </ind:xmlfilecontent_state>
 </def-group>def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="configure_firewalld_rate_limiting" version="1">
+    <metadata>
+      <title>Configure firewalld To Rate Limit Connections</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_wrlinux</platform>
+      </affected>
+      <description>Create a direct firewall rule to protect against DoS attacks by rate limiting incoming connections.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="check if the file /etc/firewalld/direct.xml contains correct rule" test_ref="test_firewalld_rate_limiting"/>
+    </criteria>
+  </definition>
+
+  <ind:xmlfilecontent_test check="at least one" check_existence="all_exist" comment="firewalld rate limiting incoming connections"
+  id="test_firewalld_rate_limiting" version="1">
+    <ind:object object_ref="object_firewalld_rate_limiting"/>
+    <ind:state state_ref="state_firewalld_rate_limiting" />
+  </ind:xmlfilecontent_test>
+
+  <ind:xmlfilecontent_object id="object_firewalld_rate_limiting" version="1">
+    <ind:filepath>/etc/firewalld/direct.xml</ind:filepath>
+    <ind:xpath>/direct/rule[@chain="INPUT_direct" and @priority="0" and @table="filter" and @ipv="ipv4"]/text()</ind:xpath>
+  </ind:xmlfilecontent_object>
+
+  <ind:xmlfilecontent_state id="state_firewalld_rate_limiting" version="1">
+    <ind:value_of datatype="string">-p tcp -m limit --limit 25/minute --limit-burst 100 -j INPUT_ZONES</ind:value_of>
+  </ind:xmlfilecontent_state>
+</def-group>def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
@@ -7,7 +7,7 @@ title: 'Configure firewalld To Rate Limit Connections'
 description: |-
     Create a direct firewall rule to protect against DoS attacks with the following
     command:
-    <pre>$ sudo firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j ACCEPT</pre>
+    <pre>$ sudo firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES</pre>
 
 rationale: |-
     DoS is a condition when a resource is not available for legitimate users. When
@@ -43,4 +43,4 @@ ocil: |-
     on impacted network interfaces, run the following command:
     <pre>$ sudo firewall-cmd --permanent --direct --get-rules ipv4 filter INPUT_direct</pre>
     The output should return:
-    <pre>0 -p tcp -m limit --limit 25/minute --limit-burst 100 -j ACCEPT</pre>
+    <pre>0 -p tcp -m limit --limit 25/minute --limit-burst 100 -j INPUT_ZONES</pre>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
@@ -1,6 +1,7 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8
+# todo: the remediation is broken on rhel8
+prodtype: wrlinux1019,rhel7
 
 title: 'Configure firewalld To Rate Limit Connections'
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_two_wrong_rules.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_two_wrong_rules.fail.sh
@@ -4,6 +4,7 @@
 
 # ensure firewalld installed
 yum install -y firewalld
-# add wrong rule
+# add wrong rules
 firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j ACCEPT
+firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j DROP
 firewall-cmd --reload

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_wrong_rule.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_wrong_rule.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+
+
+# ensure firewalld installed
+yum install -y firewalld
+# add wrong rule
+firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j ACCEPT
+firewall-cmd --reload

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/correct.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+
+
+# ensure firewalld installed
+yum install -y firewalld
+
+# add correct rule
+firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES
+firewall-cmd --reload

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+# platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 
 # ensure firewalld installed

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/file_missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+
+
+# ensure firewalld installed
+yum install -y firewalld
+
+rm -f /etc/firewalld/direct.xml

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/file_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+# platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 
 # ensure firewalld installed

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/rule_in_wrong_chain.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/rule_in_wrong_chain.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+
+# ensure firewalld installed
+yum install -y firewalld
+# put rule into wrong chain
+firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES
+firewall-cmd --reload

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/rule_in_wrong_chain.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/rule_in_wrong_chain.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_wrlinux
+# platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 # ensure firewalld installed
 yum install -y firewalld

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel7,rhel8
+prodtype: wrlinux1019,rhel7,rhel8,ocp4
 
 title: 'Configure Kernel to Rate Limit Sending of Duplicate TCP Acknowledgments'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -29,7 +29,7 @@ rationale: |-
 severity: medium
 
 identifiers:
-    cce@rhel7: 82365-8
+    cce@rhel7: 82893-9
 
 references:
     disa: "2385"
@@ -47,7 +47,8 @@ ocil: |-
     <pre># grep 'net.ipv4.tcp_invalid_ratelimit' /etc/sysctl.conf /etc/sysctl.d/*</pre>
     The command should output the following line:
     <pre>/etc/sysctl.conf:net.ipv4.tcp_invalid_ratelimit = 500</pre>
-    The file where the line has been found can differ, but it must be either <tt>/etc/sysctl.conf</tt> or a file located under the <tt>/etc/sysctl.d/</tt> directory.
+    The file where the line has been found can differ, but it must be either <tt>/etc/sysctl.conf</tt>
+    or a file located under the <tt>/etc/sysctl.d/</tt> directory.
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -1,0 +1,57 @@
+documentation_complete: true
+
+prodtype: wrlinux1019,rhel7,rhel8
+
+title: 'Configure kernel To Rate limit sending of duplicate TCP acknowledgments'
+
+description: |-
+    Make sure that the system is configured to rate limit sending of duplicate TCP acknowledgments.
+    This measure protects against or limits effects of DoS attacks against the system.
+    Set the system to implement rate-limiting measures by adding the following line to <tt>/etc/sysctl.conf</tt> or a configuration file in the <tt>/etc/sysctl.d/</tt> directory (or modify the line to have the required value):
+    <pre>net.ipv4.tcp_invalid_ratelimit = 500</pre>
+    Issue the following command to make the changes take effect:
+    <pre># sysctl --system</pre>
+
+rationale: |-
+    DoS is a condition when a resource is not available for legitimate users. When
+    this occurs, the organization either cannot accomplish its mission or must
+    operate at degraded capacity.
+    <br /><br />
+    This requirement addresses the configuration of
+    the operating system to mitigate the impact of DoS attacks that have occurred or
+    are ongoing on system availability. For each system, known and potential DoS
+    attacks must be identified and solutions for each type implemented. A variety of
+    technologies exist to limit or, in some cases, eliminate the effects of DoS
+    attacks (e.g., limiting processes or establishing memory partitions). Employing
+    increased capacity and bandwidth, combined with service redundancy, may reduce
+    the susceptibility to some DoS attacks.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 82365-8
+
+references:
+    disa: "2385"
+    nist: SC-5
+    srg: SRG-OS-000420-GPOS-00186
+    vmmsrg: SRG-OS-000420-VMM-001690
+    stigid@rhel7: "040510"
+
+ocil_clause: 'rate limiting of duplicate TCP acknowledgments is not configured'
+
+ocil: |-
+    To verify that the operating system protects against or limits the effects of DoS
+    attacks by ensuring implementation of rate-limiting measures
+    on impacted network interfaces, run the following command:
+    <pre># grep 'net.ipv4.tcp_invalid_ratelimit' /etc/sysctl.conf /etc/sysctl.d/*</pre>
+    The command should output the following line:
+    <pre>/etc/sysctl.conf:net.ipv4.tcp_invalid_ratelimit = 500</pre>
+    The file where the line has been found can differ, but it must be either <tt>/etc/sysctl.conf</tt> or a file located under the <tt>/etc/sysctl.d/</tt> directory.
+
+template:
+    name: sysctl
+    vars:
+        sysctlvar: net.ipv4.tcp_invalid_ratelimit
+        sysctlval: 500
+        datatype: int

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -5,9 +5,12 @@ prodtype: wrlinux1019,rhel7,rhel8
 title: 'Configure Kernel to Rate Limit Sending of Duplicate TCP Acknowledgments'
 
 description: |-
-    Make sure that the system is configured to limit the maximal rate for sending duplicate acknowledgments in response to incoming TCP packets that are for an existing connection but that are invalid due to any of these reasons:
+    Make sure that the system is configured to limit the maximal rate for sending
+    duplicate acknowledgments in response to incoming TCP packets that are for
+    an existing connection but that are invalid due to any of these reasons:
 
-    (a) out-of-window sequence number, (b) out-of-window acknowledgment number, or (c) PAWS (Protection Against Wrapped Sequence numbers) check failure
+    (a) out-of-window sequence number, (b) out-of-window acknowledgment number,
+    or (c) PAWS (Protection Against Wrapped Sequence numbers) check failure
     This measure protects against or limits effects of DoS attacks against the system.
     Set the system to implement rate-limiting measures by adding the following line to
     <tt>/etc/sysctl.conf</tt> or a configuration file in the <tt>/etc/sysctl.d/</tt> directory

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -2,29 +2,30 @@ documentation_complete: true
 
 prodtype: wrlinux1019,rhel7,rhel8
 
-title: 'Configure kernel To Rate limit sending of duplicate TCP acknowledgments'
+title: 'Configure Kernel to Rate Limit Sending of Duplicate TCP Acknowledgments'
 
 description: |-
-    Make sure that the system is configured to rate limit sending of duplicate TCP acknowledgments.
+    Make sure that the system is configured to limit the maximal rate for sending duplicate acknowledgments in response to incoming TCP packets that are for an existing connection but that are invalid due to any of these reasons:
+
+    (a) out-of-window sequence number, (b) out-of-window acknowledgment number, or (c) PAWS (Protection Against Wrapped Sequence numbers) check failure
     This measure protects against or limits effects of DoS attacks against the system.
-    Set the system to implement rate-limiting measures by adding the following line to <tt>/etc/sysctl.conf</tt> or a configuration file in the <tt>/etc/sysctl.d/</tt> directory (or modify the line to have the required value):
+    Set the system to implement rate-limiting measures by adding the following line to
+    <tt>/etc/sysctl.conf</tt> or a configuration file in the <tt>/etc/sysctl.d/</tt> directory
+    (or modify the line to have the required value):
     <pre>net.ipv4.tcp_invalid_ratelimit = 500</pre>
     Issue the following command to make the changes take effect:
     <pre># sysctl --system</pre>
 
 rationale: |-
-    DoS is a condition when a resource is not available for legitimate users. When
+    Denial of Service (DoS) is a condition when a resource is not available for legitimate users. When
     this occurs, the organization either cannot accomplish its mission or must
     operate at degraded capacity.
     <br /><br />
-    This requirement addresses the configuration of
-    the operating system to mitigate the impact of DoS attacks that have occurred or
-    are ongoing on system availability. For each system, known and potential DoS
-    attacks must be identified and solutions for each type implemented. A variety of
-    technologies exist to limit or, in some cases, eliminate the effects of DoS
-    attacks (e.g., limiting processes or establishing memory partitions). Employing
-    increased capacity and bandwidth, combined with service redundancy, may reduce
-    the susceptibility to some DoS attacks.
+    This can help mitigate simple “ack loop” DoS attacks, wherein a buggy or
+    malicious middlebox or man-in-the-middle can rewrite TCP header fields in
+    manner that causes each endpoint to think that the other is sending invalid
+    TCP segments, thus causing each side to send an unterminating stream of
+    duplicate acknowledgments for invalid segments.
 
 severity: medium
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -12,7 +12,7 @@ description: |-
     Set the system to implement rate-limiting measures by adding the following line to
     <tt>/etc/sysctl.conf</tt> or a configuration file in the <tt>/etc/sysctl.d/</tt> directory
     (or modify the line to have the required value):
-    <pre>net.ipv4.tcp_invalid_ratelimit = 500</pre>
+    <pre>net.ipv4.tcp_invalid_ratelimit = <sub idref="sysctl_net_ipv4_tcp_invalid_ratelimit_value" /></pre>
     Issue the following command to make the changes take effect:
     <pre># sysctl --system</pre>
 
@@ -47,7 +47,7 @@ ocil: |-
     on impacted network interfaces, run the following command:
     <pre># grep 'net.ipv4.tcp_invalid_ratelimit' /etc/sysctl.conf /etc/sysctl.d/*</pre>
     The command should output the following line:
-    <pre>/etc/sysctl.conf:net.ipv4.tcp_invalid_ratelimit = 500</pre>
+    <pre>/etc/sysctl.conf:net.ipv4.tcp_invalid_ratelimit = <sub idref="sysctl_net_ipv4_tcp_invalid_ratelimit_value" /></pre>
     The file where the line has been found can differ, but it must be either <tt>/etc/sysctl.conf</tt>
     or a file located under the <tt>/etc/sysctl.d/</tt> directory.
 
@@ -55,5 +55,4 @@ template:
     name: sysctl
     vars:
         sysctlvar: net.ipv4.tcp_invalid_ratelimit
-        sysctlval: 500
         datatype: int

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit_value.var
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit_value.var
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: net.ipv4.tcp_invalid_ratelimit
+
+description: |-
+    Configure  the maximal rate for sending duplicate acknowledgments in
+    response to incoming invalid TCP packets.
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    default: 500
+    one_thousand: 1000
+    five_hundred: 500
+    two_hundred_fifty: 250
+    one_hundred: 100

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -252,7 +252,7 @@ selections:
     - sshd_use_priv_separation
     - sshd_disable_compression
     - chronyd_or_ntpd_set_maxpoll
-    - configure_firewalld_rate_limiting
+    - sysctl_net_ipv4_tcp_invalid_ratelimit
     - service_firewalld_enabled
     - display_login_attempts
     - no_user_host_based_files


### PR DESCRIPTION
#### Description:

create new rule.yml and make the rule templated using the sysctl template
replace the old rate limiting rule using firewalld with this one in rhel7/stig profile


#### Rationale:

Based on this issue:
https://github.com/ComplianceAsCode/content/issues/3495
a new rule based on updated rhel7 STIG was created and replaced the appropriate rule in rhel7 profile.
This PR is a reaction to [RHBZ#1609014](https://bugzilla.redhat.com/show_bug.cgi?id=1609014)