### PR TITLE
Fix missing ignition remediations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/ignition/shared.yml
@@ -7,5 +7,5 @@ spec:
       version: 2.2.0
     systemd:
       units:
-        enabled: false
+      - enabled: false
         name: debug-shell.service

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/ignition/shared.yml
@@ -7,5 +7,5 @@ spec:
       version: 2.2.0
     systemd:
       units:
-        enabled: false
+      - enabled: false
         name: autofs.service

--- a/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/ignition/shared.yml
@@ -7,5 +7,5 @@ spec:
       version: 2.2.0
     systemd:
       units:
-        enabled: false
+      - enabled: false
         name: systemd-coredump.socket

--- a/tests/unit/kubernetes/helpers.go
+++ b/tests/unit/kubernetes/helpers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	mcfgapi "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,10 +75,8 @@ func (ctx *unitTestContext) assertWithRelevantFiles(assertion func(path string))
 }
 
 func isMachineConfig(obj *unstructured.Unstructured) bool {
-	mcfg := &mcfgv1.MachineConfig{}
-	mcfggvk := mcfg.GroupVersionKind()
 	objgvk := obj.GroupVersionKind()
-	return mcfggvk.Kind == objgvk.Kind && mcfggvk.Group == objgvk.Group
+	return "MachineConfig" == objgvk.Kind && mcfgapi.GroupName == objgvk.Group
 }
 
 func isRelevantDir(path string, info os.FileInfo) bool {

--- a/tests/unit/kubernetes/vendor/github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/install.go
+++ b/tests/unit/kubernetes/vendor/github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/install.go
@@ -1,0 +1,15 @@
+package machineconfiguration
+
+import (
+	machineconfigurationv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// GroupName defines the API group for machineconfiguration.
+const GroupName = "machineconfiguration.openshift.io"
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(machineconfigurationv1.Install)
+	// Install is a function which adds every version of this group to a scheme
+	Install = SchemeBuilder.AddToScheme
+)

--- a/tests/unit/kubernetes/vendor/modules.txt
+++ b/tests/unit/kubernetes/vendor/modules.txt
@@ -29,6 +29,7 @@ github.com/google/gofuzz
 # github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad
 github.com/openshift/api/config/v1
 # github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible => github.com/openshift/machine-config-operator v0.0.1-0.20200305103412-b9fa5093eb95
+github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io
 github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1
 # github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 github.com/vincent-petithory/dataurl


### PR DESCRIPTION
* The kube unit tests that checked for specific ignition validity was failing. This was due to the fact that an empty MachineConfig object is not enough to check the object's metadata. This fixes that by doing string comparison in the unit tests instead.
* resulting from this fix came some errors in the ignition definitions, this PR fixes them.