### PR TITLE
Create script to build datastream images from source

### DIFF
--- a/ocp-resources/ds-build.yaml
+++ b/ocp-resources/ds-build.yaml
@@ -1,0 +1,28 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: "openscap-$PRODUCT-ds" 
+  namespace: openshift-compliance
+---
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: "openscap-$PRODUCT-ds" 
+  namespace: openshift-compliance
+spec:
+  runPolicy: "Serial" 
+  triggers: 
+    -
+      type: "ImageChange"
+  source: 
+    dockerfile: |
+      FROM registry.access.redhat.com/ubi8/ubi-minimal
+      WORKDIR /
+      COPY ssg-$PRODUCT-ds.xml .
+  strategy: 
+    dockerStrategy:
+      noCache: true
+  output: 
+    to:
+      kind: "ImageStreamTag"
+      name: "openscap-$PRODUCT-ds:latest"

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+product=$1
+
+root_dir=$(git rev-parse --show-toplevel)
+
+# build the product's content
+"$root_dir/build_product" "$product"
+
+# Ensure openshift-compliance namespace exists. If it already exists, this is
+# not a problem.
+oc adm new-project openshift-compliance || true
+
+# Create buildconfig and ImageStream
+# This enables us to create a configuration so we can build a container
+# with the datastream
+# If they already exist, this is not a problem
+cat ocp-resources/ds-build.yaml | sed "s/\$PRODUCT/$product/" | oc create -f - || true
+
+# Start build
+oc start-build -n openshift-compliance "openscap-$product-ds" --from-file="build/ssg-$product-ds.xml"
+
+latest_build=$(oc get --no-headers buildconfigs "openscap-$product-ds" | awk '{print $4}')
+
+while true; do
+    build_status=$(oc get builds --no-headers "openscap-$product-ds-$latest_build" | awk '{print $4}')
+
+    if [ "$build_status" == "Complete" ]; then
+        # Get built image
+        image=$(oc get imagestreams --no-headers | awk '{printf "%s:%s",$2, $3}')
+
+        echo "Success!"
+        echo "********"
+        echo "Your image is available at: $image"
+        exit 0
+    elif [ "$build_status" == "Error" ]; then
+        echo "Error!"
+        echo "******"
+        echo "Check the logs"
+        exit 1
+    fi
+    echo "Retrying... build status is still: $build_status"
+done
+


### PR DESCRIPTION
This script runs the build_product script (taking the product as a
parameter), and it pushes the `ssg-$PRODUCT-ds.xml` file to a container.

The container is created by using a BuildConfig and an ImageStream,
these are updated by pushing the local XML file to the container build.

This is just one step of the build process which helps with local
development. In further iterations, I'll create a BuildConfig that builds
inside a container as opposed to requiring a local file.

Example:

    ./utils/build_ds_container.sh ocp4
