### PR TITLE
Relabel IDs of object_references

### DIFF
--- a/ssg/id_translate.py
+++ b/ssg/id_translate.py
@@ -88,6 +88,10 @@ class IDTranslator(object):
                 element.text = self.generate_id("{%s}variable" % oval_ns,
                                                 element.text)
                 continue
+            if element.tag == "{%s}object_reference" % oval_ns:
+                element.text = self.generate_id("{%s}object" % oval_ns,
+                                                element.text)
+                continue
             for attr in element.keys():
                 if attr in OVALREFATTR_TO_TAG.keys():
                     element.set(attr, self.generate_id(


### PR DESCRIPTION

#### Description:

- Relabel the ID of the objects referenced by an `object_reference`

#### Rationale:
- `<object_reference>` is used by [`<set>`](https://github.com/OVALProject/Language/blob/7fa7bba7b48f09decb732d00b2be032a487ff9fc/docs/oval-definitions-schema.md#-set-)

- Related to #4379
