### PR TITLE
remove ntp mention from rule title

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-title: 'A remote NTP server for Chrony is configured'
+title: 'A remote time server for Chrony is configured'
 
 description: |-
     <tt>Chrony</tt> is a daemon which implements the Network Time Protocol (NTP). It is designed to


### PR DESCRIPTION
#### Description:

Remove reference to ntp from title of rule chronyd_specify_remote_server.

#### Rationale:

It might be confused with the ntp package.