### PR TITLE
Update link to debian packaging tools.

### DIFF
--- a/linux_os/guide/intro/general-principles/principle-minimize-software/group.yml
+++ b/linux_os/guide/intro/general-principles/principle-minimize-software/group.yml
@@ -8,7 +8,7 @@ description: |-
     {{%- if pkg_system == "rpm" -%}}
         the RPM Package Manager (originally Red Hat Package Manager, abbreviated RPM)
     {{%- elif pkg_system == "dpkg" -%}}
-        the Package Manager (originally {{{ weblink(link="https://www.debian.org/doc/manuals/debian-faq/ch-pkgtools.en.html", text="apt") }}} ),
+        the Package Manager (originally {{{ weblink(link="https://www.debian.org/doc/manuals/debian-faq/pkgtools.en.html", text="apt") }}} ),
     {{%- endif %}}
     allows for careful management of
     the set of software packages installed on a system. Installed software


### PR DESCRIPTION
#### Description:

- Update link to debian packaging tools.

#### Rationale:

- Old one is not found (404)
