### PR TITLE
Fix broken incomplete profiles build

### DIFF
--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -71,11 +71,11 @@ def create_parser():
     return parser
 
 
-def make_name_to_profile_mapping(profile_files):
+def make_name_to_profile_mapping(profile_files, env_yaml):
     name_to_profile = {}
     for f in profile_files:
         try:
-            p = ResolvableProfile.from_yaml(f)
+            p = ResolvableProfile.from_yaml(f, env_yaml)
             name_to_profile[p.id_] = p
         except Exception as exc:
             # The profile is probably doc-incomplete
@@ -110,7 +110,7 @@ def main():
 
     profile_files = get_profile_files_from_root(env_yaml, args.product_yaml)
     profile_files.extend(args.profile_file)
-    profiles = make_name_to_profile_mapping(profile_files)
+    profiles = make_name_to_profile_mapping(profile_files, env_yaml)
     for pname in profiles:
         profiles[pname].resolve(profiles)
 


### PR DESCRIPTION
After recent changes (https://github.com/ComplianceAsCode/content/pull/5209), build of incomplete profiles have been disabled even in debug mode.

    ./build_product --debug rhel7

resulted in debug being enabled

    build type: Debug

while at the same time incomplete profiles being disabled

    [  0%] [rhel7-content] compiling profiles
    Not building profile from rhel7/./profiles/tower-stig.profile: documentation not complete and not a debug build
    Not building profile from rhel7/./profiles/ipa-stig.profile: documentation not complete and not a debug build
    Not building profile from rhel7/./profiles/satellite-stig.profile: documentation not complete and not a debug build
    Not building profile from rhel7/./profiles/C2S-docker.profile: documentation not complete and not a debug build
    Not building profile from rhel7/./profiles/http-stig.profile: documentation not complete and not a debug build
    Not building profile from rhel7/./profiles/docker-host.profile: documentation not complete and not a debug build
