### PR TITLE
Permit setting sshd GSSAPI to yes

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/rule.yml
@@ -1,0 +1,38 @@
+documentation_complete: true
+
+title: 'Enable GSSAPI Authentication'
+
+description: |-
+    Sites setup to use Kerberos or other GSSAPI Authenticaion require setting
+    sshd to accept this authentication.
+    To enable GSSAPI authentication, add or correct the following line in the
+    <tt>/etc/ssh/sshd_config</tt> file:
+    <pre>GSSAPIAuthentication yes</pre>
+
+rationale: |-
+    Kerberos authentication for SSH is often implemented using GSSAPI. If
+    Kerberos is enabled through SSH, the SSH daemon provides a means of access
+    to the system's Kerberos implementation. Vulnerabilities in the system's
+    Kerberos implementations may be subject to exploitation.
+
+    For enterprises, Kerberos is often enabled and used with GSSAPI for 
+    centralized user account management which may necessitate enabling of
+    GSSAPI functionality in SSH. 
+
+severity: medium
+
+ocil_clause: 'it is commented out or is not enabled'
+
+ocil: |-
+    To check if GSSAPIAuthentication is enabled or set correctly, run the following
+    command:
+    <pre>$ sudo grep GSSAPIAuthentication /etc/ssh/sshd_config</pre>
+    If configured properly, output should be <pre>yes</pre>
+
+template:
+    name: sshd_lineinfile
+    vars:
+        missing_parameter_pass: 'false'
+        parameter: GSSAPIAuthentication
+        rule_id: sshd_enable_gssapi_auth
+        value: 'yes'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/tests/correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if grep -q "^GSSAPIAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^GSSAPIAuthentication.*/GSSAPIAuthentication yes/" /etc/ssh/sshd_config
+else
+	echo "GSSAPIAuthentication yes" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/tests/line_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i "/^GSSAPIAuthentication.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/tests/wrong_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if grep -q "^GSSAPIAuthentication" /etc/ssh/sshd_config; then
+	sed -i "s/^GSSAPIAuthentication.*/GSSAPIAuthentication no/" /etc/ssh/sshd_config
+else
+	echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
+fi


### PR DESCRIPTION
#### Description:

Set GSSAPIAuth to enabled for SSHD

#### Rationale:

Sites using Kerberos/GSSAPI would benefit from having a rule to ensure GSSAPI is enabled.