### PR TITLE
Remove ocp4 checks

### DIFF
--- a/ocp4/profiles/coreos-ncp.profile
+++ b/ocp4/profiles/coreos-ncp.profile
@@ -261,7 +261,6 @@ selections:
     - configure_crypto_policy
     - harden_sshd_crypto_policy
     - harden_ssh_client_crypto_policy
-    - configure_bind_crypto_policy
     - configure_openssl_crypto_policy
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module

--- a/ocp4/profiles/coreos-ncp.profile
+++ b/ocp4/profiles/coreos-ncp.profile
@@ -192,7 +192,6 @@ selections:
     ### Install Required Packages
     #- package_sssd-ipa_installed
     - package_aide_installed
-    - package_firewalld_installed
     - package_iptables_installed
     #- package_libcap-ng-utils_installed
     #- package_openscap-scanner_installed
@@ -338,7 +337,7 @@ selections:
 
     ## Enable Host-Based Firewall
     ## SC-7(12) / FMT_MOF_EXT.1
-    - service_firewalld_enabled
+    # TODO (Check for iptables and the kubelet config instead)
 
     ## Configure Name/Addres of Remote Management Server
     ##  From Which to Receive Config Settings

--- a/ocp4/profiles/coreos-ncp.profile
+++ b/ocp4/profiles/coreos-ncp.profile
@@ -205,7 +205,6 @@ selections:
     ####
     #- package_scap-security-guide_installed
     - package_audit_installed
-    - package_libreswan_installed
 
     ### Remove Prohibited Packages
     #- package_sendmail_removed
@@ -264,7 +263,6 @@ selections:
     - harden_ssh_client_crypto_policy
     - configure_bind_crypto_policy
     - configure_openssl_crypto_policy
-    - configure_libreswan_crypto_policy
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module
 

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -258,7 +258,6 @@ selections:
     - configure_crypto_policy
     - harden_sshd_crypto_policy
     - harden_ssh_client_crypto_policy
-    - configure_bind_crypto_policy
     - configure_openssl_crypto_policy
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -202,7 +202,6 @@ selections:
     #- package_audispd-plugins_installed
     ####
     #- package_scap-security-guide_installed
-    - package_libreswan_installed
 
     ### Remove Prohibited Packages
     #- package_sendmail_removed
@@ -261,7 +260,6 @@ selections:
     - harden_ssh_client_crypto_policy
     - configure_bind_crypto_policy
     - configure_openssl_crypto_policy
-    - configure_libreswan_crypto_policy
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module
 

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -190,7 +190,6 @@ selections:
     # We won't check AIDE directly, we'll need to check cluster-wide for the
     # file-integrity-operator
     # package_aide_installed
-    - package_firewalld_installed
     - package_iptables_installed
     #- package_libcap-ng-utils_installed
     #- package_openscap-scanner_installed
@@ -336,7 +335,7 @@ selections:
 
     ## Enable Host-Based Firewall
     ## SC-7(12) / FMT_MOF_EXT.1
-    - service_firewalld_enabled
+    # TODO (Check for iptables and the kubelet config instead)
 
     ## Configure Name/Addres of Remote Management Server
     ##  From Which to Receive Config Settings


### PR DESCRIPTION
#### Description:

This removes some unneeded checks from the ocp4 profiles:

* libreswan checks (since libreswan isn't shipped in RHCOS)
* BIND crypto policy check (Since we don't run BIND, but instead use CoreDNS)
* firewalld checks (since we run iptables, driven by the kubelet).

#### Rationale:

These checks are irrelevant to RHCOS and OpenShift.
