### PR TITLE
ocp4: Remove the rule that disables user namespaces

### DIFF
--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -143,9 +143,6 @@ selections:
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_yama_ptrace_scope
     - sysctl_kernel_perf_event_paranoid
-    - sysctl_user_max_user_namespaces
-    - sysctl_user_max_user_namespaces.role=unscored
-    - sysctl_user_max_user_namespaces.severity=info
     - sysctl_kernel_unprivileged_bpf_disabled
     - sysctl_net_core_bpf_jit_harden
 


### PR DESCRIPTION
#### Description:
Do not disable user namespaces via sysctl for RHCOS.

#### Rationale:
As the rule itself says, we should not disable the support for user
namespaces on container hosts such as RHCOS.