### PR TITLE
Add Ignition remediation for sysctl parameters in the OCP4 moderate profile

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv6.conf.all.accept_source_route%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv6_conf_all_accept_source_route.conf

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv6.conf.default.accept_source_route%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv6_conf_default_accept_source_route.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.all.accept_redirects%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_accept_redirects.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.all.accept_source_route%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_accept_source_route.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.all.log_martians%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_log_martians.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.all.rp_filter%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_rp_filter.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.all.secure_redirects%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_secure_redirects.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.default.accept_redirects%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_default_accept_redirects.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.default.accept_source_route%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_default_accept_source_route.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.default.log_martians%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_default_log_martians.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.default.rp_filter%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_default_rp_filter.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.default.secure_redirects%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_default_secure_redirects.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.icmp_echo_ignore_broadcasts%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_icmp_echo_ignore_broadcasts.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.icmp_ignore_bogus_error_responses%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_icmp_ignore_bogus_error_responses.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.tcp_syncookies%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_tcp_syncookies.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.all.send_redirects%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_send_redirects.conf

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,net.ipv4.conf.default.send_redirects%3D0%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_default_send_redirects.conf

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,fs.protected_hardlinks%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_fs_protected_hardlinks.conf

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,fs.protected_symlinks%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_fs_protected_symlinks.conf

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,kernel.kptr_restrict%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_kernel_kptr_restrict.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,kernel.dmesg_restrict%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_kernel_dmesg_restrict.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,kernel.kexec_load_disabled%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_kernel_kexec_load_disabled.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,kernel.perf_event_paranoid%3D2%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_kernel_perf_event_paranoid.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,kernel.unprivileged_bpf_disabled%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_kernel_unprivileged_bpf_disabled.conf

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,kernel.yama.ptrace_scope%3D1%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/sysctl.d/75-sysctl_kernel_yama_ptrace_scope.conf


### PR DESCRIPTION
#### Description:
The patchset adds remediations for sysctl rules in the OCP4 moderate
profile. There is a patch per rule, which might look a bit odd, but I
thought it would provide for an easier review as is't then clearer which
file is created and even the content is quite readable. If you think this
many patches would pollute the git history too much, just let me know and
I can squash them.


#### Rationale:
We need to increase the content coverage of the OCP4 profile in
general. Adding the rules is also a good way of finding issues with the
tooling and UI/UX.