### PR TITLE
Fix typo in OCIL clause

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
@@ -29,7 +29,7 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/gshadow-", perms=target_perms) }}}'
 
-ocil: -
+ocil: |-
     {{{ ocil_file_permissions(file="/etc/gshadow-", perms=target_perms) }}}
 
 template:


### PR DESCRIPTION
#### Description:

-  Fix typo in rule `file_permissions_backup_etc_gshadow`
  - I'm baffled that CI let it through
