### PR TITLE
ssg test suite: wait 30 seconds for reboot to finish

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -281,7 +281,6 @@ class GenericRunner(object):
         # the system to finish startup, there were problems with
         # temporary files created by Dracut during image generation interfering
         # with the scan
-        # expressed in seconds
         self.time_to_finish_startup = 30
 
     def _make_arf_path(self):
@@ -431,7 +430,7 @@ class ProfileRunner(GenericRunner):
             logging.info("Rebooting domain '{0}' before final scan."
                          .format(self.environment.domain_name))
             self.environment.reboot()
-            logging.info("Waiting for {0} seconds to let the system finish startup and delete possible Dracut temporary files"
+            logging.info("Waiting for {0} seconds to let the system finish startup."
                          .format(self.time_to_finish_startup))
             time.sleep(self.time_to_finish_startup)
         return GenericRunner.final(self)

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -277,6 +277,12 @@ class GenericRunner(object):
         self.command_base = []
         self.command_options = []
         self.command_operands = []
+        # number of seconds to sleep after reboot of vm to let
+        # the system to finish startup, there were problems with
+        # temporary files created by Dracut during image generation interfering
+        # with the scan
+        # expressed in seconds
+        self.time_to_finish_startup = 30
 
     def _make_arf_path(self):
         self.arf_file = self._get_arf_file()
@@ -425,8 +431,9 @@ class ProfileRunner(GenericRunner):
             logging.info("Rebooting domain '{0}' before final scan."
                          .format(self.environment.domain_name))
             self.environment.reboot()
-            logging.info("Sleeping for 60 seconds.")
-            time.sleep(60)
+            logging.info("Waiting for {0} seconds to let the system finish startup and delete possible Dracut temporary files"
+                         .format(self.time_to_finish_startup))
+            time.sleep(self.time_to_finish_startup)
         return GenericRunner.final(self)
 
     def make_oscap_call(self):

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -10,6 +10,7 @@ import json
 import datetime
 import socket
 import sys
+import time
 
 from ssg.constants import OSCAP_PROFILE_ALL_ID
 
@@ -424,6 +425,8 @@ class ProfileRunner(GenericRunner):
             logging.info("Rebooting domain '{0}' before final scan."
                          .format(self.environment.domain_name))
             self.environment.reboot()
+            logging.info("Sleeping for 60 seconds.")
+            time.sleep(60)
         return GenericRunner.final(self)
 
     def make_oscap_call(self):


### PR DESCRIPTION
#### Description:

add 30 seconds delay after machine reboot

#### Rationale:

While working on https://github.com/ComplianceAsCode/content/pull/5569 it appeared that Dracut is creating some temporary files which are deleted shortly after reboot. They interfered with test results.
