### PR TITLE
force strict ordering in group network-firewalld

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -678,7 +678,9 @@ class Group(object):
         # are after rules that install or remove it.
         groups_in_group = list(self.groups.keys())
         # The FIPS group should come before Crypto - if we want to set a different (stricter) Crypto Policy than FIPS.
-        priority_order = ["fips", "crypto"]
+        # the firewalld_activation must come before ruleset_modifications, othervise
+        # remediations for ruleset_modifications won't work
+        priority_order = ["fips", "crypto", "firewalld_activation", "ruleset_modifications"]
         groups_in_group = reorder_according_to_ordering(groups_in_group, priority_order)
         for group_id in groups_in_group:
             _group = self.groups[group_id]


### PR DESCRIPTION
#### Description:

Force strict ordering of group firewalld_activation before group ruleset_modifications within the network-firewalld group. This is done during build.

#### Rationale:

If groups are not in this order, remediations do not work because remediations within the ruleset_modifications group depend on Firewalld service being enabled.
