### PR TITLE
Add and fix few entries of SRG mapping.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     ospp: FIA_AFL.1
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil: |-
     To determine whether the SSH service is configured to use strong entropy seed,

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -37,6 +37,7 @@ references:
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS05.02,DSS05.05,DSS06.06
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4,A.9.1.2
     cis-csc: 11,14,3,9
+    srg: SRG-OS-000096-GPOS-00050
 
 {{{ complete_ocil_entry_module_disable(module="dccp") }}}
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
+    srg: SRG-OS-000368-GPOS-00154
 
 platform: machine
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -34,7 +34,7 @@ references:
     nist-csf: PR.AC-7
     ospp: FMT_MOF_EXT.1
     pcidss: Req-8.1.8
-    srg: OS-SRG-000029-GPOS-00010
+    srg: SRG-OS-000029-GPOS-00010
     stigid@rhel7: "010110"
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -35,7 +35,7 @@ references:
     nist-csf: PR.AC-7
     ospp: FMT_MOF_EXT.1
     pcidss: Req-8.1.8
-    srg: SRG-OS-000028-GPOS-00009,OS-SRG-000030-GPOS-00011
+    srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@rhel7: "010060"
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     ospp: FIA_AFL.1
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil: |-
     To determine whether OpenSSL is wrapped by a shell function that ensures that every invocation

--- a/linux_os/guide/system/software/system-tools/package_dnf-plugin-subscription-manager_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_dnf-plugin-subscription-manager_installed/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     ospp: FPT_TUD_EXT.1,FPT_TUD_EXT.2
+    srg: SRG-OS-000366-GPOS-00153
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/software/system-tools/package_pigz_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_pigz_removed/rule.yml
@@ -18,6 +18,9 @@ severity: low
 identifiers:
     cce@rhel8: 82397-1
 
+references:
+    srg: SRG-OS-000433-GPOS-00192
+
 {{{ complete_ocil_entry_package(package="pigz") }}}
 
 template:


### PR DESCRIPTION
#### Description:

- Add and fix SRG mapping

#### Rationale:

- STIG profiles of RHEL7 and RHEL8 only contain rules that have SRG mapped

There are still few missing SRG's that need to be identified and mapped properly, here is the list:

RHEL8:
~`package_dnf-plugin-subscription-manager_installed`~ addressed in 31101d1 
`package_gnutls-utils_installed` issue filed for this rule https://github.com/ComplianceAsCode/content/issues/5172
`package_nss-tools_installed` issued filed for this rule https://github.com/ComplianceAsCode/content/issues/5172
~`package_pigz_removed`~ addressed in 477eb05 
~`sshd_use_strong_rng`~ addressed in 8c38980
~`openssl_use_strong_entropy`~ addressed in 8c38980

RHEL7:
```
dconf_db_up_to_date
```

Fixes: #5169