### PR TITLE
Use jinja macros for bash remediation in rule sshd_set_keepalive.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/bash/shared.sh
@@ -5,4 +5,4 @@
 
 populate var_sshd_set_keepalive
 
-replace_or_append '/etc/ssh/sshd_config' '^ClientAliveCountMax' "$var_sshd_set_keepalive" '@CCENUM@' '%s %s'
+{{{ bash_sshd_config_set(parameter="ClientAliveCountMax", value="$var_sshd_set_keepalive") }}}


### PR DESCRIPTION
#### Description:

- Use jinja macros in favor of plain bash functions.

#### Rationale:

- Less error prone
