### PR TITLE
Add support for kubernetes remediation type

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -282,8 +282,8 @@ macro(ssg_build_ansible_playbooks PRODUCT)
 endmacro()
 
 macro(ssg_build_remediations PRODUCT)
-    message(STATUS "Scanning for dependencies of ${PRODUCT} fixes (bash, ansible, puppet, anaconda and ignition)...")
-    _ssg_build_remediations_for_language(${PRODUCT} "bash;ansible;puppet;anaconda;ignition")
+    message(STATUS "Scanning for dependencies of ${PRODUCT} fixes (bash, ansible, puppet, anaconda, ignition and kubernetes)...")
+    _ssg_build_remediations_for_language(${PRODUCT} "bash;ansible;puppet;anaconda;ignition;kubernetes")
 
     # only enable the ansible syntax checks if we are using openscap 1.2.17 or higher
     # older openscap causes syntax errors, see https://github.com/OpenSCAP/openscap/pull/977
@@ -314,7 +314,7 @@ macro(ssg_build_xccdf_with_remediations PRODUCT)
     string(REPLACE " " "%20" CMAKE_CURRENT_BINARY_DIR_NO_SPACES "${CMAKE_CURRENT_BINARY_DIR}")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam bash_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/bash-fixes.xml" --stringparam ansible_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ansible-fixes.xml" --stringparam puppet_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/puppet-fixes.xml" --stringparam anaconda_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/anaconda-fixes.xml" --stringparam ignition_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ignition-fixes.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam bash_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/bash-fixes.xml" --stringparam ansible_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ansible-fixes.xml" --stringparam puppet_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/puppet-fixes.xml" --stringparam anaconda_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/anaconda-fixes.xml" --stringparam ignition_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ignition-fixes.xml" --stringparam kubernetes_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/kubernetes-fixes.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
         DEPENDS generate-internal-${PRODUCT}-xccdf-unlinked-ocilrefs.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
@@ -328,6 +328,8 @@ macro(ssg_build_xccdf_with_remediations PRODUCT)
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/anaconda-fixes.xml"
         DEPENDS generate-internal-${PRODUCT}-ignition-fixes.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ignition-fixes.xml"
+        DEPENDS generate-internal-${PRODUCT}-kubernetes-fixes.xml
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/kubernetes-fixes.xml"
         DEPENDS "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt"
         COMMENT "[${PRODUCT}-content] generating xccdf-unlinked.xml"
     )

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -762,7 +762,7 @@ If customizing content via SCAP Workbench, or directly writing your tailoring XM
 
 == Contributing with XCCDFs, OVALs and remediations
 
-There are three main types of content in the project, they are rules, defined using the XCCDF standard, checks, usually written in link:https://oval.mitre.org/language/about/[OVAL] format, and remediations, that can be executed on ansible, bash, anaconda installer, puppet and ignition.
+There are three main types of content in the project, they are rules, defined using the XCCDF standard, checks, usually written in link:https://oval.mitre.org/language/about/[OVAL] format, and remediations, that can be executed on ansible, bash, anaconda installer, puppet, ignition and kubernetes.
 ComplianceAsCode also has its own templating mechanism, allowing content writers to create models and use it to generate a number of checks and remediations.
 
 === Contributing
@@ -1005,6 +1005,7 @@ contain the following subdirectories:
  - `oval` -- for OVAL check content, ending in `.xml`
  - `puppet` -- for Puppet remediation content, ending in `.pp`
  - `ignition` -- for Ignition remediation content, ending in `.yml`
+ - `kubernetes` -- for Kubernetes remediation content, ending in `.yml`
 
 In each of these subdirectories, a file named `shared.ext` will apply to all
 products and be included in all builds, but `{{{ product }}}.ext` will
@@ -1201,7 +1202,7 @@ This ensures consistent, high quality OVAL checks that we can edit in one place 
 
 === Remediations
 
-Remediations, also called fixes, are used to change the state of the machine, so that previously non-passing rules can pass. There can be multiple versions of the same remediation meant to be executed by different applications, more specifically Ansible, Bash, Anaconda, Puppet and Ignition.
+Remediations, also called fixes, are used to change the state of the machine, so that previously non-passing rules can pass. There can be multiple versions of the same remediation meant to be executed by different applications, more specifically Ansible, Bash, Anaconda, Puppet, Ignition and Kubernetes.
 They also have to be idempotent, meaning that they must be able to be executed multiple times without causing the fixes to accumulate. The Ansible's language works in such a way that this behavior is built-in, however, for the other versions, the remediations must have it implemented explicitly.
 Remediations also carry metadata that should be present at the beginning of the files. This meta data will be converted in link:https://scap.nist.gov/specifications/xccdf/xccdf_element_dictionary.html#fixType[XCCDF tags] during the building process. That is how it looks like and what it means:
 
@@ -1386,10 +1387,11 @@ used for the new rule you only need to specify the template name and its paramet
 `rule.yml` and the content will be generated during the build.
 
 The templating system currently supports generating OVAL checks and Ansible,
-Bash, Anaconda, Puppet and Ignition remediations.  All templates can be found in
-`link:{rootdir}/shared/templates[shared/templates]` directory. The files are
-named `template_<TYPE>_<NAME>`, where `<TYPE>` should be OVAL, ANSIBLE, BASH,
-ANACONDA, PUPPET or IGNITION and `<NAME>` is the template name.
+Bash, Anaconda, Puppet, Ignition and Kubernetes remediations.  All templates
+can be found in `link:{rootdir}/shared/templates[shared/templates]` directory.
+The files are named `template_<TYPE>_<NAME>`, where `<TYPE>` should be OVAL,
+ANSIBLE, BASH, ANACONDA, PUPPET, IGNITION and KUBERNETES and `<NAME>` is the
+template name.
 
 ==== Using Templates
 
@@ -1746,7 +1748,7 @@ name that is used in `rule.yml` in `name:` key, for example
 The callback must have 2 parameters:
 
 - `data` - dictionary which contains the contents of `vars:` dictionary from `rule.yml`
-- `lang` - string, describes language, can be one of: `"anaconda"`, `"ansible"`, `"bash"`, `"oval"`, `"puppet"`, `"ignition"`
+- `lang` - string, describes language, can be one of: `"anaconda"`, `"ansible"`, `"bash"`, `"oval"`, `"puppet"`, `"ignition"`, `"kubernetes"`
 
 The callback function is executed for every supported language, so it can process the data differently for each language.
 
@@ -1759,8 +1761,8 @@ In that situation the function just returns `data` parameter.
 will register the template in the templating engine. The decorator has a single
 parameter which is a list of languages that the template provides. The list can
 contain the following values: `"anaconda"`, `"ansible"`, `"bash"`, `"oval"`,
-`"puppet"`, `"ignition"`. The decorator parameter is mandatory. Insert the `@template`
-decorator on the line before the callback function definition.
+`"puppet"`, `"ignition"`, `"kubernetes"`. The decorator parameter is mandatory.
+Insert the `@template` decorator on the line before the callback function definition.
 
 For example, if the template name is `package_installed` and it provides
 Ansible template in `shared/templates/template_ANSIBLE_package_installed` and

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -2,7 +2,7 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" exclude-result-prefixes="xccdf">
 
 <!-- This transform expects stringparams "bash_remediations", "ansible_remediations", "puppet_remediations",
-     "anaconda_remediations", "ignition_remediations"
+     "anaconda_remediations", "ignition_remediations", "kubernetes_remediations"
      specifying a filenames containing a list of remediations.  It inserts these into the Rules
      specified inside the remediations file. -->
 <xsl:param name="bash_remediations"/>
@@ -10,6 +10,7 @@
 <xsl:param name="puppet_remediations"/>
 <xsl:param name="anaconda_remediations"/>
 <xsl:param name="ignition_remediations"/>
+<xsl:param name="kubernetes_remediations"/>
 
 <xsl:variable name="bash_remediations_doc" select="document($bash_remediations)" />
 <xsl:variable name="bash_fixgroup" select="$bash_remediations_doc/xccdf:fix-content/xccdf:fix-group" />
@@ -31,10 +32,14 @@
 <xsl:variable name="ignition_fixgroup" select="$ignition_remediations_doc/xccdf:fix-content/xccdf:fix-group" />
 <xsl:variable name="ignition_fixcommongroup" select="$ignition_remediations_doc/xccdf:fix-content/xccdf:fix-common-group" />
 
+<xsl:variable name="kubernetes_remediations_doc" select="document($kubernetes_remediations)" />
+<xsl:variable name="kubernetes_fixgroup" select="$kubernetes_remediations_doc/xccdf:fix-content/xccdf:fix-group" />
+<xsl:variable name="kubernetes_fixcommongroup" select="$kubernetes_remediations_doc/xccdf:fix-content/xccdf:fix-common-group" />
 
 
-<xsl:variable name="fixgroups" select="$bash_fixgroup | $ansible_fixgroup | $puppet_fixgroup | $anaconda_fixgroup | $ignition_fixgroup" />
-<xsl:variable name="fixcommongroups" select="$bash_fixcommongroup | $ansible_fixcommongroup | $puppet_fixcommongroup | $anaconda_fixcommongroup | $ignition_fixcommongroup" />
+
+<xsl:variable name="fixgroups" select="$bash_fixgroup | $ansible_fixgroup | $puppet_fixgroup | $anaconda_fixgroup | $ignition_fixgroup | $kubernetes_fixgroup" />
+<xsl:variable name="fixcommongroups" select="$bash_fixcommongroup | $ansible_fixcommongroup | $puppet_fixcommongroup | $anaconda_fixcommongroup | $ignition_fixcommongroup | $kubernetes_fixcommongroup" />
 
 <xsl:template name="find-and-replace">
   <xsl:param name="text"/>
@@ -143,6 +148,10 @@
 
   <xsl:if test="$ignition_remediations='' or not($ignition_remediations_doc)">
     <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$ignition_remediations"/>".</xsl:message>
+  </xsl:if>
+
+  <xsl:if test="$kubernetes_remediations='' or not($kubernetes_remediations_doc)">
+    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$kubernetes_remediations"/>".</xsl:message>
   </xsl:if>
 
   <xsl:copy>

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -24,7 +24,8 @@ REMEDIATION_TO_EXT_MAP = {
     'ansible': '.yml',
     'bash': '.sh',
     'puppet': '.pp',
-    'ignition': '.yml'
+    'ignition': '.yml',
+    'kubernetes': '.yml'
 }
 
 FILE_GENERATED_HASH_COMMENT = '# THIS FILE IS GENERATED'
@@ -102,6 +103,12 @@ def get_fixgroup_for_type(fixcontent, remediation_type):
         return ElementTree.SubElement(
             fixcontent, "fix-group", id="ignition",
             system="urn:xccdf:fix:script:ignition",
+            xmlns="http://checklists.nist.gov/xccdf/1.1")
+
+    elif remediation_type == 'kubernetes':
+        return ElementTree.SubElement(
+            fixcontent, "fix-group", id="kubernetes",
+            system="urn:xccdf:fix:script:kubernetes",
             xmlns="http://checklists.nist.gov/xccdf/1.1")
 
     sys.stderr.write("ERROR: Unknown remediation type '%s'!\n"
@@ -386,12 +393,19 @@ class IgnitionRemediation(Remediation):
             file_path, "ignition")
 
 
+class KubernetesRemediation(Remediation):
+    def __init__(self, file_path):
+        super(KubernetesRemediation, self).__init__(
+              file_path, "kubernetes")
+
+
 REMEDIATION_TO_CLASS = {
     'anaconda': AnacondaRemediation,
     'ansible': AnsibleRemediation,
     'bash': BashRemediation,
     'puppet': PuppetRemediation,
     'ignition': IgnitionRemediation,
+    'kubernetes': KubernetesRemediation,
 }
 
 
@@ -515,6 +529,8 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
     """
 
     if remediation_type == "ignition":
+        return
+    if remediation_type == "kubernetes":
         return
     elif remediation_type == "ansible":
         fix_text = fix.text

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -33,6 +33,8 @@ JINJA_MACROS_ANSIBLE_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-ansible.jinja")
 JINJA_MACROS_IGNITION_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-ignition.jinja")
+JINJA_MACROS_KUBERNETES_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
+    __file__)), "shared", "macros-kubernetes.jinja")
 JINJA_MACROS_OVAL_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-oval.jinja")
 JINJA_MACROS_BASH_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
@@ -52,6 +54,7 @@ xccdf_footer = "</xccdf>"
 bash_system = "urn:xccdf:fix:script:sh"
 ansible_system = "urn:xccdf:fix:script:ansible"
 ignition_system = "urn:xccdf:fix:script:ignition"
+kubernetes_system = "urn:xccdf:fix:script:kubernetes"
 puppet_system = "urn:xccdf:fix:script:puppet"
 anaconda_system = "urn:redhat:anaconda:pre"
 cce_uri = "https://nvd.nist.gov/cce/index.cfm"

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -8,7 +8,7 @@ from xml.sax.saxutils import unescape
 
 import ssg.build_yaml
 
-languages = ["anaconda", "ansible", "bash", "oval", "puppet", "ignition"]
+languages = ["anaconda", "ansible", "bash", "oval", "puppet", "ignition", "kubernetes"]
 
 lang_to_ext_map = {
     "anaconda": ".anaconda",
@@ -16,7 +16,8 @@ lang_to_ext_map = {
     "bash": ".sh",
     "oval": ".xml",
     "puppet": ".pp",
-    "ignition": ".yml"
+    "ignition": ".yml",
+    "kubernetes": ".yml"
 }
 
 def sanitize_input(string):


### PR DESCRIPTION
This introduces support for kubernetes remediation types. They're meant
to be generic kubernetes objects that can be taken into use to remediate
an issue in a Kubernetes distribution. These are basically a super-set
of the `ignition` remediation. `ignition` remediations only deal with
MachineConfig objects, while Kubernetes remediations can do any
kubernetes object. In the future, kubernetes remediations will deprecate
ignition remediations in the compliance-operator and in this content.

Note that this needs https://github.com/OpenSCAP/openscap/pull/1514 to
merge first.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
