### PR TITLE
changed missing parameter pass from true to false per stig 40440

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
@@ -47,7 +47,7 @@ ocil: |-
 template:
     name: sshd_lineinfile
     vars:
-        missing_parameter_pass: 'true'
+        missing_parameter_pass: 'false'
         parameter: KerberosAuthentication
         rule_id: sshd_disable_kerb_auth
         value: 'no'


### PR DESCRIPTION
#### Description:

- Edited rule.yml, changed missing parameter to false per stig 40440.

#### Rationale:

- Scan was showing pass even when parameter was missing. STIG dictates this represents a finding.

