### PR TITLE
Fix the profile compilation.

### DIFF
--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -44,6 +44,8 @@ class ResolvableProfile(ssg.build_yaml.Profile):
             resolved_selections.discard(uns)
 
         self.unselected = []
+        self.extends = None
+
         self.selected = sorted(resolved_selections)
 
         self.resolved = True


### PR DESCRIPTION
After resolving the actual "extends" relationship, remove the reference to the extended profile.
One can either keep unselections and extends, or one has to get rid of both.

Fixes: #5561 