### PR TITLE
ocp4/moderate: Enable more kernel module checks

### DIFF
--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
 
 title: 'Disable Mounting of freevxfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
 
 title: 'Disable Mounting of hfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
 
 title: 'Disable Mounting of hfsplus'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
 
 title: 'Disable Mounting of jffs2'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,ocp4
 
 title: 'Disable Mounting of udf'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
 
 title: 'Disable Mounting of FAT filesystems'
 

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -616,5 +616,11 @@ selections:
     - directory_access_var_log_audit
 
     # CM-7
-    - kernel_module_usb-storage_disabled
+    - kernel_module_freevxfs_disabled
+    - kernel_module_hfs_disabled
+    - kernel_module_hfsplus_disabled
+    - kernel_module_jffs2_disabled
     - kernel_module_squashfs_disabled
+    - kernel_module_udf_disabled
+    - kernel_module_usb-storage_disabled
+    - kernel_module_vfat_disabled


### PR DESCRIPTION
These checks are relevant to the AC-6/CM-6 controls.
