### PR TITLE
OCP4: Add ignition remediation for disabling certain Linux kernel modules

### DIFF
--- a/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20atm%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_atm_disabled.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20can%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_can_disabled.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20firewire-core%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_firewire-core_disabled.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20sctp%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_sctp_disabled.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20tipc%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_tipc_disabled.conf

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20bluetooth%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_bluetooth_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20cramfs%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_cramfs_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20freevxfs%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_freevxfs_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20hfs%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_hfs_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20hfsplus%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_hfsplus_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20jffs2%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_jffs2_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20squashfs%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_squashfs_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20udf%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_udf_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20usb-storage%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_usb-storage_disabled.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,install%20vfat%20/bin/true%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/modprobe.d/75-kernel_module_vfat_disabled.conf


### PR DESCRIPTION
#### Description:
Adds Ignition remediations that cover all the kernel module related rules
in the content.


#### Rationale:
Increase the coverage of the OCP4 profile
- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._