### PR TITLE
Add dconf_db_up_to_date to RHEL8 STIG profile.

### DIFF
--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -20,6 +20,7 @@ extends: ospp
 
 selections:
     - login_banner_text=dod_banners
+    - dconf_db_up_to_date
     - dconf_gnome_banner_enabled
     - banner_etc_issue
     - accounts_password_set_min_life_existing

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -83,6 +83,7 @@ selections:
 - configure_usbguard_auditbackend
 - coredump_disable_backtraces
 - coredump_disable_storage
+- dconf_db_up_to_date
 - dconf_gnome_banner_enabled
 - disable_ctrlaltdel_burstaction
 - disable_ctrlaltdel_reboot


### PR DESCRIPTION
#### Description:

- The rule dconf_db_up_to_date makes sure that the dconf database is up to date with regards to keyfiles. Rules that touch dconf settings only mention configuration under keyfiles, so if someone follows only the rules description guidance, value won't be reflected to the actual dconf database. So we need to make sure that the values are compiled to the binary database.
