### PR TITLE
Revert "changed missing parameter pass from true to false per stig 40440"

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
@@ -47,7 +47,7 @@ ocil: |-
 template:
     name: sshd_lineinfile
     vars:
-        missing_parameter_pass: 'false'
+        missing_parameter_pass: 'true'
         parameter: KerberosAuthentication
         rule_id: sshd_disable_kerb_auth
         value: 'no'


### PR DESCRIPTION
Reverts ComplianceAsCode/content#5303

Similar to ComplianceAsCode/content#5327

KerberosAuthentication is disable by default so there is no need to explicitly check for it. This represents a bug in the DISA content, not ComplianceAsCode, and should be reverted.