### PR TITLE
Revert "changed missing parameter pass to false per stig requirement"

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml
@@ -46,7 +46,7 @@ ocil: |-
 template:
     name: sshd_lineinfile
     vars:
-        missing_parameter_pass: 'false'
+        missing_parameter_pass: 'true'
         parameter: StrictModes
         rule_id: sshd_enable_strictmodes
         value: 'yes'


### PR DESCRIPTION
Reverts ComplianceAsCode/content#5310

strictmodes is enabled by default so there is no need to explicitly check for it. This represents a bug in the DISA content, not ComplianceAsCode, and should be reverted.