### PR TITLE
Update rpm_verification group rules with OL support

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = high

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Verify ownership of installed packages
       by comparing the installed files with information about the

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4,ocp4
+prodtype: rhel6,rhel7,rhel8,rhv4,ocp4,ol7,ol8
 
 title: 'Verify and Correct Ownership with RPM'
 
@@ -56,9 +56,11 @@ ocil: |-
     is expected by the RPM database:
     <pre>$ rpm -Va | rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'</pre>
 
+{{% if product == "rhel6" %}}
 warnings:
     - general: |-
         <b>Note: Due to a bug in the <tt>gdm</tt> package,
         the RPM verify command may continue to fail even after file permissions have
         been correctly set on <tt>/var/log/gdm</tt>. This is being tracked in Red Hat
         Bugzilla #1277603.</b>
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -64,9 +64,11 @@ ocil: |-
     is expected by the RPM database:
     <pre>$ rpm -Va | awk '{ if (substr($0,2,1)=="M") print $NF }'</pre>
 
+{{% if product == "rhel6" %}}
 warnings:
     - general: |-
         <b>Note: Due to a bug in the <tt>gdm</tt> package,
         the RPM verify command may continue to fail even after file permissions have
         been correctly set on <tt>/var/log/gdm</tt>. This is being tracked in Red Hat
         Bugzilla #1277603.</b>
+{{% endif %}}


### PR DESCRIPTION
#### Description

Added OL support to rpm_verify_ownership rule.
As rhbz1277603 is RHEL6 specific make gdm warning conditional in rpm_verify_ownership and rpm_verify_permissions rules.

#### Rationale:

- Set of shared packages and services rules is applicable to Oracle Linux releases.

#### Testing:
- Checked successful ol7, ol8, rhel6 builds and generated rules content
- Checked rules to work on ol7 and ol8 systems

