### PR TITLE
macOS build fixes

### DIFF
--- a/macos1015/profiles/moderate.profile
+++ b/macos1015/profiles/moderate.profile
@@ -29,3 +29,4 @@ description: |-
 
 selections:
     - service_auditd_enabled
+    - audit_failure_halt

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -118,6 +118,8 @@ def is_applicable_for_product(platform, product):
     product_name = ""
     # Get official name for product
     if product_version is not None:
+        if product == "ubuntu" or product == "macos":
+            product_version = product_version[:2] + "." + product_version[2:]
         product_name = map_name(product) + ' ' + product_version
     else:
         product_name = map_name(product)


### PR DESCRIPTION
- Add audit_failure_halt rule to moderate profile
- Fix remediation script builds to allow decimal in versions