### PR TITLE
Restrict kernel_module and service_rsyncd_disabled rules as machine-only

### DIFF
--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -13,6 +13,8 @@ rationale: |-
 
 severity: medium
 
+platform: machine
+
 identifiers:
     cce@rhel7: 83334-3
     cce@rhel8: 83335-0

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -19,6 +19,8 @@ rationale: |-
 
 severity: low
 
+platform: machine
+
 identifiers:
     cce@rhel6: 26340-0
     cce@rhel7: 80137-3

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
@@ -19,6 +19,8 @@ rationale: |-
 
 severity: low
 
+platform: machine
+
 identifiers:
     cce@rhel6: 26404-4
     cce@rhel7: 80142-3

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -20,6 +20,8 @@ rationale: |-
 
 severity: low
 
+platform: machine
+
 identifiers:
     cce@rhel6: 26677-5
     cce@rhel7: 80143-1

--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
@@ -19,6 +19,8 @@ rationale: |-
 
 severity: low
 
+platform: machine
+
 identifiers:
     cce@rhel6: 82167-8
     cce@rhel7: 82169-4


### PR DESCRIPTION
#### Description:
Restrict rules which are not applicable for containers as machine-only.

#### Rationale:
Containers use host OS kernel thus `kernel_module_*` rules don't make sense to be checked in them.

`service_rsyncd_disabled` is a newly added rule where probably was forgotten machine-only specification.