### PR TITLE
Added support for rawhide gpgkey check/remediation.

### DIFF
--- a/fedora/product.yml
+++ b/fedora/product.yml
@@ -11,7 +11,6 @@ pkg_manager: "dnf"
 init_system: "systemd"
 
 # The fingerprint and pkg_version are retrieved from https://getfedora.org/keys/
-# Future version is not used, but it makes updating latest_version easier.
 future_version: 32
 future_release_fingerprint: "97A1AE57C3A2372CCA3A4ABA6C13026D12C944D0"
 future_pkg_version: "12c944d0"

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -9,6 +9,8 @@ function get_release_fingerprint {
         readonly FEDORA_RELEASE_FINGERPRINT="{{{ latest_release_fingerprint }}}"
     elif [ "${fedora_version}" -eq "{{{ previous_version }}}" ]; then
         readonly FEDORA_RELEASE_FINGERPRINT="{{{ previous_release_fingerprint }}}"
+    elif [ "${fedora_version}" -eq "{{{ future_version }}}" ]; then
+        readonly FEDORA_RELEASE_FINGERPRINT="{{{ future_release_fingerprint }}}"
     else
         {{{ die("This Fedora version '$fedora_version' is not supported anymore, please upgrade to a newer version.", action="return") | indent(8)}}}
     fi

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
@@ -30,6 +30,7 @@
     <criteria comment="Fedora Vendor keys" operator="AND">
       <extend_definition comment="Fedora installed" definition_ref="installed_OS_is_fedora" />
       <criteria comment="Supported Fedora key is installed" operator="OR">
+          {{{ fedora_gpgkey_criterion(future_version, future_pkg_release, future_pkg_version) }}}
           {{{ fedora_gpgkey_criterion(latest_version, latest_pkg_release, latest_pkg_version) }}}
           {{{ fedora_gpgkey_criterion(previous_version, previous_pkg_release, previous_pkg_version) }}}
       </criteria>
@@ -42,6 +43,7 @@
   </linux:rpminfo_object>
 
   <!-- Perform the particular tests themselves -->
+  {{{ fedora_gpgkey_check(future_version, future_pkg_release, future_pkg_version) }}}
   {{{ fedora_gpgkey_check(latest_version, latest_pkg_release, latest_pkg_version) }}}
   {{{ fedora_gpgkey_check(previous_version, previous_pkg_release, previous_pkg_version) }}}
 


### PR DESCRIPTION
Rawhide may be used for testing, and there is no reason to not support it, although we have all bits that are required already in place.