### PR TITLE
Revert "ocp4: Comment out sysctl checks"

### DIFF
--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -79,27 +79,27 @@ selections:
     - chronyd_no_chronyc_network
 
     ### Network Settings
-    #- sysctl_net_ipv6_conf_all_accept_ra
-    #- sysctl_net_ipv6_conf_default_accept_ra
-    #- sysctl_net_ipv4_conf_all_accept_redirects
-    #- sysctl_net_ipv4_conf_default_accept_redirects
-    #- sysctl_net_ipv6_conf_all_accept_redirects
-    #- sysctl_net_ipv6_conf_default_accept_redirects
-    #- sysctl_net_ipv4_conf_all_accept_source_route
-    #- sysctl_net_ipv4_conf_default_accept_source_route
-    #- sysctl_net_ipv6_conf_all_accept_source_route
-    #- sysctl_net_ipv6_conf_default_accept_source_route
-    #- sysctl_net_ipv4_conf_all_secure_redirects
-    #- sysctl_net_ipv4_conf_default_secure_redirects
-    #- sysctl_net_ipv4_conf_all_send_redirects
-    #- sysctl_net_ipv4_conf_default_send_redirects
-    #- sysctl_net_ipv4_conf_all_log_martians
-    #- sysctl_net_ipv4_conf_default_log_martians
-    #- sysctl_net_ipv4_conf_all_rp_filter
-    #- sysctl_net_ipv4_conf_default_rp_filter
-    #- sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-    #- sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-    #- sysctl_net_ipv4_tcp_syncookies
+    - sysctl_net_ipv6_conf_all_accept_ra
+    - sysctl_net_ipv6_conf_default_accept_ra
+    - sysctl_net_ipv4_conf_all_accept_redirects
+    - sysctl_net_ipv4_conf_default_accept_redirects
+    - sysctl_net_ipv6_conf_all_accept_redirects
+    - sysctl_net_ipv6_conf_default_accept_redirects
+    - sysctl_net_ipv4_conf_all_accept_source_route
+    - sysctl_net_ipv4_conf_default_accept_source_route
+    - sysctl_net_ipv6_conf_all_accept_source_route
+    - sysctl_net_ipv6_conf_default_accept_source_route
+    - sysctl_net_ipv4_conf_all_secure_redirects
+    - sysctl_net_ipv4_conf_default_secure_redirects
+    - sysctl_net_ipv4_conf_all_send_redirects
+    - sysctl_net_ipv4_conf_default_send_redirects
+    - sysctl_net_ipv4_conf_all_log_martians
+    - sysctl_net_ipv4_conf_default_log_martians
+    - sysctl_net_ipv4_conf_all_rp_filter
+    - sysctl_net_ipv4_conf_default_rp_filter
+    - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+    - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+    - sysctl_net_ipv4_tcp_syncookies
 
     ### systemd
     - disable_ctrlaltdel_reboot
@@ -133,17 +133,17 @@ selections:
     - grub2_pti_argument
 
     ## Security Settings
-    #- sysctl_kernel_kptr_restrict
-    #- sysctl_kernel_dmesg_restrict
-    #- sysctl_kernel_kexec_load_disabled
-    #- sysctl_kernel_yama_ptrace_scope
-    #- sysctl_kernel_perf_event_paranoid
-    #- sysctl_kernel_unprivileged_bpf_disabled
-    #- sysctl_net_core_bpf_jit_harden
+    - sysctl_kernel_kptr_restrict
+    - sysctl_kernel_dmesg_restrict
+    - sysctl_kernel_kexec_load_disabled
+    - sysctl_kernel_yama_ptrace_scope
+    - sysctl_kernel_perf_event_paranoid
+    - sysctl_kernel_unprivileged_bpf_disabled
+    - sysctl_net_core_bpf_jit_harden
 
     ## File System Settings
-    #- sysctl_fs_protected_hardlinks
-    #- sysctl_fs_protected_symlinks
+    - sysctl_fs_protected_hardlinks
+    - sysctl_fs_protected_symlinks
 
     ### Audit
     # AC-2(4) and others
@@ -213,7 +213,7 @@ selections:
 
     ### Login
     - disable_users_coredumps
-    #- sysctl_kernel_core_pattern
+    - sysctl_kernel_core_pattern
     - coredump_disable_storage
     - coredump_disable_backtraces
     - service_systemd-coredump_disabled


### PR DESCRIPTION
This reverts commit 249e70b638da0544f4870191f6d174d215e031bf.

The node-tuning-operator was stumbling upon this remediation. This PR tests that theory.