### PR TITLE
fix wrong value in test scenario

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/wrong_value.fail.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^INACTIVE" /etc/default/useradd; then
-	sed -i "s/^INACTIVE.*/INACTIVE=90/" /etc/default/useradd
+	sed -i "s/^INACTIVE.*/INACTIVE=-1/" /etc/default/useradd
 else
-	echo "INACTIVE=90" >> /etc/default/useradd
+	echo "INACTIVE=-1" >> /etc/default/useradd
 fi


### PR DESCRIPTION
#### Description:

use -1 as wrong value in test scenario for account_disable_post_pw_activation

#### Rationale:

Value used previously was actually correct for certain values of XCCDF variable and therefore the test was passing instead of failing in certain cases.
