### PR TITLE
shared/partition.sh: Increase the size of a test device

### DIFF
--- a/tests/shared/partition.sh
+++ b/tests/shared/partition.sh
@@ -3,7 +3,9 @@
 PARTITION="/root/new_partition"
 
 create_partition() {
-	dd if=/dev/zero of=$PARTITION bs=1M count=50
+	# Some scenarios re-mount this device as '/tmp', therefore its size
+	# needs to be enough for the produced logs.
+	dd if=/dev/zero of=$PARTITION bs=1M count=200
 	mkfs.ext2 -F $PARTITION
 }
 


### PR DESCRIPTION
#### Description:

In some test scenarios (`fstab.fail.sh`) we create a new device
with size of 50MB to test rule `mount_option_tmp_noexec` and it
is re-mounted as the `/tmp`. This causes that there is not enough
space in `/tmp` where our test suite produces logs and result files.
This commit increases the size of the created device so logs can
fit in. Logs are copied from the guest to the host before the testing
device mounted as `/tmp` is unmounted and removed so logs are not lost
~~-- because of this the `separate.fail.sh` test scenario's remediation
is also allowed from now.~~