### PR TITLE
create checks for (grub2|uefi)_no_removeable_media

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/oval/shared.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_config_file(path='/boot/grub2/grub.cfg', prefix_regex='^[ \\t]*', parameter='set root', separator_regex='=', value="'(?!fd)(?!cd)(?!usb).*'", missing_parameter_pass=false, missing_config_file_fail=true) }}}

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: wrlinux1019,rhel7,rhel8,ol7,ol8,rhv4
 
-title: 'Boat Loader Is Not Installed On Removeable Media'
+title: 'Boot Loader Is Not Installed On Removeable Media'
 
 description: |-
     The system must not allow removable media to be used as the boot loader.

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/cd.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/cd.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat > /boot/grub2/grub.cfg << EOM
+set root='cd'
+EOM

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/cd.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/cd.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 cat > /boot/grub2/grub.cfg << EOM
 set root='cd'

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat > /boot/grub2/grub.cfg << EOM
+set root='hd0,msdos1'
+EOM

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 cat > /boot/grub2/grub.cfg << EOM
 set root='hd0,msdos1'

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/fd.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/fd.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat > /boot/grub2/grub.cfg << EOM
+set root='fd0,msdos1'
+EOM

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/fd.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/fd.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 cat > /boot/grub2/grub.cfg << EOM
 set root='fd0,msdos1'

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/no_such_line.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/no_such_line.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 cat > /boot/grub2/grub.cfg << EOM
 some random line

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/no_such_line.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/no_such_line.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cat > /boot/grub2/grub.cfg << EOM
+some random line
+not set root
+EOM

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/usb.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/usb.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 cat > /boot/grub2/grub.cfg << EOM
 set root='usb0,1'

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/usb.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/tests/usb.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat > /boot/grub2/grub.cfg << EOM
+set root='usb0,1'
+EOM

--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/oval/shared.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_config_file(path='/boot/efi/EFI/redhat/grub.cfg', prefix_regex='^[ \\t]*', parameter='set root', separator_regex='=', value="'(?!fd)(?!cd)(?!usb).*'", missing_parameter_pass=false, missing_config_file_fail=true) }}}

--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel7,rhel8
 
-title: 'UEFI Boat Loader Is Not Installed On Removeable Media'
+title: 'UEFI Boot Loader Is Not Installed On Removeable Media'
 
 description: |-
     The system must not allow removable media to be used as the boot loader.


### PR DESCRIPTION
#### Description:

Created oval checks for rules grub2_no_removeable_media and uefi_no_removeable_media. Created test only for one instance as the checks are the same, only the file path is different. Fixed rule titles, although Boat Loader is nice, it is not correct.

#### Rationale:

Rules were missing checks.
