### PR TITLE
ocp4: Upgrade to compliance-operator v0.1.8

### DIFF
--- a/ocp-resources/compliance-operator-alpha-subscription.yaml
+++ b/ocp-resources/compliance-operator-alpha-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: compliance-operator-bundle
   source: compliance-operator
   sourceNamespace: openshift-marketplace
-  startingCSV: compliance-operator.v0.1.7
+  startingCSV: compliance-operator.v0.1.8


### PR DESCRIPTION
New validations in OpenShift detect an issue we had in the upgrade
graph. And now previous versions are not usable.