### PR TITLE
Fix service check service_chronyd_enabled to use proper rhel package name

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -34,3 +34,4 @@ template:
     name: service_enabled
     vars:
         servicename: chronyd
+        packagename: chrony


### PR DESCRIPTION
#### Description:
Fix service check service_chronyd_enabled to use proper rhel package name
currently it checks for packagename chronyd but package is chrony in rhel7/8

#### Rationale:
Use proper package name. Thanks for the help on irc with locating this.