### PR TITLE
Extend timeout for VM restarts

### DIFF
--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -168,7 +168,7 @@ def start_domain(domain):
 
 
 def reboot_domain(domain, domain_ip, ssh_port):
-    timeout = 120           # Timeout for domain shutdown and boot.
+    timeout = 300           # Timeout for domain shutdown and boot.
     connection_timeout = 5  # Timeout on the socket before attempting to connect.
 
     logging.debug("Shutting down domain '{0}'".format(domain.name()))


### PR DESCRIPTION
#### Description:
Extent timeout to 5min.

#### Rationale:
The previous timeout wasn't enough for slow machines and tests are failing because of that.