### PR TITLE
change rules for disabling ipv6 in CIS profile

### DIFF
--- a/rhel7/profiles/cis.profile
+++ b/rhel7/profiles/cis.profile
@@ -351,7 +351,7 @@ selections:
     - sysctl_net_ipv6_conf_default_accept_redirects
 
     ### 3.3.3 Ensure IPv6 is disabled (Not Scored)
-    - grub2_ipv6_disable_argument
+    - kernel_module_ipv6_option_disabled
 
     ## 3.4 TCP Wrappers
     ### 3.4.1 Ensure TCP Wrappers is installed (Scored)

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -518,7 +518,7 @@ selections:
     - wireless_disable_interfaces
 
     ## 3.6 Disable IPv6 (Not Scored)
-    - grub2_ipv6_disable_argument
+    - kernel_module_ipv6_option_disabled
 
     # Logging and Auditing
 


### PR DESCRIPTION
#### Description:

Replace grub2_ipv6_disable_argument with kernel_module_ipv6_option_disabled in both rhel7 and rhel8 cis profiles.

#### Rationale:

Although the benchmark recommends to use the grub2_ipv6_disable_argument approach, at the same time it breaks other rules, see https://github.com/ComplianceAsCode/content/issues/5568.

The final solution will be probably to document several options for disabling IPv6 and letting user pick the right one.