### PR TITLE
WIP: Revert "ocp4: Disable slub debug check for moderate profile"

### DIFF
--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -550,7 +550,6 @@ selections:
     - package_audit_installed
     - grub2_audit_argument
     - grub2_audit_backlog_limit_argument
-    #- grub2_slub_debug_argument
     - grub2_page_poison_argument
     - grub2_vsyscall_argument
 

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -550,7 +550,7 @@ selections:
     - package_audit_installed
     - grub2_audit_argument
     - grub2_audit_backlog_limit_argument
-    #- grub2_slub_debug_argument
+    - grub2_slub_debug_argument
     - grub2_page_poison_argument
     - grub2_vsyscall_argument
 


### PR DESCRIPTION
This reverts commit 7ce8915e0fda955fdc62e38ffbf1f09db973fafd.

Initially, this remediation made the nodes crash. This tests it again, in an isolated manner, with the CI tests having merged.