### PR TITLE
Fix regular expression for RHCOS 4.4 OVAL check (test_rhel8_coreos)

### DIFF
--- a/shared/checks/oval/installed_OS_is_rhel8.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8.xml
@@ -51,7 +51,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_rhel8_coreos" version="1">
     <ind:filepath>/etc/os-release</ind:filepath>
-    <ind:pattern operation="pattern match">^PRETTY_NAME=&quot;Red Hat Enterprise Linux CoreOS \d+\.(\d)\d+\.\d+\.\d+ \([\w\s]+\)&quot;$</ind:pattern>
+    <ind:pattern operation="pattern match">^PRETTY_NAME=&quot;Red Hat Enterprise Linux CoreOS \d+\.(\d)\d+\.[\d\.\-]+ \([\w\s]+\)&quot;$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_rhel8_coreos" version="1">


### PR DESCRIPTION
RHCOS 4.4 now has a dash in the tailing part of the version string.

Fixes #5161.