### PR TITLE
ocp4/moderate: Remove check for AIDE package

### DIFF
--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -187,7 +187,9 @@ selections:
 
     ### Install Required Packages
     #- package_sssd-ipa_installed
-    - package_aide_installed
+    # We won't check AIDE directly, we'll need to check cluster-wide for the
+    # file-integrity-operator
+    # package_aide_installed
     - package_firewalld_installed
     - package_iptables_installed
     #- package_libcap-ng-utils_installed


### PR DESCRIPTION
AIDE will run in openshift as an operator, so no need to check the
package in the node.
