### PR TITLE
Added possibility of the test suite to expand platforms of the benchmark

### DIFF
--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -142,7 +142,12 @@ def add_platform_to_benchmark(root, cpe_regex):
 
     for benchmark in benchmarks:
         existing_platform_element = benchmark.find("xccdf-1.2:platform", PREFIX_TO_NS)
-        platform_index = benchmark.getchildren().index(existing_platform_element)
+        if existing_platform_element is None:
+            logging.warn(
+                "Couldn't find platform element in a benchmark, "
+                "not adding any additional platforms as a result.")
+            continue
+        platform_index = list(benchmark).index(existing_platform_element)
         for cpe_str in cpes_to_add:
             e = ET.Element("xccdf-1.2:platform", idref=cpe_str)
             benchmark.insert(platform_index, e)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -78,8 +78,8 @@ def parse_args():
             "--remove-machine-only",
             default=False,
             action="store_true",
-            help="Whether to remove machine-only platform in rules "
-            "to increase usefulness of the container backend.")
+            help="Removes machine-only platform constraint from rules "
+            "to enable testing these rules on container backends.")
     common_parser.add_argument("--loglevel",
                                dest="loglevel",
                                metavar="LOGLEVEL",

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -52,21 +52,6 @@ def parse_args():
                                help=("Path to the Source DataStream on this "
                                      "machine which is going to be tested"))
     benchmarks = common_parser.add_mutually_exclusive_group()
-    benchmarks.add_argument(
-            "--add-platform",
-            metavar="<CPE REGEX>",
-            default=None,
-            help="Find all CPEs in the datastream that match the provided regex, "
-            "and add them as platforms to all datastream benchmarks. "
-            "If the regex doesn't match anything, it will be treated "
-            "as a literal CPE, and added as a platform. "
-            "For example, use 'cpe:/o:fedoraproject:fedora:30' or 'enterprise_linux'.")
-    benchmarks.add_argument(
-            "--keep-machine-only",
-            default=False,
-            action="store_true",
-            help="Whether to keep machine-only platform in rules which is stripped by default "
-            "to increase usefulness of the container backend.")
     benchmarks.add_argument("--xccdf-id",
                                dest="xccdf_id",
                                metavar="REF-ID",
@@ -80,6 +65,21 @@ def parse_args():
                                default=0,
                                help="Selection number of reference ID related "
                                     "to benchmark to be used.")
+    common_parser.add_argument(
+            "--add-platform",
+            metavar="<CPE REGEX>",
+            default=None,
+            help="Find all CPEs in the datastream that match the provided regex, "
+            "and add them as platforms to all datastream benchmarks. "
+            "If the regex doesn't match anything, it will be treated "
+            "as a literal CPE, and added as a platform. "
+            "For example, use 'cpe:/o:fedoraproject:fedora:30' or 'enterprise_linux'.")
+    common_parser.add_argument(
+            "--remove-machine-only",
+            default=False,
+            action="store_true",
+            help="Whether to remove machine-only platform in rules "
+            "to increase usefulness of the container backend.")
     common_parser.add_argument("--loglevel",
                                dest="loglevel",
                                metavar="LOGLEVEL",
@@ -355,7 +355,7 @@ def main():
         options.datastream = stashed_datastream
 
         with xml_operations.datastream_root(stashed_datastream, stashed_datastream) as root:
-            if not options.keep_machine_only:
+            if options.remove_machine_only:
                 xml_operations.remove_machine_platform(root)
             if options.add_platform:
                 xml_operations.add_platform_to_benchmark(root, options.add_platform)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -69,7 +69,8 @@ def parse_args():
             "--add-platform",
             metavar="<CPE REGEX>",
             default=None,
-            help="Find all CPEs in the datastream that match the provided regex, "
+            help="Find all CPEs that are present in local OpenSCAP's CPE dictionary "
+            "that match the provided regex, "
             "and add them as platforms to all datastream benchmarks. "
             "If the regex doesn't match anything, it will be treated "
             "as a literal CPE, and added as a platform. "


### PR DESCRIPTION
TLDR: Allow datastream of platform A to be tested using our test suite on a system (container, VM) of platform B != A.

This PR features these changes/improvements:

- Put the datastream into a temp dir upon tests initialization, so it can be modified, and one can do rebuilds while tests run.
- Test suite now can modify the datastream prior to the testing.
- Remove machine-only platform from rules/groups in the datastream unless it is explicitly requested to be preserved. This allows testing tests of all textfile-based rules in containers (e.g. sshd config, audit config etc.)
- If a CPE regex is supplied, skim the datastream for matching CPEs, and expand the benchmark platform list with them. If there is no matching CPE, treat the supplied argument as a CPE and extend the benchmark accordingly.
- Become able to take tests from other benchmark directories, as platform is not an obstacle any more.

Notes:

- Our test suite won't be able to handle yaml tests, as invalid datastreams are a major obstacle for e.g. `oscap-ssh`.
- All RHEL CPEs are present literally in the datastream, but for Fedora, there is a parametrized CPE. So if you would like to scan e.g. RHEL6 content on RHEL7 VM, you can pass `--add-platform enterprise_linux`, but for Fedora, you have to use e.g. `--add-platform 'cpe:/o:fedoraproject:fedora:30'`. If you pass `--add-platform fedora`, only Fedora 28 CPE will be added, which won't work other Fedoras than 28.

Special thanks to @yuumasato and @jan-cerny that shared their wisdom, so this could be hacked together.