### PR TITLE
Re-add configure_firewalld_rate_limiting to rhel7 stig profile

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -252,7 +252,7 @@ selections:
     - sshd_use_priv_separation
     - sshd_disable_compression
     - chronyd_or_ntpd_set_maxpoll
-    - sysctl_net_ipv4_tcp_invalid_ratelimit
+    - configure_firewalld_rate_limiting
     - service_firewalld_enabled
     - display_login_attempts
     - no_user_host_based_files


### PR DESCRIPTION
#### Description:

- Re-add configure_firewalld_rate_limiting to rhel7 stig profile

#### Rationale:

- configure_firewalls_rate_limiting handles all types of connections (which is expected) whereas sysctl_net_ipv4_tcp_invalid_ratelimit is for only invalid tcp connections
