### PR TITLE
fix ansible remediations to avoid creating duplicate entries

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -27,7 +27,7 @@
 - name: Check existence of syscalls for 32 bit architecture in /etc/audit/rules.d/*
   find:
     paths: "/etc/audit/rules.d"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*{{ item }}.*$'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
     patterns: "*.rules"
   register: audit_kernel_found_32_rules_d
   loop: "{{ syscalls }}"
@@ -38,7 +38,7 @@
 - name: Check existence of syscalls for 64 bit architecture in /etc/audit/rules.d/*
   find:
     paths: "/etc/audit/rules.d"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*{{ item }}.*$'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
     patterns: "*.rules"
   register: audit_kernel_found_64_rules_d
   loop: "{{ syscalls }}"
@@ -49,7 +49,7 @@
 - name: Check existence of syscalls for 32 bit architecture in /etc/audit/audit.rules
   find:
     paths: "/etc/audit"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*{{ item }}.*$'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
     patterns: "audit.rules"
   register: audit_kernel_found_32_audit_rules
   loop: "{{ syscalls }}"
@@ -60,7 +60,7 @@
 - name: Check existence of syscalls for 64 bit architecture in /etc/audit/audit.rules
   find:
     paths: "/etc/audit"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*{{ item }}.*$'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
     patterns: "audit.rules"
   register: audit_kernel_found_64_audit_rules
   loop: "{{ syscalls }}"
@@ -70,7 +70,7 @@
 
 
 #
-# Inserts/replaces the rule in /etc/audit/rules.d
+# Inserts the rule in /etc/audit/rules.d
 #
 
 - name: Search /etc/audit/rules.d for other kernel module loading audit rules
@@ -93,17 +93,17 @@
       - "{{ find_modules.files | map(attribute='path') | list | first }}"
   when: find_modules.matched is defined and find_modules.matched > 0
 
-- name: Inserts/replaces the modules rule in rules.d when on x86
+- name: Inserts the modules rule in rules.d when on x86
   block:
-    - name: start the line
+    - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b32 "
-    - name: add syscalls
+    - name: "Construct rule: add syscalls"
       set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
       loop: "{{ audit_kernel_found_32_rules_d.results }}"
       when: item.matched is defined and item.matched == 0
-    - name: finish the line
+    - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert/replace the line in appropriate file
+    - name: insert the line in appropriate file
       lineinfile:
         path: "{{ all_files[0] }}"
         line: "{{ tmpline }}"
@@ -111,17 +111,17 @@
         state: present
   when: audit_kernel_matched_32_rules_d < audit_kernel_number_of_syscalls
 
-- name: Inserts/replaces the modules rule in rules.d when on x86_64
+- name: Inserts the modules rule in rules.d when on x86_64
   block:
-    - name: start the line
+    - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b64 "
-    - name: add syscalls
+    - name: "Construct rule: add syscalls"
       set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
       loop: "{{ audit_kernel_found_64_rules_d.results }}"
       when: item.matched is defined and item.matched == 0
-    - name: finish the line
+    - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert/replace the line in appropriate file
+    - name: insert the line in appropriate file
       lineinfile:
         path: "{{ all_files[0] }}"
         line: "{{ tmpline }}"
@@ -131,20 +131,20 @@
 
 
 #   
-# Inserts/replaces the rule in /etc/audit/audit.rules
+# Inserts the rule in /etc/audit/audit.rules
 #
 
-- name: Inserts/replaces the modules rule in audit.rules when on x86
+- name: Inserts the modules rule in audit.rules when on x86
   block:
-    - name: start the line
+    - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b32 "
-    - name: add syscalls
+    - name: "Construct rule: add syscalls"
       set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
       loop: "{{ audit_kernel_found_32_audit_rules.results }}"
       when: item.matched is defined and item.matched == 0
-    - name: finish the line
+    - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert/replace the line in appropriate file
+    - name: insert the line in appropriate file
       lineinfile:
         path: "/etc/audit/audit.rules"
         line: "{{ tmpline }}"
@@ -152,17 +152,17 @@
         state: present
   when: audit_kernel_matched_32_audit_rules < audit_kernel_number_of_syscalls
 
-- name: Inserts/replaces the modules rule in rules.d when on x86_64
+- name: Inserts the modules rule in rules.d when on x86_64
   block:
-    - name: start the line
+    - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b64 "
-    - name: add syscalls
+    - name: "Construct rule: add syscalls"
       set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
       loop: "{{ audit_kernel_found_64_audit_rules.results }}"
       when: item.matched is defined and item.matched == 0
-    - name: finish the line
+    - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert/replace the line in appropriate file
+    - name: insert the line in appropriate file
       lineinfile:
         path: "/etc/audit/audit.rules"
         line: "{{ tmpline }}"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -20,14 +20,14 @@
       - "finit_module"
       {{% endif %}}
 
-- name: declare number of syscalls
+- name: Declare number of syscalls
   set_fact: audit_kernel_number_of_syscalls="{{ syscalls|length|int }}"
 
 #
 #rules in /etc/audit/rules.d/*
 #
 
-- name: Check existence of syscalls for 32 bit architecture in /etc/audit/rules.d/*
+- name: Check existence of syscalls for 32 bit architecture in /etc/audit/rules.d/
   find:
     paths: "/etc/audit/rules.d"
     contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
@@ -35,10 +35,10 @@
   register: audit_kernel_found_32_rules_d
   loop: "{{ syscalls }}"
 
-- name: get number of matched 32 bit syscalls in /etc/audit/rules.d/*
+- name: Get number of matched 32 bit syscalls in /etc/audit/rules.d/
   set_fact: audit_kernel_matched_32_rules_d="{{audit_kernel_found_32_rules_d.results|sum(attribute='matched')|int }}"
 
-- name: Check existence of syscalls for 64 bit architecture in /etc/audit/rules.d/*
+- name: Check existence of syscalls for 64 bit architecture in /etc/audit/rules.d/
   find:
     paths: "/etc/audit/rules.d"
     contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
@@ -46,7 +46,7 @@
   register: audit_kernel_found_64_rules_d
   loop: "{{ syscalls }}"
 
-- name: get number of matched 64 bit syscalls in /etc/audit/rules.d/*
+- name: Get number of matched 64 bit syscalls in /etc/audit/rules.d/
   set_fact: audit_kernel_matched_64_rules_d="{{audit_kernel_found_64_rules_d.results|sum(attribute='matched')|int }}"
 
 - name: Search /etc/audit/rules.d for other kernel module loading audit rules
@@ -57,7 +57,7 @@
     patterns: "*.rules"
   register: find_modules
 
-- name: If existing kernel module loading ruleset not found, use /etc/audit/rules.d/modules.rules as the recipient for the rule
+- name: Use /etc/audit/rules.d/modules.rules as the recipient for the rule
   set_fact:
     all_files:
       - /etc/audit/rules.d/modules.rules
@@ -69,7 +69,7 @@
       - "{{ find_modules.files | map(attribute='path') | list | first }}"
   when: find_modules.matched is defined and find_modules.matched > 0
 
-- name: Inserts the modules rule in rules.d when on x86
+- name: "Insert the modules rule in {{ all_files[0] }} when on x86"
   block:
     - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b32 "
@@ -79,7 +79,7 @@
       when: item.matched is defined and item.matched == 0
     - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert the line in appropriate file
+    - name: "Insert the line in {{ all_files[0] }}"
       lineinfile:
         path: "{{ all_files[0] }}"
         line: "{{ tmpline }}"
@@ -87,7 +87,7 @@
         state: present
   when: audit_kernel_matched_32_rules_d < audit_kernel_number_of_syscalls
 
-- name: Inserts the modules rule in rules.d when on x86_64
+- name: "Insert the modules rule in {{ all_files[0] }} when on x86_64"
   block:
     - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b64 "
@@ -97,7 +97,7 @@
       when: item.matched is defined and item.matched == 0
     - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert the line in appropriate file
+    - name: "Insert the line in {{ all_files[0] }}"
       lineinfile:
         path: "{{ all_files[0] }}"
         line: "{{ tmpline }}"
@@ -118,7 +118,7 @@
   register: audit_kernel_found_32_audit_rules
   loop: "{{ syscalls }}"
 
-- name: get number of matched 32 bit syscalls in /etc/audit/audit.rules
+- name: Get number of matched 32 bit syscalls in /etc/audit/audit.rules
   set_fact: audit_kernel_matched_32_audit_rules="{{audit_kernel_found_32_audit_rules.results|sum(attribute='matched')|int }}"
 
 - name: Check existence of syscalls for 64 bit architecture in /etc/audit/audit.rules
@@ -129,10 +129,10 @@
   register: audit_kernel_found_64_audit_rules
   loop: "{{ syscalls }}"
 
-- name: get number of matched 64 bit syscalls in /etc/audit/rules.d/*
+- name: Get number of matched 64 bit syscalls in /etc/audit/rules.d/*
   set_fact: audit_kernel_matched_64_audit_rules="{{audit_kernel_found_64_audit_rules.results|sum(attribute='matched')|int }}"
 
-- name: Inserts the modules rule in audit.rules when on x86
+- name: Insert the modules rule in /etc/audit/audit.rules when on x86
   block:
     - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b32 "
@@ -142,7 +142,7 @@
       when: item.matched is defined and item.matched == 0
     - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert the line in appropriate file
+    - name: Insert the line in /etc/audit/audit.rules
       lineinfile:
         path: "/etc/audit/audit.rules"
         line: "{{ tmpline }}"
@@ -150,7 +150,7 @@
         state: present
   when: audit_kernel_matched_32_audit_rules < audit_kernel_number_of_syscalls
 
-- name: Inserts the modules rule in rules.d when on x86_64
+- name: Insert the modules rule in /etc/audit/rules.d when on x86_64
   block:
     - name: "Construct rule: add rule list, action and arch"
       set_fact: tmpline="-a always,exit -F arch=b64 "
@@ -160,7 +160,7 @@
       when: item.matched is defined and item.matched == 0
     - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k modules' }}"
-    - name: insert the line in appropriate file
+    - name: Insert the line in /etc/audit/audit.rules
       lineinfile:
         path: "/etc/audit/audit.rules"
         line: "{{ tmpline }}"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -30,7 +30,7 @@
 - name: Check existence of syscalls for 32 bit architecture in /etc/audit/rules.d/
   find:
     paths: "/etc/audit/rules.d"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
+    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
     patterns: "*.rules"
   register: audit_kernel_found_32_rules_d
   loop: "{{ syscalls }}"
@@ -41,7 +41,7 @@
 - name: Check existence of syscalls for 64 bit architecture in /etc/audit/rules.d/
   find:
     paths: "/etc/audit/rules.d"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
+    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
     patterns: "*.rules"
   register: audit_kernel_found_64_rules_d
   loop: "{{ syscalls }}"
@@ -113,7 +113,7 @@
 - name: Check existence of syscalls for 32 bit architecture in /etc/audit/audit.rules
   find:
     paths: "/etc/audit"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
+    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
     patterns: "audit.rules"
   register: audit_kernel_found_32_audit_rules
   loop: "{{ syscalls }}"
@@ -124,7 +124,7 @@
 - name: Check existence of syscalls for 64 bit architecture in /etc/audit/audit.rules
   find:
     paths: "/etc/audit"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
+    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
     patterns: "audit.rules"
   register: audit_kernel_found_64_audit_rules
   loop: "{{ syscalls }}"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -11,103 +11,73 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-#
-# check if rules don't exist already
-#
+- name: Declare list of syscals
+  set_fact:
+    syscalls:
+      - "init_module"
+      - "delete_module"
+      {{% if product != "rhel6" %}}
+      - "finit_module"
+      {{% endif %}}
 
-- name: Check if rule for x86 init_module already exists in /etc/audit/rules.d/*
+- name: declare number of syscalls
+  set_fact: audit_kernel_number_of_syscalls="{{ syscalls|length|int }}"
+
+
+- name: Check existence of syscalls for 32 bit architecture in /etc/audit/rules.d/*
   find:
-    paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+init_module[\s$]+'
+    paths: "/etc/audit/rules.d"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*{{ item }}.*$'
     patterns: "*.rules"
-  register: find_existing_kernel_init_module_32_rules_d
+  register: audit_kernel_found_32_rules_d
+  loop: "{{ syscalls }}"
 
-- name: Check if rule for x86 delete_module already exists in /etc/audit/rules.d/*
+- name: get number of matched 32 bit syscalls in /etc/audit/rules.d/*
+  set_fact: audit_kernel_matched_32_rules_d="{{audit_kernel_found_32_rules_d.results|sum(attribute='matched')|int }}"
+
+- name: Check existence of syscalls for 64 bit architecture in /etc/audit/rules.d/*
   find:
-    paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+delete_module[\s$]+'
+    paths: "/etc/audit/rules.d"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*{{ item }}.*$'
     patterns: "*.rules"
-  register: find_existing_kernel_delete_module_32_rules_d
+  register: audit_kernel_found_64_rules_d
+  loop: "{{ syscalls }}"
 
-- name: Check if rule for x86 finit_module already exists in /etc/audit/rules.d/*
-  find:
-    paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+finit_module[\s$]+'
-    patterns: "*.rules"
-  register: find_existing_kernel_finit_module_32_rules_d
+- name: get number of matched 64 bit syscalls in /etc/audit/rules.d/*
+  set_fact: audit_kernel_matched_64_rules_d="{{audit_kernel_found_64_rules_d.results|sum(attribute='matched')|int }}"
 
-- name: Check if rule for x86_64 init_module already exists in /etc/audit/rules.d/*
+- name: Check existence of syscalls for 32 bit architecture in /etc/audit/audit.rules
   find:
-    paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+init_module[\s$]+'
-    patterns: "*.rules"
-  register: find_existing_kernel_init_module_64_rules_d
-
-- name: Check if rule for x86_64 delete_module already exists in /etc/audit/rules.d/*
-  find:
-    paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+delete_module[\s$]+'
-    patterns: "*.rules"
-  register: find_existing_kernel_delete_module_64_rules_d
-
-- name: Check if rule for x86_64 finit_module already exists in /etc/audit/rules.d/*
-  find:
-    paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+finit_module[\s$]+'
-    patterns: "*.rules"
-  register: find_existing_kernel_finit_module_64_rules_d
-
-- name: Check if rule for x86 init_module already exists in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+init_module[\s$]+'
+    paths: "/etc/audit"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*{{ item }}.*$'
     patterns: "audit.rules"
-  register: find_existing_kernel_init_module_32_audit_rules
+  register: audit_kernel_found_32_audit_rules
+  loop: "{{ syscalls }}"
 
-- name: Check if rule for x86 delete_module already exists in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+delete_module[\s$]+'
-    patterns: "audit.rules"
-  register: find_existing_kernel_delete_module_32_audit_rules
+- name: get number of matched 32 bit syscalls in /etc/audit/audit.rules
+  set_fact: audit_kernel_matched_32_audit_rules="{{audit_kernel_found_32_audit_rules.results|sum(attribute='matched')|int }}"
 
-- name: Check if rule for x86 finit_module already exists in /etc/audit/audit.rules
+- name: Check existence of syscalls for 64 bit architecture in /etc/audit/audit.rules
   find:
-    paths: "/etc/audit/audit.rules"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+finit_module[\s$]+'
+    paths: "/etc/audit"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*{{ item }}.*$'
     patterns: "audit.rules"
-  register: find_existing_kernel_finit_module_32_audit_rules
+  register: audit_kernel_found_64_audit_rules
+  loop: "{{ syscalls }}"
 
-- name: Check if rule for x86_64 init_module already exists in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+init_module[\s$]+'
-    patterns: "audit.rules"
-  register: find_existing_kernel_init_module_64_audit_rules
-
-- name: Check if rule for x86_64 delete_module already exists in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+delete_module[\s$]+'
-    patterns: "audit.rules"
-  register: find_existing_kernel_delete_module_64_audit_rules
-
-- name: Check if rule for x86_64 finit_module already exists in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+finit_module[\s$]+'
-    patterns: "audit.rules"
-  register: find_existing_kernel_finit_module_64_audit_rules
+- name: get number of matched 64 bit syscalls in /etc/audit/rules.d/*
+  set_fact: audit_kernel_matched_64_audit_rules="{{audit_kernel_found_64_audit_rules.results|sum(attribute='matched')|int }}"
 
 
 #
 # Inserts/replaces the rule in /etc/audit/rules.d
 #
+
 - name: Search /etc/audit/rules.d for other kernel module loading audit rules
   find:
     paths: "/etc/audit/rules.d"
     recurse: no
-    contains: "-F key=modules$"
+    contains: "(-F key=modules)|(-k modules)$"
     patterns: "*.rules"
   register: find_modules
 
@@ -123,197 +93,79 @@
       - "{{ find_modules.files | map(attribute='path') | list | first }}"
   when: find_modules.matched is defined and find_modules.matched > 0
 
-#
-# create resulting lines to be inserted into appropriate files
-#
-
-- name: Start creating remediation line for 32 bit rule in /etc/audit/rules.d
-  set_fact:
-    audit_kernel_line_32_rules_d = "-a always,exit -F arch=b32 "
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0)
-  {{% else %}}
-  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) or (find_existing_kernel_finit_module_32_rules_d is defined and find_existing_kernel_finit_module_32_rules_d.matched == 0)
-  {{% endif %}}
-
-- name: add init_module into line for 32 bit rules.d
-  set_fact:
-    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-S init_module ' }}
-  when: find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0 and audit_kernel_line_32_rules_d is defined
-
-- name: add delete_module into line for 32 bit rules.d
-  set_fact:
-    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-S delete_module ' }}
-  when: find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0 and audit_kernel_line_32_rules_d is defined
-
-{{% if product != "rhel6" %}}
-- name: add finit_module into line for 32 bit rules.d
-  set_fact:
-    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-S finit_module ' }}
-  when: find_existing_kernel_finit_module_32_rules_d is defined and find_existing_finit_delete_module_32_rules_d.matched == 0 and audit_kernel_line_32_rules_d is defined
-{{% endif %}}
-
-- name: Finish creating remediation line for 32 bit rule in /etc/audit/rules.d
-  set_fact:
-    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-k modules' }}
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
-  {{% else %}}
-  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) or (find_existing_kernel_finit_module_32_rules_d is defined and find_existing_kernel_finit_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
-  {{% endif %}}
-
-- name: Start creating remediation line for 64 bit rule in /etc/audit/rules.d
-  set_fact:
-    audit_kernel_line_64_rules_d = "-a always,exit -F arch=b64 "
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0)
-  {{% else %}}
-  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) or (find_existing_kernel_finit_module_64_rules_d is defined and find_existing_kernel_finit_module_64_rules_d.matched == 0)
-  {{% endif %}}
-
-- name: add init_module into line for 64 bit rules.d
-  set_fact:
-    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-S init_module ' }}
-  when: find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0 and audit_kernel_line_64_rules_d is defined
-
-- name: add delete_module into line for 64 bit rules.d
-  set_fact:
-    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-S delete_module ' }}
-  when: find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0 and audit_kernel_line_64_rules_d is defined
-
-{{% if product != "rhel6" %}}
-- name: add finit_module into line for 64 bit rules.d
-  set_fact:
-    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-S finit_module ' }}
-  when: find_existing_kernel_finit_module_64_rules_d is defined and find_existing_finit_delete_module_64_rules_d.matched == 0 and audit_kernel_line_64_rules_d is defined
-{{% endif %}}
-
-- name: Finish creating remediation line for 64 bit rule in /etc/audit/rules.d
-  set_fact:
-    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-k modules' }}
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
-  {{% else %}}
-  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) or (find_existing_kernel_finit_module_64_rules_d is defined and find_existing_kernel_finit_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
-  {{% endif %}}
-
-- name: Start creating remediation line for 32 bit rule in /etc/audit/audit.rules
-  set_fact:
-    audit_kernel_line_32_audit_rules = "-a always,exit -F arch=b32 "
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0)
-  {{% else %}}
-  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) or (find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_kernel_finit_module_32_audit_rules.matched == 0)
-  {{% endif %}}
-
-- name: add init_module into line for 32 bit rules.d
-  set_fact:
-    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-S init_module ' }}
-  when: find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0 and audit_kernel_line_32_audit_rules is defined
-
-- name: add delete_module into line for 32 bit rules.d
-  set_fact:
-    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-S delete_module ' }}
-  when: find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0 and audit_kernel_line_32_audit_rules is defined
-
-{{% if product != "rhel6" %}}
-- name: add finit_module into line for 32 bit rules.d
-  set_fact:
-    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-S finit_module ' }}
-  when: find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_finit_delete_module_32_audit_rules.matched == 0 and audit_kernel_line_32_audit_rules is defined
-{{% endif %}}
-
-- name: Finish creating remediation line for 32 bit rule in /etc/audit/audit.rules
-  set_fact:
-    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-k modules' }}
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
-  {{% else %}}
-  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) or (find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_kernel_finit_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
-  {{% endif %}}
-
-- name: Start creating remediation line for 64 bit rule in /etc/audit/audit.rules
-  set_fact:
-    audit_kernel_line_64_audit_rules = "-a always,exit -F arch=b64 "
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0)
-  {{% else %}}
-  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) or (find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_kernel_finit_module_64_audit_rules.matched == 0)
-  {{% endif %}}
-
-- name: add init_module into line for 64 bit rules.d
-  set_fact:
-    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-S init_module ' }}
-  when: find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0 and audit_kernel_line_64_audit_rules is defined
-
-- name: add delete_module into line for 64 bit rules.d
-  set_fact:
-    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-S delete_module ' }}
-  when: find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0 and audit_kernel_line_64_audit_rules is defined
-
-{{% if product != "rhel6" %}}
-- name: add finit_module into line for 64 bit rules.d
-  set_fact:
-    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-S finit_module ' }}
-  when: find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_finit_delete_module_64_audit_rules.matched == 0 and audit_kernel_line_64_audit_rules is defined
-{{% endif %}}
-
-- name: Finish creating remediation line for 64 bit rule in /etc/audit/audit.rules
-  set_fact:
-    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-k modules' }}
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
-  {{% else %}}
-  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) or (find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_kernel_finit_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
-  {{% endif %}}
-
-
-
 - name: Inserts/replaces the modules rule in rules.d when on x86
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "{{ audit_kernel_line_32_rules_d }}"
-    create: yes
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
-  {{% else %}}
-  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) or (find_existing_kernel_finit_module_32_rules_d is defined and find_existing_kernel_finit_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
-  {{% endif %}}
+  block:
+    - name: start the line
+      set_fact: tmpline="-a always,exit -F arch=b32 "
+    - name: add syscalls
+      set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
+      loop: "{{ audit_kernel_found_32_rules_d.results }}"
+      when: item.matched is defined and item.matched == 0
+    - name: finish the line
+      set_fact: tmpline="{{ tmpline + '-k modules' }}"
+    - name: insert/replace the line in appropriate file
+      lineinfile:
+        path: "{{ all_files[0] }}"
+        line: "{{ tmpline }}"
+        create: true
+        state: present
+  when: audit_kernel_matched_32_rules_d < audit_kernel_number_of_syscalls
 
 - name: Inserts/replaces the modules rule in rules.d when on x86_64
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "{{ audit_kernel_line_32_rules_d }}"
-    create: yes
-  {{% if product == "rhel6" %}}
-  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
-  {{% else %}}
-  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) or (find_existing_kernel_finit_module_64_rules_d is defined and find_existing_kernel_finit_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
-  {{% endif %}}
+  block:
+    - name: start the line
+      set_fact: tmpline="-a always,exit -F arch=b64 "
+    - name: add syscalls
+      set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
+      loop: "{{ audit_kernel_found_64_rules_d.results }}"
+      when: item.matched is defined and item.matched == 0
+    - name: finish the line
+      set_fact: tmpline="{{ tmpline + '-k modules' }}"
+    - name: insert/replace the line in appropriate file
+      lineinfile:
+        path: "{{ all_files[0] }}"
+        line: "{{ tmpline }}"
+        create: true
+        state: present
+  when: audit_kernel_matched_64_rules_d < audit_kernel_number_of_syscalls and audit_arch is defined and audit_arch == 'b64'
+
 
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
-- name: Inserts/replaces the modules rule in /etc/audit/audit.rules when on x86
-  lineinfile:
-    line: "{{ audit_kernel_line_32_audit_rules }}"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  {{% if product == "rhel6" %}}
-  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
-  {{% else %}}
-  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) or (find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_kernel_finit_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
-  {{% endif %}}
 
-- name: Inserts/replaces the modules rule in audit.rules when on x86_64
-  lineinfile:
-    line: "{{ audit_kernel_line_64_audit_rules }}"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  {{% if product == "rhel6" %}}
-  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
-  {{% else %}}
-  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) or (find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_kernel_finit_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
-  {{% endif %}}
+- name: Inserts/replaces the modules rule in audit.rules when on x86
+  block:
+    - name: start the line
+      set_fact: tmpline="-a always,exit -F arch=b32 "
+    - name: add syscalls
+      set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
+      loop: "{{ audit_kernel_found_32_audit_rules.results }}"
+      when: item.matched is defined and item.matched == 0
+    - name: finish the line
+      set_fact: tmpline="{{ tmpline + '-k modules' }}"
+    - name: insert/replace the line in appropriate file
+      lineinfile:
+        path: "/etc/audit/audit.rules"
+        line: "{{ tmpline }}"
+        create: true
+        state: present
+  when: audit_kernel_matched_32_audit_rules < audit_kernel_number_of_syscalls
+
+- name: Inserts/replaces the modules rule in rules.d when on x86_64
+  block:
+    - name: start the line
+      set_fact: tmpline="-a always,exit -F arch=b64 "
+    - name: add syscalls
+      set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
+      loop: "{{ audit_kernel_found_64_audit_rules.results }}"
+      when: item.matched is defined and item.matched == 0
+    - name: finish the line
+      set_fact: tmpline="{{ tmpline + '-k modules' }}"
+    - name: insert/replace the line in appropriate file
+      lineinfile:
+        path: "/etc/audit/audit.rules"
+        line: "{{ tmpline }}"
+        create: true
+        state: present
+  when: audit_kernel_matched_64_audit_rules < audit_kernel_number_of_syscalls and audit_arch is defined and audit_arch == 'b64'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -23,6 +23,9 @@
 - name: declare number of syscalls
   set_fact: audit_kernel_number_of_syscalls="{{ syscalls|length|int }}"
 
+#
+#rules in /etc/audit/rules.d/*
+#
 
 - name: Check existence of syscalls for 32 bit architecture in /etc/audit/rules.d/*
   find:
@@ -45,33 +48,6 @@
 
 - name: get number of matched 64 bit syscalls in /etc/audit/rules.d/*
   set_fact: audit_kernel_matched_64_rules_d="{{audit_kernel_found_64_rules_d.results|sum(attribute='matched')|int }}"
-
-- name: Check existence of syscalls for 32 bit architecture in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
-    patterns: "audit.rules"
-  register: audit_kernel_found_32_audit_rules
-  loop: "{{ syscalls }}"
-
-- name: get number of matched 32 bit syscalls in /etc/audit/audit.rules
-  set_fact: audit_kernel_matched_32_audit_rules="{{audit_kernel_found_32_audit_rules.results|sum(attribute='matched')|int }}"
-
-- name: Check existence of syscalls for 64 bit architecture in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
-    patterns: "audit.rules"
-  register: audit_kernel_found_64_audit_rules
-  loop: "{{ syscalls }}"
-
-- name: get number of matched 64 bit syscalls in /etc/audit/rules.d/*
-  set_fact: audit_kernel_matched_64_audit_rules="{{audit_kernel_found_64_audit_rules.results|sum(attribute='matched')|int }}"
-
-
-#
-# Inserts the rule in /etc/audit/rules.d
-#
 
 - name: Search /etc/audit/rules.d for other kernel module loading audit rules
   find:
@@ -131,8 +107,30 @@
 
 
 #   
-# Inserts the rule in /etc/audit/audit.rules
+# rules in /etc/audit/audit.rules
 #
+
+- name: Check existence of syscalls for 32 bit architecture in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
+    patterns: "audit.rules"
+  register: audit_kernel_found_32_audit_rules
+  loop: "{{ syscalls }}"
+
+- name: get number of matched 32 bit syscalls in /etc/audit/audit.rules
+  set_fact: audit_kernel_matched_32_audit_rules="{{audit_kernel_found_32_audit_rules.results|sum(attribute='matched')|int }}"
+
+- name: Check existence of syscalls for 64 bit architecture in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+.*-S\s+.*[\s,]+{{ item }}[\s,]+.*$'
+    patterns: "audit.rules"
+  register: audit_kernel_found_64_audit_rules
+  loop: "{{ syscalls }}"
+
+- name: get number of matched 64 bit syscalls in /etc/audit/rules.d/*
+  set_fact: audit_kernel_matched_64_audit_rules="{{audit_kernel_found_64_audit_rules.results|sum(attribute='matched')|int }}"
 
 - name: Inserts the modules rule in audit.rules when on x86
   block:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -12,6 +12,95 @@
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
 #
+# check if rules don't exist already
+#
+
+- name: Check if rule for x86 init_module already exists in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+init_module[\s$]+'
+    patterns: "*.rules"
+  register: find_existing_kernel_init_module_32_rules_d
+
+- name: Check if rule for x86 delete_module already exists in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+delete_module[\s$]+'
+    patterns: "*.rules"
+  register: find_existing_kernel_delete_module_32_rules_d
+
+- name: Check if rule for x86 finit_module already exists in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+finit_module[\s$]+'
+    patterns: "*.rules"
+  register: find_existing_kernel_finit_module_32_rules_d
+
+- name: Check if rule for x86_64 init_module already exists in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+init_module[\s$]+'
+    patterns: "*.rules"
+  register: find_existing_kernel_init_module_64_rules_d
+
+- name: Check if rule for x86_64 delete_module already exists in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+delete_module[\s$]+'
+    patterns: "*.rules"
+  register: find_existing_kernel_delete_module_64_rules_d
+
+- name: Check if rule for x86_64 finit_module already exists in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+finit_module[\s$]+'
+    patterns: "*.rules"
+  register: find_existing_kernel_finit_module_64_rules_d
+
+- name: Check if rule for x86 init_module already exists in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+init_module[\s$]+'
+    patterns: "audit.rules"
+  register: find_existing_kernel_init_module_32_audit_rules
+
+- name: Check if rule for x86 delete_module already exists in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+delete_module[\s$]+'
+    patterns: "audit.rules"
+  register: find_existing_kernel_delete_module_32_audit_rules
+
+- name: Check if rule for x86 finit_module already exists in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/audit.rules"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+finit_module[\s$]+'
+    patterns: "audit.rules"
+  register: find_existing_kernel_finit_module_32_audit_rules
+
+- name: Check if rule for x86_64 init_module already exists in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+init_module[\s$]+'
+    patterns: "audit.rules"
+  register: find_existing_kernel_init_module_64_audit_rules
+
+- name: Check if rule for x86_64 delete_module already exists in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+delete_module[\s$]+'
+    patterns: "audit.rules"
+  register: find_existing_kernel_delete_module_64_audit_rules
+
+- name: Check if rule for x86_64 finit_module already exists in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+finit_module[\s$]+'
+    patterns: "audit.rules"
+  register: find_existing_kernel_finit_module_64_audit_rules
+
+
+#
 # Inserts/replaces the rule in /etc/audit/rules.d
 #
 - name: Search /etc/audit/rules.d for other kernel module loading audit rules
@@ -34,48 +123,197 @@
       - "{{ find_modules.files | map(attribute='path') | list | first }}"
   when: find_modules.matched is defined and find_modules.matched > 0
 
+#
+# create resulting lines to be inserted into appropriate files
+#
+
+- name: Start creating remediation line for 32 bit rule in /etc/audit/rules.d
+  set_fact:
+    audit_kernel_line_32_rules_d = "-a always,exit -F arch=b32 "
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0)
+  {{% else %}}
+  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) or (find_existing_kernel_finit_module_32_rules_d is defined and find_existing_kernel_finit_module_32_rules_d.matched == 0)
+  {{% endif %}}
+
+- name: add init_module into line for 32 bit rules.d
+  set_fact:
+    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-S init_module ' }}
+  when: find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0 and audit_kernel_line_32_rules_d is defined
+
+- name: add delete_module into line for 32 bit rules.d
+  set_fact:
+    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-S delete_module ' }}
+  when: find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0 and audit_kernel_line_32_rules_d is defined
+
+{{% if product != "rhel6" %}}
+- name: add finit_module into line for 32 bit rules.d
+  set_fact:
+    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-S finit_module ' }}
+  when: find_existing_kernel_finit_module_32_rules_d is defined and find_existing_finit_delete_module_32_rules_d.matched == 0 and audit_kernel_line_32_rules_d is defined
+{{% endif %}}
+
+- name: Finish creating remediation line for 32 bit rule in /etc/audit/rules.d
+  set_fact:
+    audit_kernel_line_32_rules_d= {{ audit_kernel_line_32_rules_d + '-k modules' }}
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
+  {{% else %}}
+  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) or (find_existing_kernel_finit_module_32_rules_d is defined and find_existing_kernel_finit_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
+  {{% endif %}}
+
+- name: Start creating remediation line for 64 bit rule in /etc/audit/rules.d
+  set_fact:
+    audit_kernel_line_64_rules_d = "-a always,exit -F arch=b64 "
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0)
+  {{% else %}}
+  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) or (find_existing_kernel_finit_module_64_rules_d is defined and find_existing_kernel_finit_module_64_rules_d.matched == 0)
+  {{% endif %}}
+
+- name: add init_module into line for 64 bit rules.d
+  set_fact:
+    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-S init_module ' }}
+  when: find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0 and audit_kernel_line_64_rules_d is defined
+
+- name: add delete_module into line for 64 bit rules.d
+  set_fact:
+    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-S delete_module ' }}
+  when: find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0 and audit_kernel_line_64_rules_d is defined
+
+{{% if product != "rhel6" %}}
+- name: add finit_module into line for 64 bit rules.d
+  set_fact:
+    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-S finit_module ' }}
+  when: find_existing_kernel_finit_module_64_rules_d is defined and find_existing_finit_delete_module_64_rules_d.matched == 0 and audit_kernel_line_64_rules_d is defined
+{{% endif %}}
+
+- name: Finish creating remediation line for 64 bit rule in /etc/audit/rules.d
+  set_fact:
+    audit_kernel_line_64_rules_d= {{ audit_kernel_line_64_rules_d + '-k modules' }}
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
+  {{% else %}}
+  when: (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) or (find_existing_kernel_finit_module_64_rules_d is defined and find_existing_kernel_finit_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
+  {{% endif %}}
+
+- name: Start creating remediation line for 32 bit rule in /etc/audit/audit.rules
+  set_fact:
+    audit_kernel_line_32_audit_rules = "-a always,exit -F arch=b32 "
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0)
+  {{% else %}}
+  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) or (find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_kernel_finit_module_32_audit_rules.matched == 0)
+  {{% endif %}}
+
+- name: add init_module into line for 32 bit rules.d
+  set_fact:
+    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-S init_module ' }}
+  when: find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0 and audit_kernel_line_32_audit_rules is defined
+
+- name: add delete_module into line for 32 bit rules.d
+  set_fact:
+    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-S delete_module ' }}
+  when: find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0 and audit_kernel_line_32_audit_rules is defined
+
+{{% if product != "rhel6" %}}
+- name: add finit_module into line for 32 bit rules.d
+  set_fact:
+    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-S finit_module ' }}
+  when: find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_finit_delete_module_32_audit_rules.matched == 0 and audit_kernel_line_32_audit_rules is defined
+{{% endif %}}
+
+- name: Finish creating remediation line for 32 bit rule in /etc/audit/audit.rules
+  set_fact:
+    audit_kernel_line_32_audit_rules= {{ audit_kernel_line_32_audit_rules + '-k modules' }}
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
+  {{% else %}}
+  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) or (find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_kernel_finit_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
+  {{% endif %}}
+
+- name: Start creating remediation line for 64 bit rule in /etc/audit/audit.rules
+  set_fact:
+    audit_kernel_line_64_audit_rules = "-a always,exit -F arch=b64 "
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0)
+  {{% else %}}
+  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) or (find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_kernel_finit_module_64_audit_rules.matched == 0)
+  {{% endif %}}
+
+- name: add init_module into line for 64 bit rules.d
+  set_fact:
+    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-S init_module ' }}
+  when: find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0 and audit_kernel_line_64_audit_rules is defined
+
+- name: add delete_module into line for 64 bit rules.d
+  set_fact:
+    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-S delete_module ' }}
+  when: find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0 and audit_kernel_line_64_audit_rules is defined
+
+{{% if product != "rhel6" %}}
+- name: add finit_module into line for 64 bit rules.d
+  set_fact:
+    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-S finit_module ' }}
+  when: find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_finit_delete_module_64_audit_rules.matched == 0 and audit_kernel_line_64_audit_rules is defined
+{{% endif %}}
+
+- name: Finish creating remediation line for 64 bit rule in /etc/audit/audit.rules
+  set_fact:
+    audit_kernel_line_64_audit_rules= {{ audit_kernel_line_64_audit_rules + '-k modules' }}
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
+  {{% else %}}
+  when: (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) or (find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_kernel_finit_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
+  {{% endif %}}
+
+
+
 - name: Inserts/replaces the modules rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    {{% if product == "rhel6" %}}
-    line: "-a always,exit -F arch=b32 -S init_module -S delete_module -k modules"
-    {{% else %}}
-    line: "-a always,exit -F arch=b32 -S init_module -S delete_module -S finit_module -k modules"
-    {{% endif %}}
+    line: "{{ audit_kernel_line_32_rules_d }}"
     create: yes
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
+  {{% else %}}
+  when: (find_existing_kernel_init_module_32_rules_d is defined and find_existing_kernel_init_module_32_rules_d.matched == 0) or (find_existing_kernel_delete_module_32_rules_d is defined and find_existing_kernel_delete_module_32_rules_d.matched == 0) or (find_existing_kernel_finit_module_32_rules_d is defined and find_existing_kernel_finit_module_32_rules_d.matched == 0) and audit_kernel_line_32_rules_d is defined
+  {{% endif %}}
 
 - name: Inserts/replaces the modules rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
-    {{% if product == "rhel6" %}}
-    line: "-a always,exit -F arch=b64 -S init_module -S delete_module -k modules"
-    {{% else %}}
-    line: "-a always,exit -F arch=b64 -S init_module -S delete_module -S finit_module -k modules"
-    {{% endif %}}
+    line: "{{ audit_kernel_line_32_rules_d }}"
     create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
+  {{% if product == "rhel6" %}}
+  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
+  {{% else %}}
+  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_rules_d is defined and find_existing_kernel_init_module_64_rules_d.matched == 0) or (find_existing_kernel_delete_module_64_rules_d is defined and find_existing_kernel_delete_module_64_rules_d.matched == 0) or (find_existing_kernel_finit_module_64_rules_d is defined and find_existing_kernel_finit_module_64_rules_d.matched == 0) and audit_kernel_line_64_rules_d is defined
+  {{% endif %}}
+
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
 - name: Inserts/replaces the modules rule in /etc/audit/audit.rules when on x86
   lineinfile:
-    {{% if product == "rhel6" %}}
-    line: "-a always,exit -F arch=b32 -S init_module -S delete_module -k modules"
-    {{% else %}}
-    line: "-a always,exit -F arch=b32 -S init_module -S delete_module -S finit_module -k modules"
-    {{% endif %}}
+    line: "{{ audit_kernel_line_32_audit_rules }}"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
+  {{% if product == "rhel6" %}}
+  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
+  {{% else %}}
+  when: (find_existing_kernel_init_module_32_audit_rules is defined and find_existing_kernel_init_module_32_audit_rules.matched == 0) or (find_existing_kernel_delete_module_32_audit_rules is defined and find_existing_kernel_delete_module_32_audit_rules.matched == 0) or (find_existing_kernel_finit_module_32_audit_rules is defined and find_existing_kernel_finit_module_32_audit_rules.matched == 0) and audit_kernel_line_32_audit_rules is defined
+  {{% endif %}}
 
 - name: Inserts/replaces the modules rule in audit.rules when on x86_64
   lineinfile:
-    {{% if product == "rhel6" %}}
-    line: "-a always,exit -F arch=b64 -S init_module -S delete_module -k modules"
-    {{% else %}}
-    line: "-a always,exit -F arch=b64 -S init_module -S delete_module -S finit_module -k modules"
-    {{% endif %}}
+    line: "{{ audit_kernel_line_64_audit_rules }}"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
+  {{% if product == "rhel6" %}}
+  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
+  {{% else %}}
+  when: audit_arch is defined and audit_arch == 'b64' and (find_existing_kernel_init_module_64_audit_rules is defined and find_existing_kernel_init_module_64_audit_rules.matched == 0) or (find_existing_kernel_delete_module_64_audit_rules is defined and find_existing_kernel_delete_module_64_audit_rules.matched == 0) or (find_existing_kernel_finit_module_64_audit_rules is defined and find_existing_kernel_finit_module_64_audit_rules.matched == 0) and audit_kernel_line_64_audit_rules is defined
+  {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/default.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S
-# remediation = bash
+
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_multiple_per_arg.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S
-# remediation = bash
+
 
 # Use auditctl, on RHEL7, default is to use augenrules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_arg.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S
-# remediation = bash
+
 
 # Use auditctl, on RHEL7, default is to use augenrules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S
-# remediation = bash
+
 
 # Use auditctl, on RHEL7, default is to use augenrules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line_one_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S
-# remediation = bash
+
 
 # Use auditctl, on RHEL7, default is to use augenrules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line_one_missing.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+# Use auditctl, on RHEL7, default is to use augenrules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+rm -f /etc/audit/rules.d/*
+
+# cut out irrelevant rules for this test
+sed -e '11,18d' -e '/.*init.*/d' test_audit.rules > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/ansible/shared.yml
@@ -12,6 +12,39 @@
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
 #
+# check if rules are already present
+#
+
+- name: Check if the rule for x86_64 is already present in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    patterns: "*.rules"
+  register: find_existing_media_export_64_rules_d
+
+- name: Check if the rule for x86 is already present in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    patterns: "*.rules"
+  register: find_existing_media_export_32_rules_d
+
+- name: Check if the rule for x86_64 is already present in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    patterns: "audit.rules"
+  register: find_existing_media_export_64_audit_rules
+
+- name: Check if the rule for x86 is already present in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    patterns: "audit.rules"
+  register: find_existing_media_export_32_audit_rules
+
+
+#
 # Inserts/replaces the rule in /etc/audit/rules.d
 #
 - name: Search /etc/audit/rules.d for other media export audit rules
@@ -21,31 +54,33 @@
     contains: "-F key=export$"
     patterns: "*.rules"
   register: find_mount
+  when: (find_existing_media_export_32_rules_d is defined and find_existing_media_export_32_rules_d.matched == 0) or (find_existing_media_export_64_rules_d is defined and find_existing_media_export_64_rules_d.matched == 0)
 
 - name: If existing media export ruleset not found, use /etc/audit/rules.d/export.rules as the recipient for the rule
   set_fact:
     all_files:
       - /etc/audit/rules.d/export.rules
-  when: find_mount.matched is defined and find_mount.matched == 0
+  when: find_mount.matched is defined and find_mount.matched == 0 and ((find_existing_media_export_32_rules_d is defined and find_existing_media_export_32_rules_d.matched == 0) or (find_existing_media_export_64_rules_d is defined and find_existing_media_export_64_rules_d.matched == 0))
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
       - "{{ find_mount.files | map(attribute='path') | list | first }}"
-  when: find_mount.matched is defined and find_mount.matched > 0
+  when: find_mount.matched is defined and find_mount.matched > 0 and ((find_existing_media_export_32_rules_d is defined and find_existing_media_export_32_rules_d.matched == 0) or (find_existing_media_export_64_rules_d is defined and find_existing_media_export_64_rules_d.matched == 0))
 
 - name: Inserts/replaces the media export rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b32 -S mount -F auid>={{{ auid }}} -F auid!=unset -F key=export"
     create: yes
+  when: find_existing_media_export_32_rules_d is defined and find_existing_media_export_32_rules_d.matched == 0
 
 - name: Inserts/replaces the media export rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b64 -S mount -F auid>={{{ auid }}} -F auid!=unset -F key=export"
     create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
+  when: audit_arch is defined and audit_arch == 'b64' and find_existing_media_export_64_rules_d is defined and find_existing_media_export_64_rules_d.matched == 0
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
@@ -55,6 +90,7 @@
     state: present
     dest: /etc/audit/audit.rules
     create: yes
+  when: find_existing_media_export_32_audit_rules is defined and find_existing_media_export_32_audit_rules.matched == 0
 
 - name: Inserts/replaces the media export rule in audit.rules when on x86_64
   lineinfile:
@@ -62,4 +98,4 @@
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
+  when: audit_arch is defined and audit_arch == 'b64' and find_existing_media_export_64_audit_rules is defined and find_existing_media_export_64_audit_rules.matched == 0


### PR DESCRIPTION
#### Description:

Ansible remediations for audit_rules_kernel_module_loading and audit_rules_media_export are modified to check if needed Audit lines already exist. Therefore, they should not create duplicates.
There is also new test checking for that in audit_rules_kernel_module_loading, as the remediation is quite complex.

#### Rationale:

avoid duplicate Audit rules