### PR TITLE
Fix OVAL for audit_rules_unsuccessful_file_modification_*

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -10,24 +10,24 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccesful-access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -52,7 +52,7 @@
       <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{{ NAME }}}[\s]+|([\s]+|[,]){{{ NAME }}}([\s]+|[,]))).*</value>
   </constant_variable>
   <constant_variable id="var_arufm_{{{ NAME }}}_tail" version="1" datatype="string" comment="audit rule auid and key">
-    <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+    <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)unsuccesful-access[\s]*$</value>
   </constant_variable>
 
   <!-- 32bit EACCES rules -->

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
@@ -54,7 +54,7 @@
       <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_creat_tail" version="1" datatype="string" comment="audit rule auid and key">
-    <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+    <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)unsuccesful-create[\s]*$</value>
   </constant_variable>
 
   <!-- Regex to match anything between targeted rules -->

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
@@ -54,7 +54,7 @@
       <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_trunc_tail" version="1" datatype="string" comment="audit rule auid and key">
-    <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+    <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)unsuccesful-modification[\s]*$</value>
   </constant_variable>
 
   <!-- Regex to match anything between targeted rules -->


### PR DESCRIPTION
#### Description:

The OVAL template was too broad and it allowed key=anything at the end of the audit rules. The lines mentioned in the rule description were not in sync with the actual file which is used for testing. The testing file contains
key=unsuccessful-access
but the rule description contained
key=access
Looking into example files provided by Audit I believe key=unsuccessful-access is correct.
@stevegrubb could you please confirm that?
If it is correct there are more rule descriptions need fixing.

#### Rationale:

Tests for the rule were not passing.