### PR TITLE
Fix template mount_option_removable_partitions

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1555,12 +1555,9 @@ mount_option_remote_filesystems::
 * Languages: Ansible, Bash, OVAL
 
 mount_option_removable_partitions::
-* Checks if all removable media mounts are mounted with a specific option.
+* Checks if all removable media mounts are mounted with a specific option. Unlike other mount option templates, this template doesn't use the mount point, but the block device. The block device path (eg. `/dev/cdrom`) is always set to `var_removable_partition`. This is an XCCDF Value, defined in `link:{rootdir}/linux_os/guide/system/permissions/partitions/var_removable_partition.var[var_removable_partition.var]`
 * Parameters:
-** *mountpoint* - always set to `var_removable_partition`. This is an XCCDF Value, defined in `link:{rootdir}/linux_os/guide/system/permissions/partitions/var_removable_partition.var[var_removable_partition.var]`
 ** *mountoption* - mount option, eg. `nodev`
-** *filesystem* - filesystem of new mount point (used when adding new entry in `/etc/fstab`), eg. `tmpfs`. Used only in Bash remediation.
-** *mount_has_to_exist* - Used only in Bash remediation. Specifies if the *mountpoint* entry has to exist in `/etc/fstab` before the remediation is executed. If set to `yes` and the *mountpoint* entry is not present in `/etc/fstab` the Bash remediation terminates. If set to `no` the *mountpoint* entry will be created in `/etc/fstab`.
 * Languages: Anaconda, Ansible, Bash, OVAL
 
 package_installed::

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
@@ -39,8 +39,6 @@ platform: machine
 template:
     name: mount_option_removable_partitions
     vars:
-        mount_has_to_exist: 'yes'
         mountoption: nodev
-        mountpoint: var_removable_partition
     backends:
         anaconda: 'off'

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
@@ -47,8 +47,6 @@ platform: machine
 template:
     name: mount_option_removable_partitions
     vars:
-        mount_has_to_exist: 'yes'
         mountoption: noexec
-        mountpoint: var_removable_partition
     backends:
         anaconda: 'off'

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_bad_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_bad_opts.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /var/cdrom iso9660 ro 0 0" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_good_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_good_opts.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /var/cdrom iso9660 noexec 0 0" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,nodev,defaults 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,noexec,nodev 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_first.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_first.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 noexec,ro,noauto,nosuid,nodev 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_last.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_last.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,nodev,noexec 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/dvd_bad_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/dvd_bad_opts.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_C2S
-
-. $SHARED/removable_partitions.sh
-
-touch /dev/dvd
-dvdrom_fstab_line > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/dvd_good_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/dvd_good_opts.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_C2S
-
-. $SHARED/removable_partitions.sh
-
-touch /dev/dvd
-dvdrom_fstab_line noexec > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/no_partitions.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/no_partitions.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+
+# Regression test for rhbz#1403905
+# The rule should pass if there is no removable media entry in /etc/fstab
 
 touch /dev/cdrom
 echo "" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
@@ -41,8 +41,6 @@ platform: machine
 template:
     name: mount_option_removable_partitions
     vars:
-        mount_has_to_exist: 'yes'
         mountoption: nosuid
-        mountpoint: var_removable_partition
     backends:
         anaconda: 'off'

--- a/shared/templates/template_ANACONDA_mount_option_removable_partitions
+++ b/shared/templates/template_ANACONDA_mount_option_removable_partitions
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = high
 
-part (anaconda-populate {{{ MOUNTPOINT }}}) --mountoptions="{{{ MOUNTOPTION }}}"
+part (anaconda-populate var_removable_partition) --mountoptions="{{{ MOUNTOPTION }}}"

--- a/shared/templates/template_ANSIBLE_mount_option_removable_partitions
+++ b/shared/templates/template_ANSIBLE_mount_option_removable_partitions
@@ -3,31 +3,11 @@
 # strategy = configure
 # complexity = low
 # disruption = high
-- (xccdf-var {{{ MOUNTPOINT }}})
+- (xccdf-var var_removable_partition)
 
-- name: get back mount information associated to mountpoint
-  command: findmnt --fstab '{{ {{{ MOUNTPOINT }}} }}'
-  register: device_name
-  failed_when: device_name.rc > 1
-  changed_when: False
-
-- name: create mount_info dictionary variable
-  set_fact:
-    mount_info: "{{ mount_info|default({})|combine({item.0: item.1}) }}"
-  with_together:
-    - "{{ device_name.stdout_lines[0].split() | list | lower }}"
-    - "{{ device_name.stdout_lines[1].split() | list }}"
-  when:
-    - device_name.stdout is defined and device_name.stdout_lines is defined
-    - (device_name.stdout | length > 0)
-
-- name: Ensure permission {{{ MOUNTOPTION }}} are set on {{{ MOUNTPOINT }}}
-  mount:
-    path: "{{ {{{ MOUNTPOINT }}} }}"
-    src: "{{ mount_info.source }}"
-    opts: "{{ mount_info.options }},{{{ MOUNTOPTION }}}"
-    state: "mounted"
-    fstype: "{{ mount_info.fstype }}"
-  when:
-    - device_name.stdout is defined
-    - (device_name.stdout | length > 0)
+- name: Ensure permission {{{ MOUNTOPTION }}} are set on var_removable_partition
+  lineinfile:
+    path: /etc/fstab
+    regexp: '^\s*({{ var_removable_partition }})\s+([^\s]*)\s+([^\s]*)\s+([^\s]*)(.*)$'
+    backrefs: yes
+    line: '\1 \2 \3 \4,{{{ MOUNTOPTION }}} \5'

--- a/shared/templates/template_BASH_mount_option_removable_partitions
+++ b/shared/templates/template_BASH_mount_option_removable_partitions
@@ -4,19 +4,15 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-populate {{{ MOUNTPOINT }}}
+populate var_removable_partition
 
-include_mount_options_functions
+device_regex="^\s*$var_removable_partition\s\+"
+mount_option="{{{ MOUNTOPTION }}}"
 
-function perform_remediation {
-	# test "$mount_has_to_exist" = 'yes'
-	if test "{{{ MOUNT_HAS_TO_EXIST }}}" = 'yes'; then
-		assert_mount_point_in_fstab "${{{ MOUNTPOINT }}}" || { echo "Not remediating, because there is no record of ${{{ MOUNTPOINT }}} in /etc/fstab" >&2; return 1; }
-	fi
-
-	ensure_mount_option_in_fstab "${{{ MOUNTPOINT }}}" "{{{ MOUNTOPTION }}}" "{{{ FILESYSTEM }}}" "{{{ TYPE }}}"
-
-	ensure_partition_is_mounted "${{{ MOUNTPOINT }}}"
-}
-
-perform_remediation
+if grep -q $device_regex /etc/fstab ; then
+    previous_opts=$(grep $device_regex /etc/fstab | awk '{print $4}')
+    sed -i "s|\($device_regex.*$previous_opts\)|\1,$mount_option|" /etc/fstab
+else
+    echo "Not remediating, because there is no record of $var_removable_partition in /etc/fstab" >&2
+    return 1
+fi

--- a/shared/templates/template_OVAL_mount_option_removable_partitions
+++ b/shared/templates/template_OVAL_mount_option_removable_partitions
@@ -1,39 +1,31 @@
 <def-group>
-  <definition class="compliance" id="mount_option_{{{ MOUNTOPTION }}}_removable_partitions" version="4">
+  <definition class="compliance" id="mount_option_{{{ MOUNTOPTION }}}_removable_partitions" version="5">
     <metadata>
       <title>Add {{{ MOUNTOPTION }}} Option to Removable Media Partitions</title>
       {{{- oval_affected(products) }}}
       <description>The {{{ MOUNTOPTION }}} option should be enabled for all removable devices mounts in /etc/fstab.</description>
     </metadata>
     <criteria operator="OR">
-      <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab & runtime configuration
+      <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab
            since there's no device to check against -->
       <extend_definition comment="Check if removable partition really exists on the system"
       definition_ref="removable_partition_doesnt_exist" />
       <!-- Removable device exists. Check if it's CD/DVD drive. If so, verify that at least one from all of the possible its alternative
-           names in /etc/fstab & runtime configuration are configured with '{{{ MOUNTOPTION }}}' option -->
+           names in /etc/fstab are configured with '{{{ MOUNTOPTION }}}' option -->
       <criteria operator="AND">
         <extend_definition comment="Check if removable partition value represents CD/DVD drive"
         definition_ref="var_removable_partition_is_cd_dvd_drive" />
         <criteria operator="OR">
-          <criteria operator="AND">
-            <criterion test_ref="test_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive"
+          <criterion test_ref="test_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive"
             comment="Check if at least one from CD/DVD drive alternative names is using '{{{ MOUNTOPTION }}}' mount option in /etc/fstab" />
-            <criterion test_ref="test_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive"
-            comment="Check if at least one from CD/DVD drive alternative names is using '{{{ MOUNTOPTION }}}' mount option in runtime configuration" />
-          </criteria>
           <extend_definition definition_ref="no_cd_dvd_drive_in_etc_fstab"
           comment="Check if CD/DVD drive is not configured to automount in /etc/fstab" />
         </criteria>
       </criteria>
       <!-- Removable device exists & isn't CD/DVD drive. Check the particular devices is configured with '{{{ MOUNTOPTION }}}' mount option in both
-           /etc/fstab & runtime configuration -->
-      <criteria operator="AND">
-        <criterion test_ref="test_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive"
+           /etc/fstab -->
+      <criterion test_ref="test_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive"
         comment="Check if removable partition is using '{{{ MOUNTOPTION }}}' mount option in /etc/fstab" />
-        <criterion test_ref="test_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive"
-        comment="Check if removable partition is using '{{{ MOUNTOPTION }}}' mount option in runtime configuration" />
-      </criteria>
     </criteria>
   </definition>
 
@@ -74,25 +66,6 @@
     <ind:subexpression operation="pattern match" datatype="string">^.*,?{{{ MOUNTOPTION }}},?.*$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <linux:partition_test id="test_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" check="all" comment="'{{{ MOUNTOPTION }}}' mount option used for at least one CD / DVD drive alternative names in runtime configuration" version="1">
-    <linux:object object_ref="object_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" />
-  </linux:partition_test>
-
-  <linux:partition_object id="object_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" version="1">
-    <!-- CD / DVD drive can be mounted under any mount_point. We don't know ahead its exact name.
-         => Capture all & filter out only the relevant ones via the corresponding state -->
-    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
-    <!-- Therefore from all the captured mount points select only those having
-         device set to some CD / DVD drive alternative name and simultaneously
-         having '{{{ MOUNTOPTION }}}' mount option used -->
-    <filter action="include">state_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive</filter>
-  </linux:partition_object>
-
-  <linux:partition_state id="state_{{{ MOUNTOPTION }}}_runtime_cd_dvd_drive" version="1">
-    <linux:device datatype="string" operation="equals" var_ref="variable_cd_dvd_drive_alternative_names_{{{ MOUNTOPTION }}}" var_check="at least one" />
-    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
-  </linux:partition_state>
-
   <!-- Specified removable partition exists & doesn't represent a CD/DVD drive.
        Check if configured with '{{{ MOUNTOPTION }}}' mount option in both /etc/fstab & runtime configuration -->
   <ind:textfilecontent54_test id="test_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" check="at least one" check_existence="all_exist" comment="Check if removable partition is configured with '{{{ MOUNTOPTION }}}' mount option in /etc/fstab" version="1">
@@ -120,25 +93,6 @@
   <ind:textfilecontent54_state id="state_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" version="1">
     <ind:subexpression operation="pattern match" datatype="string">^.*,?{{{ MOUNTOPTION }}},?.*</ind:subexpression>
   </ind:textfilecontent54_state>
-
-  <linux:partition_test id="test_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" check="all" check_existence="all_exist" comment="'{{{ MOUNTOPTION }}}' mount option used for removable partition in runtime configuration" version="1">
-    <linux:object object_ref="object_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" />
-  </linux:partition_test>
-
-  <linux:partition_object id="object_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" version="1">
-    <!-- Removable partition can be mounted under any mount point. We don't know it's
-         exact name ahead => Capture all & filter out only those relevant later via state -->
-    <linux:mount_point operation="pattern match">^.*$</linux:mount_point>
-    <!-- From all the captured mount points select only those having device equal
-         to 'var_removable_partition' variable value and simultaneously having
-         '{{{ MOUNTOPTION }}}' mount option set -->
-    <filter action="include">state_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive</filter>
-  </linux:partition_object>
-
-  <linux:partition_state id="state_{{{ MOUNTOPTION }}}_runtime_not_cd_dvd_drive" version="1">
-    <linux:device datatype="string" operation="equals" var_ref="var_removable_partition" var_check="at least one" />
-    <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
-  </linux:partition_state>
 
   <external_variable comment="removable partition" datatype="string" id="var_removable_partition" version="1" />
 

--- a/shared/templates/template_OVAL_mount_option_removable_partitions
+++ b/shared/templates/template_OVAL_mount_option_removable_partitions
@@ -50,7 +50,7 @@
   </local_variable>
 
   <!-- If specified removable partition represents CD / DVD drive, use all alternative
-       names to check /etc/fstab & runtime settings -->
+       names to check /etc/fstab -->
   <ind:textfilecontent54_test id="test_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" check_existence="any_exist" check="all" comment="'{{{ MOUNTOPTION }}}' mount option used for at least one CD / DVD drive alternative names in /etc/fstab" version="1">
     <ind:object object_ref="object_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" />
     <ind:state state_ref="state_{{{ MOUNTOPTION }}}_etc_fstab_cd_dvd_drive" />
@@ -67,7 +67,7 @@
   </ind:textfilecontent54_state>
 
   <!-- Specified removable partition exists & doesn't represent a CD/DVD drive.
-       Check if configured with '{{{ MOUNTOPTION }}}' mount option in both /etc/fstab & runtime configuration -->
+       Check if configured with '{{{ MOUNTOPTION }}}' mount option in both /etc/fstab -->
   <ind:textfilecontent54_test id="test_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" check="at least one" check_existence="all_exist" comment="Check if removable partition is configured with '{{{ MOUNTOPTION }}}' mount option in /etc/fstab" version="1">
     <ind:object object_ref="object_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" />
     <ind:state state_ref="state_{{{ MOUNTOPTION }}}_etc_fstab_not_cd_dvd_drive" />

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -237,7 +237,7 @@ def mount_option_remote_filesystems(data, lang):
 
 @template(["anaconda", "ansible", "bash", "oval"])
 def mount_option_removable_partitions(data, lang):
-    return _mount_option(data, lang)
+    return data
 
 
 @template(["anaconda", "ansible", "bash", "oval", "puppet"])


### PR DESCRIPTION
There are multiple problems that we try to address by this patch.

1. The test scenario dvd_bad_opts.fail.sh for rule
mount_option_noexec_removable_partitions was failing because scanner
returned pass instead of expected fail. That is because the rule checks
if path specified by var_removable_partition exists and if it doesn't
exist the rule fail. This variable is always set to /dev/cdrom in all
profiles, as the variable definition has only this value. See
/linux_os/guide/system/permissions/partitions/var_removable_partition.var
Unless tailoring is used, the rule always passes if /dev/cdrom doesn't
exist. As the test scenario didn't create /dev/cdrom, but /dev/dvd,
the rule passed.

2. The test scenario dvd_good_opts.pass.sh for rule
mount_option_noexec_removable_partitions was also broken even if it
returned OK. The test scenario was creating /dev/dvd. So again, the
OVAL check passed because /dev/cdrom didn't exist.  Therefore the test
scenario was not testing the actual regular expression matching
in /etc/fstab.

3. The Bash and Ansible remediation weren't functional, because they
operated with a mount point (second column of /etc/fstab) but they
were passed values of the block device (which is in first column of
/etc/fstab). I think that people can mount the removable media to
arbitrary directories so we should base our checks on the block device
path instead of mount points. Actually, in all 3 rules we passed the
device path (/dev/cdrom) as a mount point.  That was probably a wrong
understanding of the remediation code. The remediations are reworked
to find entry starting with var_removable_partition value.

4. The OVAL check wasn't checking only /etc/fstab configuration, but was
also checking runtime state. That didn't conform to the rule
description. My understanding of the rule description is that the rule
is only about configuration, there is no mention of runtime.  Moreover,
the removable device doesn't have to be mounted at the moment of system
evaluation.

5. The test scenarios didn't cover multiple situation, so apart of
fixing the broken scenarios, new test scenarios have been added.

We still have a problem that /dev/cdrom is not the only possible
removable device that could exist. Think of USB flash drives, memory
cards, etc. The rule descriptions speak about removable media and
mention USB keys, but the checks don't check them. The challenge
will be recognizing removable media.

Resolves: RHBZ#1691579

This is opened for discussion. I wasn't able to understand this rule. Maybe I accidentally removed something that is intentional. Please review and let me know.
