### PR TITLE
Permit enforcement of nosuid on /var

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: rhel6,rhel7,rhel8,fedora
+
+title: 'Add nosuid Option to /var'
+
+description: |-
+    The <tt>nosuid</tt> mount option can be used to prevent
+    execution of setuid programs in <tt>/var</tt>. The SUID and SGID permissions
+    should not be required for this directory.
+    {{{ describe_mount(option="nosuid", part="/var") }}}
+
+rationale: |-
+    The presence of SUID and SGID executables should be tightly controlled.
+
+{{{ complete_ocil_entry_mount_option("/var", "nosuid") }}}
+
+severity: unknown
+
+platform: machine
+
+template:
+    name: mount_option
+    vars:
+        mountpoint: /var
+        mountoption: nosuid
+        mount_has_to_exist: 'yes'


### PR DESCRIPTION
#### Description:

The use of SUID binaries from `/var` strikes me as terribly odd.

#### Rationale:

My super quick scan of Fedora 31 shows no SUID binaries in `/var` so adding a rule to permit marking this partition as `nosuid` should be fairly safe while adding additional safeguards should one of the various daemons writing to `/var` attempt something tricky.