### PR TITLE
[WIP] Add rule metadata

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -52,6 +52,9 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="PermitRootLogin", value="no") }}}
 
+metadata:
+    meta_cathegory: SAMPLE_METADATA
+
 template:
     name: sshd_lineinfile
     vars:

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -73,6 +73,7 @@
           <xsl:apply-templates select="description[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="warning[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="ref[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
+          <xsl:apply-templates select="metadata[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="rationale[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="platform[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <xsl:apply-templates select="requires[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
@@ -80,7 +81,7 @@
           <xsl:apply-templates select="ident[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
           <!-- order oval (shorthand tag) first, to indicate to tools to prefer its automated checks -->
           <xsl:apply-templates select="oval[contains(@prodtype, $prod_type) or not(@prodtype)]"/>
-          <xsl:apply-templates select="node()[not(self::title|self::description|self::warning|self::ref|self::rationale|self::requires|self::conflicts|self::platform|self::ident|self::oval|self::prodtype)]"/>
+          <xsl:apply-templates select="node()[not(self::title|self::description|self::warning|self::ref|self::metadata|self::rationale|self::requires|self::conflicts|self::platform|self::ident|self::oval|self::prodtype)]"/>
         </Rule>
       </xsl:when>
     </xsl:choose>
@@ -101,6 +102,7 @@
       <xsl:apply-templates select="description"/>
       <xsl:apply-templates select="warning"/>
       <xsl:apply-templates select="ref"/>
+      <xsl:apply-templates select="metadata"/>
       <xsl:apply-templates select="rationale"/>
       <xsl:apply-templates select="platform"/>
       <xsl:apply-templates select="requires"/>
@@ -108,7 +110,7 @@
       <xsl:apply-templates select="ident"/>
       <!-- order oval (shorthand tag) first, to indicate to tools to prefer its automated checks -->
       <xsl:apply-templates select="oval"/>
-      <xsl:apply-templates select="node()[not(self::title|self::description|self::warning|self::ref|self::rationale|self::requires|self::conflicts|self::platform|self::ident|self::oval)]"/>
+      <xsl:apply-templates select="node()[not(self::title|self::description|self::warning|self::ref|self::metadata|self::rationale|self::requires|self::conflicts|self::platform|self::ident|self::oval)]"/>
     </Rule>
   </xsl:template>
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -25,7 +25,7 @@ from .xml import ElementTree as ET
 from .shims import unicode_func
 
 
-def add_sub_element(parent, tag, data):
+def add_sub_element(parent, tag, data=''):
     """
     Creates a new child element under parent with tag tag, and sets
     data as the content under the tag. In particular, data is a string
@@ -781,6 +781,7 @@ class Rule(object):
         "conflicts": lambda: list(),
         "requires": lambda: list(),
         "platform": lambda: None,
+        "metadata": lambda: dict(),
         "template": lambda: None,
     }
 
@@ -800,6 +801,7 @@ class Rule(object):
         self.requires = []
         self.conflicts = []
         self.platform = None
+        self.metadata = dict()
         self.template = None
 
     @classmethod
@@ -1022,6 +1024,12 @@ class Rule(object):
         add_sub_element(rule, 'title', self.title)
         add_sub_element(rule, 'description', self.description)
         add_sub_element(rule, 'rationale', self.rationale)
+
+        if self.metadata:
+            meta = add_sub_element(rule, 'metadata')
+            for meta_tag, meta_text in self.metadata.items():
+                meta_tag_with_ns = "xml:{tag}".format(tag=meta_tag)
+                add_sub_element(meta, meta_tag_with_ns, str(meta_text))
 
         main_ident = ET.Element('ident')
         for ident_type, ident_val in self.identifiers.items():


### PR DESCRIPTION
Added rule metadata support to `rule.yml`.

Rule metadata are supported by the XCCDF standard (see the [XCCDF spec](https://csrc.nist.gov/CSRC/media/Publications/nistir/7275/rev-4/final/documents/nistir-7275r4_updated-march-2012_markup.pdf), page number 10:

> When used, the `<xccdf:metadata>` element SHALL contain document metadata expressed in XML. The metadata element can appear one or more times as a child of the `<xccdf:Benchmark>`, `<xccdf:Rule>`, ...

Judging by [the schema](https://github.com/OpenSCAP/openscap/blob/maint-1.3/schemas/xccdf/1.2/xccdf_1.2.xsd#L511), it looks like that it is expected that the metadata tag has at least one XML children of a non-xccdf namespace, so I have proposed to specify them as YAML dictionaries. FYI, the XCCDF standard suggest usage of the DCMI metadata schema for the metadata itself, but that's completely optional.

The PR has currently these problems:

1. The PR is stuck on the scanner refusing to compile the datastream.
2. I have used the "xml" namespace as the namespace for metadata sub-elements, which is a temp workaround.
3. It may be that rule's metadata element is supported in XCCDF 1.2, but not in XCCDF 1.1. If it turns out to be the case, what does this imply?