### PR TITLE
Remove krb5-server

### DIFF
--- a/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
+++ b/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: ol7,ol8,rhel6,rhel7,rhel8
+
+title: 'Remove the Kerberos Server Package'
+
+description: |-
+    The <tt>krb5-server</tt> package should be removed if not in use.
+    Is this system the Kerberos server? If not, remove the package.
+    {{{ describe_package_remove(package="krb5-server") }}}
+    The krb5-server RPM is not installed by default on a {{{ full_name }}}
+    system. It is needed only by the Kerberos servers, not by the
+    clients which use Kerberos for authentication. If the system is not
+    intended for use as a Kerberos Server it should be removed.
+
+rationale: |-
+    Unnecessary packages should not be installed to decrease the attack
+    surface of the system.  While this software is clearly essential on an KDC
+    server, it is not necessary on typical desktop or workstation systems.
+
+severity: low
+
+ocil_clause: 'the package is installed'
+
+ocil: '{{{ ocil_package(package="krb5-server") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: krb5-server


### PR DESCRIPTION
#### Description:

The krb5-server packages are not required in most instances, but can be problematic in unexpected places.

#### Rationale:

Similar to "remove the ldap servers if you don't need them", the kerberos-server packages can provide confusion and possibly setup rogue authentication.