### PR TITLE
Added OL support to ospp profile rules

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/bash/shared.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
 
 cp /usr/share/doc/audit*/rules/10-base-config.rules /etc/audit/rules.d
 cp /usr/share/doc/audit*/rules/11-loginuid.rules /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/oval/shared.xml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/oval/shared.xml
@@ -37,6 +37,7 @@
       <affected family="unix">
         <platform>Red Hat Enterprise Linux 7</platform>
         <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Compare configure audit rules againd the recommended pre-configured files</description>
     </metadata>

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/rule.yml
@@ -1,12 +1,12 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'Configure audit according to OSPP requirements'
 
 {{% set docs_dir="" %}}
-{{# in rhel7, docs dir are versioned #}}
-{{% if product == "rhel7" %}}
+{{# in rhel7,ol7 docs dir are versioned #}}
+{{% if product in ["rhel7", "ol7"] %}}
   {{% set docs_dir="-VERSION" %}}
 {{% endif %}}
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4
+prodtype: rhel6,rhel7,rhel8,fedora,rhv4,ocp4,ol7,ol8
 
 title: 'Disable Mounting of cramfs'
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 SECURITY_LIMITS_FILE="/etc/security/limits.conf"
 
 if grep -qE '\*\s+hard\s+core' $SECURITY_LIMITS_FILE; then

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,fedora,ocp4
+prodtype: rhel6,rhel7,rhel8,fedora,ocp4,ol7,ol8
 
 title: 'Disable Core Dumps for All Users'
 

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,ol7
+prodtype: rhel7,rhel8,ol7,ol8
 
 title: 'Ensure /var/tmp Located On Separate Partition'
 


### PR DESCRIPTION
#### Description:

Added OL support in following ospp profile applicable rules:
- partition_for_var_tmp
- kernel_module_cramfs_disabled
- disable_users_coredumps
- audit_rules_for_ospp

#### Rationale:

Set of shared packages and services rules from ospp profile found to be applicable to Oracle Linux releases.

#### Testing:

- Checked successful ol7, ol8, rhel7 builds and generated rules content
- Checked rules to work on ol7 and ol8 systems
