### PR TITLE
Made the affected OVAL metadata macro-generated in shared OVALs

### DIFF
--- a/applications/openshift/api-server/api_server_anonymous_auth/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_anonymous_auth" version="1">
     <metadata>
       <title>Disable Anonymous Authentication to the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Anonymous access is allowed by default and should be disabled.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_audit_log_maxage/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxage/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_audit_log_maxage" version="1">
     <metadata>
       <title>Configure the Audit Log Maxage</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Configure audit log retention.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_audit_log_maxbackup" version="1">
     <metadata>
       <title>Configure the Maximum Retained Audit Logs</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Configure how many rotations of audit logs are retained.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_audit_log_maxsize" version="1">
     <metadata>
       <title>Configure Maximum Audit Log Size</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Configure maximum audit log size.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_audit_log_path/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_audit_log_path/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_audit_log_path" version="1">
     <metadata>
       <title>Configure the Audit Log Path</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>To enable auditing on the OpenShift API Server, the audit log path
       must be set.</description>
     </metadata>

--- a/applications/openshift/api-server/api_server_authorization_mode/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_authorization_mode/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_authorization_mode" version="1">
     <metadata>
       <title>Ensure authorization-mode is set to Webhook</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>If authorization-mode is configured, it should be set to Webhook.</description>
     </metadata>
     <criteria operator="OR">

--- a/applications/openshift/api-server/api_server_basic_auth/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_basic_auth/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_basic_auth" version="1">
     <metadata>
       <title>Disable basic-auth-file for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>basic-auth-file should not be configured on the master node.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_client_ca/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_client_ca/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_client_ca" version="1">
     <metadata>
       <title>Configure the Client Certificate Authority for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The client certificate authority should be configured in servingInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_etcd_ca/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_etcd_ca/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_etcd_ca" version="1">
     <metadata>
       <title>Configure the etcd Certificate Authority for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate authority file should be configured in etcdClientInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_etcd_cert/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_etcd_cert/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_etcd_cert" version="1">
     <metadata>
       <title>Configure the etcd Certificate for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate should be configured in etcdClientInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_etcd_key/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_etcd_key/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_etcd_key" version="1">
     <metadata>
       <title>Configure the etcd Certificate Key for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate key should be configured in etcdClientInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_insecure_bind_address/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_insecure_bind_address" version="1">
     <metadata>
       <title>Disable Use of the Insecure Bind Address</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>OpenShift should not bind to non-loopback insecure addresses.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_insecure_port/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_insecure_port/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_insecure_port" version="1">
     <metadata>
       <title>Prevent Insecure Port Access</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>All components that use the API should connect via the secured port,
     authenticate themselves, and be authorized to use the API.</description>
     </metadata>

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_kubelet_certificate_authority" version="1">
     <metadata>
       <title>Configure the kubelet Certificate Authority for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate authority file should be configured in kubeletClientInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_kubelet_client_cert" version="1">
     <metadata>
       <title>Configure the kubelet Certificate for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate file should be configured in kubeletClientInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_kubelet_client_key/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_kubelet_client_key" version="1">
     <metadata>
       <title>Configure the kubelet Certificate Key for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate key should be configured in kubeletClientInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_kubelet_https/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_kubelet_https/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_kubelet_https" version="1">
     <metadata>
       <title>Enable kubelet HTTPS connections to the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>HTTPS should be used for connections between the API Server and Kubelets.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_request_timeout/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_request_timeout/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_request_timeout" version="1">
     <metadata>
       <title>Configure the API Server Request Timeout</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>All components that use the API should connect via the secured port,
     authenticate themselves, and be authorized to use the API.</description>
     </metadata>

--- a/applications/openshift/api-server/api_server_secure_port/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_secure_port/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_secure_port" version="1">
     <metadata>
       <title>Enable the Secure Port for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>To ensure traffic is served over HTTPS, secure-port should not be zero.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_service_account_public_key/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_service_account_public_key" version="1">
     <metadata>
       <title>Configure the Service Account Public Key for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The service account public key should be configured in serviceAccountConfig.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_tls_cert/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_tls_cert/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_tls_cert" version="1">
     <metadata>
       <title>Configure the Certificate for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate file should be configured in servingInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_tls_private_key/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_tls_private_key/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_tls_private_key" version="1">
     <metadata>
       <title>Configure the Certificate Key for the API Server</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The certificate key should be configured in servingInfo.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/api-server/api_server_token_auth/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_token_auth/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="api_server_token_auth" version="1">
     <metadata>
       <title>Disable Token-based Authentication</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>token-auth-file should not be configured on the master node.</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_auto_tls/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_auto_tls/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_auto_tls" version="1">
     <metadata>
       <title>Disable etcd Self-Signed Certificates</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Ensure OpenShift is not using Self-Signed Certificates</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_cert_file/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_cert_file/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_cert_file" version="1">
     <metadata>
       <title>Ensure That etcd Client Certificate Correctly Set</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>ETCD_CERT_FILE is correctly set</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_client_cert_auth/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_client_cert_auth" version="1">
     <metadata>
       <title>Enable Client Certificate Authentication</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Ensure OpenShift has enabled Client Certificate Authentication</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_key_file/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_key_file/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_key_file" version="1">
     <metadata>
       <title>Ensure That etcd Key File Correctly Set</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>ETCD_KEY_FILE is correctly set</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_peer_auto_tls/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_peer_auto_tls" version="1">
     <metadata>
       <title>Disable etcd Peer Self-Signed Certificates</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Ensure OpenShift is not using Peer Self-Signed Certificates</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_peer_cert_file/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_peer_cert_file" version="1">
     <metadata>
       <title>Ensure etcd Peer Client Certificate is Correctly Set</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>ETCD_PEER_CERT_FILE is correctly set</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_peer_client_cert_auth" version="1">
     <metadata>
       <title>Enable Peer Client Certificate Authentication</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Ensure OpenShift has enabled Peer Client Certificate Authentication</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_peer_key_file/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_peer_key_file/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_peer_key_file" version="1">
     <metadata>
       <title>Ensure etcd Peer Client Key is Correctly Set</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>ETCD_PEER_KEY_FILE is correctly set</description>
     </metadata>
     <criteria operator="AND">

--- a/applications/openshift/etcd/etcd_unique_ca/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_unique_ca/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_unique_ca" version="1">
     <metadata>
       <title>Configure unique etcd Certificate</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Ensure OpenShift is using a unique certificate for etcd.</description>
     </metadata>
     <criteria>

--- a/applications/openshift/etcd/etcd_wal_dir/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_wal_dir/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="etcd_wal_dir" version="1">
     <metadata>
       <title>Configure etcd Log Storage</title>
-      <affected family="unix">
-        <platform>multi_platform_ocp</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Ensure OpenShift is configured to store etcd logs in a separate directory from the data.</description>
     </metadata>
     <criteria>

--- a/jre/guide/java/java_jre_configure_crypto_policy/oval/shared.xml
+++ b/jre/guide/java/java_jre_configure_crypto_policy/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="java_jre_configure_crypto_policy" version="1">
     <metadata>
       <title>Configure JRE to use System Crypto Policy.</title>
-      <affected family="unix">
-        <platform>Java Runtime Environment</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>JRE should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="chronyd_client_only" version="1">
     <metadata>
       <title>Disable chrony daemon from acting as server</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Configure the port setting in /etc/chrony.conf to disable
       server operation.</description>
     </metadata>

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="chronyd_no_chronyc_network" version="1">
     <metadata>
       <title>Disable network management of chrony daemon</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Configure the cmdport setting in /etc/chrony.conf to disable
       chronyc management connections over network.</description>
     </metadata>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="chronyd_or_ntpd_set_maxpoll" version="1">
     <metadata>
       <title>Configure Time Service Maxpoll Interval</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Configure the maxpoll setting in /etc/ntp.conf or chrony.conf
       to continuously poll the time source servers.</description>
     </metadata>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="chronyd_or_ntpd_specify_multiple_servers" version="1">
     <metadata>
       <title>Specify Multiple Remote chronyd Or ntpd NTP Servers for Time Data</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Multiple remote chronyd or ntpd NTP Servers for time synchronization should be specified (and dependencies are met)</description>
     </metadata>
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="chronyd_or_ntpd_specify_remote_server" version="1">
     <metadata>
       <title>Specify Remote NTP chronyd Or ntpd Server for Time Data</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>A remote chronyd or ntpd NTP Server for time synchronization should be specified (and dependencies are met)</description>
     </metadata>
 

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="service_chronyd_or_ntpd_enabled" version="1">
     <metadata>
       <title>Service chronyd Or Service ntpd Enabled</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>At least one of the chronyd or ntpd services should be enabled if possible.</description>
     </metadata>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="sshd_disable_rhosts_rsa" version="1">
     <metadata>
       <title>Disable SSH Support for Rhosts RSA Authentication</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>SSH can allow authentication through the obsolete rsh command
       through the use of the authenticating user's SSH keys. This should be disabled.</description>
     </metadata>

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="sssd_run_as_sssd_user" version="1">
     <metadata>
       <title>Configure SSSD to run as user sssd</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>SSSD processes should be configured to run as user sssd, not root.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/oval/shared.xml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="usbguard_allow_hid_and_hub" version="1">
     <metadata>
       <title>Check that USB human interface devices and hubs are allowed by USBGuard rules</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Check that /etc/usbguard/rules.conf contains at least one non whitespace character and exists.</description>
     </metadata>
     <criteria comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." operator="AND">

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="banner_etc_issue" version="2">
     <metadata>
       <title>System Login Banner Compliance</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The system login banner text should be set correctly.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="disable_ctrlaltdel_burstaction" version="1">
     <metadata>
       <title>Disable Ctrl-Alt-Del Burst Action</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf
       to none to prevent a reboot if Ctrl-Alt-Delete is pressed more than 7 times in 2 seconds.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
@@ -5,13 +5,7 @@
   <definition class="compliance" id="disable_ctrlaltdel_reboot" version="1">
     <metadata>
       <title>Disable Ctrl-Alt-Del Reboot Activation</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>By default, the system will reboot when the
       Ctrl-Alt-Del key sequence is pressed.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="grub2_disable_interactive_boot" version="4">
     <metadata>
       <title>Verify that Interactive Boot is Disabled</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The ability for users to perform interactive startups should
       be disabled.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="require_singleuser_auth" version="1">
     <metadata>
       <title>Require Authentication for Single-User Mode</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The requirement for a password to boot into single-user mode
       should be configured correctly.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="no_empty_passwords" version="1">
     <metadata>
       <title>No nullok Option in /etc/pam.d/system-auth</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The file /etc/pam.d/system-auth should not contain the nullok option</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="no_netrc_files" version="1">
     <metadata>
       <title>Verify No netrc Files Exist</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The .netrc files contain login information used to auto-login into FTP servers and reside in the user's home directory. Any .netrc files should be removed.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="accounts_no_uid_except_zero" version="1">
     <metadata>
       <title>UID 0 Belongs Only To Root</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Only the root account should be assigned a user id of 0.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="no_direct_root_logins" version="1">
     <metadata>
       <title>Direct root Logins Not Allowed</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Preventing direct root logins help ensure accountability for actions
       taken on the system using the root account.</description>
     </metadata>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="no_shelllogin_for_systemaccounts" version="2">
     <metadata>
       <title>System Accounts Do Not Run a Shell</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The root account is the only system account that should have
       a login shell.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="audit_rules_kernel_module_loading_delete" version="1">
     <metadata>
       <title>Audit Kernel Module Loading and Unloading - delete_module</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
@@ -2,14 +2,7 @@
   <definition class="compliance" id="audit_rules_kernel_module_loading_finit" version="1">
     <metadata>
       <title>Audit Kernel Module Loading and Unloading - finit_module</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="audit_rules_kernel_module_loading_init" version="1">
     <metadata>
       <title>Audit Kernel Module Loading and Unloading - init_module</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="audit_rules_privileged_commands" version="1">
     <metadata>
       <title>Ensure auditd Collects Information on the Use of Privileged Commands</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules about the information on the use of privileged commands are enabled.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_immutable" version="1">
     <metadata>
       <title>Make Audit Configuration Immutable</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Force a reboot to change audit rules is enabled</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_mac_modification" version="1">
     <metadata>
       <title>Record Events that Modify the System's Mandatory Access Controls</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules that detect changes to the system's mandatory access controls (SELinux) are enabled.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_media_export" version="1">
     <metadata>
       <title>Audit Information Export To Media</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules that detect the mounting of filesystems should be enabled.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_networkconfig_modification" version="1">
     <metadata>
       <title>Record Events that Modify the System's Network Environment</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The network environment should not be modified by anything other than
       administrator action. Any change to network parameters should be audited.</description>
     </metadata>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_session_events" version="1">
     <metadata>
       <title>Record Attempts to Alter Process and Session Initiation Information</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules should capture information about session initiation.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="audit_rules_sysadmin_actions" version="1">
     <metadata>
       <title>Audit System Administrator Actions</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit actions taken by system administrators on the system.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_time_adjtimex" version="1">
     <metadata>
       <title>Record Attempts to Alter Time Through Adjtimex</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Record attempts to alter time through adjtimex.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_time_clock_settime" version="2">
     <metadata>
       <title>Record Attempts to Alter Time Through Clock_settime</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Record attempts to alter time through clock_settime.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_time_settimeofday" version="1">
     <metadata>
       <title>Record Attempts to Alter Time Through Settimeofday</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Record attempts to alter time through settimeofday.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_time_stime" version="1">
     <metadata>
       <title>Record Attempts to Alter Time Through Stime</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Record attempts to alter time through stime. Note that on
       64-bit architectures the stime system call is not defined in the audit
       system calls lookup table.</description>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_time_watch_localtime" version="1">
     <metadata>
       <title>Record Attempts to Alter Time Through the Localtime File</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Record attempts to alter time through /etc/localtime.</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="directory_access_var_log_audit" version="1">
     <metadata>
       <title>Ensure auditd Collects Information Read Access to /var/log/audit</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules about the read events to /var/log/audit</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
@@ -2,10 +2,7 @@
   <definition class="compliance" id="directory_permissions_var_log_audit" version="1">
     <metadata>
       <title>Verify /var/log/audit Directory Permissions</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Checks for correct permissions for /var/log/audit.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="file_ownership_var_log_audit" version="3">
     <metadata>
       <title>Verify /var/log/audit Ownership</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Checks that all /var/log/audit files and directories are owned by the root user and group.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="file_permissions_var_log_audit" version="2">
     <metadata>
       <title>Verify /var/log/audit Permissions</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Checks for correct permissions for all log files in /var/log/audit.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_disk_error_action" version="1">
     <metadata>
       <title>Auditd Action to Take When Disk Errors</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>disk_error_action setting in /etc/audit/auditd.conf is set to a certain action</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_disk_full_action" version="1">
     <metadata>
       <title>Auditd Action to Take When Disk Is Full</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>disk_full_action setting in /etc/audit/auditd.conf is set to a certain action</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_action_mail_acct" version="2">
     <metadata>
       <title>Auditd Email Account to Notify Upon Action</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>action_mail_acct setting in /etc/audit/auditd.conf is set to a certain account</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_admin_space_left_action" version="2">
     <metadata>
       <title>Auditd Action to Take When Disk is Low on Space</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>admin_space_left_action setting in /etc/audit/auditd.conf is set to a certain action</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_flush" version="1">
     <metadata>
       <title>Auditd priority for flushing data to disk</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The setting for flush in /etc/audit/auditd.conf</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_max_log_file" version="2">
     <metadata>
       <title>Auditd Maximum Log File Size</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>max_log_file setting in /etc/audit/auditd.conf is set to at least a certain value</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_max_log_file_action" version="2">
     <metadata>
       <title>Auditd Action to Take When Maximum Log Size Reached</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>max_log_file_action setting in /etc/audit/auditd.conf is set to a certain action</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_num_logs" version="2">
     <metadata>
       <title>Auditd Maximum Number of Logs to Retain</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>num_logs setting in /etc/audit/auditd.conf is set to at least a certain value</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_space_left" version="2">
     <metadata>
       <title>Configure auditd space_left on Low Disk Space</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>space_left setting in /etc/audit/auditd.conf is set to at least a certain value</description>
     </metadata>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/oval/shared.xml
@@ -2,9 +2,7 @@
   <definition class="compliance" id="auditd_data_retention_space_left_action" version="3">
     <metadata>
       <title>Auditd Action to Take When Disk Starting to Run Low on Space</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>space_left_action setting in /etc/audit/auditd.conf is set to a certain action</description>
     </metadata>
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/oval/shared.xml
@@ -2,14 +2,7 @@
   <definition class="compliance" id="grub2_uefi_password" version="1">
     <metadata>
       <title>Set the UEFI Boot Loader Password</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The UEFI grub2 boot loader should have password protection enabled.</description>
     </metadata>
 

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
@@ -2,10 +2,7 @@
   <definition class="compliance" id="wireless_disable_interfaces" version="1">
     <metadata>
       <title>Deactivate Wireless Interfaces</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>All wireless interfaces should be disabled.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="network_nmcli_permissions" version="1">
     <metadata>
       <title>Ensure non-Privileged Users Cannot Change Network Settings</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>polkit is properly configured to prevent non-privilged users from changing networking settings</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/oval/shared.xml
@@ -2,10 +2,7 @@
   <definition class="compliance" id="disable_users_coredumps" version="1">
     <metadata>
       <title>Disable Core Dumps</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Core dumps for all users should be disabled</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="grub2_enable_selinux" version="1">
     <metadata>
       <title>Enable SELinux in the GRUB2 Bootloader"</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>
         Check if selinux=0 OR enforcing=0 within the GRUB2 configuration files, fail if found.
       </description>

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
@@ -2,15 +2,7 @@
   <definition class="compliance" id="selinux_confinement_of_daemons" version="1">
     <metadata>
       <title>Ensure No Daemons are Unconfined by SELinux</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>WRLinux 8</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>All pids in /proc should be assigned an SELinux security context other than 'initrc_t'.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="selinux_policytype" version="1">
     <metadata>
       <title>Enable SELinux</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The SELinux policy should be set appropriately.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/selinux/selinux_state/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_state/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="selinux_state" version="1">
     <metadata>
       <title>SELinux Enforcing</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The SELinux state should be enforcing the local policy.</description>
     </metadata>
     <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="dconf_gnome_disable_ctrlaltdel_reboot" version="1">
     <metadata>
       <title>Disable Ctrl-Alt-Del Reboot Key Sequence in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Disable the GNOME3 ctrl-alt-del reboot key sequence in GNOME3.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="configure_bind_crypto_policy" version="1">
     <metadata>
       <title>Configure BIND to use System Crypto Policy.</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>BIND should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="configure_crypto_policy" version="1">
     <metadata>
       <title>Configure System Cryptographic Policies</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Look for crypto policy correctly configured in /etc/crypto-policies/config, and the policy is current.</description>
     </metadata>
     <criteria operator="AND">

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
@@ -5,11 +5,7 @@
   <definition class="compliance" id="configure_kerberos_crypto_policy" version="2">
     <metadata>
       <title>Configure kerberos to use System Crypto Policy</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Kerberos should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria operator="OR" comment="The config file is always a symlink to the backend, but the backend itself may be either a file, or a symlink. For this reason, we need two tests, if one passes, the other one is expected to either fail, or error.">

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="configure_libreswan_crypto_policy" version="1">
     <metadata>
       <title>Configure Libreswan to use System Crypto Policy.</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Libreswan should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria operator="OR">

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="configure_openssl_crypto_policy" version="1">
     <metadata>
       <title>Configure OpenSSL to use System Crypto Policy</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>OpenSSL should be configured to use the system-wide crypto policy setting.</description>
     </metadata>
     <criteria>

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/oval/shared.xml
@@ -133,13 +133,7 @@
   <definition class="compliance" id="harden_ssh_client_crypto_policy" version="3">
     <metadata>
       <title>Harden SSH client Crypto Policy</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Look for specific parameters in /etc/ssh/ssh_config.d/02-ospp.conf</description>
     </metadata>
     <criteria comment="SSH client is configured correctly"

--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="enable_dracut_fips_module" version="1">
     <metadata>
       <title>Enable Dracut FIPS Module</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>fips module should be enabled in Dracut configuration</description>
     </metadata>
     <criteria operator="AND">

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -2,11 +2,7 @@
   <definition class="compliance" id="enable_fips_mode" version="1">
     <metadata>
       <title>Enable FIPS Mode</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Check if FIPS mode is enabled on the system</description>
     </metadata>
     <criteria operator="AND">

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
@@ -2,12 +2,7 @@
   <definition class="compliance" id="grub2_enable_fips_mode" version="1">
     <metadata>
       <title>Enable FIPS Mode in GRUB2</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>Oracle Linux 7</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Look for argument fips=1 in the kernel line in /etc/default/grub.</description>
     </metadata>
     <criteria operator="AND">

--- a/shared/templates/template_OVAL_accounts_password
+++ b/shared/templates/template_OVAL_accounts_password
@@ -2,12 +2,7 @@
   <definition class="compliance" id="accounts_password_pam_{{{ VARIABLE }}}" version="3">
     <metadata>
       <title>Set Password {{{ VARIABLE }}} Requirements</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The password {{{ VARIABLE }}} should meet minimum requirements</description>
     </metadata>
 {{% if product == "rhel6" %}}

--- a/shared/templates/template_OVAL_audit_rules_dac_modification
+++ b/shared/templates/template_OVAL_audit_rules_dac_modification
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_dac_modification_{{{ ATTR }}}" version="1">
     <metadata>
       <title>Audit Discretionary Access Control Modification Events - {{{ ATTR }}}</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The changing of file permissions and attributes should be audited.</description>
     </metadata>
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_file_deletion_events
+++ b/shared/templates/template_OVAL_audit_rules_file_deletion_events
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_file_deletion_events_{{{ NAME }}}" version="1">
     <metadata>
       <title>Audit File Deletion Events - {{{ NAME }}}</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The deletion of files should be audited.</description>
     </metadata>
 

--- a/shared/templates/template_OVAL_audit_rules_login_events
+++ b/shared/templates/template_OVAL_audit_rules_login_events
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_login_events_{{{ NAME }}}" version="2">
     <metadata>
       <title>Record Attempts to Alter Login and Logout Events - {{{ NAME }}}</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules should be configured to log successful and unsuccessful login and logout events.</description>
     </metadata>
 

--- a/shared/templates/template_OVAL_audit_rules_path_syscall
+++ b/shared/templates/template_OVAL_audit_rules_path_syscall
@@ -2,13 +2,7 @@
   <definition class="compliance" id="audit_rules_{{{ PATHID }}}_{{{ SYSCALL }}}" version="1">
     <metadata>
       <title>Ensure auditd Collects Write Events to {{{ PATH }}}</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules about the write events to {{{ PATH }}}</description>
     </metadata>
 

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -2,13 +2,7 @@
   <definition class="compliance" id="{{{ ID }}}" version="1">
     <metadata>
       <title>{{{ TITLE }}}</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules about the information on the use of {{{ NAME }}} is enabled.</description>
     </metadata>
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -2,12 +2,7 @@
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ NAME }}}" version="1">
     <metadata>
       <title>Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful) - {{{ NAME }}}</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.</description>
     </metadata>
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
@@ -2,13 +2,7 @@
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_o_creat" version="1">
     <metadata>
       <title>Ensure auditd Collects Information on Unsuccesful Creation Attempts to Files - {{{ SYSCALL }}} o_creat</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules about the information on the unsuccessful use of {{{ SYSCALL }}} O_CREAT is enabled.</description>
     </metadata>
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
@@ -2,13 +2,7 @@
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_o_trunc_write" version="1">
     <metadata>
       <title>Ensure auditd Collects Information on Unsuccesful Creation Attempts to Files - {{{ SYSCALL }}} o_trunc</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>Audit rules about the information on the unsuccessful use of {{{ SYSCALL }}} O_TRUNC is enabled.</description>
     </metadata>
 

--- a/shared/templates/template_OVAL_mount_option_removable_partitions
+++ b/shared/templates/template_OVAL_mount_option_removable_partitions
@@ -2,12 +2,7 @@
   <definition class="compliance" id="mount_option_{{{ MOUNTOPTION }}}_removable_partitions" version="4">
     <metadata>
       <title>Add {{{ MOUNTOPTION }}} Option to Removable Media Partitions</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The {{{ MOUNTOPTION }}} option should be enabled for all removable devices mounts in /etc/fstab.</description>
     </metadata>
     <criteria operator="OR">


### PR DESCRIPTION
As we have filename-based distinction between different products
i.e. shared.xml vs fedora.xml, manual enumeration inside shared
check files is redundant and error-prone.


So far done for rules that are included in OCP4 profiles, as we don't have consistent rule applicability and prodtypes in all rules, so it can happen that the affected autogeneration hits extend definitions.

