### PR TITLE
ocp4: Upgrade compliance-operator used for testing to v0.1.7

### DIFF
--- a/ocp-resources/compliance-operator-alpha-subscription.yaml
+++ b/ocp-resources/compliance-operator-alpha-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: compliance-operator-bundle
   source: compliance-operator
   sourceNamespace: openshift-marketplace
-  startingCSV: compliance-operator.v0.1.6
+  startingCSV: compliance-operator.v0.1.7


### PR DESCRIPTION
This should fix some installation issues that were starting to pop up
with v0.1.6.