### PR TITLE
Add support to Ignition remediation type.

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -273,8 +273,8 @@ macro(ssg_build_ansible_playbooks PRODUCT)
 endmacro()
 
 macro(ssg_build_remediations PRODUCT)
-    message(STATUS "Scanning for dependencies of ${PRODUCT} fixes (bash, ansible, puppet and anaconda)...")
-    _ssg_build_remediations_for_language(${PRODUCT} "bash;ansible;puppet;anaconda")
+    message(STATUS "Scanning for dependencies of ${PRODUCT} fixes (bash, ansible, puppet, anaconda and ignition)...")
+    _ssg_build_remediations_for_language(${PRODUCT} "bash;ansible;puppet;anaconda;ignition")
 
     # only enable the ansible syntax checks if we are using openscap 1.2.17 or higher
     # older openscap causes syntax errors, see https://github.com/OpenSCAP/openscap/pull/977
@@ -305,7 +305,7 @@ macro(ssg_build_xccdf_with_remediations PRODUCT)
     string(REPLACE " " "%20" CMAKE_CURRENT_BINARY_DIR_NO_SPACES "${CMAKE_CURRENT_BINARY_DIR}")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam bash_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/bash-fixes.xml" --stringparam ansible_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ansible-fixes.xml" --stringparam puppet_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/puppet-fixes.xml" --stringparam anaconda_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/anaconda-fixes.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam bash_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/bash-fixes.xml" --stringparam ansible_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ansible-fixes.xml" --stringparam puppet_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/puppet-fixes.xml" --stringparam anaconda_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/anaconda-fixes.xml" --stringparam ignition_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ignition-fixes.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
         DEPENDS generate-internal-${PRODUCT}-xccdf-unlinked-ocilrefs.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
@@ -317,6 +317,8 @@ macro(ssg_build_xccdf_with_remediations PRODUCT)
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/puppet-fixes.xml"
         DEPENDS generate-internal-${PRODUCT}-anaconda-fixes.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/anaconda-fixes.xml"
+        DEPENDS generate-internal-${PRODUCT}-ignition-fixes.xml
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ignition-fixes.xml"
         DEPENDS "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt"
         COMMENT "[${PRODUCT}-content] generating xccdf-unlinked.xml"
     )

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ignition/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ignition/shared.yml
@@ -1,0 +1,18 @@
+# platform = multi_platform_all
+apiVersion: machineconfiguration.openshift.io/v1
+kind: Ignition
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-worker-empty-securetty
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,
+        filesystem: root
+        mode: 0600
+        path: /etc/securetty

--- a/ocp4/profiles/coreos-ncp.profile
+++ b/ocp4/profiles/coreos-ncp.profile
@@ -77,6 +77,7 @@ selections:
     #- sshd_set_keepalive
     #- sshd_enable_warning_banner
     #- sshd_rekey_limit
+    
 
     # Time Server
     - chronyd_client_only

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -2,13 +2,14 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" exclude-result-prefixes="xccdf">
 
 <!-- This transform expects stringparams "bash_remediations", "ansible_remediations", "puppet_remediations",
-     & "anaconda_remediations"
+     "anaconda_remediations", "ignition_remediations"
      specifying a filenames containing a list of remediations.  It inserts these into the Rules
      specified inside the remediations file. -->
 <xsl:param name="bash_remediations"/>
 <xsl:param name="ansible_remediations"/>
 <xsl:param name="puppet_remediations"/>
 <xsl:param name="anaconda_remediations"/>
+<xsl:param name="ignition_remediations"/>
 
 <xsl:variable name="bash_remediations_doc" select="document($bash_remediations)" />
 <xsl:variable name="bash_fixgroup" select="$bash_remediations_doc/xccdf:fix-content/xccdf:fix-group" />
@@ -26,10 +27,14 @@
 <xsl:variable name="anaconda_fixgroup" select="$anaconda_remediations_doc/xccdf:fix-content/xccdf:fix-group" />
 <xsl:variable name="anaconda_fixcommongroup" select="$anaconda_remediations_doc/xccdf:fix-content/xccdf:fix-common-group" />
 
+<xsl:variable name="ignition_remediations_doc" select="document($ignition_remediations)" />
+<xsl:variable name="ignition_fixgroup" select="$ignition_remediations_doc/xccdf:fix-content/xccdf:fix-group" />
+<xsl:variable name="ignition_fixcommongroup" select="$ignition_remediations_doc/xccdf:fix-content/xccdf:fix-common-group" />
 
 
-<xsl:variable name="fixgroups" select="$bash_fixgroup | $ansible_fixgroup | $puppet_fixgroup | $anaconda_fixgroup" />
-<xsl:variable name="fixcommongroups" select="$bash_fixcommongroup | $ansible_fixcommongroup | $puppet_fixcommongroup | $anaconda_fixcommongroup" />
+
+<xsl:variable name="fixgroups" select="$bash_fixgroup | $ansible_fixgroup | $puppet_fixgroup | $anaconda_fixgroup | $ignition_fixgroup" />
+<xsl:variable name="fixcommongroups" select="$bash_fixcommongroup | $ansible_fixcommongroup | $puppet_fixcommongroup | $anaconda_fixcommongroup | $ignition_fixcommongroup" />
 
 <xsl:template name="find-and-replace">
   <xsl:param name="text"/>
@@ -134,6 +139,10 @@
 
   <xsl:if test="$puppet_remediations='' or not($puppet_remediations_doc)">
     <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$puppet_remediations"/>".</xsl:message>
+  </xsl:if>
+
+  <xsl:if test="$ignition_remediations='' or not($ignition_remediations_doc)">
+    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$ignition_remediations"/>".</xsl:message>
   </xsl:if>
 
   <xsl:copy>

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -23,7 +23,8 @@ REMEDIATION_TO_EXT_MAP = {
     'anaconda': '.anaconda',
     'ansible': '.yml',
     'bash': '.sh',
-    'puppet': '.pp'
+    'puppet': '.pp',
+    'ignition': '.yml'
 }
 
 FILE_GENERATED_HASH_COMMENT = '# THIS FILE IS GENERATED'
@@ -95,6 +96,12 @@ def get_fixgroup_for_type(fixcontent, remediation_type):
         return ElementTree.SubElement(
             fixcontent, "fix-group", id="puppet",
             system="urn:xccdf:fix:script:puppet",
+            xmlns="http://checklists.nist.gov/xccdf/1.1")
+
+    elif remediation_type == 'ignition':
+        return ElementTree.SubElement(
+            fixcontent, "fix-group", id="ignition",
+            system="urn:xccdf:fix:script:ignition",
             xmlns="http://checklists.nist.gov/xccdf/1.1")
 
     sys.stderr.write("ERROR: Unknown remediation type '%s'!\n"
@@ -373,11 +380,18 @@ class PuppetRemediation(Remediation):
             file_path, "puppet")
 
 
+class IgnitionRemediation(Remediation):
+    def __init__(self, file_path):
+        super(IgnitionRemediation, self).__init__(
+            file_path, "ignition")
+
+
 REMEDIATION_TO_CLASS = {
     'anaconda': AnacondaRemediation,
     'ansible': AnsibleRemediation,
     'bash': BashRemediation,
     'puppet': PuppetRemediation,
+    'ignition': IgnitionRemediation,
 }
 
 
@@ -500,7 +514,9 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
             function_name "arg1" "arg2" ... "argN"
     """
 
-    if remediation_type == "ansible":
+    if remediation_type == "ignition":
+        return
+    elif remediation_type == "ansible":
         fix_text = fix.text
 
         if "(ansible-populate " in fix_text:

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -50,6 +50,7 @@ bash_system = "urn:xccdf:fix:script:sh"
 ansible_system = "urn:xccdf:fix:script:ansible"
 puppet_system = "urn:xccdf:fix:script:puppet"
 anaconda_system = "urn:redhat:anaconda:pre"
+ignition_system = "urn:xccdf:fix:script:ignition"
 cce_uri = "https://nvd.nist.gov/cce/index.cfm"
 stig_ns = "https://public.cyber.mil/stigs/srg-stig-tools/"
 stig_refs = 'https://public.cyber.mil/stigs/'

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -12,12 +12,14 @@ from ssg.constants import bash_system as bash_rem_system
 from ssg.constants import ansible_system as ansible_rem_system
 from ssg.constants import puppet_system as puppet_rem_system
 from ssg.constants import anaconda_system as anaconda_rem_system
+from ssg.constants import ignition_system as ignition_rem_system
 
 SYSTEM_ATTRIBUTE = {
     'bash': bash_rem_system,
     'ansible': ansible_rem_system,
     'puppet': puppet_rem_system,
     'anaconda': anaconda_rem_system,
+    'ignition': ignition_rem_system,
 }
 
 NAMESPACES = {


### PR DESCRIPTION
#### Description:

- Add support to Ignition remediation type


How to generate the remediation meanwhile OpenSCAP doesn't support this specific type:

`oscap xccdf generate fix --profile coreos-ncp --template urn:xccdf:fix:script:ignition  build/ssg-ocp4-ds.xml`
