### PR TITLE
Add XCCDF conflicts and requires

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -791,6 +791,10 @@ A rule itself contains these attributes:
 The <tt>/tmp</tt> partition is used as temporary storage by many programs. Placing <tt>/tmp</tt> in its own partition enables the setting of more restrictive mount options, which can help protect programs which use it.
 * `description`: Human-readable HTML description, which provides broader context for non-experts than the rationale. For example, description of the `partition_for_tmp` rule states that:
 +
+* `requires`: The `id` of another rule or group that must be selected and enabled in a profile.
++
+* `conflicts`: The `id` of another rule or group that must not be selected and disabled in a profile.
++
 The <tt>/var/tmp</tt> directory is a world-writable directory used for temporary file storage. Ensure it has its own partition or logical volume at installation time, or migrate it using LVM.
 * `severity`: Is used for metrics and tracking. It can have one of the following values: `unknown`, `info`, `low`, `medium`, or `high`.
 +

--- a/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
@@ -20,6 +20,9 @@ rationale: |-
 
 severity: high
 
+requires:
+    - package_audit_installed
+
 identifiers:
     cce@rhel6: 27058-7
     cce@rhel7: 27407-6

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -20,6 +20,9 @@ medium
 high
 {{%- endif %}}
 
+conflicts:
+    - selinux_state
+
 identifiers:
     cce@rhel6: 27409-2
     cce@rhel7: 26818-5

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -56,6 +56,7 @@
   </xsl:template>
 
   <!-- hack for OpenSCAP validation quirk: must place reference after description/warning, but prior to others -->
+  <!-- Another hack for OpenSCAP validation quirk: must place platform after reference/rationale, but prior to others -->
   <xsl:template match="Rule">
     <xsl:choose>
       <xsl:when test="contains(@prodtype, $prod_type) or @prodtype = 'all'">
@@ -73,9 +74,9 @@
           <xsl:apply-templates select="warning[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="ref[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
+          <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="requires[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
-          <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="ident[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <!-- order oval (shorthand tag) first, to indicate to tools to prefer its automated checks -->
           <xsl:apply-templates select="oval[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
@@ -122,9 +123,9 @@
           <xsl:apply-templates select="warning[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="ref[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
+          <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="requires[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="conflicts[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
-          <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="node()[not(self::title|self::description|self::warning|self::ref|self::rationale|self::requires|self::conflicts|self::platform|self::prodtype)]"/>
         </Group>
       </xsl:when>
@@ -140,9 +141,9 @@
       <xsl:apply-templates select="warning"/>
       <xsl:apply-templates select="ref"/>
       <xsl:apply-templates select="rationale"/>
+      <xsl:apply-templates select="platform"/>
       <xsl:apply-templates select="requires"/>
       <xsl:apply-templates select="conflicts"/>
-      <xsl:apply-templates select="platform"/>
       <xsl:apply-templates select="node()[not(self::title|self::description|self::warning|self::ref|self::rationale|self::requires|self::conflicts|self::platform)]"/>
     </Group>
   </xsl:template>

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -90,6 +90,14 @@ def add_warning_elements(element, warnings):
         warning.set("category", list(warning_dict.keys())[0])
 
 
+def add_nondata_subelements(element, subelement, attribute, attr_data):
+    """Add multiple iterations of a sublement that contains an attribute but no data
+       For example, <requires id="my_required_id"/>"""
+    for data in attr_data:
+        req = ET.SubElement(element, subelement)
+        req.set(attribute, data)
+
+
 class Profile(object):
     """Represents XCCDF profile
     """
@@ -600,6 +608,8 @@ class Group(object):
         self.title = ""
         self.description = ""
         self.warnings = []
+        self.requires = []
+        self.conflicts = []
         self.values = {}
         self.groups = {}
         self.rules = {}
@@ -619,6 +629,8 @@ class Group(object):
         group.description = required_key(yaml_contents, "description")
         del yaml_contents["description"]
         group.warnings = yaml_contents.pop("warnings", [])
+        group.conflicts = yaml_contents.pop("conflicts", [])
+        group.requires = yaml_contents.pop("requires", [])
         group.platform = yaml_contents.pop("platform", None)
 
         for warning_list in group.warnings:
@@ -649,6 +661,8 @@ class Group(object):
         title.text = self.title
         add_sub_element(group, 'description', self.description)
         add_warning_elements(group, self.warnings)
+        add_nondata_subelements(group, "requires", "id", self.requires)
+        add_nondata_subelements(group, "conflicts", "id", self.conflicts)
 
         if self.platform:
             platform_el = ET.SubElement(group, "platform")
@@ -745,6 +759,8 @@ class Rule(object):
         "ocil": lambda: None,
         "oval_external_content": lambda: None,
         "warnings": lambda: list(),
+        "conflicts": lambda: list(),
+        "requires": lambda: list(),
         "platform": lambda: None,
         "template": lambda: None,
     }
@@ -762,6 +778,8 @@ class Rule(object):
         self.ocil = None
         self.oval_external_content = None
         self.warnings = []
+        self.requires = []
+        self.conflicts = []
         self.platform = None
         self.template = None
 
@@ -1038,6 +1056,8 @@ class Rule(object):
                 ocil.set("clause", self.ocil_clause)
 
         add_warning_elements(rule, self.warnings)
+        add_nondata_subelements(rule, "requires", "id", self.requires)
+        add_nondata_subelements(rule, "conflicts", "id", self.conflicts)
 
         if self.platform:
             platform_el = ET.SubElement(rule, "platform")


### PR DESCRIPTION
#### Description:

- Adds the capability of specifying `<xccdf:requires/>` and `<xccdf:conflicts/>` in benchmark writing to allow finer control over rules/groups that either depend on each other or conflict with each other. 