### PR TITLE
Fix the utils/ignition-remediation.py helper script

### DIFF
--- a/utils/ignition-remediation.py
+++ b/utils/ignition-remediation.py
@@ -286,7 +286,7 @@ def main():
     elif args.ACTION == 'decode':
         rem_path = resolve_for_decode(args.rule, args.infile)
         try:
-            decode(rem_path)
+            print(decode(rem_path))
         except IOError as e:
             # The rule probably couldn't be loaded
             print(e)


### PR DESCRIPTION
#### Description:
The decode action would decode the urlencoded part of the ignition remediation,
but not print the result. Oops.

#### Rationale:
The script is handy to review ignition remediations. For example, to review
a rule from PR #5271, you could call:
```
python3 utils/ignition-remediation.py decode --rule=$rulename
```