### PR TITLE
ocp4/e2e: display remediations for second scan

### DIFF
--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -35,7 +35,7 @@ func TestE2e(t *testing.T) {
 		// Create suite and auto-apply remediations
 		suite := ctx.createComplianceSuiteForProfile("1", true)
 		ctx.waitForComplianceSuite(suite)
-		numberOfRemediationsInit = ctx.getRemediationsForSuite(suite)
+		numberOfRemediationsInit = ctx.getRemediationsForSuite(suite, false)
 	})
 
 	t.Run("Wait for Remediations to apply", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestE2e(t *testing.T) {
 		// Create suite and auto-apply remediations
 		suite := ctx.createComplianceSuiteForProfile("2", false)
 		ctx.waitForComplianceSuite(suite)
-		numberOfRemediationsEnd = ctx.getRemediationsForSuite(suite)
+		numberOfRemediationsEnd = ctx.getRemediationsForSuite(suite, true)
 	})
 
 	t.Run("We should have less remediations to apply", func(t *testing.T) {

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -355,7 +355,7 @@ func (ctx *e2econtext) waitForNodesToBeReady() {
 	}
 }
 
-func (ctx *e2econtext) getRemediationsForSuite(s *cmpv1alpha1.ComplianceSuite) int {
+func (ctx *e2econtext) getRemediationsForSuite(s *cmpv1alpha1.ComplianceSuite, display bool) int {
 	remList := &cmpv1alpha1.ComplianceRemediationList{}
 	labelSelector, _ := labels.Parse(cmpv1alpha1.SuiteLabel + "=" + s.Name)
 	opts := &client.ListOptions{
@@ -364,6 +364,14 @@ func (ctx *e2econtext) getRemediationsForSuite(s *cmpv1alpha1.ComplianceSuite) i
 	err := ctx.dynclient.List(goctx.TODO(), remList, opts)
 	if err != nil {
 		ctx.t.Fatalf("Couldn't get remediation list")
+	}
+	if display {
+		if len(remList.Items) > 0 {
+			ctx.t.Logf("Remediations from ComplianceSuite: %s", s.Name)
+		}
+		for _, rem := range remList.Items {
+			ctx.t.Logf("- %s", rem.Name)
+		}
 	}
 	return len(remList.Items)
 }


### PR DESCRIPTION
These remediations were applied but didn't actually remediate the issues
found on the nodes (or simply the check isn't working properly). So it's
useful to display them as part of the test output.