### PR TITLE
Add ansible and bash remediation for rule sshd_set_max_auth_tries.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- (xccdf-var sshd_max_auth_tries_value)
+
+{{{ ansible_sshd_set(parameter="MaxAuthTries", value="{{ sshd_max_auth_tries_value }}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/bash/shared.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+populate sshd_max_auth_tries_value
+
+{{{ bash_sshd_config_set(parameter="MaxAuthTries", value="$sshd_max_auth_tries_value") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/rule.yml
@@ -6,7 +6,7 @@ description: |-
     The <tt>MaxAuthTries</tt> parameter specifies the maximum number of authentication attempts
     permitted per connection. Once the number of failures reaches half this value, additional failures are logged.
     to set MaxAUthTries edit <tt>/etc/ssh/sshd_config</tt> as follows:
-    <pre>MaxAuthTries <b>tries</b></pre>
+    <pre>MaxAuthTries <sub idref="sshd_max_auth_tries_value"/></pre>
 
 rationale: |-
     Setting the MaxAuthTries parameter to a low number will minimize the risk of successful
@@ -30,4 +30,4 @@ ocil: |-
     To ensure the <tt>MaxAuthTries</tt> parameter is set, run the following command:
     <pre>$ sudo grep MaxAuthTries /etc/ssh/sshd_config</pre>
     If properly configured, output should be:
-    <pre>MaxAuthTries <b>tries</b></pre>
+    <pre>MaxAuthTries <sub idref="sshd_max_auth_tries_value"/></pre>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/comment.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^MaxAuthTries" $SSHD_CONFIG; then
+	sed -i "s/^MaxAuthTries.*/# MaxAuthTries 4/" $SSHD_CONFIG
+else
+	echo "# MaxAuthTries 4" >> $SSHD_CONFIG
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/correct_value.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^MaxAuthTries" $SSHD_CONFIG; then
+	sed -i "s/^MaxAuthTries.*/MaxAuthTries 4/" $SSHD_CONFIG
+else
+	echo "MaxAuthTries 4" >> $SSHD_CONFIG
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/correct_value_less_than.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/correct_value_less_than.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^MaxAuthTries" $SSHD_CONFIG; then
+	sed -i "s/^MaxAuthTries.*/MaxAuthTries 2/" $SSHD_CONFIG
+else
+	echo "MaxAuthTries 2" >> $SSHD_CONFIG
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/line_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i "/^MaxAuthTries.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/wrong_value.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^MaxAuthTries" $SSHD_CONFIG; then
+	sed -i "s/^MaxAuthTries.*/MaxAuthTries 50/" $SSHD_CONFIG
+else
+	echo "MaxAuthTries 50" >> $SSHD_CONFIG
+fi

--- a/rhel7/profiles/cis.profile
+++ b/rhel7/profiles/cis.profile
@@ -581,6 +581,7 @@ selections:
     - sshd_disable_x11_forwarding
     
     ### 5.2.5 Ensure SSH MaxAuthTries is set to 4 or less (Scored)
+    - sshd_max_auth_tries_value=4
     - sshd_set_max_auth_tries
 
     ### 5.2.6 Ensure SSH IgnoreRhosts is enabled (Scored)


### PR DESCRIPTION
#### Description:

- Add ansible and bash remediation for rule `sshd_set_max_auth_tries`.

#### Rationale:

- Remediations were missing
- Rule is part of CIS profile.
