### PR TITLE
Add OL support to configuring_ipv6 rules

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_default_gateway/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_default_gateway/oval/shared.xml
@@ -5,6 +5,7 @@
       <title>Manually Assign IPv6 Router Address</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Define default gateways for IPv6 traffic</description>
     </metadata>

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_default_gateway/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_default_gateway/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Manually Assign IPv6 Router Address'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 
 # enable randomness in ipv6 address generation
 for interface in /etc/sysconfig/network-scripts/ifcfg-*

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/oval/shared.xml
@@ -7,6 +7,7 @@
         <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Enable privacy extensions for IPv6</description>
     </metadata>

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Use Privacy Extensions for Address'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/oval/shared.xml
@@ -5,6 +5,7 @@
       <title>Manually Assign Global IPv6 Address</title>
       <affected family="unix">
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Manually configure addresses for IPv6</description>
     </metadata>

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora
+prodtype: rhel6,rhel7,rhel8,fedora,ol7,ol8
 
 title: 'Manually Assign Global IPv6 Address'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4,ocp4
+prodtype: rhel6,rhel7,rhel8,rhv4,ocp4,ol7,ol8
 
 title: 'Configure Accepting Router Advertisements on All IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4,ocp4
+prodtype: rhel6,rhel7,rhel8,rhv4,ocp4,ol7,ol8
 
 title: 'Disable Accepting ICMP Redirects for All IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel6,rhel7,rhel8,rhv4,ocp4
+prodtype: wrlinux1019,rhel6,rhel7,rhel8,rhv4,ocp4,ol7,ol8
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4
+prodtype: rhel6,rhel7,rhel8,rhv4,ol7,ol8
 
 title: 'Disable Kernel Parameter for IPv6 Forwarding'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4,ol7,ol8
 
 title: 'Disable Accepting Router Advertisements on all IPv6 Interfaces by Default'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4,ol7,ol8
 
 title: 'Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4,ocp4
+prodtype: rhel6,rhel7,rhel8,rhv4,ocp4,ol7,ol8
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on IPv6 Interfaces by Default'
 


### PR DESCRIPTION
#### Description:

Rules from configuring_ipv6 group applicable to Oracle Linux releases
    
#### Testing:
- Checked successful ol7, ol8 build and generated rules content
- Checked rules to work on ol8
