### PR TITLE
Enable rules that cover AU-9 better in OCP4 moderate profile

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4
+prodtype: rhel6,rhel7,rhel8,rhv4,ocp4
 
 title: 'Verify and Correct Ownership with RPM'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4
+prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,ol7,ol8,rhv4,ocp4
 
 title: 'Verify and Correct File Permissions with RPM'
 

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -563,10 +563,12 @@ selections:
     - chronyd_or_ntpd_specify_multiple_servers
 
     # AU-9
-    #- rpm_verify_ownership
-    #- rpm_verify_permissions
+    - rpm_verify_ownership
+    - rpm_verify_permissions
     - selinux_confinement_of_daemons
-    #- ensure_logrotate_activated
+    # TODO - we should update this rule to parameterize the rotation cadence.
+    # The check curently expects it to be daily, but OCP4 nodes rotate weekly.
+    - ensure_logrotate_activated
     - file_permissions_var_log_audit
     - file_ownership_var_log_audit
     - directory_permissions_var_log_audit


### PR DESCRIPTION
This enables a few rules that pertain to the AU-9 control in the OCP4
moderate profile.  Note that the logrotate check will need to be updated
in a future patch to allow a variable for the rotation cadence, as it is
currently hardcoded to 'daily'.  AU-9 does not require a specific rotation
cadence.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
