### PR TITLE
Create docker file for publishing content in container image

### DIFF
--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -1,0 +1,10 @@
+FROM fedora:latest as builder
+
+RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
+RUN git clone --depth 1 https://github.com/ComplianceAsCode/content
+WORKDIR /content
+RUN ./build_product --debug ocp4
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /
+COPY --from=builder /content/build/ssg-ocp4-ds.xml .


### PR DESCRIPTION
This will allow us to build ComplianceAsCode automatically in the quay and distribute content automatically to whoever needs to use compliance-operator.

Without this change, people are required to build their own [content image](https://github.com/jhrozek/ocp4-openscap-content) like Jakub Hrozek did.