### PR TITLE
ocp4 content image: Use fedora image registry instead of docker.io

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -1,5 +1,5 @@
 # This dockerfile builds the content in the current repo for OCP4
-FROM fedora-minimal:latest as builder
+FROM registry.fedoraproject.org/fedora-minimal:latest as builder
 
 WORKDIR /content
 


### PR DESCRIPTION
We weren't specifying the image registry, so it was defaulting to
docker. Lets use the official fedora one instead.