### PR TITLE
SSGTS: profile mode extended to reboot VM before performing the final scan

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -103,7 +103,7 @@ def main():
 
     if not data.url:
         if data.distro == "fedora":
-            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/29/Everything/x86_64/os"
+            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os"
         elif data.distro == "centos7":
             data.url = "http://mirror.centos.org/centos/7/os/x86_64"
     if not data.url:

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -144,7 +144,7 @@ def generate_fixes_remotely(formatting, verbose_path):
 
 def run_stage_remediation_ansible(run_type, formatting, verbose_path):
     """
-       Returns False on error, or True in case of successful bash scripts
+       Returns False on error, or True in case of successful Ansible playbook
        run."""
     formatting['output_template'] = _ANSIBLE_TEMPLATE
     send_arf_to_remote_machine_and_generate_remediations_there(
@@ -175,7 +175,7 @@ def run_stage_remediation_ansible(run_type, formatting, verbose_path):
 
 def run_stage_remediation_bash(run_type, formatting, verbose_path):
     """
-       Returns False on error, or True in case of successful Ansible playbook
+       Returns False on error, or True in case of successful bash scripts
        run."""
     formatting['output_template'] = _BASH_TEMPLATE
     send_arf_to_remote_machine_and_generate_remediations_there(
@@ -346,7 +346,7 @@ class GenericRunner(object):
             for fname in tuple(self._filenames_to_clean_afterwards):
                 try:
                     os.remove(fname)
-                except OSError as exc:
+                except OSError:
                     logging.error(
                         "Failed to cleanup file '{0}'"
                         .format(fname))
@@ -411,6 +411,13 @@ class ProfileRunner(GenericRunner):
 
     def _get_results_file(self):
         return '{0}-{1}-results'.format(self.profile, self.stage)
+
+    def final(self):
+        if self.environment.name == 'libvirt-based':
+            logging.info("Rebooting domain '{0}' before final scan."
+                         .format(self.environment.domain_name))
+            self.environment.reboot()
+        GenericRunner.final(self)
 
     def make_oscap_call(self):
         self.prepare_online_scanning_arguments()

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -623,6 +623,8 @@ class Checker(object):
             logging.info("Terminating the test run due to keyboard interrupt.")
         except RuntimeError as exc:
             logging.error("Terminating due to error: {msg}.".format(msg=str(exc)))
+        except TimeoutError as exc:
+            logging.error("Terminating due to timeout: {msg}".format(msg=str(exc)))
         finally:
             self.finalize()
 

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -503,7 +503,7 @@ class RuleRunner(GenericRunner):
 
         if rule_result != self.context:
             local_success = False
-            if rule_result is 'notselected':
+            if rule_result == 'notselected':
                 msg = (
                     'Rule {0} has not been evaluated! '
                     'Wrong profile selected in test scenario?'

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -145,6 +145,15 @@ class VMTestEnv(TestEnv):
 
         self._origin = self._save_state("origin")
 
+    def reboot(self):
+        from ssg_test_suite import virt
+
+        if self.domain is None:
+            self.domain = virt.connect_domain(
+                self.hypervisor, self.domain_name)
+
+        virt.reboot_domain(self.domain, self.domain_ip, self.ssh_port)
+
     def finalize(self):
         self._delete_saved_state(self._origin)
         # self.domain.shutdown()

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -45,7 +45,7 @@ class SavedState(object):
         finally:
             try:
                 environment._delete_saved_state(state_handle)
-            except KeyboardInterrupt as exc:
+            except KeyboardInterrupt:
                 print("Hang on for a minute, cleaning up the saved state '{0}'."
                       .format(state_name), file=sys.stderr)
                 environment._delete_saved_state(state_handle)
@@ -122,7 +122,8 @@ class VMTestEnv(TestEnv):
         try:
             import libvirt
         except ImportError:
-            raise RuntimeError("Can't import libvirt module, libvirt backend will therefore not work.")
+            raise RuntimeError("Can't import libvirt module, libvirt backend will "
+                               "therefore not work.")
 
         self.domain = None
 
@@ -306,6 +307,7 @@ class DockerTestEnv(ContainerTestEnv):
             self.client.ping()
         except Exception as exc:
             msg = (
+                "{}\n"
                 "Unable to start the Docker test environment, "
                 "is the Docker service started "
                 "and do you have rights to access it?"
@@ -340,7 +342,7 @@ class DockerTestEnv(ContainerTestEnv):
 
     def _local_oscap_check_base_arguments(self):
         return ['oscap-docker', "container", self.current_container.id,
-                                                            'xccdf', 'eval']
+                'xccdf', 'eval']
 
 
 class PodmanTestEnv(ContainerTestEnv):
@@ -357,7 +359,8 @@ class PodmanTestEnv(ContainerTestEnv):
         try:
             subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
+            msg = "Command '{0}' returned {1}:\n{2}".format(
+                " ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
             raise RuntimeError(msg)
 
     def _new_container_from_image(self, image_name, container_name):
@@ -368,7 +371,8 @@ class PodmanTestEnv(ContainerTestEnv):
         try:
             podman_output = subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
+            msg = "Command '{0}' returned {1}:\n{2}".format(
+                " ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
             raise RuntimeError(msg)
         container_id = podman_output.decode("utf-8").strip()
         return container_id
@@ -378,17 +382,20 @@ class PodmanTestEnv(ContainerTestEnv):
         try:
             podman_output = subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
+            msg = "Command '{0}' returned {1}:\n{2}".format(
+                " ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
             raise RuntimeError(msg)
         ip_address = podman_output.decode("utf-8").strip()
         return ip_address
 
     def _get_container_ports(self, container):
-        podman_cmd = ["podman", "inspect", container, "--format", "{{json .NetworkSettings.Ports}}"]
+        podman_cmd = ["podman", "inspect", container, "--format",
+                      "{{json .NetworkSettings.Ports}}"]
         try:
             podman_output = subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
+            msg = "Command '{0}' returned {1}:\n{2}".format(
+                " ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
             raise RuntimeError(msg)
         ports = {}
         for pb in json.loads(podman_output):
@@ -402,13 +409,15 @@ class PodmanTestEnv(ContainerTestEnv):
             try:
                 subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:
-                msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
+                msg = "Command '{0}' returned {1}:\n{2}".format(
+                    " ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
                 raise RuntimeError(msg)
             podman_cmd = ["podman", "rm", running_state]
             try:
                 subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:
-                msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
+                msg = "Command '{0}' returned {1}:\n{2}".format(
+                    " ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
                 raise RuntimeError(msg)
 
     def _remove_image(self, image):
@@ -416,7 +425,8 @@ class PodmanTestEnv(ContainerTestEnv):
         try:
             subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            msg = "Command '{0}' returned {1}:\n{2}".format(" ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
+            msg = "Command '{0}' returned {1}:\n{2}".format(
+                " ".join(e.cmd), e.returncode, e.output.decode("utf-8"))
             raise RuntimeError(msg)
 
     def _local_oscap_check_base_arguments(self):

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -174,8 +174,9 @@ def reboot_domain(domain, domain_ip, ssh_port):
     while domain.isActive():
         time.sleep(1)
         if time.perf_counter() - start_time >= timeout:
-            raise TimeoutError("Timeout reached: '{0}' domain failed to shutdown."
-                               .format(domain.name()))
+            str_err = "Timeout reached: '{0}' domain failed to shutdown.".format(domain.name())
+            logging.debug(str_err)
+            raise TimeoutError(str_err)
 
     logging.debug("Starting domain '{0}'".format(domain.name()))
     domain.create()
@@ -190,5 +191,7 @@ def reboot_domain(domain, domain_ip, ssh_port):
         except OSError as exc:
             time.sleep(1)
             if time.perf_counter() - start_time >= timeout:
-                raise TimeoutError("Timeout reached: '{0}' ({1}:22) domain does not "
-                                   "accept connections.".format(domain.name(), domain_ip)) from exc
+                str_err = ("Timeout reached: '{0}' ({1}:{2}) domain does not "
+                           "accept connections.".format(domain.name(), domain_ip, ssh_port))
+                logging.debug(str_err)
+                raise TimeoutError(str_err) from exc

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -169,7 +169,7 @@ def reboot_domain(domain, domain_ip, ssh_port):
     domain.shutdown()
 
     # Wait until domain shuts down.
-    logging.debug("Waiting for domain to shutdown")
+    logging.debug("Waiting for domain to shutdown (max. {0}s)".format(timeout))
     start_time = time.perf_counter()
     while domain.isActive():
         time.sleep(1)
@@ -182,7 +182,7 @@ def reboot_domain(domain, domain_ip, ssh_port):
     domain.create()
 
     # Wait until SSH (on ssh_port) starts accepting TCP connections.
-    logging.debug("Waiting for domain to boot")
+    logging.debug("Waiting for domain to boot (max. {0}s)".format(timeout))
     start_time = time.perf_counter()
     while True:
         try:

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 import argparse
+import textwrap
 import logging
 import os
 import os.path
@@ -97,6 +98,15 @@ def parse_args():
     subparsers.required = True
 
     parser_profile = subparsers.add_parser("profile",
+                                           formatter_class=argparse.RawDescriptionHelpFormatter,
+                                           epilog=textwrap.dedent("""\
+                    In case that tested profile contains rules which might prevent root ssh access
+                    to the testing VM consider unselecting these rules. To unselect certain rules
+                    from a datastream use `ds_unselect_rules.sh` script. List of such rules already
+                    exists, see `unselect_rules_list` file.
+                    Example usage:
+                        ./ds_unselect_rules.sh ../build/ssg-fedora-ds.xml unselect_rules_list
+                                           """),
                                            help=("Testing profile-based "
                                                  "remediation applied on already "
                                                  "installed machine"),


### PR DESCRIPTION
#### Description:

Some rules (for example `configure_crypto_policy`) require reboot of a machine
after a remediation to fully pass. Therefore, this commit adds reboot functionality
into the libvirt backend of the SSGTS. Reboot is performed only when testing using
the SSGTS profile mode after the remediation of a profile and before the final scan.
    
Other SSGTS updates:
* `tests/install_vm.py`: updated url to point to Fedora 31
* Addressed various pep8 code issues.
