### PR TITLE
Set no_extra_spaces when enabling gpgcheck

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
@@ -18,6 +18,7 @@
     section: main
     option: gpgcheck
     value: 1
+    no_extra_spaces: yes
     create: False
   when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or yum_config_file.stat.exists)
 
@@ -27,5 +28,6 @@
     section: main
     option: gpgcheck
     value: 1
+    no_extra_spaces: yes
     create: False
   when: ansible_distribution == "Fedora"


### PR DESCRIPTION
#### Description:

- Set no_extra_spaces when enabling gpgcheck

#### Rationale:

- /etc/yum.conf generally does not use spaces around the =.  Currently I get:

```
--- before: /etc/yum.conf (content)
+++ after: /etc/yum.conf (content)
@@ -6,7 +6,7 @@
 logfile=/var/log/yum.log
 exactarch=1
 obsoletes=1
-gpgcheck=1
+gpgcheck = 1
 plugins=1
 installonly_limit=3
 localpkg_gpgcheck = 1
```