### PR TITLE
Add multi_platform_rhel,multi_platform_fedora to the rest of the ignition remediations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ignition/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/auditing/grub2_audit_argument/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/ignition/shared.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/ignition/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ocp
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:


### PR DESCRIPTION
#### Description:

This is an extension of
https://github.com/ComplianceAsCode/content/pull/5601

#### Rationale:

Enabling the other platforms except for OCP lets the ignition
remediations be more useful across different platforms.