### PR TITLE
fix ansible remediation for openssl_use_strong_entropy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/ansible/shared.yml
@@ -9,3 +9,4 @@
     dest: /etc/profile.d/openssl-rand.sh
     content: |+
         {{{ openssl_strong_entropy_config_file()|indent(8) }}}
+        {{{''}}}


### PR DESCRIPTION
#### Description:

Tweak ansible to add empty line after macro.

#### Rationale:

As the file is checked by the sha256 checksum, the missing new line made the check fail.
