### PR TITLE
ocp4/e2e: Add Makefile variable to optionally skip the operator install

### DIFF
--- a/tests/ocp4e2e/Makefile
+++ b/tests/ocp4e2e/Makefile
@@ -5,6 +5,8 @@ TEST_DIR=$(ROOT_DIR)/tests/ocp4e2e
 TEST_FLAGS?=-v -timeout 120m
 # Skip pushing the container to your cluster
 SKIP_CONTAINER_PUSH?=false
+# Should the test attempt to install the operator?
+INSTALL_OPERATOR?=true
 
 .PHONY: all
 all: e2e
@@ -12,7 +14,7 @@ all: e2e
 .PHONY: e2e
 e2e: image-to-cluster ## Run the e2e tests. This requires that the PROFILE environment variable be set. This will upload images to the cluster as part of the run with the `image-to-cluster` target.
 	pushd $(TEST_DIR) && \
-	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -content-image="$(CONTENT_IMAGE)"
+	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
 
 .PHONY: image-to-cluster
 image-to-cluster: ## Upload a content image to the cluster. The SKIP_CONTAINER_PUSH environment variable skips this step; the CONTENT_IMAGE environment variable takes a pre-uploaded image into use.

--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -15,11 +15,15 @@ func TestE2e(t *testing.T) {
 
 	t.Run("Operator setup", func(t *testing.T) {
 		ctx.ensureNamespaceExistsAndSet()
-		ctx.ensureOperatorSourceExists()
-		ctx.ensureCatalogSourceConfigExists()
-		ctx.ensureOperatorGroupExists()
-		ctx.ensureSubscriptionExists()
-		ctx.waitForOperatorToBeReady()
+		if ctx.installOperator {
+			ctx.ensureOperatorSourceExists()
+			ctx.ensureCatalogSourceConfigExists()
+			ctx.ensureOperatorGroupExists()
+			ctx.ensureSubscriptionExists()
+			ctx.waitForOperatorToBeReady()
+		} else {
+			t.Logf("Skipping operator install as requested")
+		}
 		ctx.resetClientMappings()
 	})
 

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -42,6 +42,7 @@ const (
 
 var profile string
 var contentImage string
+var installOperator bool
 
 type e2econtext struct {
 	// These are public because they're needed in the template
@@ -49,17 +50,20 @@ type e2econtext struct {
 	ContentImage           string
 	OperatorNamespacedName types.NamespacedName
 	// These are only needed for the test and will only be used in this package
-	rootdir       string
-	profilepath   string
-	resourcespath string
-	dynclient     dynclient.Client
-	restMapper    *restmapper.DeferredDiscoveryRESTMapper
-	t             *testing.T
+	rootdir         string
+	profilepath     string
+	resourcespath   string
+	installOperator bool
+	dynclient       dynclient.Client
+	restMapper      *restmapper.DeferredDiscoveryRESTMapper
+	t               *testing.T
 }
 
 func init() {
 	flag.StringVar(&profile, "profile", "", "The profile to check")
 	flag.StringVar(&contentImage, "content-image", "", "The path to the image with the content to test")
+	flag.BoolVar(&installOperator, "install-operator", true, "Should the test-code install the operator or not? "+
+		"This is useful if you need to test with your own deployment of the operator")
 }
 
 func newE2EContext(t *testing.T) *e2econtext {
@@ -79,6 +83,7 @@ func newE2EContext(t *testing.T) *e2econtext {
 		rootdir:                rootdir,
 		profilepath:            profilepath,
 		resourcespath:          resourcespath,
+		installOperator:        installOperator,
 		t:                      t,
 	}
 }


### PR DESCRIPTION
In cases where folks are testing on their own deployments, it's useful
to tell the e2e test not to install the operator. This will instead use
whatever folks have installed in their system.