### PR TITLE
add service_auditd_enabled ignition remediation

### DIFF
--- a/linux_os/guide/system/auditing/service_auditd_enabled/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/ignition/shared.yml
@@ -1,0 +1,11 @@
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+      - name: auditd.service
+        enabled: true


### PR DESCRIPTION
I've been testing this out but it's not working yet;  First I logged into a node and ran `systemctl disable auditd` to test this out. The scan runs, but there's no hit for the disabled systemd unit. I poked around for the service disable code, I noticed the following in the jinja macros:
```
{{%- macro systemd_ocil_service_disabled(service) %}}
    To check that the <code>{{{ service }}}</code> service is disabled in system boot configuration, run the following command:
    <pre>$ systemctl is-enabled <code>{{{ service }}}</code></pre>
    Output should indicate the <code>{{{ service }}}</code> service has either not been installed,
    or has been disabled at all runlevels, as shown in the example below:
    <pre>$ systemctl is-enabled <code>{{{ service }}}</code><br/> disabled</pre>

    Run the following command to verify <code>{{{ service }}}</code> is not active (i.e. not running) through current runtime configuration:
    <pre>$ systemctl is-active {{{ service }}}</pre>

    If the service is not running the command will return the following output:
    <pre>inactive</pre>

    By default the service will also be masked, to check that the <code>{{{ service }}}</code> is masked, run the following command:
    <pre>$ systemctl show <code>{{{ service }}}</code> | grep "LoadState\|UnitFileState"</pre>

    If the service is masked the command will return the following outputs:

    <pre>LoadState=masked</pre>

    <pre>UnitFileState=masked</pre>

{{%- endmacro %}}


{{%- macro systemd_ocil_service_enabled(service) %}}
    Run the following command to determine the current status of the
    <code>{{{ service }}}</code> service:
    <pre>$ systemctl is-active {{{ service }}}</pre>
    If the service is running, it should return the following: <pre>active</pre>
{{%- endmacro %}}
```

The service_disabled macro checks that the systemd unit is disabled, I was basically expecting the inverse for service_enabled, but it's a running check instead. I thought this might be why the check did not work, so I then tried killing auditd (making systemctl is-active return "inactive"), but no dice. I think I'm missing something else here.. 
/cc @JAORMX @jhrozek  