### PR TITLE
fix regex in accounts_passwords_pam_faillock_deny

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
@@ -101,7 +101,7 @@
   <!-- step 5 -->
   <local_variable id="var_accounts_passwords_pam_faillock_preauth_default_lines_regex_password-auth" datatype="string" version="1" comment="Regex containing skipped lines">
     <concat>
-      <literal_component datatype="string">pam_unix(?:.*[\n](?:.*[\n]){</literal_component>
+      <literal_component datatype="string">^[^#]*pam_unix(?:.*[\n](?:.*[\n]){</literal_component>
       <object_component item_field="subexpression" object_ref="object_accounts_passwords_pam_faillock_lines_value_password-auth" />
       <literal_component datatype="string">})(?:.*[\n])*auth.*pam_faillock.so[\s]+[^\n]*deny=([0-9]+)</literal_component>
     </concat>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_config_skip_longer_comment
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_config_skip_longer_comment
@@ -1,8 +1,8 @@
 # This pam config allows pam_unix to skip past pam_faillock
-# But by mentioning pam_unix in the comment here, it triggers
+# But by mentioning auth something pam_unix in the comment here, it triggered
 # https://bugzilla.redhat.com/show_bug.cgi?id=1549671
 
-auth        required      pam_env.so
+auth        required      pam_env.so # and the comment can be also inline and mention auth pam_unix and it passes
 auth        required      pam_faildelay.so delay=2000000
 auth        required      pam_faillock.so preauth silent deny=3 unlock_time=1200
 auth        [success=done ignore=ignore default=3]    pam_unix.so nullok try_first_pass


### PR DESCRIPTION
#### Description:

oval is updated to ignore mentions of pam_unix in commented lines
test is updated to showcase that it works also for inline comments

#### Rationale:

In case some comment contained string "pam_unix", a rule might have been evaulated as passed although the PAM configuration was not correct.
