### PR TITLE
Ansible remediation for configure_openssl_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -1,0 +1,31 @@
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+
+- name: "Test for crypto_policy group"
+  command: grep '^\s*\[\s*crypto_policy\s*]' /etc/pki/tls/openssl.cnf
+  register: test_crypto_policy_group
+  ignore_errors: yes
+  changed_when: False
+  check_mode: no
+
+- name: "Add .include for openssl.config to crypto_policy section"
+  lineinfile:
+    create: yes
+    insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
+    line: ".include /etc/crypto-policies/back-ends/openssl.config"
+    path: /etc/pki/tls/openssl.cnf
+  when:
+    - test_crypto_policy_group.stdout is defined
+    - test_crypto_policy_group.stdout | length > 0
+
+- name: "Add crypto_policy group and set include openssl.config"
+  lineinfile:
+    create: yes
+    line: "[crypto_policy]\n.include /etc/crypto-policies/back-ends/openssl.config"
+    path: /etc/pki/tls/openssl.cnf
+  when:
+    - test_crypto_policy_group.stdout is defined
+    - test_crypto_policy_group.stdout | length < 1


### PR DESCRIPTION
#### Description:
Add ansible remediation that uses `lineinfile` module.

`ini_file` module wasn't possible to use, because it automatically adds `=` delimiter and according to https://github.com/ansible/ansible/issues/40786 it is not standard INI file without `=`.

#### Rationale:
The rule is in `ospp` and `pci-dss` profiles.
