### PR TITLE
Ticket40450 sshd enable strictmodes

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
@@ -46,7 +46,7 @@ ocil: |-
 template:
     name: sshd_lineinfile
     vars:
-        missing_parameter_pass: 'true'
+        missing_parameter_pass: 'false'
         parameter: StrictModes
         rule_id: sshd_enable_strictmodes
         value: 'yes'


### PR DESCRIPTION
#### Description:

- Edited rule.yml, changed missing parameter pass to false per stig 40450

#### Rationale:

- Scan was showing pass even though parameter was not present in file. Stig shows this as a finding.

