### PR TITLE
Fix audit_basic_configuration ignition remediation

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/ignition/shared.yml
@@ -8,7 +8,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:,%23%23%20First%20rule%20-%20delete%20all%0A-D%0A%0A%23%23%20Increase%20the%20buffers%20to%20survive%20stress%20events.%0A%23%23%20Make%20this%20bigger%20for%20busy%20systems%0A-b%208192%0A%0A%23%23%20This%20determine%20how%20long%20to%20wait%20in%20burst%20of%20events%0A--backlog_wait_time%2060000%0A%0A%23%23%20Set%20failure%20mode%20to%20syslog%0A-f%201%0A%0A
+          source: data:,%23%23%20First%20rule%20-%20delete%20all%0A-D%0A%0A%23%23%20Increase%20the%20buffers%20to%20survive%20stress%20events.%0A%23%23%20Make%20this%20bigger%20for%20busy%20systems%0A-b%208192%0A%0A%23%23%20This%20determine%20how%20long%20to%20wait%20in%20burst%20of%20events%0A--backlog_wait_time%2060000%0A%0A%23%23%20Set%20failure%20mode%20to%20syslog%0A-f%201%0A
         filesystem: root
         mode: 0600
         path: /etc/audit/rules.d/10-base-config.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8
+prodtype: ol8,rhel8,ocp4
 
 title: 'Configure basic parameters of Audit system'
 


### PR DESCRIPTION
#### Description:

The ignition remediation when applied was still failing the rule check
becuase the underlying oval check compares the file with a precise
expected value and the remediation had an extra newline at the end.

Also, I added ocp4 as a product type. I'm not sure if it's needed,
but since ignition is mostly used in OCP4, I think it makes sense if
the rule is usable for the OCP4 product.

#### Rationale:

- the ignition remediation, while technically correct, was still causing
the rule to fail when applied.