### PR TITLE
changed missing parameter pass to false per stig requirement

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
@@ -46,7 +46,7 @@ ocil: |-
 template:
     name: sshd_lineinfile
     vars:
-        missing_parameter_pass: 'true'
+        missing_parameter_pass: 'false'
         parameter: StrictModes
         rule_id: sshd_enable_strictmodes
         value: 'yes'


### PR DESCRIPTION
#### Description:

- SSHD enable strictmodes, missing parameter pass changed to false

#### Rationale:

- Current STIG requires parameter be present

