### PR TITLE
force order of disabling_ipv6 group before configuring_ipv6 group

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -681,7 +681,7 @@ class Group(object):
         # the firewalld_activation must come before ruleset_modifications, othervise
         # remediations for ruleset_modifications won't work
         # rules from group disabling_ipv6 must precede rules from configuring_ipv6,
-        # othervise the remediation prints error although it is successful
+        # otherwise the remediation prints error although it is successful
         priority_order = ["fips", "crypto", "firewalld_activation",
         "ruleset_modifications", "disabling_ipv6", "configuring_ipv6"]
         groups_in_group = reorder_according_to_ordering(groups_in_group, priority_order)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -680,7 +680,10 @@ class Group(object):
         # The FIPS group should come before Crypto - if we want to set a different (stricter) Crypto Policy than FIPS.
         # the firewalld_activation must come before ruleset_modifications, othervise
         # remediations for ruleset_modifications won't work
-        priority_order = ["fips", "crypto", "firewalld_activation", "ruleset_modifications"]
+        # rules from group disabling_ipv6 must precede rules from configuring_ipv6,
+        # othervise the remediation prints error although it is successful
+        priority_order = ["fips", "crypto", "firewalld_activation",
+        "ruleset_modifications", "disabling_ipv6", "configuring_ipv6"]
         groups_in_group = reorder_according_to_ordering(groups_in_group, priority_order)
         for group_id in groups_in_group:
             _group = self.groups[group_id]


### PR DESCRIPTION
#### Description:

During build time, force ordering of XCCDF groups mentioned in the title.

#### Rationale:

It was found that if the groups are in a different order, the remediation of the rule sysctl_net_ipv6_conf_all_disable_ipv6 results in an error. Precisely, the remediation is performed correctly, but the verification by OVAL check just after remediation fails. Subsequent checks pass.
This approach was chosen because functionality is not affected, the error message would only confuse the user. This behaviour was not spotted in any other case.