### PR TITLE
Update rule.yml

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
@@ -50,7 +50,7 @@ references:
 template:
     name: sshd_lineinfile
     vars:
-        missing_parameter_pass: 'true'
+        missing_parameter_pass: 'false'
         parameter: HostbasedAuthentication
         rule_id: disable_host_auth
         value: 'no'


### PR DESCRIPTION

#### Description:

- Changed missing parameter pass to false per stig 10470 requirement

#### Rationale:

- Scan reported pass when parameter was not present. STIG requires parameter to be present.

