### PR TITLE
add ntp and chrony cpes

### DIFF
--- a/debian10/cpe/debian10-cpe-dictionary.xml
+++ b/debian10/cpe/debian10-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -31,6 +36,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/debian8/cpe/debian8-cpe-dictionary.xml
+++ b/debian8/cpe/debian8-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -31,6 +36,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/debian9/cpe/debian9-cpe-dictionary.xml
+++ b/debian9/cpe/debian9-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -31,6 +36,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/fedora/cpe/fedora-cpe-dictionary.xml
+++ b/fedora/cpe/fedora-cpe-dictionary.xml
@@ -52,6 +52,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -66,6 +71,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/ocp4/cpe/ocp4-cpe-dictionary.xml
+++ b/ocp4/cpe/ocp4-cpe-dictionary.xml
@@ -12,6 +12,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ol7/cpe/ol7-cpe-dictionary.xml
+++ b/ol7/cpe/ol7-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -31,6 +36,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/ol8/cpe/ol8-cpe-dictionary.xml
+++ b/ol8/cpe/ol8-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/opensuse/cpe/opensuse-cpe-dictionary.xml
+++ b/opensuse/cpe/opensuse-cpe-dictionary.xml
@@ -32,6 +32,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -46,6 +51,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/rhel6/cpe/rhel6-cpe-dictionary.xml
+++ b/rhel6/cpe/rhel6-cpe-dictionary.xml
@@ -37,6 +37,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -51,6 +56,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/rhel7/cpe/rhel7-cpe-dictionary.xml
+++ b/rhel7/cpe/rhel7-cpe-dictionary.xml
@@ -47,6 +47,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -61,6 +66,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/rhel8/cpe/rhel8-cpe-dictionary.xml
+++ b/rhel8/cpe/rhel8-cpe-dictionary.xml
@@ -22,6 +22,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/rhv4/cpe/rhv4-cpe-dictionary.xml
+++ b/rhv4/cpe/rhv4-cpe-dictionary.xml
@@ -22,6 +22,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/shared/checks/oval/installed_env_has_chrony_package.xml
+++ b/shared/checks/oval/installed_env_has_chrony_package.xml
@@ -1,0 +1,20 @@
+<def-group>
+
+  <definition class="inventory"
+  id="installed_env_has_chrony_package" version="1">
+    <metadata>
+      <title>Package chrony is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package chrony is installed.</description>
+      <reference ref_id="cpe:/a:chrony" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package chrony is installed" test_ref="test_env_has_chrony_installed" />
+    </criteria>
+  </definition>
+
+  {{{ oval_test_package_installed(package='chrony', evr='', test_id='test_env_has_chrony_installed') }}}
+
+</def-group>

--- a/shared/checks/oval/installed_env_has_ntp_package.xml
+++ b/shared/checks/oval/installed_env_has_ntp_package.xml
@@ -1,0 +1,20 @@
+<def-group>
+
+  <definition class="inventory"
+  id="installed_env_has_ntp_package" version="1">
+    <metadata>
+      <title>Package ntp is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package ntp is installed.</description>
+      <reference ref_id="cpe:/a:ntp" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package ntp is installed" test_ref="test_env_has_ntp_installed" />
+    </criteria>
+  </definition>
+
+  {{{ oval_test_package_installed(package='ntp', evr='', test_id='test_env_has_ntp_installed') }}}
+
+</def-group>

--- a/sle11/cpe/sle11-cpe-dictionary.xml
+++ b/sle11/cpe/sle11-cpe-dictionary.xml
@@ -22,6 +22,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -36,6 +41,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/sle12/cpe/sle12-cpe-dictionary.xml
+++ b/sle12/cpe/sle12-cpe-dictionary.xml
@@ -22,6 +22,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -36,6 +41,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -439,9 +439,11 @@ OCILREFATTR_TO_TAG = {
 XCCDF_PLATFORM_TO_CPE = {
     "machine": "cpe:/a:machine",
     "container": "cpe:/a:container",
+    "chrony": "cpe:/a:chrony",
     "gdm": "cpe:/a:gdm",
     "libuser": "cpe:/a:libuser",
     "nss-pam-ldapd": "cpe:/a:nss-pam-ldapd",
+    "ntp": "cpe:/a:ntp",
     "pam": "cpe:/a:pam",
     "login_defs": "cpe:/a:login_defs",
     "sssd": "cpe:/a:sssd",

--- a/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
+++ b/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -31,6 +36,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
+++ b/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -31,6 +36,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
+++ b/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
@@ -17,6 +17,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -31,6 +36,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
+++ b/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
@@ -2,10 +2,10 @@
 <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
-      <cpe-item name="cpe:/o:windriver:wrlinux:1019">        
-            <title xml:lang="en-us">Wind River Linux 1019</title>        
+      <cpe-item name="cpe:/o:windriver:wrlinux:1019">
+            <title xml:lang="en-us">Wind River Linux 1019</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_wrlinux1019</check>
-      </cpe-item>        
+      </cpe-item>
       <cpe-item name="cpe:/a:container">
             <title xml:lang="en-us">Container</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -15,6 +15,11 @@
             <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
@@ -30,6 +35,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>

--- a/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
+++ b/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
@@ -2,10 +2,10 @@
 <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
-      <cpe-item name="cpe:/o:windriver:wrlinux:8">        
-            <title xml:lang="en-us">Wind River Linux 8</title>        
+      <cpe-item name="cpe:/o:windriver:wrlinux:8">
+            <title xml:lang="en-us">Wind River Linux 8</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_wrlinux8</check>
-      </cpe-item>        
+      </cpe-item>
       <cpe-item name="cpe:/a:container">
             <title xml:lang="en-us">Container</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
@@ -15,6 +15,11 @@
             <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:gdm">
             <title xml:lang="en-us">Package gdm is installed</title>
@@ -30,6 +35,11 @@
             <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
       </cpe-item>
       <cpe-item name="cpe:/a:pam">
             <title xml:lang="en-us">Package pam is installed</title>


### PR DESCRIPTION
#### Description:

Add CPEs for package_ntp_installed and package_chrony_installed to relevant platforms I know about.

#### Rationale:

These applicability CPEs will be used in batch of rules pertaining to ntp and chrony.

