### PR TITLE
Fix grub path in grub2_enable_fips_mode bash script

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
@@ -26,7 +26,7 @@ BOOT_UUID=$(findmnt --noheadings --output uuid --target /boot)
 
 if grep -q '^GRUB_CMDLINE_LINUX=".*boot=.*"'  /etc/default/grub; then
 	# modify the GRUB command-line if a boot= arg already exists
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)boot=[^[:space:]]*\(.*"\)/\1 boot=UUID='"${BOOT_UUID} \2/" /etc/default/ grub
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)boot=[^[:space:]]*\(.*"\)/\1 boot=UUID='"${BOOT_UUID} \2/" /etc/default/grub
 else
 	# no existing boot=arg is present, append it
 	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 boot=UUID='${BOOT_UUID}'"/'  /etc/default/grub


### PR DESCRIPTION
#### Description:

Fixed typo in bash remediation which might lead to bulk remediation failure.

#### Testing:
- checked ol7 build
- verified bash remediation script doesn't fail