### PR TITLE
Revert "Added machine-only CPEs to a subset of rules requiring non-virtualized systems"

### DIFF
--- a/linux_os/guide/services/base/package_abrt_removed/rule.yml
+++ b/linux_os/guide/services/base/package_abrt_removed/rule.yml
@@ -19,8 +19,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine
-
 identifiers:
     cce@rhel7: 81040-8
     cce@rhel8: 80948-3

--- a/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
@@ -14,8 +14,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine
-
 ocil: '{{{ ocil_service_disabled(service="cockpit") }}}'
 
 ocil_clause: 'it is not disabled'

--- a/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
+++ b/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
@@ -21,8 +21,6 @@ rationale: |-
 
 severity: high
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 80442-7
 

--- a/linux_os/guide/services/docker/docker_storage_configured/rule.yml
+++ b/linux_os/guide/services/docker/docker_storage_configured/rule.yml
@@ -18,8 +18,6 @@ rationale: |-
 
 severity: low
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 80441-9
 

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/group.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/group.yml
@@ -8,5 +8,3 @@ description: |-
     All of these daemons run with elevated privileges, and many listen for network
     connections. If they are not needed, they should be disabled to improve system
     security posture.
-
-platform: machine

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
@@ -24,6 +24,8 @@ identifiers:
 references:
     cis: 2.2.7
 
+platform: machine
+
 template:
     name: service_disabled
     vars:

--- a/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
@@ -15,8 +15,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: 82988-7
     cce@ocp4: 82465-6

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/rule.yml
@@ -15,8 +15,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: 82840-0
     cce@ocp4: 82466-4

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -21,8 +21,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 80439-3
     cce@ocp4: 82684-2

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -37,8 +37,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 27012-4
     cce@rhel8: 80764-4

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -36,8 +36,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 27278-1
     cce@rhel8: 80765-1

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -35,8 +35,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 27444-9
     cce@rhel8: 80874-1

--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -17,8 +17,6 @@ identifiers:
     cce@rhel7: 80363-5
     cce@rhel8: 82440-9
 
-platform: machine
-
 references:
     nist: CM-6(a),IA-5(10)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -27,8 +27,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 80570-5
     cce@rhel8: 80909-5

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
@@ -22,8 +22,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 82445-8
     cce@rhel7: 80364-3

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
@@ -19,8 +19,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 82447-4
     cce@rhel7: 80365-0

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
@@ -20,8 +20,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 82441-7
     cce@rhel7: 80366-8

--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
@@ -14,8 +14,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine
-
 identifiers:
     cce@rhel8: 82853-3
     cce@ocp4: 82537-2

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -32,8 +32,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 27440-7
     cce@rhel7: 80207-4

--- a/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
@@ -22,8 +22,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The oscap interface probe doesn't support offline mode
-
 identifiers:
     cce@rhel6: 27152-8
     cce@rhel7: 80174-6

--- a/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
@@ -16,8 +16,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine
-
 identifiers:
     cce@rhel8: 82881-4
     cce@ocp4: 82530-7

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -22,8 +22,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The oscap sysctl probe doesn't support offline mode
-
 identifiers:
     cce@hrel6: 27007-4
     cce@rhel7: 27211-2

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
@@ -17,8 +17,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine
-
 references:
     anssi: NT28(R12)
 

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -26,8 +26,6 @@ rationale: |-
 
 severity: high
 
-platform: machine  # The check uses syscyl_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: 80942-6
     cce@ocp4: 82540-6

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
@@ -19,8 +19,6 @@ rationale: |-
 
 severity: high
 
-platform: machine  # The oscap sysctl probe doesn't support offline mode
-
 identifiers:
     cce@rhel7: 80658-8
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
@@ -13,8 +13,6 @@ rationale: |-
 
 severity: low
 
-platform: machine
-
 identifiers:
     cce@rhel6: 82928-3
     cce@rhel7: 82927-5


### PR DESCRIPTION
Reverts ComplianceAsCode/content#5104

That PR incorrectly marked many rules as only applicable to bare metal deployments.