### PR TITLE
Skip generation of remediation when using special the default profile

### DIFF
--- a/ssg/build_guides.py
+++ b/ssg/build_guides.py
@@ -94,7 +94,7 @@ def _benchmark_profile_pair_sort_key(benchmark_id, profile_id, profile_title):
         benchmark_id = "AAA" + benchmark_id
 
     # The default profile comes last
-    if profile_id == "":
+    if not profile_id:
         profile_title = "zzz(default)"
 
     return (benchmark_id, profile_title)

--- a/ssg/build_profile_remediations.py
+++ b/ssg/build_profile_remediations.py
@@ -70,7 +70,7 @@ def get_output_paths(benchmarks, benchmark_profile_pairs, path_base, extension,
 
     for benchmark_id, profile_id, _ in benchmark_profile_pairs:
         # profile (default) is not applicable when generating remediation
-        if profile_id == "":
+        if not profile_id:
             continue
 
         if _is_blacklisted_profile(profile_id):
@@ -97,7 +97,7 @@ def fill_queue(benchmarks, benchmark_profile_pairs, input_path, path_base,
 
     for benchmark_id, profile_id, _ in benchmark_profile_pairs:
         # profile (default) is not applicable when generating remediation
-        if profile_id == "":
+        if not profile_id:
             continue
 
         if _is_blacklisted_profile(profile_id):

--- a/ssg/build_profile_remediations.py
+++ b/ssg/build_profile_remediations.py
@@ -69,6 +69,10 @@ def get_output_paths(benchmarks, benchmark_profile_pairs, path_base, extension,
     paths = []
 
     for benchmark_id, profile_id, _ in benchmark_profile_pairs:
+        # profile (default) is not applicable when generating remediation
+        if profile_id == "":
+            continue
+
         if _is_blacklisted_profile(profile_id):
             continue
 
@@ -92,6 +96,10 @@ def fill_queue(benchmarks, benchmark_profile_pairs, input_path, path_base,
                                'extension', 'remediation_path', 'template'])
 
     for benchmark_id, profile_id, _ in benchmark_profile_pairs:
+        # profile (default) is not applicable when generating remediation
+        if profile_id == "":
+            continue
+
         if _is_blacklisted_profile(profile_id):
             continue
 

--- a/tests/stable_profile_ids.py
+++ b/tests/stable_profile_ids.py
@@ -72,7 +72,7 @@ def gather_profiles_from_datastream(path, build_dir, profiles_per_benchmark):
                                "prefixed with '%s'."
                                % (bench_id, path, BENCHMARK_ID_PREFIX))
 
-        if profile_id == "":
+        if not profile_id:
             # default profile can be skipped, we know for sure that
             # it will be present in all benchmarks
             continue


### PR DESCRIPTION
#### Description:

- Skips the generation of remediation when profile id is empty (also known as the `default` profile)

#### Rationale:

- It generates empty files that are useless.

Below is a sample when generating remediation and there is no profile specified:

```
$ oscap xccdf generate fix /usr/share/xml/scap/ssg/content/ssg-fedora-xccdf.xml
      #!/bin/bash
      ###############################################################################
      #
      # Bash Remediation Script for No profile (default benchmark)
      #
      # Profile Description:
      # Not available
      #
      # Profile ID:  (null)
      # Benchmark ID:  FEDORA
      # Benchmark Version:  0.1.49
      # XCCDF Version:  1.1
      #
      # This file was generated by OpenSCAP 1.3.2 using:
      # $ oscap xccdf generate fix --profile (null) --fix-type bash xccdf-file.xml
      #
      # This Bash Remediation Script is generated from an OpenSCAP profile without preliminary evaluation.
      # It attempts to fix every selected rule, even if the system is already compliant.
      #
      # How to apply this Bash Remediation Script:
      # $ sudo ./remediation-script.sh
      #
      ##############################################################################
```
