### PR TITLE
Add several kernel arguments for the OCP4 content

### DIFF
--- a/linux_os/guide/system/auditing/grub2_audit_argument/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/ignition/shared.yml
@@ -1,0 +1,6 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  kernelArguments:
+    - audit=1

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/ignition/shared.yml
@@ -1,0 +1,6 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  kernelArguments:
+    - audit_backlog_limit=8192

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/ignition/shared.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/ignition/shared.yml
@@ -1,0 +1,6 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  kernelArguments:
+    - pti=on

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/ignition/shared.yml
@@ -1,0 +1,6 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  kernelArguments:
+    - page_poison=1

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/ignition/shared.yml
@@ -1,0 +1,6 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  kernelArguments:
+    - slub_debug=P


### PR DESCRIPTION
#### Description:
Add several kernel arguments for the OCP4 content. Not all are added as
there are some open questions e.g. for disabling interactive boot or for
the nousb argument we might take advantage of tailoring and only include
a version of content for VM-based clusters and a different one for
bare-metal clusters.

#### Rationale:
Increases the coverage of the OCP4 content