### PR TITLE
ocp4: fix image pullspec output from build_ds_container.sh

### DIFF
--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -23,19 +23,19 @@ cat "$root_dir/ocp-resources/ds-build.yaml" | sed "s/\$PRODUCT/$product/" | oc a
 oc start-build -n openshift-compliance "openscap-$product-ds" \
     --from-file="$root_dir/build/ssg-$product-ds.xml"
 
-# Wait a couple of seconds until the object gets persisted
-sleep 3
+# Wait some seconds until the object gets persisted
+sleep 5
 
-latest_build=$(oc get --no-headers buildconfigs "openscap-$product-ds" | awk '{print $4}')
+latest_build=$(oc get -n openshift-compliance --no-headers buildconfigs "openscap-$product-ds" | awk '{print $4}')
 
 popd
 
 while true; do
-    build_status=$(oc get builds --no-headers "openscap-$product-ds-$latest_build" | awk '{print $4}')
+    build_status=$(oc get builds -n openshift-compliance --no-headers "openscap-$product-ds-$latest_build" | awk '{print $4}')
 
     if [ "$build_status" == "Complete" ]; then
         # Get built image
-        image=$(oc get imagestreams --no-headers | awk '{printf "%s:%s",$2, $3}')
+        image=$(oc get imagestreams -n openshift-compliance --no-headers "openscap-$product-ds" | awk '{printf "%s:%s",$2, $3}')
 
         echo "Success!"
         echo "********"


### PR DESCRIPTION
It was assuming there would only be one imagestream in the namespace.
But this is not necessarily the case. So this calls specifically for the
imagestream that's being built and only outputs the pullspec when the
build is complete.

For slow connections, this also waits now 5 seconds for the build to
appear in k8s

Finally, this adds the namespace parameters to all `oc` calls, so this
can be called from another namespace and still work.