### PR TITLE
don't add boot UUID if same as root UUID

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/bash/shared.sh
@@ -21,16 +21,25 @@ else
 	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 fips=1"/'  /etc/default/grub
 fi
 
+# Get the UUID of the device mounted at root (/).
+ROOT_UUID=$(findmnt --noheadings --output uuid --target /)
+
 # Get the UUID of the device mounted at /boot.
 BOOT_UUID=$(findmnt --noheadings --output uuid --target /boot)
 
-if grep -q '^GRUB_CMDLINE_LINUX=".*boot=.*"'  /etc/default/grub; then
-	# modify the GRUB command-line if a boot= arg already exists
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)boot=[^[:space:]]*\(.*"\)/\1 boot=UUID='"${BOOT_UUID} \2/" /etc/default/grub
+if [ "${ROOT_UUID}" == "${BOOT_UUID}" ]; then
+	# root UUID same as boot UUID, so do not modify the GRUB command-line or add boot arg to kernel command line
+	# Correct the form of kernel command line for each installed kernel in the bootloader
+	/sbin/grubby --update-kernel=ALL --args="fips=1"
 else
-	# no existing boot=arg is present, append it
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 boot=UUID='${BOOT_UUID}'"/'  /etc/default/grub
+	# root UUID different from boot UUID, so modify the GRUB command-line and add boot arg to kernel command line
+	if grep -q '^GRUB_CMDLINE_LINUX=".*boot=.*"'  /etc/default/grub; then
+		# modify the GRUB command-line if a boot= arg already exists
+		sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)boot=[^[:space:]]*\(.*"\)/\1 boot=UUID='"${BOOT_UUID} \2/" /etc/default/grub
+	else
+		# no existing boot=arg is present, append it
+		sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 boot=UUID='${BOOT_UUID}'"/'  /etc/default/grub
+	fi
+	# Correct the form of kernel command line for each installed kernel in the bootloader
+	/sbin/grubby --update-kernel=ALL --args="fips=1 boot=UUID=${BOOT_UUID}"
 fi
-
-# Correct the form of kernel command line for each installed kernel in the bootloader
-/sbin/grubby --update-kernel=ALL --args="fips=1 boot=UUID=${BOOT_UUID}"


### PR DESCRIPTION
#### Description:

- Only add boot UUID to the GRUB command-line and add as boot arg to kernel command line if different from root UUID.

#### Rationale:

- Boot UUID should only be added to the GRUB command-line (and added as boot arg to kernel command line) if different from root UUID. Adding UUID when the same results in boot fail.  Discussed in https://github.com/ComplianceAsCode/content/issues/2248

- Fixes #2248
