### PR TITLE
40470 sshd disable compression

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
@@ -1,1 +1,1 @@
-{{{ oval_sshd_config(parameter="Compression", value="(no|delayed)", missing_parameter_pass=true) }}}
+{{{ oval_sshd_config(parameter="Compression", value="(no|delayed)", missing_parameter_pass=false) }}}

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -22,7 +22,6 @@ selections:
     - var_screensaver_lock_delay=5_seconds
     - sshd_idle_timeout_value=10_minutes
     - sshd_approved_macs=stig
-    - var_sshd_disable_compression=no
     - var_accounts_fail_delay=4
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -22,6 +22,7 @@ selections:
     - var_screensaver_lock_delay=5_seconds
     - sshd_idle_timeout_value=10_minutes
     - sshd_approved_macs=stig
+    - var_sshd_disable_compression=no
     - var_accounts_fail_delay=4
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted


### PR DESCRIPTION
#### Description:

- SSHD disable compression. Add reference to var file in rhel7 profile. Missing param pass changed to false per STIG in oval.

#### Rationale:

- Rhel7 stig profile did not list the .var. STIG 40470 requires parameter to be present in file.

