### PR TITLE
ocp4: reset client in e2e tests after installing operator

### DIFF
--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -20,6 +20,7 @@ func TestE2e(t *testing.T) {
 		ctx.ensureOperatorGroupExists()
 		ctx.ensureSubscriptionExists()
 		ctx.waitForOperatorToBeReady()
+		ctx.resetClientMappings()
 	})
 
 	t.Run("Run compliance scan", func(t *testing.T) {


### PR DESCRIPTION
This client reset is needed because the available resources in the
cluster are cached y a caching client, but when this client starts
doing operators, the operator hasn't been installed.

What results from this is that the compliance-operator's resources can't
be used by the time we try to test.

To address this, we reset the cache after installing the operator.