### PR TITLE
Select package_audit_installed

### DIFF
--- a/linux_os/guide/system/auditing/package_audit_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audit_installed/rule.yml
@@ -20,6 +20,7 @@ references:
     nist: AC-7(a),AU-7(1),AU-7(2),AU-14,AU-12(2),AU-2(a),CM-6(a)
     anssi: NT28(R50)
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000122-GPOS-00063
+    cis@rhel8: 4.1.1.1
 
 template:
     name: package_installed

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -525,7 +525,7 @@ selections:
     ### 4.1.1 Ensure auditing is enabled
 
     #### 4.1.1.1 Ensure auditd is installed (Scored)
-    # NEEDS RULE - https://github.com/ComplianceAsCode/content/issues/5261
+    - package_audit_installed
 
     #### 4.1.1.2 Ensure auditd service is enabled (Scored)
     - service_auditd_enabled


### PR DESCRIPTION
Package audit depends on audit-libs.

#### Description:

- Select rule to install audit package.

#### Rationale:

- `audit` package requires `audit-libs`, so I think the requirement is pretty much covered.

- Fixes #5261
