### PR TITLE
Fix newline discrepancies in jinja macros for file content

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_not_identical.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_not_identical.fail.sh
@@ -1,4 +1,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-cp /usr/share/audit/sample-rules/10-base-config.rules /etc/audit/rules.d/
+cp $SHARED/audit/10-base-config.rules /etc/audit/rules.d/
 echo "some additional text" >> /etc/audit/rules.d/10-base-config.rules

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -214,6 +214,6 @@
   copy:
     dest: "{{{ filepath }}}"
     content: |+
-        {{{ contents|indent(8) }}}
+        {{{ contents|trim()|indent(8) }}}
     force: yes
 {{%- endmacro %}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -518,5 +518,6 @@ fi
 #}}
 {{%- macro bash_file_contents(filepath='', contents='') %}}
 cat << 'EOF' > {{{ filepath }}}
-{{{ contents }}}EOF
+{{{ contents|trim() }}}
+EOF
 {{%- endmacro %}}

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -484,7 +484,8 @@
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_state id="state_whole_file_contents_{{{ filepath_id }}}" version="1">
-      <ind:text operation="equals">{{{ contents }}}</ind:text>
+      <ind:text operation="equals">{{{ contents|trim() }}}
+</ind:text>
     </ind:textfilecontent54_state>
 
   </def-group>

--- a/tests/shared/audit/10-base-config.rules
+++ b/tests/shared/audit/10-base-config.rules
@@ -10,4 +10,3 @@
 
 ## Set failure mode to syslog
 -f 1
-

--- a/tests/shared/audit/11-loginuid.rules
+++ b/tests/shared/audit/11-loginuid.rules
@@ -1,3 +1,2 @@
 ## Make the loginuid immutable. This prevents tampering with the auid.
 --loginuid-immutable
-

--- a/tests/shared/audit/30-ospp-v42.rules
+++ b/tests/shared/audit/30-ospp-v42.rules
@@ -77,4 +77,3 @@
 ## FPT_SRP_EXT.1 Software Restriction Policies. This event is intended to
 ## state results from that policy. This would be handled entirely by
 ## that daemon.
-


### PR DESCRIPTION
#### Description:

On older systems (for example RHEL-7.4) newlines at the end of jinja
macros might get stripped during processing. This commit makes the file
content jinja macros to work in any case by explicitly making sure that
there are no whitespaces at the beginning nor at the end of the variables
which are used in the macros.

This change also requires removal of trailing newlines from test files
in the `tests/shared/audit` as these files are not being trimmed of
whitespaces compared to oval, bash and ansible jinja macros.