### PR TITLE
adding oval check for rule

### DIFF
--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/oval/shared.xml
@@ -1,27 +1,13 @@
-<def-group>
-  <definition class="compliance" id="postfix_prevent_unrestricted_relay" version="1">
-    <metadata>
-      <title>Configure Postfix Against Unrestricted Mail Relay</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-		<platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>Protect against unrestricted relay of mail.</description>
-    </metadata>
-    <criteria operator="AND">
-      <criterion comment="prevent unrestricted mail relay" test_ref="test_prevent_unrestricted_relay" />
-    </criteria>
-  </definition>
-
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
-  comment="Set banner" id="test_prevent_unrestricted_relay" version="1">
-    <ind:object object_ref="obj_postfix_restrict_relay" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_postfix_restrict_relay" version="1">
-    <ind:filepath>/etc/postfix/main.cf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*smtpd_client_restrictions[\s]*=[\s]*permit_mynetworks,+reject[\s]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-</def-group>
+{{{
+oval_check_config_file(
+	"/etc/postfix/main.cf",
+	prefix_regex="^[ \\t]*",
+	parameter="smtpd_client_restrictions",
+	separator_regex=' = ',
+	value="permit_mynetworks,reject",
+	missing_parameter_pass=false,
+	application="mail",
+	multi_value=false,
+	missing_config_file_fail=true
+	)
+}}}

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="postfix_prevent_unrestricted_relay" version="1">
+    <metadata>
+      <title>Configure Postfix Against Unrestricted Mail Relay</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+		<platform>multi_platform_wrlinux</platform>
+      </affected>
+      <description>Protect against unrestricted relay of mail.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="prevent unrestricted mail relay" test_ref="test_prevent_unrestricted_relay" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Set banner" id="test_prevent_unrestricted_relay" version="1">
+    <ind:object object_ref="obj_postfix_restrict_relay" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_postfix_restrict_relay" version="1">
+    <ind:filepath>/etc/postfix/main.cf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*smtpd_client_restrictions[\s]*=[\s]*permit_mynetworks,+reject[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/absent.fail.sh
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/absent.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /etc/postfix
+echo > /etc/postfix/main.cf

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/defective.fail.sh
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/defective.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /etc/postfix
+echo 'smtpd_client_restrictions = permit_mynetworks,dont_reject' > /etc/postfix/main.cf

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/ok.pass.sh
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/ok.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /etc/postfix
+echo 'smtpd_client_restrictions = permit_mynetworks,reject' > /etc/postfix/main.cf


### PR DESCRIPTION
#### Description:

- _Added oval check for rule postfix_prevent_unrestricted_relay_

#### Rationale:

- _Oscap was not performing the check or remediation for this rule because the oval check did not exist?_

