### PR TITLE
fix ansible remediation for postfix_network_listening_disabled

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
@@ -5,4 +5,8 @@
 # disruption = low
 - (xccdf-var var_postfix_inet_interfaces)
 
-{{{ ansible_lineinfile(msg='Ensure mail transfer agent is configured for local-only mode', path='/etc/postfix/main.cf', regex='^inet_interfaces\s*=\s.*', new_line='inet_interfaces = {{ var_postfix_inet_interfaces }}', create='no', state='present', insert_after='^inet_interfaces\s*=\s.*') }}}
+- name: "Gather list of packages"
+  package_facts:
+    manager: auto
+
+{{{ ansible_lineinfile(msg='Make changes to Postfix configuration file', path='/etc/postfix/main.cf', regex='^inet_interfaces\s*=\s.*', new_line='inet_interfaces = {{ var_postfix_inet_interfaces }}', create='no', state='present', insert_after='^inet_interfaces\s*=\s.*', when='"postfix" in ansible_facts.packages') }}}


### PR DESCRIPTION
#### Description:

Ansible remediation checks for presence of postfix package and proceeds only if it is installed.

#### Rationale:

This rule is in CIS but CIS does not mandate installation of postfix.

