### PR TITLE
Make the datastream namespaces readable again

### DIFF
--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -77,8 +77,7 @@ def main():
         warning = SL_WARNING
         derivative = "Scientific Linux"
 
-    tree = ssg.xml.ElementTree.ElementTree()
-    tree.parse(options.input_content)
+    tree = ssg.xml.open_xml(options.input_content)
     root = tree.getroot()
 
     benchmarks = []

--- a/build-scripts/sds_move_ocil_to_checks.py
+++ b/build-scripts/sds_move_ocil_to_checks.py
@@ -166,7 +166,7 @@ def main():
     # Output datastream file
     outdatastreamfile = sys.argv[2]
     # Datastream element tree
-    datastreamtree = ssg.xml.ElementTree.parse(indatastreamfile)
+    datastreamtree = ssg.xml.open_xml(indatastreamfile)
 
     # Locate <ds:extended-components> element in datastream
     extendedcomps = datastreamtree.getroot().find("./{%s}extended-components" % datastream_ns)

--- a/build-scripts/unselect_empty_xccdf_groups.py
+++ b/build-scripts/unselect_empty_xccdf_groups.py
@@ -86,7 +86,7 @@ def main():
         parser.print_help()
         raise RuntimeError("Please specify output with --output.")
 
-    input_tree = ssg.xml.ElementTree.parse(options.input_content)
+    input_tree = ssg.xml.open_xml(options.input_content)
     root_element = input_tree.getroot()
     if root_element.tag != "{%s}Benchmark" % (XCCDF11_NS):
         raise RuntimeError(

--- a/build-scripts/update_sds_version.py
+++ b/build-scripts/update_sds_version.py
@@ -120,7 +120,7 @@ def main():
     args = parse_args()
 
     # Datastream element tree
-    datastreamtree = ssg.xml.ElementTree.parse(args.input).getroot()
+    datastreamtree = ssg.xml.parse_file(args.input)
 
     if args.version == "1.3":
         # Set SCAP version to 1.3

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -92,6 +92,7 @@ ALL_NS = {
     "xccdf-1.2": XCCDF12_NS,
     "xlink": xlink_namespace,
     "cpe-dict": "http://cpe.mitre.org/dictionary/2.0",
+    "cat": "urn:oasis:names:tc:entity:xmlns:xml:catalog",
 }
 
 

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -83,7 +83,7 @@ OVAL_SUB_NS = dict(
 )
 
 
-ALL_NS = {
+PREFIX_TO_NS = {
     "oval-def": oval_namespace,
     "oval": "http://oval.mitre.org/XMLSchema/oval-common-5",
     "ds": datastream_namespace,
@@ -92,14 +92,14 @@ ALL_NS = {
     "xccdf-1.2": XCCDF12_NS,
     "xlink": xlink_namespace,
     "cpe-dict": "http://cpe.mitre.org/dictionary/2.0",
-    "cat": "urn:oasis:names:tc:entity:xmlns:xml:catalog",
+    "cat": cat_namespace,
 }
 
 
 for prefix, url_part in OVAL_SUB_NS.items():
-    assert prefix not in ALL_NS, \
+    assert prefix not in PREFIX_TO_NS, \
         "Conflict between a namespace and OVAL sub-namespace '{prefix}'".format(prefix=prefix)
-    ALL_NS[prefix] = "{oval_ns}#{suffix}".format(oval_ns=ALL_NS["oval-def"], suffix=url_part)
+    PREFIX_TO_NS[prefix] = "{oval_ns}#{suffix}".format(oval_ns=PREFIX_TO_NS["oval-def"], suffix=url_part)
 
 
 oval_header = (

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -75,6 +75,32 @@ ansible_version_requirement_pre_task_name = \
     "Verify Ansible meets SCAP-Security-Guide version requirements."
 standard_profiles = ['standard', 'pci-dss', 'desktop', 'server']
 
+
+OVAL_SUB_NS = dict(
+    ind="independent",
+    unix="unix",
+    linux="linux",
+)
+
+
+ALL_NS = {
+    "oval-def": oval_namespace,
+    "oval": "http://oval.mitre.org/XMLSchema/oval-common-5",
+    "ds": datastream_namespace,
+    "ocil": ocil_namespace,
+    "xccdf-1.1": XCCDF11_NS,
+    "xccdf-1.2": XCCDF12_NS,
+    "xlink": xlink_namespace,
+    "cpe-dict": "http://cpe.mitre.org/dictionary/2.0",
+}
+
+
+for prefix, url_part in OVAL_SUB_NS.items():
+    assert prefix not in ALL_NS, \
+        "Conflict between a namespace and OVAL sub-namespace '{prefix}'".format(prefix=prefix)
+    ALL_NS[prefix] = "{oval_ns}#{suffix}".format(oval_ns=ALL_NS["oval-def"], suffix=url_part)
+
+
 oval_header = (
     """
 <oval_definitions

--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import platform
 
-from .constants import xml_version, oval_header, timestamp
+from .constants import xml_version, oval_header, timestamp, ALL_NS
 
 
 try:
@@ -24,11 +24,26 @@ def oval_generated_header(product_name, schema_version, ssg_version):
                        schema_version, timestamp)
 
 
+def open_xml(filename):
+    """
+    Given a filename, register all possible namespaces, and return the XML tree.
+    """
+    try:
+        for prefix, uri in ALL_NS.items():
+            ElementTree.register_namespace(prefix, uri)
+    except Exception:
+        # Probably an old version of Python
+        # Doesn't matter, as this is non-essential.
+        pass
+    return ElementTree.parse(filename)
+
+
 def parse_file(filename):
     """
     Given a filename, return the root of the ElementTree
     """
-    return ElementTree.parse(filename).getroot()
+    tree = open_xml(filename)
+    return tree.getroot()
 
 
 def map_elements_to_their_ids(tree, xpath_expr):

--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import platform
 
-from .constants import xml_version, oval_header, timestamp, ALL_NS
+from .constants import xml_version, oval_header, timestamp, PREFIX_TO_NS
 
 
 try:
@@ -29,7 +29,7 @@ def open_xml(filename):
     Given a filename, register all possible namespaces, and return the XML tree.
     """
     try:
-        for prefix, uri in ALL_NS.items():
+        for prefix, uri in PREFIX_TO_NS.items():
             ElementTree.register_namespace(prefix, uri)
     except Exception:
         # Probably an old version of Python


### PR DESCRIPTION
Build your favourite product and examine the built datastream - there should be no occurrences of `ns0`, `ns1` and other namespaces - there should be human-readable identifiers instead.

What this PR does:

- Consolidates known XML namespaces in a dictionary.
- Registers those namespaces with the XML parser, if it supports that.
- Makes sure that all build scripts use functions that register those namespaces.