### PR TITLE
fix sshd_allow_only_protocol2

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/ansible/shared.yml
@@ -1,0 +1,6 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{{ ansible_sshd_set(parameter="Protocol", value="2") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/ssh/sshd_config' '^Protocol' '2' '@CCENUM@' '%s %s'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/oval/shared.xml
@@ -2,14 +2,7 @@
   <definition class="compliance" id="sshd_allow_only_protocol2" version="1">
     <metadata>
       <title>Ensure Only Protocol 2 Connections Allowed</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_ubuntu</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The OpenSSH daemon should be running protocol 2.</description>
     </metadata>
     <criteria comment="SSH is configured correctly or is not installed"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/oval/shared.xml
@@ -1,0 +1,45 @@
+<def-group>
+  <definition class="compliance" id="sshd_allow_only_protocol2" version="1">
+    <metadata>
+      <title>Ensure Only Protocol 2 Connections Allowed</title>
+      <affected family="unix">
+        <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_debian</platform>
+        <platform>multi_platform_ubuntu</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>The OpenSSH daemon should be running protocol 2.</description>
+    </metadata>
+    <criteria comment="SSH is configured correctly or is not installed"
+    operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server removed"
+        definition_ref="package_openssh-server_removed" />
+      </criteria>
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+        <criteria comment="SSH version is equal or higher than 7.4 or it is configured with protocol 2" operator="OR">
+          <extend_definition comment="OpenSSH version 7.4 or higher supports only protocol 2" definition_ref="sshd_version_equal_or_higher_than_74" />
+          <criterion comment="Check Protocol in /etc/ssh/sshd_config"
+          test_ref="test_sshd_allow_only_protocol2" />
+        </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="sshd uses protocol 2" id="test_sshd_allow_only_protocol2" version="1">
+    <ind:object object_ref="object_sshd_allow_only_protocol2" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_sshd_allow_only_protocol2" version="3">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*(?i)Protocol[\s]+2[\s]*(?:|(?:#.*))?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
@@ -62,11 +62,3 @@ warnings:
         As of <tt>openssh-server</tt> version <tt>7.4</tt> and above, the only protocol
         supported is version 2, and line <pre>Protocol 2</pre> in
         <tt>/etc/ssh/sshd_config</tt> is not necessary.
-
-template:
-    name: sshd_lineinfile
-    vars:
-        missing_parameter_pass: 'false'
-        parameter: Protocol
-        rule_id: sshd_allow_only_protocol2
-        value: '2'


### PR DESCRIPTION
#### Description:

This rule was templated. However, the template does not agree with the rule description. Therefore, it was decided to revert to prior checks and remediations which were used before templating.

#### Rationale:

The template searched for the "protocol" parameter in the /etc/ssh/sshd_config. OpenSSH servers with version higher than 7.4 support only protocol 2 and therefore the config file doesn't need to contain this configuration.

Fixes: RHBZ#1823576