### PR TITLE
ocp4: Remove fapolicyd checks from RHCOS moderate profile

### DIFF
--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -229,10 +229,6 @@ selections:
     - var_selinux_policy_name=targeted
     - selinux_policytype
 
-    ### Application Whitelisting (RHEL 8)
-    - package_fapolicyd_installed
-    - service_fapolicyd_enabled
-
     ### Enable the Hardware RNG Entropy Gatherer Service
     - service_rngd_enabled
 


### PR DESCRIPTION
This package is not applicable to RHCOS and will not be included. So
Lets remove it.