### PR TITLE
Ansible audit sysadmin actions

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/ansible/shared.yml
@@ -1,0 +1,53 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+# Inserts/replaces the rule in /etc/audit/rules.d
+
+- name: Search /etc/audit/rules.d for audit rule entries for sysadmin actions
+  find:
+    paths: "/etc/audit/rules.d"
+    recurse: no
+    contains: "^.*/etc/sudoers.*$"
+    patterns: "*.rules"
+  register: find_audit_sysadmin_actions
+
+- name: Use /etc/audit/rules.d/actions.rules as the recipient for the rule
+  set_fact:
+    all_sysadmin_actions_files:
+      - /etc/audit/rules.d/actions.rules
+  when: find_audit_sysadmin_actions.matched is defined and find_audit_sysadmin_actions.matched == 0
+
+- name: Use matched file as the recipient for the rule
+  set_fact:
+    all_sysadmin_actions_files:
+      - "{{ find_audit_sysadmin_actions.files | map(attribute='path') | list | first }}"
+  when: find_audit_sysadmin_actions.matched is defined and find_audit_sysadmin_actions.matched > 0
+
+- name: Inserts/replaces audit rule for /etc/sudoers rule in rules.d
+  lineinfile:
+    path: "{{ all_sysadmin_actions_files[0] }}"
+    line: '-w /etc/sudoers -p wa -k actions'
+    create: yes
+
+- name: Inserts/replaces audit rule for /etc/sudoers.d rule in rules.d
+  lineinfile:
+    path: "{{ all_sysadmin_actions_files[0] }}"
+    line: '-w /etc/sudoers.d/ -p wa -k actions'
+    create: yes
+
+# Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
+
+- name: Inserts/replaces audit rule for /etc/sudoers in audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-w /etc/sudoers -p wa -k actions'
+    create: yes
+
+- name: Inserts/replaces audit rule for /etc/sudoers.d in audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-w /etc/sudoers.d/ -p wa -k actions'
+    create: yes

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/bash/shared.sh
@@ -7,5 +7,5 @@
 fix_audit_watch_rule "auditctl" "/etc/sudoers" "wa" "actions"
 fix_audit_watch_rule "augenrules" "/etc/sudoers" "wa" "actions"
 
-fix_audit_watch_rule "auditctl" "/etc/sudoers.d" "wa" "actions"
-fix_audit_watch_rule "augenrules" "/etc/sudoers.d" "wa" "actions"
+fix_audit_watch_rule "auditctl" "/etc/sudoers.d/" "wa" "actions"
+fix_audit_watch_rule "augenrules" "/etc/sudoers.d/" "wa" "actions"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
@@ -9,10 +9,12 @@
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
         <criterion comment="audit augenrules sudoers" test_ref="test_audit_rules_sysadmin_actions_sudoers_augenrules" />
+        <criterion comment="audit augenrules sudoers_d" test_ref="test_audit_rules_sysadmin_actions_sudoers_d_augenrules" />
       </criteria>
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
         <criterion comment="audit auditctl sudoers" test_ref="test_audit_rules_sysadmin_actions_sudoers_auditctl" />
+        <criterion comment="audit auditctl sudoers_d" test_ref="test_audit_rules_sysadmin_actions_sudoers_d_auditctl" />
       </criteria>
     </criteria>
   </definition>
@@ -26,12 +28,30 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  <ind:textfilecontent54_test check="all" comment="audit augenrules sudoers" id="test_audit_rules_sysadmin_actions_sudoers_d_augenrules" version="1">
+    <ind:object object_ref="object_audit_rules_sysadmin_actions_sudoers_d_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_sysadmin_actions_sudoers_d_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sudoers\.d/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
   <ind:textfilecontent54_test check="all" comment="audit auditctl sudoers" id="test_audit_rules_sysadmin_actions_sudoers_auditctl" version="1">
     <ind:object object_ref="object_audit_rules_sysadmin_actions_sudoers_auditctl" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_audit_rules_sysadmin_actions_sudoers_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match">^\-w[\s]+/etc/sudoers[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)[-\w]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl sudoers" id="test_audit_rules_sysadmin_actions_sudoers_d_auditctl" version="1">
+    <ind:object object_ref="object_audit_rules_sysadmin_actions_sudoers_d_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_sysadmin_actions_sudoers_d_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sudoers\.d/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)[-\w]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
@@ -1,0 +1,4 @@
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
+echo "-w /etc/sudoers.d/ -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/empty.fail.sh
@@ -1,0 +1,4 @@
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
@@ -1,0 +1,4 @@
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
+echo "-w /etc/sudoers.d -p wa -k actions" >> /etc/audit/rules.d/actions.rules


### PR DESCRIPTION
#### Description:

- Implement OVAL check for audit rules for `/etc/sudoers.d/`
- Fix remediation for `/etc/sudoers.d/` based on rule description and linux-audit [rules](https://github.com/linux-audit/audit-userspace/blob/master/rules/30-stig.rules#L131)
- Add Ansible remediation

#### Rationale:
- Remediation was improved in https://github.com/ComplianceAsCode/content/commit/1304a15d4ffed113b5cc3baaa392b5f279317c7a, but OVAL didn't follow.
- It seems the rule description always mentioned watching `/etc/sudoers.d/`, but OVAL never checked for it, :sweat_smile:.
