### PR TITLE
Improved handling of grub2 password/admin checks.

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_password/oval/shared.xml
@@ -1,3 +1,4 @@
+{{% set grub_cfg_prefix = "/boot/grub2" %}}
 <def-group>
   <definition class="compliance" id="grub2_password" version="1">
     <metadata>
@@ -7,7 +8,7 @@
     </metadata>
 
     <criteria operator="OR">
-      {{{ oval_file_absent_criterion("/boot/grub2/grub.cfg", rule_id + "_grub_cfg") }}}
+      {{{ oval_file_absent_criterion(grub_cfg_prefix + "/grub.cfg", rule_id + "_grub_cfg") }}}
       <criteria operator="AND">
         <criteria comment="check both files to account for procedure change in documenation" operator="OR">
           <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_grub2_password_usercfg" />
@@ -18,13 +19,13 @@
     </criteria>
   </definition>
 
-{{{ oval_file_absent("/boot/grub2/grub.cfg", rule_id + "_grub_cfg") }}}
+  {{{ oval_file_absent(grub_cfg_prefix + "/grub.cfg", rule_id + "_grub_cfg") }}}
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /boot/grub2/grub.cfg files." id="test_bootloader_superuser" version="2">
     <ind:object object_ref="object_bootloader_superuser" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_superuser" version="2">
-    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:filepath>{{{ grub_cfg_prefix }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -33,7 +34,7 @@
     <ind:object object_ref="object_grub2_password_usercfg" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_grub2_password_usercfg" version="1">
-    <ind:filepath>/boot/grub2/user.cfg</ind:filepath>
+    <ind:filepath>{{{ grub_cfg_prefix }}}/user.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*GRUB2_PASSWORD=grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -42,7 +43,7 @@
     <ind:object object_ref="object_grub2_password_grubcfg" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_grub2_password_grubcfg" version="1">
-    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:filepath>{{{ grub_cfg_prefix }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/tests/default.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/tests/default.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# remediation = none
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+set_superusers "root"

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/tests/no-grub.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/tests/no-grub.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+rm -f "$GRUB_CFG_ROOT/grub.cfg"
+

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/tests/unique-username.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/tests/unique-username.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+set_superusers "koskic"

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/oval/shared.xml
@@ -26,18 +26,11 @@
 
   {{{ oval_file_absent(grub_cfg_prefix + "/grub.cfg", rule_id + "_grub_cfg") }}}
 
-   <unix:file_test check="all" check_existence="none_exist" comment="/boot/efi/EFI/redhat/grub.cfg does not exist" id="test_bootloader_uefi_grub_cfg" version="1">
-    <unix:object object_ref="object_bootloader_uefi_grub_cfg" />
-  </unix:file_test>
-  <unix:file_object id="object_bootloader_uefi_grub_cfg" version="1">
-    <unix:filepath>{{{ grub_cfg_prefix }}}/grub.cfg</unix:filepath>
-  </unix:file_object>
-
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /boot/efi/EFI/redhat/grub.cfg." id="test_bootloader_uefi_superuser" version="2">
     <ind:object object_ref="object_bootloader_uefi_superuser" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_uefi_superuser" version="2">
-    <ind:filepath>{{{ grub_cfg_prefix }}}/grub.cfg$</ind:filepath>
+    <ind:filepath>{{{ grub_cfg_prefix }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/invalid_username.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/invalid_username.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# remediation = none
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+make_grub_password
+
+set_superusers "use r"

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/missing.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/missing.fail.sh
@@ -4,5 +4,7 @@
 
 . $SHARED/grub2.sh
 
+set_grub_uefi_root
+
 touch "$GRUB_CFG_ROOT/grub.cfg"
 rm -f "$GRUB_CFG_ROOT/user.cfg"

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/no-grub.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/no-grub.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+rm -f "$GRUB_CFG_ROOT/grub.cfg"

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/password-set.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/password-set.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+make_grub_password

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/unquoted_username.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/tests/unquoted_username.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+make_grub_password
+
+set_superusers_unquoted "koksic"

--- a/tests/shared/grub2.sh
+++ b/tests/shared/grub2.sh
@@ -1,6 +1,16 @@
-GRUB_CFG_ROOT=/boot/grub2
+test -n "$GRUB_CFG_ROOT" || GRUB_CFG_ROOT=/boot/grub2
+
+function set_grub_uefi_root {
+	if grep NAME /etc/os-release | grep -iq fedora; then
+		GRUB_CFG_ROOT=/boot/efi/EFI/fedora
+	else
+		GRUB_CFG_ROOT=/boot/efi/EFI/redhat
+	fi
+}
 
 function make_grub_password {
+	mkdir -p "$GRUB_CFG_ROOT"
+	set_superusers "root"
 	# password is "lala"
 	echo 'GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.8F7F0A0D0F30D1924648F26D8A063A72373584C38DF22AEEC7B2C66329A47B04D16B92D73B58B36DB30E0AF85BD461F9AEB22BDE7290A9C212329BE21D2CDDEC.FDFD532D964C7F2EB2230A575C3630757502B2DC7A347987AABF64AE392EEDF3EEA86D6BCFAB8951F3003EA29435446964E54D2CC50AA0AC957C4B94BA8184FE' > "$GRUB_CFG_ROOT/user.cfg"
 }
@@ -12,5 +22,6 @@ function set_superusers {
 
 
 function set_superusers_unquoted {
+	mkdir -p "$GRUB_CFG_ROOT"
 	echo "set superusers=$1" > "$GRUB_CFG_ROOT/grub.cfg"
 }


### PR DESCRIPTION
- Fixed a check typo.
- Made the UEFI OVAL similar to the BIOS OVAL.
- Copied and ported BIOS tests to UEFI rules.
- Made tests more robust, so they work even if grub is not present on the system in the required mode.