### PR TITLE
Change permissions to 644 for passwd- file from rule file_permissions_backup_etc_passwd

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Verify Permissions on Backup passwd File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/passwd-", perms="0600") }}}
+    {{{ describe_file_permissions(file="/etc/passwd-", perms="0644") }}}
 
 rationale: |-
     The <tt>/etc/passwd-</tt> file is a backup file of <tt>/etc/passwd</tt>, and as such,
@@ -21,14 +21,14 @@ references:
     cis@rhel8: 6.1.6
     cis@sle15: 6.1.7
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/passwd-", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/passwd-", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/passwd-", perms="-rw-------") }}}
+    {{{ ocil_file_permissions(file="/etc/passwd-", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions
     vars:
         filepath: /etc/passwd-
-        filemode: '0600'
+        filemode: '0644'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/tests/adduser.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/tests/adduser.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+USER=ssgttuser
+
+# set wrong permissions
+chmod 600 /etc/passwd-
+
+# useradd will copy the backup file with permissions from the
+# actual /etc/passwd file containing correct permissions
+useradd ${USER}
+

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/tests/correct_value.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+chmod 644 /etc/passwd-
+

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/tests/wrong_value.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# the expected is 644
+chmod 660 /etc/passwd-
+

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -922,7 +922,7 @@ selections:
     - file_owner_backup_etc_passwd
     - file_groupowner_backup_etc_passwd
 
-    # chmod 600 /etc/passwd-
+    # chmod 644 /etc/passwd-
     - file_permissions_backup_etc_passwd
 
     ### 6.1.7 Ensure permissions on /etc/shadow- are configured (Scored)


### PR DESCRIPTION
#### Description:

- Update expected permissions to `644` from file `/etc/passwd-`

#### Rationale:

- According to latest CIS RHEL7 benchmark (v2.2.0) the actual value is `644` instead of `600`

From section `6.1.6 Ensure permissions on /etc/passwd- are configured (Scored)`
```
Run the following command and verify Uid and Gid are both 0/root and Access is 644 or
more restrictive:
# stat /etc/passwd-
Access: (0644/-rw-------)
```
The problem here was that when the backup file is regenerated by `adduser` command for example, it has the same permissions as the original file (`/etc/passwd` has `644`), then the check would always fail after the backup file gets updated.

Now, RHEL8 benchmark still says to check for `600` even in the latest version, but we believe this is a finding, since for RHEL7 had the same behavior, also there was a support ticket created in order to update to `644` in the RHEL7 benchmark. I have created a ticket under official CIS ticket system to update this configuration for RHEL8.

Fixes #5611 
