### PR TITLE
Parametrized the sshd_use_approved_ciphers rule

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -3,4 +3,6 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-{{{ ansible_sshd_set(parameter="Ciphers", value="aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc") }}}
+- (xccdf-var sshd_approved_ciphers)
+
+{{{ ansible_sshd_set(parameter="Ciphers", value="{{ sshd_approved_ciphers }}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -3,4 +3,6 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-replace_or_append '/etc/ssh/sshd_config' '^Ciphers' 'aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc' '@CCENUM@' '%s %s'
+populate sshd_approved_ciphers
+
+replace_or_append '/etc/ssh/sshd_config' '^Ciphers' "$sshd_approved_ciphers" '@CCENUM@' '%s %s'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
@@ -32,14 +32,39 @@
       </criteria>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+
+  <ind:variable_test check="all" check_existence="all_exist"
   comment="tests the value of Ciphers setting in the /etc/ssh/sshd_config file"
   id="test_sshd_use_approved_ciphers" version="1">
     <ind:object object_ref="obj_sshd_use_approved_ciphers" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_sshd_use_approved_ciphers" version="2">
+    <ind:state state_ref="ste_sshd_use_approved_ciphers" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_sshd_use_approved_ciphers" version="1">
+    <ind:var_ref>var_sshd_config_ciphers</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state comment="approved ciphers" id="ste_sshd_use_approved_ciphers" version="1">
+    <ind:value operation="equals" datatype="string" var_ref="var_sshd_approved_ciphers" var_check="at least one" />
+  </ind:variable_state>
+
+  <ind:textfilecontent54_object id="obj_sshd_config_ciphers" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+((aes128-ctr|aes192-ctr|aes256-ctr|aes128-cbc|aes192-cbc|aes256-cbc|3des-cbc|rijndael-cbc@lysator\.liu\.se),?)+[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?i)Ciphers(?-i)[\s]+([\w,-@]+)+[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <local_variable id="var_sshd_config_ciphers" datatype="string" version="1" comment="Ciphers values splitted on comma">
+    <split delimiter=",">
+      <object_component item_field="subexpression" object_ref="obj_sshd_config_ciphers" />
+    </split>
+  </local_variable>
+
+  <local_variable id="var_sshd_approved_ciphers" datatype="string" version="1" comment="approved ciphers values splitted on comma">
+    <split delimiter=",">
+      <variable_component var_ref="sshd_approved_ciphers" />
+    </split>
+  </local_variable>
+
+  <external_variable comment="SSH Approved Ciphers by FIPS" datatype="string" id="sshd_approved_ciphers" version="1" />
 </def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -13,7 +13,7 @@ description: |-
     The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
 {{% if product in ["rhel7","ol7"] %}}
     <br /><br />
-    The following ciphers are FIPS 140-2 certified on {{{ full_name }}}:
+    Only the following ciphers are FIPS 140-2 certified on {{{ full_name }}}:
     <br />- aes128-ctr
     <br />- aes192-ctr
     <br />- aes256-ctr
@@ -31,6 +31,7 @@ description: |-
     {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
     {{% endif %}}
 {{% endif %}}
+    The rule is parametrized to use the following ciphers: <code>{{{ sub_var_value("sshd_approved_ciphers") }}}</code>.
 
 rationale: |-
     Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_comment.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+if grep -q "^Ciphers" /etc/ssh/sshd_config; then
+	sed -i "s/^Ciphers.*/# Ciphers aes128-ctr,aes192-ctr,aes256-ctr/" /etc/ssh/sshd_config
+else
+	echo "# Ciphers aes128-ctr,aes192-ctr,aes256-ctr" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_correct_reduced_list.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_correct_reduced_list.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+if grep -q "^Ciphers" /etc/ssh/sshd_config; then
+	sed -i "s/^Ciphers.*/Ciphers aes128-ctr,aes192-ctr/" /etc/ssh/sshd_config
+else
+	echo "Ciphers aes128-ctr,aes192-ctr" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_correct_scrambled.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_correct_scrambled.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+if grep -q "^Ciphers" /etc/ssh/sshd_config; then
+	sed -i "s/^Ciphers.*/Ciphers aes192-ctr,aes128-ctr,aes256-ctr/" /etc/ssh/sshd_config
+else
+	echo "Ciphers aes192-ctr,aes128-ctr,aes256-ctr" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_correct_value_full.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_correct_value_full.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+if grep -q "^Ciphers" /etc/ssh/sshd_config; then
+	sed -i "s/^Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr/" /etc/ssh/sshd_config
+else
+	echo 'Ciphers aes128-ctr,aes192-ctr,aes256-ctr' >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+sed -i "/^Ciphers.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/stig_wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+if grep -q "^Ciphers" /etc/ssh/sshd_config; then
+	sed -i "s/^Ciphers.*/# Ciphers aes128-ctr,aes192-ctr,aes128-cbc,aes192-cbc,aes256-cbc,3des-cbc/" /etc/ssh/sshd_config
+else
+	echo "Ciphers aes128-ctr,aes192-ctr,aes128-cbc,aes192-cbc,aes256-cbc,3des-cbc" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/wrong_value.fail.sh
@@ -5,5 +5,5 @@
 if grep -q "^Ciphers" /etc/ssh/sshd_config; then
 	sed -i "s/^Ciphers.*/# Ciphers aes128-ctr,aes192-ctr,weak-cipher,aes128-cbc,aes192-cbc,aes256-cbc,3des-cbc,rijndael-cbc@lysator\.liu\.se/" /etc/ssh/sshd_config
 else
-	echo "Ciphers aes128-ctr,aes192-ctr,weak-cipher,aes128-cbc,aes192-cbc,aes256-cbc,3des-cbc,rijndael-cbc@lysator\.liu\.se" >> /etc/ssh/sshd_config
+	echo "# Ciphers aes128-ctr,aes192-ctr,weak-cipher,aes128-cbc,aes192-cbc,aes256-cbc,3des-cbc,rijndael-cbc@lysator\.liu\.se" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -32,6 +32,7 @@ description: |-
     {{{ weblink(link="http://csrc.nist.gov/groups/STM/cmvp/documents/140-1/140sp/140sp2630.pdf") }}}
     {{% endif %}}
 {{% endif %}}
+    The rule is parametrized to use the following MACs: <code>{{{ sub_var_value("sshd_approved_macs") }}}</code>.
 
 rationale: |-
     DoD Information Systems are required to use FIPS-approved cryptographic hash

--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'SSH Approved ciphers by FIPS'
+
+description: "Specify the FIPS approved ciphers \n\tthat are used for data integrity protection by the SSH server."
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    stig: aes128-ctr,aes192-ctr,aes256-ctr
+    default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se
+

--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'SSH Approved ciphers by FIPS'
 
-description: "Specify the FIPS approved ciphers \n\tthat are used for data integrity protection by the SSH server."
+description: "Specify the FIPS approved ciphers that are used for data integrity protection by the SSH server."
 
 type: string
 
@@ -13,4 +13,3 @@ interactive: false
 options:
     stig: aes128-ctr,aes192-ctr,aes256-ctr
     default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se
-

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -228,6 +228,7 @@ selections:
     - install_antivirus
     - accounts_max_concurrent_login_sessions
     - configure_firewalld_ports
+    - sshd_approved_ciphers=stig
     - sshd_use_approved_ciphers
     - accounts_tmout
     - sshd_enable_warning_banner

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -35,6 +35,11 @@ ocil_clause: "the {{{ option }}} is not present in the output line, or there is 
 {{%- endmacro %}}
 
 
+{{% macro sub_var_value(varname) -%}}
+<sub idref="{{{ varname }}}" />
+{{%- endmacro %}}
+
+
 {{% macro complete_ocil_entry_mount_option(point, option) -%}}
 ocil: |
     {{{ ocil_mount_option(point, option) | indent(4) }}}


### PR DESCRIPTION
This PR

- Allows parametrization of the `sshd_use_approved_ciphers` rule [related ML discussion](https://lists.fedorahosted.org/archives/list/scap-security-guide@lists.fedorahosted.org/thread/WG5DKAUG5DOUZGLFYEKMOEIRWNUGSQ37/)
- Applies the STIG parametrization to the profile, adds respective test.
- Makes the actual parametrization visible in the guide under the rule's description.