### PR TITLE
network_host_and_router_parameters group as machine-only

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/group.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/group.yml
@@ -6,3 +6,5 @@ description: |-
     Certain kernel parameters should be set for systems which are
     acting as either hosts or routers to improve the system's ability defend
     against certain types of IPv4 protocol attacks.
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
@@ -43,8 +43,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.accept_redirects", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
@@ -44,8 +44,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.accept_source_route", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
@@ -40,8 +40,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.log_martians", value="1") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -39,8 +39,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.rp_filter", value="1") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
@@ -37,8 +37,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.secure_redirects", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
@@ -42,8 +42,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.accept_redirects", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
@@ -44,8 +44,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.accept_source_route", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
@@ -35,8 +35,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.log_martians", value="1") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
@@ -38,8 +38,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.rp_filter", value="1") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
@@ -37,8 +37,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.secure_redirects", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
@@ -41,8 +41,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.icmp_echo_ignore_broadcasts", value="1") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
@@ -35,8 +35,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.icmp_ignore_bogus_error_responses", value="1") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
@@ -42,8 +42,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.tcp_syncookies", value="1") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:


### PR DESCRIPTION
#### Description:
Add machine-only platform to `network_host_and_router_parameters` `group.yml`  and remove platforms from all rules in the group (it does not need to be defined in both places).

#### Rationale:
All rules in `network_host_and_router_parameters` group should be machine-only.
