### PR TITLE
Add OL support to packages and services rules

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8
 
 title: 'Disable Avahi Server Software'
 

--- a/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/rule.yml
+++ b/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,ocp4
+prodtype: rhel8,ocp4,ol8
 
 title: 'Enable the File Access Policy Service'
 

--- a/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/rule.yml
+++ b/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8
 
 title: 'Uninstall squid Package'
 

--- a/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
+++ b/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8
+prodtype: rhel6,rhel7,rhel8,ol7,ol8
 
 title: 'Disable Squid'
 

--- a/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/rule.yml
+++ b/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'Uninstall quagga Package'
 

--- a/linux_os/guide/services/ssh/package_openssh-clients_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-clients_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Install OpenSSH client software'
 

--- a/linux_os/guide/system/network/network_sniffer_disabled/oval/shared.xml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Disable the network sniffer</description>
     </metadata>

--- a/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,rhv4
+prodtype: wrlinux1019,rhel6,rhel7,rhel8,fedora,rhv4,ol7,ol8
 
 title: 'Ensure System is Not Acting as a Network Sniffer'
 

--- a/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Install policycoreutils-python-utils package'
 

--- a/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Install crypto-policies package'
 

--- a/linux_os/guide/system/software/system-tools/package_pigz_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_pigz_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,ol8
 
 title: 'Uninstall pigz Package'
 
@@ -8,7 +8,7 @@ description: |-
     {{{ describe_package_remove(package="pigz") }}}
 
 rationale: |-
-    Binaries shipped in <tt>pigz</tt> package in Red Hat Enterprise Linux 8
+    Binaries shipped in <tt>pigz</tt> package in {{{ full_name }}}
     have not been compiled using recommended compiler flags. The binaries
     are compiled without sufficient stack protection and its address space
     layout randomization (ASLR) is weak.


### PR DESCRIPTION
#### Description:

Added OL support in following applicable packages and services rules:
- service_avahi-daemon_disabled
- service_fapolicyd_enabled
- package_squid_removed
- service_squid_disabled
- package_quagga_removed
- package_openssh-clients_installed
- network_sniffer_disabled
- package_policycoreutils-python-utils_installed
- package_crypto-policies_installed
- package_pigz_removed

#### Rationale:

Set of shared packages and services rules is applicable to Oracle Linux releases.

#### Testing:
- Checked successful ol7, ol8 builds and generated rules content
- Checked rules to work on ol7 and ol8 systems
