### PR TITLE
Print out where a Jinja expansion may have gone wrong

### DIFF
--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -106,10 +106,10 @@ def open_and_expand(yaml_file, substitutions_dict=None):
     try:
         yaml_contents = _open_yaml(expanded_template, yaml_file, substitutions_dict)
     except yaml.scanner.ScannerError as e:
-        print("A Jinja template expansion may mess up the indentation.")
+        print("A Jinja template expansion can mess up the indentation.")
         print("Please, check if the contents below are correctly expanded:")
-        print(f"Source yaml: {yaml_file}")
-        print(f"Expanded yaml: {expanded_template}")
+        print("Source yaml: {}".format(yaml_file))
+        print("Expanded yaml:\n{}".format(expanded_template))
         sys.exit(1)
 
     return yaml_contents

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -103,7 +103,15 @@ def open_and_expand(yaml_file, substitutions_dict=None):
         substitutions_dict = dict()
 
     expanded_template = process_file(yaml_file, substitutions_dict)
-    yaml_contents = _open_yaml(expanded_template, yaml_file, substitutions_dict)
+    try:
+        yaml_contents = _open_yaml(expanded_template, yaml_file, substitutions_dict)
+    except yaml.scanner.ScannerError as e:
+        print("A Jinja template expansion may mess up the indentation.")
+        print("Please, check if the contents below are correctly expanded:")
+        print(f"Source yaml: {yaml_file}")
+        print(f"Expanded yaml: {expanded_template}")
+        sys.exit(1)
+
     return yaml_contents
 
 


### PR DESCRIPTION

#### Description:

- Stop building and print contents of the file when loading a yaml file throws `yaml.scanner.ScannerError`.

#### Rationale:
- A Jinja macro or variable expansion may mess up with a yaml file indentations.

#### Notes

Compare outputs before the patch:
```
Exception while handling file: /home/wsato/git/content/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
Traceback (most recent call last):
  File "/home/wsato/git/content/build-scripts/yaml_to_shorthand.py", line 89, in <module>
    main()
  File "/home/wsato/git/content/build-scripts/yaml_to_shorthand.py", line 71, in main
    loader.process_directory_tree(benchmark_root, add_content_dirs)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1141, in process_directory_tree
    self._load_group_process_and_recurse(start_dir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1134, in _load_group_process_and_recurse
    self._recurse_into_subdirs()
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1147, in _recurse_into_subdirs
    loader.process_directory_tree(subdir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1141, in process_directory_tree
    self._load_group_process_and_recurse(start_dir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1134, in _load_group_process_and_recurse
    self._recurse_into_subdirs()
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1147, in _recurse_into_subdirs
    loader.process_directory_tree(subdir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1141, in process_directory_tree
    self._load_group_process_and_recurse(start_dir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1134, in _load_group_process_and_recurse
    self._recurse_into_subdirs()
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1147, in _recurse_into_subdirs
    loader.process_directory_tree(subdir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1141, in process_directory_tree
    self._load_group_process_and_recurse(start_dir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1134, in _load_group_process_and_recurse
    self._recurse_into_subdirs()
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1147, in _recurse_into_subdirs
    loader.process_directory_tree(subdir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1141, in process_directory_tree
    self._load_group_process_and_recurse(start_dir)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1135, in _load_group_process_and_recurse
    self._process_rules()
  File "/home/wsato/git/content/ssg/build_yaml.py", line 1181, in _process_rules
    rule = Rule.from_yaml(rule_yaml, self.env_yaml)
  File "/home/wsato/git/content/ssg/build_yaml.py", line 763, in from_yaml
    yaml_contents = open_and_macro_expand(yaml_file, env_yaml)
  File "/home/wsato/git/content/ssg/yaml.py", line 116, in open_and_macro_expand
    return open_and_expand(yaml_file, substitutions_dict)
  File "/home/wsato/git/content/ssg/yaml.py", line 106, in open_and_expand
    yaml_contents = _open_yaml(expanded_template, yaml_file, substitutions_dict)
  File "/home/wsato/git/content/ssg/yaml.py", line 73, in _open_yaml
    raise e
  File "/home/wsato/git/content/ssg/yaml.py", line 48, in _open_yaml
    yaml_contents = yaml.load(stream, Loader=yaml_SafeLoader)
  File "/usr/lib64/python3.7/site-packages/yaml/__init__.py", line 114, in load
    return loader.get_single_data()
  File "/usr/lib64/python3.7/site-packages/yaml/constructor.py", line 41, in get_single_data
    node = self.get_single_node()
  File "ext/_yaml.pyx", line 707, in _yaml.CParser.get_single_node
  File "ext/_yaml.pyx", line 725, in _yaml.CParser._compose_document
  File "ext/_yaml.pyx", line 776, in _yaml.CParser._compose_node
  File "ext/_yaml.pyx", line 892, in _yaml.CParser._compose_mapping_node
  File "ext/_yaml.pyx", line 905, in _yaml.CParser._parse_next_event
yaml.scanner.ScannerError: while scanning a simple key
  in "<unicode string>", line 23, column 1
could not find expected ':'
  in "<unicode string>", line 27, column 1
ninja: build stopped: subcommand failed.
```
And after the patch:
```
Exception while handling file: /home/wsato/git/content/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
A Jinja template expansion may mess up the indentation.
Please, check if the contents below are correctly expanded:
Source yaml: /home/wsato/git/content/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
Expanded yaml: documentation_complete: true

prodtype: wrlinux1019,rhel7,rhel8

title: 'Configure firewalld To Rate Limit Connections'

description: |-
    Create a direct firewall rule to protect against DoS attacks with the following
    command:
    <pre>$ sudo firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j ACCEPT</pre>

rationale: |-
    DoS is a condition when a resource is not available for legitimate users. When
    this occurs, the organization either cannot accomplish its mission or must
    operate at degraded capacity.
    <br /><br />
    This requirement addresses the configuration of
    the operating system to mitigate the impact of DoS attacks that have occurred or
    are ongoing on system availability. For each system, known and potential DoS
    attacks must be identified and solutions for each type implemented. A variety of
    technologies exist to limit or, in some cases, eliminate the effects of DoS
    attacks (e.g., limiting processes or establishing memory partitions). Employing
Deliberately introduced indentation error
    increased capacity and bandwidth, combined with service redundancy, may reduce
    the susceptibility to some DoS attacks.

severity: medium

identifiers:
    cce@rhel7: 80542-4

references:
    disa: "2385"
    nist: SC-5,SC-5(1),SC-5(2),SC-5(3)(a),CM-6(a)
    srg: SRG-OS-000420-GPOS-00186
    vmmsrg: SRG-OS-000420-VMM-001690
    stigid@rhel7: "040510"

ocil_clause: 'firewalld is not rate limiting connections'

ocil: |-
    To verify the operating system protects against or limits the effects of DoS
    attacks by ensuring the operating system is implementing rate-limiting measures
    on impacted network interfaces, run the following command:
    <pre>$ sudo firewall-cmd --permanent --direct --get-rules ipv4 filter INPUT_direct</pre>
    The output should return:
    <pre>0 -p tcp -m limit --limit 25/minute --limit-burst 100 -j ACCEPT</pre>
ninja: build stopped: subcommand failed.
```