### PR TITLE
Ticket40400 sshd use approved macs

### DIFF
--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -11,6 +11,5 @@ operator: equals
 interactive: false
 
 options:
-    sle12_stig: hmac-sha2-512,hmac-sha2-256
-	rhel7_stig: hmac-sha2-512,hmac-sha2-256
+    stig: hmac-sha2-512,hmac-sha2-256
     default: hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -12,4 +12,5 @@ interactive: false
 
 options:
     sle12_stig: hmac-sha2-512,hmac-sha2-256
+	rhel7_stig: hmac-sha2-512,hmac-sha2-256
     default: hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -21,7 +21,7 @@ selections:
     - inactivity_timeout_value=15_minutes
     - var_screensaver_lock_delay=5_seconds
     - sshd_idle_timeout_value=10_minutes
-    - sshd_approved_macs=rhel7_stig
+    - sshd_approved_macs=stig
     - var_accounts_fail_delay=4
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -21,6 +21,7 @@ selections:
     - inactivity_timeout_value=15_minutes
     - var_screensaver_lock_delay=5_seconds
     - sshd_idle_timeout_value=10_minutes
+    - sshd_approved_macs=rhel7_stig
     - var_accounts_fail_delay=4
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted


### PR DESCRIPTION
#### Description:

- Edited rhel7 stig profile to reference the .var file for current values. Edited the .var file to include current stig-required values for rhel7.

#### Rationale:

- The default values are no longer stig compliant. Scan and remediation previously passed on rhel 7 targets with incorrect values for  FIPS approved macs.

