### PR TITLE
Add resources to install the compliance-operator

### DIFF
--- a/ocp-resources/compliance-operator-alpha-subscription.yaml
+++ b/ocp-resources/compliance-operator-alpha-subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-bundle
+  namespace: openshift-compliance
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: compliance-operator-bundle
+  source: compliance-operator
+  sourceNamespace: openshift-marketplace
+  startingCSV: compliance-operator.v0.1.3

--- a/ocp-resources/compliance-operator-csc.yaml
+++ b/ocp-resources/compliance-operator-csc.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1
+kind: CatalogSourceConfig
+metadata:
+  name: compliance-operator
+  namespace: openshift-marketplace
+spec:
+  targetNamespace: openshift-compliance
+  packages: compliance-operator-bundle
+  source: compliance-operator

--- a/ocp-resources/compliance-operator-ns.yaml
+++ b/ocp-resources/compliance-operator-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-compliance

--- a/ocp-resources/compliance-operator-operator-group.yaml
+++ b/ocp-resources/compliance-operator-operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-compliance-
+  namespace: openshift-compliance
+spec:
+  targetNamespaces:
+  - openshift-compliance

--- a/ocp-resources/compliance-operator-source.yaml
+++ b/ocp-resources/compliance-operator-source.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: compliance-operator
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: compliance-operator
+  displayName: "OpenShift Compliance Operator"
+  publisher: "Red Hat"

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -9,13 +9,13 @@ root_dir=$(git rev-parse --show-toplevel)
 
 # Ensure openshift-compliance namespace exists. If it already exists, this is
 # not a problem.
-oc adm new-project openshift-compliance || true
+oc create -f "$root_dir/ocp-resources/compliance-operator-ns.yaml" || true
 
 # Create buildconfig and ImageStream
 # This enables us to create a configuration so we can build a container
 # with the datastream
 # If they already exist, this is not a problem
-cat ocp-resources/ds-build.yaml | sed "s/\$PRODUCT/$product/" | oc create -f - || true
+cat "$root_dir/ocp-resources/ds-build.yaml" | sed "s/\$PRODUCT/$product/" | oc create -f - || true
 
 # Start build
 oc start-build -n openshift-compliance "openscap-$product-ds" --from-file="build/ssg-$product-ds.xml"

--- a/utils/deploy_compliance_operator.sh
+++ b/utils/deploy_compliance_operator.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+root_dir=$(git rev-parse --show-toplevel)
+
+echo "Ensuring openshift-compliance namespace exists."
+# If it already exists, this is not a problem.
+oc create -f "$root_dir/ocp-resources/compliance-operator-ns.yaml" || true
+
+echo "Creating OperatorSource"
+# Create operator source so we can install the latest available release which
+# is available from an "external datastore"; meaning, it's our upstream release
+# which is not yet in OperatorHub
+oc create -f "$root_dir/ocp-resources/compliance-operator-source.yaml"
+
+echo "Creating CatalogSourceConfig"
+# This allows us to create subscriptions
+oc create -f "$root_dir/ocp-resources/compliance-operator-csc.yaml"
+
+echo "Creating OperatorGroup"
+# Create operator group (defines which namespaces are targetted by the
+# operator)
+oc create -f "$root_dir/ocp-resources/compliance-operator-operator-group.yaml"
+
+echo "Creating Subscription"
+# Create subscription (which installs the operator)
+oc create -f "$root_dir/ocp-resources/compliance-operator-alpha-subscription.yaml"


### PR DESCRIPTION
This adds the necessary resources (and a script) to install the
compliance operator in an OpenShift cluster. This is currently using the
alpha channel for the operator, and we'll eventually move it to a stable
channel once we have one.

This will eventually be used in CI to deploy the operator and another
(incoming) script will take it into use to test the ocp4 profiles.
