### PR TITLE
remove remediations for configure_etc_hosts_deny

### DIFF
--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/ansible/shared.yml
@@ -1,7 +1,0 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
-# reboot = false
-# strategy = restrict
-# complexity = low
-# disruption = medium
-
-{{{ ansible_lineinfile(msg='', path='/etc/hosts.deny', regex='', new_line='ALL: ALL', create='true', state='present') }}}

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/bash/shared.sh
@@ -1,3 +1,0 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
-
-{{{ set_config_file(path="/etc/hosts.deny", parameter="ALL:", value="ALL", create=true, insert_after="EOF", insert_before="", insensitive=true, separator=" ", separator_regex="\s\+", prefix_regex="^\s*") }}}

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/rule.yml
@@ -36,8 +36,7 @@ ocil: |-
 
 warnings:
     - functionality: |-
-        This rule affects all access to serviceswhich honor <tt>/etc/hosts.allow</tt> and <tt>/etc/hosts.deny</tt> files.
+        This rule affects all access to services which honor <tt>/etc/hosts.allow</tt> and <tt>/etc/hosts.deny</tt> files.
         Connections to services originating from hosts not explicitly mentioned in <tt>/etc/hosts.allow</tt> will be rejected.
-        As the <tt>/etc/hosts.allow</tt> is empty by default, make sure it is appropriately configured before applying remediation for this rule.
         To avoid locking down all network access to the system, this rule doesn't perform automated remediation.
         For information about manual process of remediation see the rule description.

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/rule.yml
@@ -12,7 +12,7 @@ description: |-
     <pre>ALL: ALL</pre>
     It is advised to inspect available network services which might be affected by modification of file mentioned above prior to performing the remediation of this rule.
     If there exist services which might be affected and access to them should not be blocked,
-    modify the <tt>/etc/hosts.deny</tt> file appropriately before performing the remediation.
+    modify the <tt>/etc/hosts.allow</tt> file appropriately before performing the remediation.
 
 
 rationale: |-
@@ -35,9 +35,9 @@ ocil: |-
     <pre>ALL: ALL</pre>
 
 warnings:
-    - management: |-
-        enabling this rule affects all connections to serviceswhich honor <tt>/etc/hosts.allow</tt> and <tt>/etc/hosts.deny</tt> files.
-        Connections to such servicesfrom any hosts which are not explicitly mentioned in <tt>/etc/hosts.allow</tt> will be rejected.
-        As the <tt>/etc/hosts.allow</tt> file is often left empty, there is a chance that remediation of this rule might prevent the system from accepting SSH connections and therefore limiting management access.
-        Therefore, this rule will not be remediated automatically. For information about manual process
-        of remediation see the rule description.
+    - functionality: |-
+        This rule affects all access to serviceswhich honor <tt>/etc/hosts.allow</tt> and <tt>/etc/hosts.deny</tt> files.
+        Connections to services originating from hosts not explicitly mentioned in <tt>/etc/hosts.allow</tt> will be rejected.
+        As the <tt>/etc/hosts.allow</tt> is empty by default, make sure it is appropriately configured before applying remediation for this rule.
+        To avoid locking down all network access to the system, this rule doesn't perform automated remediation.
+        For information about manual process of remediation see the rule description.

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/rule.yml
@@ -10,6 +10,10 @@ description: |-
     The following line in the file ensures that access to services supporting this mechanism is denied to any clients
     not mentioned in <tt>/etc/hosts.allow</tt>:
     <pre>ALL: ALL</pre>
+    It is advised to inspect available network services which might be affected by modification of file mentioned above prior to performing the remediation of this rule.
+    If there exist services which might be affected and access to them should not be blocked,
+    modify the <tt>/etc/hosts.deny</tt> file appropriately before performing the remediation.
+
 
 rationale: |-
     Correct configuration in <tt>/etc/hosts.deny</tt> ensures that no explicitly mentioned clients will be able to connect to services supporting this access control mechanism.
@@ -29,3 +33,11 @@ ocil: |-
     <pre>cat /etc/hosts.deny</pre>
     Verify that the output contains the following line:
     <pre>ALL: ALL</pre>
+
+warnings:
+    - management: |-
+        enabling this rule affects all connections to serviceswhich honor <tt>/etc/hosts.allow</tt> and <tt>/etc/hosts.deny</tt> files.
+        Connections to such servicesfrom any hosts which are not explicitly mentioned in <tt>/etc/hosts.allow</tt> will be rejected.
+        As the <tt>/etc/hosts.allow</tt> file is often left empty, there is a chance that remediation of this rule might prevent the system from accepting SSH connections and therefore limiting management access.
+        Therefore, this rule will not be remediated automatically. For information about manual process
+        of remediation see the rule description.


### PR DESCRIPTION
#### Description:

Remove remediations, add warning and improve description to explain how to remediate the rule manually.

#### Rationale:

If default /etc/hosts.allow is used, the remediation of this rule block SSH access to the computer, effectively preventing management. This happens actually right after installation. Therefore, I suggest that the rule should not be remediated automatically. I added instructions for manual remediation into the description and management warning.
