### PR TITLE
SSGTS: addressed incompatibilities with python2

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -8,7 +8,8 @@ import collections
 import xml.etree.ElementTree
 import json
 import datetime
-
+import socket
+import sys
 
 from ssg.constants import OSCAP_PROFILE_ALL_ID
 
@@ -17,6 +18,12 @@ from ssg_test_suite import test_env
 from ssg_test_suite import common
 
 from ssg.shims import input_func
+
+# Needed for compatibility as there is no TimeoutError in python2.
+if sys.version_info[0] < 3:
+    TimeoutException = socket.timeout
+else:
+    TimeoutException = TimeoutError
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -623,7 +630,7 @@ class Checker(object):
             logging.info("Terminating the test run due to keyboard interrupt.")
         except RuntimeError as exc:
             logging.error("Terminating due to error: {msg}.".format(msg=str(exc)))
-        except TimeoutError as exc:
+        except TimeoutException as exc:
             logging.error("Terminating due to timeout: {msg}".format(msg=str(exc)))
         finally:
             self.finalize()

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -22,7 +22,6 @@ class ProfileChecker(ssg_test_suite.oscap.Checker):
         self.run_test_for_all_profiles(profiles)
 
     def _run_test(self, profile, test_data):
-        logging.info("Evaluation of profile {0}.".format(profile))
         self.executed_tests += 1
 
         runner_cls = ssg_test_suite.oscap.REMEDIATION_PROFILE_RUNNERS[self.remediate_using]
@@ -30,6 +29,7 @@ class ProfileChecker(ssg_test_suite.oscap.Checker):
             self.test_env, profile, self.datastream, self.benchmark_id)
 
         for stage in ("initial", "remediation", "final"):
+            logging.info("Evaluation of profile {0} ({1} stage).".format(profile, stage))
             result = runner.run_stage(stage)
 
 


### PR DESCRIPTION
#### Description:

Fixed incompatibilities with python2, for example, missing
`TimeoutError`, missing support for context managers in `socket`
and missing `time.perf_counter()` function.
Logging is also updated - from now the messages about evaluation
of profile contain information about current stage (initial, remediation, final).

- Fixes #5293
