### PR TITLE
Add rules related to AU-11 for OCP4 moderate profile

### DIFF
--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -578,6 +578,7 @@ selections:
     # AU-11
     - auditd_data_retention_num_logs
     - auditd_data_retention_max_log_file
+    - auditd_data_retention_flush
 
     # AC-2(3)
     - account_disable_post_pw_expiration


### PR DESCRIPTION
For the AU-11 control, we should check the flush option is set via
the auditd_data_retention_flush rule in the OCP4 moderate profile.