### PR TITLE
Add @CCENUM@ placeholder for bash jinja macros

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -443,6 +443,7 @@ line_number="$(LC_ALL=C grep -n "{{{ insert_after }}}" "{{{ path }}}.bak" | LC_A
 if [ -z "$line_number" ]; then
     # There was no match of '{{{ insert_after }}}', insert at
     # the end of the file.
+    printf '# Per %s: Set %s in %s\n' "{{{ "@CCENUM" if has_cce else 'CCE' }}}" "{{{ line }}}" "{{{ path }}}" >> "{{{ path }}}"
     printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
 else
     head -n "$(( line_number ))" "{{{ path }}}.bak" > "{{{ path }}}"
@@ -455,6 +456,7 @@ line_number="$(LC_ALL=C grep -n "{{{ insert_before }}}" "{{{ path }}}.bak" | LC_
 if [ -z "$line_number" ]; then
     # There was no match of '{{{ insert_before }}}', insert at
     # the end of the file.
+    printf '# Per %s: Set %s in %s\n' "{{{ "@CCENUM" if has_cce else 'CCE' }}}" "{{{ line }}}" "{{{ path }}}" >> "{{{ path }}}"
     printf '%s\n' "{{{ line }}}" >> "{{{ path }}}"
 else
     head -n "$(( line_number - 1 ))" "{{{ path }}}.bak" > "{{{ path }}}"

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -214,6 +214,8 @@ class Remediation(object):
 
         self.local_env_yaml["rule_title"] = self.associated_rule.title
         self.local_env_yaml["rule_id"] = self.associated_rule.id_
+        if self.associated_rule.identifiers.get("cce", None):
+            self.local_env_yaml["has_cce"] = True
 
     def parse_from_file_with_jinja(self, env_yaml):
         return parse_from_file_with_jinja(self.file_path, env_yaml)
@@ -229,7 +231,11 @@ def process(remediation, env_yaml, fixes, rule_id):
     if not is_supported_filename(remediation.remediation_type, remediation.file_path):
         return
 
-    result = remediation.parse_from_file_with_jinja(env_yaml)
+    local_env_yaml = dict()
+    local_env_yaml.update(remediation.local_env_yaml)
+    local_env_yaml.update(env_yaml)
+
+    result = remediation.parse_from_file_with_jinja(local_env_yaml)
     platforms = result.config['platform']
 
     if not platforms:

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -444,7 +444,7 @@ class Builder(object):
         else:
             return languages
 
-    def build_rule(self, rule_id, rule_title, template, langs_to_generate):
+    def build_rule(self, rule_id, rule_title, template, langs_to_generate, rule_has_cce=False):
         """
         Builds templated content for a given rule for selected languages,
         writing the output to the correct build directories.
@@ -474,6 +474,8 @@ class Builder(object):
         local_env_yaml["rule_id"] = rule_id
         local_env_yaml["rule_title"] = rule_title
         local_env_yaml["products"] = self.env_yaml["product"]
+        local_env_yaml["has_cce"] = rule_has_cce
+
         for lang in langs_to_generate:
             self.build_lang(
                 rule_id, template_name, template_vars, lang, local_env_yaml)
@@ -500,9 +502,13 @@ class Builder(object):
             if rule.template is None:
                 # rule is not templated, skipping
                 continue
+
+            rule_has_cce = False
+            if rule.identifiers.get("cce", None):
+                rule_has_cce = True
             langs_to_generate = self.get_langs_to_generate(rule)
             self.build_rule(
-                rule.id_, rule.title, rule.template, langs_to_generate)
+                rule.id_, rule.title, rule.template, langs_to_generate, rule_has_cce)
 
     def build(self):
         """

--- a/tests/unit/bash/test_set_config_file.bats.jinja
+++ b/tests/unit/bash/test_set_config_file.bats.jinja
@@ -130,7 +130,7 @@ function call_set_config_file {
 @test "Basic Bash remediation" {
     tmp_file="$(mktemp)"
     printf "%s\n" "something=foo" > "$tmp_file"
-    expected_output="something='va lue'\n"
+    expected_output="# Per CCE: Set something='va lue' in $tmp_file\nsomething='va lue'\n"
 
     {{{ bash_shell_file_set("$tmp_file", "something", "va lue") | indent(4) }}}
 
@@ -144,7 +144,7 @@ function call_set_config_file {
 @test "Variable remediation - preserve dollar and use double quotes" {
     tmp_file="$(mktemp)"
     printf "%s\n" "something=bar" > "$tmp_file"
-    expected_output='something="$value"'"\n"
+    expected_output='# Per CCE: Set something="$value" in '"$tmp_file"'\nsomething="$value"'"\n"
 
     {{{ bash_shell_file_set("$tmp_file", "something", '$value') | indent(4) }}}
 
@@ -158,7 +158,7 @@ function call_set_config_file {
 @test "Basic Bash remediation - don't quote" {
     tmp_file="$(mktemp)"
     printf "%s\n" "something=foo" > "$tmp_file"
-    expected_output="something=va lue\n"
+    expected_output="# Per CCE: Set something=va lue in $tmp_file\nsomething=va lue\n"
 
     {{{ bash_shell_file_set("$tmp_file", "something", "va lue", no_quotes=true) | indent(4) }}}
 
@@ -172,7 +172,7 @@ function call_set_config_file {
 @test "Variable remediation - don't quote" {
     tmp_file="$(mktemp)"
     printf "%s\n" "something=bar" > "$tmp_file"
-    expected_output='something=$value'"\n"
+    expected_output='# Per CCE: Set something=$value in '"$tmp_file\nsomething="'$value'"\n"
 
     {{{ bash_shell_file_set("$tmp_file", "something", '$value', no_quotes=true) | indent(4) }}}
 


### PR DESCRIPTION
#### Description:

- Add placeholder for CCE in bash remediation. These identifiers are replaced by the xslt transformation from here: https://github.com/ComplianceAsCode/content/blob/master/shared/transforms/xccdf-addremediations.xslt#L69

#### Rationale:

- Reintroduces back the functionality implemented by the `replace_or_append` bash function.

~~There is still some strange behavior which only one remediation is getting the right `@CCENUM` placeholder. Needs investigation. Keeping it draft.~~
Update1: It was missing the preprocessing of templated rules which uses bash jinja macros
Update2: This pull request considers that a comment is always the character: `#`. So, for other types of configuration files that use a different symbol to represent comment, it will not work.

Fixes #5599 