### PR TITLE
Add ol7 stigid prefix mapping

### DIFF
--- a/ol7/transforms/constants.xslt
+++ b/ol7/transforms/constants.xslt
@@ -10,7 +10,7 @@
 <xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Oracle_Linux_7_Benchmark_v2.1.0.pdf</xsl:variable>
 <xsl:variable name="product_guide_id_name">OL-7</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
-<xsl:variable name="os-stigid-concat" >OL-07-</xsl:variable>
+<xsl:variable name="os-stigid-concat" >OL07-00-</xsl:variable>
 
 <!-- Define URI for custom CCE identifier which can be used for mapping to corporate policy -->
 <!--xsl:variable name="custom-cce-uri">https://www.example.org</xsl:variable-->

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -284,6 +284,7 @@ PRODUCT_TO_CPE_MAPPING = {
 }
 
 STIG_PLATFORM_ID_MAP = {
+    "ol7": "OL07-00",
     "rhel6": "RHEL-06",
     "rhel7": "RHEL-07",
     "rhel8": "RHEL-08",


### PR DESCRIPTION
#### Description:

OL7 STIG V1R1 officially released, adding correct prefix mapping for ol7 - "OL07-00"

#### Testing:
- checked ol7 build
- checked generated reference ids