### PR TITLE
Add rsyslog TLS configuration to STIG

### DIFF
--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -33,3 +33,9 @@ selections:
     - encrypt_partitions
     - sysctl_net_ipv4_tcp_syncookies
     - clean_components_post_updating
+
+    # Configure TLS for remote logging
+    - package_rsyslog_installed
+    - package_rsyslog-gnutls_installed
+    - rsyslog_remote_tls
+    - rsyslog_remote_tls_cacert


### PR DESCRIPTION
#### Description:

- Add rules to configure TLS communication in rsyslog

#### Rationale:

- Maintains the baseline after change in underlying profile
- Follow up from: https://github.com/ComplianceAsCode/content/pull/5158
