### PR TITLE
add ignition stats to profile_tool.py

### DIFF
--- a/shared/macros-ignition.jinja
+++ b/shared/macros-ignition.jinja
@@ -1,0 +1,3 @@
+{{#
+  Placeholder for future Ignition macros
+#}}

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -31,6 +31,8 @@ JINJA_MACROS_HIGHLEVEL_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirnam
     __file__)), "shared", "macros-highlevel.jinja")
 JINJA_MACROS_ANSIBLE_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-ansible.jinja")
+JINJA_MACROS_IGNITION_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
+    __file__)), "shared", "macros-ignition.jinja")
 JINJA_MACROS_OVAL_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-oval.jinja")
 JINJA_MACROS_BASH_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
@@ -49,9 +51,9 @@ xccdf_header = xml_version + "<xccdf>"
 xccdf_footer = "</xccdf>"
 bash_system = "urn:xccdf:fix:script:sh"
 ansible_system = "urn:xccdf:fix:script:ansible"
+ignition_system = "urn:xccdf:fix:script:ignition"
 puppet_system = "urn:xccdf:fix:script:puppet"
 anaconda_system = "urn:redhat:anaconda:pre"
-ignition_system = "urn:xccdf:fix:script:ignition"
 cce_uri = "https://nvd.nist.gov/cce/index.cfm"
 stig_ns = "https://public.cyber.mil/stigs/srg-stig-tools/"
 stig_refs = 'https://public.cyber.mil/stigs/'


### PR DESCRIPTION
Now generates ignition stats:

`````
*** rules of 'ospp' profile missing a ignition fix script: 192 of 198 [3% complete]
   accounts_max_concurrent_login_sessions       
   accounts_password_minlen_login_defs          
   accounts_password_pam_dcredit                
   accounts_password_pam_difok                  
   accounts_password_pam_lcredit                
   accounts_password_pam_maxclassrepeat         
   accounts_password_pam_maxrepeat              
   accounts_password_pam_minlen                 
   accounts_password_pam_ocredit                
   accounts_password_pam_ucredit                
   accounts_password_pam_unix_remember          
   accounts_passwords_pam_faillock_deny         
   accounts_passwords_pam_faillock_interval     
   accounts_passwords_pam_faillock_unlock_time     accounts_umask_etc_bashrc                    
   accounts_umask_etc_csh_cshrc                 
   accounts_umask_etc_profile                      audit_access_failed                          
   audit_access_success                            audit_basic_configuration                    
   audit_create_failed                             audit_create_success                         
   audit_delete_failed                             audit_delete_success                         
   audit_immutable_login_uids                      audit_modify_failed                          
   audit_modify_success                            audit_module_load                            
   audit_ospp_general                              audit_owner_change_failed                    
   audit_owner_change_success                      audit_perm_change_failed                     
   audit_perm_change_success                    
   auditd_data_retention_flush                     auditd_freq                                  
   auditd_local_events                             auditd_log_format                            
   auditd_name_format                              auditd_write_logs                            
   chronyd_client_only                          
   chronyd_no_chronyc_network                   
   configure_bashrc_exec_tmux                   
   configure_bind_crypto_policy                    configure_crypto_policy                      
   configure_kerberos_crypto_policy             
   configure_libreswan_crypto_policy            
   configure_openssl_crypto_policy              
   configure_tmux_lock_after_time               
   configure_tmux_lock_command                  
   configure_usbguard_auditbackend              
   disable_ctrlaltdel_burstaction                  disable_ctrlaltdel_reboot                    
   disable_host_auth                               disable_users_coredumps                      
   dnf-automatic_apply_updates                  
   dnf-automatic_security_updates_only             enable_dracut_fips_module                    
   enable_fips_mode                             
   ensure_gpgcheck_globally_activated           
   ensure_gpgcheck_local_packages               
   ensure_gpgcheck_never_disabled               
   ensure_redhat_gpgkey_installed                  grub2_audit_argument                         
   grub2_audit_backlog_limit_argument           
   grub2_disable_interactive_boot               
   grub2_page_poison_argument                      grub2_pti_argument                           
   grub2_slub_debug_argument                       grub2_uefi_password                          
   grub2_vsyscall_argument                      
   kerberos_disable_no_keytab                   
   kernel_module_atm_disabled                   
   kernel_module_bluetooth_disabled             
   kernel_module_can_disabled                   
   kernel_module_cramfs_disabled                
   kernel_module_firewire-core_disabled         
   kernel_module_sctp_disabled                  
   kernel_module_tipc_disabled                     mount_option_boot_nodev                      
   mount_option_boot_nosuid                     
   mount_option_dev_shm_nodev                   
   mount_option_dev_shm_noexec                  
   mount_option_dev_shm_nosuid                     mount_option_home_nodev                      
   mount_option_home_nosuid                     
   mount_option_nodev_nonroot_local_partitions     mount_option_tmp_nodev                       
   mount_option_tmp_noexec                         mount_option_tmp_nosuid                      
   mount_option_var_log_audit_nodev             
   mount_option_var_log_audit_noexec            
   mount_option_var_log_audit_nosuid            
   mount_option_var_log_nodev                   
   mount_option_var_log_noexec                  
   mount_option_var_log_nosuid                     mount_option_var_nodev                       
   mount_option_var_tmp_nodev                   
   mount_option_var_tmp_noexec                  
   mount_option_var_tmp_nosuid                     no_tmux_in_shells                            
   openssl_use_strong_entropy                   
   package_abrt-addon-ccpp_removed              
   package_abrt-addon-kerneloops_removed        
   package_abrt-addon-python_removed               package_abrt-cli_removed                     
   package_abrt-plugin-logger_removed           
   package_abrt-plugin-rhtsupport_removed       
   package_abrt-plugin-sosreport_removed           package_abrt_removed                         
   package_aide_installed                          package_audit_installed                      
   package_crypto-policies_installed            
   package_dnf-automatic_installed              
   package_dnf-plugin-subscription-manager_installed
   package_fapolicyd_installed                  
   package_firewalld_installed                     package_gssproxy_removed                     
   package_iprutils_removed                     
   package_iptables_installed                   
   package_krb5-workstation_removed                package_nfs-utils_removed                    
   package_openscap-scanner_installed           
   package_openssh-clients_installed            
   package_openssh-server_installed                package_pigz_removed                         
   package_policycoreutils-python-utils_installed
   package_policycoreutils_installed            
   package_rng-tools_installed                  
   package_scap-security-guide_installed           package_sendmail_removed                     
   package_subscription-manager_installed          package_sudo_installed                       
   package_tmux_installed                          package_tuned_removed                        
   package_usbguard_installed                      partition_for_home                           
   partition_for_var                               partition_for_var_log                        
   partition_for_var_log_audit                     require_singleuser_auth                      
   securetty_root_login_console_only               selinux_policytype                           
   selinux_state                                   service_fapolicyd_enabled                    
   service_firewalld_enabled                       service_rngd_enabled                         
   service_usbguard_enabled                     
   sshd_disable_empty_passwords                    sshd_disable_gssapi_auth                     
   sshd_disable_kerb_auth                          sshd_disable_root_login                      
   sshd_enable_strictmodes                      
   sshd_enable_warning_banner                      sshd_rekey_limit                             
   sshd_set_idle_timeout                           sshd_set_keepalive                           
   sshd_use_strong_rng                          
   sysctl_fs_protected_hardlinks                
   sysctl_fs_protected_symlinks                 
   sysctl_kernel_core_pattern                   
   sysctl_kernel_dmesg_restrict                 
   sysctl_kernel_kexec_load_disabled            
   sysctl_kernel_kptr_restrict                  
   sysctl_kernel_perf_event_paranoid            
   sysctl_kernel_unprivileged_bpf_disabled      
   sysctl_kernel_yama_ptrace_scope              
   sysctl_net_core_bpf_jit_harden               
   sysctl_net_ipv4_conf_all_accept_redirects    
   sysctl_net_ipv4_conf_all_accept_source_route 
   sysctl_net_ipv4_conf_all_log_martians        
   sysctl_net_ipv4_conf_all_rp_filter           
   sysctl_net_ipv4_conf_all_secure_redirects    
   sysctl_net_ipv4_conf_all_send_redirects      
   sysctl_net_ipv4_conf_default_accept_redirects
   sysctl_net_ipv4_conf_default_accept_source_route
   sysctl_net_ipv4_conf_default_log_martians    
   sysctl_net_ipv4_conf_default_rp_filter       
   sysctl_net_ipv4_conf_default_secure_redirects
   sysctl_net_ipv4_conf_default_send_redirects  
   sysctl_net_ipv4_icmp_echo_ignore_broadcasts  
   sysctl_net_ipv4_icmp_ignore_bogus_error_responses
   sysctl_net_ipv4_ip_forward                   
   sysctl_net_ipv4_tcp_syncookies               
   sysctl_net_ipv6_conf_all_accept_ra           
   sysctl_net_ipv6_conf_all_accept_redirects    
   sysctl_net_ipv6_conf_all_accept_source_route 
   sysctl_net_ipv6_conf_default_accept_ra       
   sysctl_net_ipv6_conf_default_accept_redirects
   sysctl_net_ipv6_conf_default_accept_source_route
   sysctl_user_max_user_namespaces              
   timer_dnf-automatic_enabled                  
   usbguard_allow_hid_and_hub  
`````