### PR TITLE
Add OL support to policy audit rules

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of unsuccessful file accesses'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of successful file accesses'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure basic parameters of Audit system'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of unsuccessful file creations'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of successful file creations'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of unsuccessful file deletions'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of successful file deletions'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure immutable Audit login UIDs'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of unsuccessful file modifications'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of successful file modifications'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of loading and unloading of kernel modules'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Perform general configuration of Audit for OSPP'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of unsuccessful ownership changes'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of successful ownership changes'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of unsuccessful permission changes'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Configure auditing of successful permission changes'
 


### PR DESCRIPTION
#### Description:

Rules from policy_rules group applicable to Oracle Linux 8, adding ol8 supported product type.

#### Testing:
- Checked successful ol8 build and generated rules content
- Checked rules to work on ol8