### PR TITLE
Fix ansible linting issue on rule ensure_gpgcheck_never_disabled.

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -11,8 +11,8 @@
 
 - name: Set gpgcheck=1 for each {{{ pkg_manager }}} repo
   ini_file:
-    path: "{{item[0]}}"
-    section: "{{item[1]}}"
+    path: "{{ item[0] }}"
+    section: "{{ item[1] }}"
     option: gpgcheck
     value: '1'
     no_extra_spaces: True


### PR DESCRIPTION
Fix the issue from ansible lint jenkins job: https://jenkins.complianceascode.io/job/scap-security-guide-lint-check/192/console
