### PR TITLE
Fix comments for kerberos_disable_no_keytab.

### DIFF
--- a/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/oval/shared.xml
+++ b/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/oval/shared.xml
@@ -16,11 +16,11 @@
     </criteria>
   </definition>
 
-  <unix:file_object id="obj_kerberos_disable_no_keytab" version="1" comment="fapolicyd.mounts">
+  <unix:file_object id="obj_kerberos_disable_no_keytab" version="1" comment="Default Kerberos keytab file">
     <unix:filepath operation="pattern match">^/etc/.+\.keytab$</unix:filepath>
   </unix:file_object>
   <unix:file_test id="test_kerberos_disable_no_keytab" check="all" check_existence="none_exist" version="1"
-    comment="Ensure a keytab file exists">
+    comment="Ensure keytab file does not exist">
     <unix:object object_ref="obj_kerberos_disable_no_keytab"/>
   </unix:file_test>
 </def-group>


### PR DESCRIPTION
#### Description:

- Fix comments for kerberos_disable_no_keytab.

#### Rationale:

- The first comment seems to have been wrong copy&paste.
- The second comment described exactly the opposite what the file_test does.