### PR TITLE
Add CPE entries for sle15 product.

### DIFF
--- a/sle15/cpe/sle15-cpe-dictionary.xml
+++ b/sle15/cpe/sle15-cpe-dictionary.xml
@@ -12,4 +12,64 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_sle15</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:container">
+            <title xml:lang="en-us">Container</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_container</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:machine">
+            <title xml:lang="en-us">Bare-metal or Virtual Machine</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_is_a_machine</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:chrony">
+            <title xml:lang="en-us">Package chrony is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_chrony_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:gdm">
+            <title xml:lang="en-us">Package gdm is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:libuser">
+            <title xml:lang="en-us">Package libuser is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_libuser_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:nss-pam-ldapd">
+            <title xml:lang="en-us">Package nss-pam-ldapd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_nss-pam-ldapd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:ntp">
+            <title xml:lang="en-us">Package ntp is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_ntp_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:pam">
+            <title xml:lang="en-us">Package pam is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_pam_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:login_defs">
+            <title xml:lang="en-us">Package providing /etc/login.defs is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_login_defs</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:sssd">
+            <title xml:lang="en-us">Package sssd-common is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_sssd-common_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:systemd">
+            <title xml:lang="en-us">Package systemd is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_systemd_package</check>
+      </cpe-item>
+      <cpe-item name="cpe:/a:yum">
+            <title xml:lang="en-us">Package yum is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
+      </cpe-item>
 </cpe-list>


### PR DESCRIPTION
#### Description:

- Add CPE entries for sle15 product. It was basically a mirroring from the existent CPE in sle12.

#### Rationale:

- Without them our scapval job fails, see here:
https://jenkins.complianceascode.io/view/All%20Green/job/scap-security-guide-scapval-scap-1.2/
https://jenkins.complianceascode.io/view/All%20Green/job/scap-security-guide-scapval-scap-1.3/

