### PR TITLE
Fix hardcoded product in remediation script comments

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/ansible/shared.yml
@@ -9,7 +9,7 @@
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
     block: |
-        ## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+        ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
         ## The purpose of these rules is to meet the requirements for Operating

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
@@ -9,7 +9,7 @@
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
     block: |
-        ## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+        ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
         ## The purpose of these rules is to meet the requirements for Operating

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
@@ -9,7 +9,7 @@
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
     block: |
-        ## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+        ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
         ## The purpose of these rules is to meet the requirements for Operating

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
@@ -9,7 +9,7 @@
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
     block: |
-        ## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+        ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
         ## The purpose of these rules is to meet the requirements for Operating

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
@@ -9,7 +9,7 @@
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
     block: |
-        ## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+        ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
         ## The purpose of these rules is to meet the requirements for Operating

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
@@ -9,7 +9,7 @@
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
     block: |
-        ## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+        ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
         ## The purpose of these rules is to meet the requirements for Operating

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
@@ -9,7 +9,7 @@
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: yes
     block: |
-        ## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+        ## This content is a section of an Audit config snapshot recommended for {{{ full_name }}} systems that target OSPP compliance.
         ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
         ## The purpose of these rules is to meet the requirements for Operating

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/rhel6.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/rhel6.sh
@@ -1,8 +1,0 @@
-# platform = Red Hat Enterprise Linux 6
-
-# Include source function library.
-. /usr/share/scap-security-guide/remediation_functions
-
-# Perform the remediation
-perform_audit_rules_privileged_commands_remediation "auditctl" "500"
-perform_audit_rules_privileged_commands_remediation "augenrules" "500"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
@@ -1,8 +1,8 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-perform_audit_rules_privileged_commands_remediation "auditctl" "1000"
-perform_audit_rules_privileged_commands_remediation "augenrules" "1000"
+perform_audit_rules_privileged_commands_remediation "auditctl" "{{{ auid }}}"
+perform_audit_rules_privileged_commands_remediation "augenrules" "{{{ auid }}}"

--- a/shared/bash_remediation_functions/create_audit_remediation_unsuccessful_file_modification_detailed.sh
+++ b/shared/bash_remediation_functions/create_audit_remediation_unsuccessful_file_modification_detailed.sh
@@ -2,7 +2,7 @@ function create_audit_remediation_unsuccessful_file_modification_detailed {
 	mkdir -p "$(dirname "$1")"
 	# The - option to mark a here document limit string (<<-EOF) suppresses leading tabs (but not spaces) in the output.
 	cat <<-EOF > "$1"
-		## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+		## This content is a section of an Audit config snapshot recommended for linux systems that target OSPP compliance.
 		## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 
 		## The purpose of these rules is to meet the requirements for Operating

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -6,7 +6,6 @@
 # 			One of 'auditctl' or 'augenrules'
 #
 # min_auid		Minimum original ID the user logged in with
-# 			'500' for RHEL-6 and before, '1000' for RHEL-7 and after.
 #
 # Example Call(s):
 #

--- a/shared/templates/template_BASH_grub2_bootloader_argument
+++ b/shared/templates/template_BASH_grub2_bootloader_argument
@@ -13,6 +13,6 @@ fi
 # Correct the form of kernel command line for each installed kernel in the bootloader
 grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"
 {{% else %}}
-#in later versions of rhel grub2-editenv is used
+# Correct grub2 kernelopts value using grub2-editenv
 grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) {{{ ARG_NAME_VALUE }}}"
 {{% endif %}}


### PR DESCRIPTION
#### Description:

Replaced hardcoded product from shared remediation script comments:
- rules audit_rules_unsuccessful_file_modification_*
- bash_remediation_function create_audit_remediation_unsuccessful_file_modification_detailed.sh
- template template_BASH_grub2_bootloader_argument

Just let me know if suggested change is not applicable for RHEL to wrap original ones into conditional statements.

#### Rationale:

Some shared scripts contain hardcoded product reference in comments not applicable to other supported products.

#### Testing:

- Checked successful ol7, ol8, rhel7, rhel8 builds and generated content

