### PR TITLE
ocp4: Expand unit tests to validate profile selections

### DIFF
--- a/ocp4/profiles/coreos-ncp.profile
+++ b/ocp4/profiles/coreos-ncp.profile
@@ -148,9 +148,6 @@ selections:
     - sysctl_kernel_kexec_load_disabled
     - sysctl_kernel_yama_ptrace_scope
     - sysctl_kernel_perf_event_paranoid
-    - sysctl_user_max_user_namespaces
-    - sysctl_user_max_user_namespaces.role=unscored
-    - sysctl_user_max_user_namespaces.severity=info
     - sysctl_kernel_unprivileged_bpf_disabled
     - sysctl_net_core_bpf_jit_harden
 

--- a/tests/unit/kubernetes/go.mod
+++ b/tests/unit/kubernetes/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50 // indirect
 	go4.org v0.0.0-20200104003542-c7e774b10ea0 // indirect
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.2 // indirect
 	k8s.io/apimachinery v0.17.2
 )

--- a/tests/unit/kubernetes/unit_test.go
+++ b/tests/unit/kubernetes/unit_test.go
@@ -7,12 +7,29 @@ import (
 func TestUnit(t *testing.T) {
 	ctx := newUnitTestContext(t)
 	t.Run("Verify kubernetes files are correct", func(t *testing.T) {
-		ctx.assertWithRelevantFiles(func(path string) {
+		ctx.assertWithRelevantContentFiles(func(path string) {
 			obj := ctx.assertObjectIsValid(path)
 
 			if isMachineConfig(obj) {
 				ctx.assertMachineConfigIsValid(obj, path)
 			}
+		})
+	})
+
+	t.Run("Verify OCP profiles don't contain invalid checks", func(t *testing.T) {
+		ctx.asssertWithOCPProfiles(func(path string) {
+			obj := ctx.assertProfileIsValid(path)
+			ctx.asssertSelectionsNotInOCPProfile(obj.Selections, path,
+				[]undesiredSelection{
+					{
+						Name:   "sysctl_net_ipv4_ip_forward",
+						Reason: "Disabling IP forwarding breaks the SDN.",
+					},
+					{
+						Name:   "sysctl_user_max_user_namespaces",
+						Reason: "Limiting user namespaces affects the usage of rootless containers and limits general container capabilities.",
+					},
+				})
 		})
 	})
 }


### PR DESCRIPTION
Some checks are not valid for OCP. Let's start checking those and
erroring out with a reasonable message so folks don't try to enable
them.

As a result:

* This comments out the check related to user namespaces in the coreos-ncp profile, since this isn't a valid test for OCP (It'll cripple the deployment).