### PR TITLE
Add OL support to sudo and important dirs permissions rules

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 find /bin/ \
 /usr/bin/ \
 /usr/local/bin/ \

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>
         Checks that /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 for LIBDIR in /usr/lib /usr/lib64 /lib /lib64
 do
   if [ -d $LIBDIR ]

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>
         Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 DIRS="/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -exec chmod go-w '{}' \;

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>
         Checks that binary files under /bin, /sbin, /usr/bin, /usr/sbin,

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = high

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
+# platform = Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -type f -exec chmod go-w '{}' \;

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/oval/shared.xml
@@ -6,6 +6,7 @@
         <platform>Red Hat Virtualization 4</platform>
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>
         Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/oval/shared.xml
@@ -9,6 +9,7 @@
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ubuntu</platform>
         <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Checks sudo usage without authentication</description>
     </metadata>

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/oval/shared.xml
@@ -9,6 +9,7 @@
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ubuntu</platform>
         <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Checks sudo usage without password</description>
     </metadata>

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
@@ -8,6 +8,7 @@
         <platform>multi_platform_fedora</platform>
         <platform>multi_platform_rhel</platform>
         <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_ol</platform>
       </affected>
       <description>Checks sudo usage without password</description>
     </metadata>


### PR DESCRIPTION
#### Description:

Added OL product type to supported sudo and permissions_within_important_dirs groups rules:
- file_ownership_binary_dirs
- file_ownership_library_dirs
- file_permissions_binary_dirs
- file_permissions_library_dirs
- sudo_remove_no_authenticate
- sudo_remove_nopasswd
- sudo_require_authentication

#### Rationale:

Shared rules from sudo and permissions_within_important_dirs groups are applicable to Oracle Linux releases.

#### Testing:

- Checked successful ol7, ol8 builds and generated rules content
- Checked rules to work on ol7 and ol8 systems

