### PR TITLE
ocp4/e2e: Remove references to catalogSourceConfig object

### DIFF
--- a/ocp-resources/compliance-operator-csc.yaml
+++ b/ocp-resources/compliance-operator-csc.yaml
@@ -1,9 +1,0 @@
-apiVersion: operators.coreos.com/v1
-kind: CatalogSourceConfig
-metadata:
-  name: compliance-operator
-  namespace: openshift-marketplace
-spec:
-  targetNamespace: openshift-compliance
-  packages: compliance-operator-bundle
-  source: compliance-operator

--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -18,7 +18,6 @@ func TestE2e(t *testing.T) {
 		ctx.ensureNamespaceExistsAndSet()
 		if ctx.installOperator {
 			ctx.ensureOperatorSourceExists()
-			ctx.ensureCatalogSourceConfigExists()
 			ctx.ensureOperatorGroupExists()
 			ctx.ensureSubscriptionExists()
 			ctx.waitForOperatorToBeReady()

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -36,12 +36,11 @@ import (
 )
 
 const (
-	namespacePath           = "compliance-operator-ns.yaml"
-	operatorSourcePath      = "compliance-operator-source.yaml"
-	catalogSourceConfigPath = "compliance-operator-csc.yaml"
-	operatorGroupPath       = "compliance-operator-operator-group.yaml"
-	subscriptionPath        = "compliance-operator-alpha-subscription.yaml"
-	apiPollInterval         = 5 * time.Second
+	namespacePath      = "compliance-operator-ns.yaml"
+	operatorSourcePath = "compliance-operator-source.yaml"
+	operatorGroupPath  = "compliance-operator-operator-group.yaml"
+	subscriptionPath   = "compliance-operator-alpha-subscription.yaml"
+	apiPollInterval    = 5 * time.Second
 )
 
 var profile string
@@ -179,11 +178,6 @@ func (ctx *e2econtext) ensureNamespaceExistsAndSet() {
 
 func (ctx *e2econtext) ensureOperatorSourceExists() {
 	path := path.Join(ctx.resourcespath, operatorSourcePath)
-	ctx.ensureObjectExists(path)
-}
-
-func (ctx *e2econtext) ensureCatalogSourceConfigExists() {
-	path := path.Join(ctx.resourcespath, catalogSourceConfigPath)
 	ctx.ensureObjectExists(path)
 }
 


### PR DESCRIPTION
This object is no longer required.