### PR TITLE
Fix profile metadata in test scenarios for auditd_audispd_syslog_plugin_activated

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 . $SHARED/auditd_utils.sh


### PR DESCRIPTION
#### Description:

- Rule is no longer in `ospp` profile, it is selected in `pci-dss` or `stig` profiles