### PR TITLE
ocp4: Upgrade to using compliance-operator v0.1.6

### DIFF
--- a/ocp-resources/compliance-operator-alpha-subscription.yaml
+++ b/ocp-resources/compliance-operator-alpha-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: compliance-operator-bundle
   source: compliance-operator
   sourceNamespace: openshift-marketplace
-  startingCSV: compliance-operator.v0.1.5
+  startingCSV: compliance-operator.v0.1.6


### PR DESCRIPTION
Brings in some fixes needed for the CI tests.