### PR TITLE
Update GNOME group text for OL products

### DIFF
--- a/linux_os/guide/system/software/gnome/group.yml
+++ b/linux_os/guide/system/software/gnome/group.yml
@@ -9,7 +9,11 @@ description: |-
     switching contexts as well as display server management.
     <br /><br />
     GNOME is developed by the GNOME Project and is considered the default
+    {{% if product in ['ol7', 'ol8'] %}}
+    Oracle Linux Graphical environment.
+    {{% else %}}
     Red Hat Graphical environment.
+    {{% endif %}}
     <br /><br />
     For more information on GNOME and the GNOME Project, see <b>{{{ weblink(link="https://www.gnome.org") }}}</b>.
 


### PR DESCRIPTION
#### Description:

Minor change - updated default graphical environment note for OL prodtypes

#### Rationale:

GNOME Desktop Environment group contains note that GNOME is considered the default Red Hat Graphical environment for OL prodtypes.

#### Testing:

- Checked ol7, ol8 and rhel7 builds 
- Checked in generated guides: "GNOME Desktop Environment" group text to reflect product specific  information.