### PR TITLE
Fix typo in CCE assignment

### DIFF
--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/file_owner_etc_hosts_allow/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/file_owner_etc_hosts_allow/rule.yml
@@ -16,7 +16,7 @@ severity: medium
 
 identifiers:
     cce@rhel6: 83825-0
-    cce@rhel7: 83826-0
+    cce@rhel7: 83826-8
 
 references:
     cis@rhel7: 3.4.4


### PR DESCRIPTION
#### Description:

- Fix typo in CCE checksum number, introduced in d53500477288c69027127257802bb42355ca7848.

#### Rationale:

- Fixes:
```
ValueError: CCE Identifier value is not a valid checksum: invalid value '83826-0' for CEE 'cce@rhel7' in file '/home/josorior/development/complianceAsCodeContent/linux_os/guide/services/obsolete/inetd_and_xinetd/file_owner_etc_hosts_allow/rule.yml'
```