### PR TITLE
use freq param for both 'incremental' and 'incremental_async' of var_…

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
@@ -7,10 +7,10 @@ AUDITCONFIG=/etc/audit/auditd.conf
 # if flush is present, flush param edited to var_auditd_flush
 # else flush param is defined by var_auditd_flush
 #
-# the freq param is only used value 'incremental' and will be
-# commented out if flush != incremental
+# the freq param is only used for values 'incremental' and 'incremental_async' and will be
+# commented out if flush != incremental or flush != incremental_async
 #
-# if flush == incremental && freq param is not defined, it 
+# if flush == incremental or flush == incremental_async && freq param is not defined, it 
 # will be defined as the package-default value of 20
 
 grep -q ^flush $AUDITCONFIG && \
@@ -19,9 +19,9 @@ if ! [ $? -eq 0 ]; then
   echo "flush = $var_auditd_flush" >> $AUDITCONFIG
 fi
 
-if ! [ "$var_auditd_flush" == "incremental" ]; then
+if ! [ "$var_auditd_flush" == "incremental" ] && ! [ "$var_auditd_flush" == "incremental_async" ]; then
   sed -i 's/^freq/##freq/g' $AUDITCONFIG
-elif [ "$var_auditd_flush" == "incremental" ]; then
+elif [ "$var_auditd_flush" == "incremental" ] || [ "$var_auditd_flush" == "incremental_async" ]; then
   grep -q freq $AUDITCONFIG && \
     sed -i 's/^#\+freq/freq/g' $AUDITCONFIG
   if ! [ $? -eq 0 ]; then


### PR DESCRIPTION
…auditd_flush

#### Description:

-  This PR modifies the associated auditd bash remediation rule to use the freq parameter along with an "incremental_async" auditd flush value. 

#### Rationale:

- As noted in the RHEL 7 security guide (https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-configuring_the_audit_service), a flush value of "incremental_async" should be used in combination with the freq parameter.
- Current code comments out the freq parameter for "incremental_async", which generates the error "Error - incremental flushing chosen, but 0 selected for freq" in auditd sanity_check (see https://github.com/linux-audit/audit-userspace/blob/master/src/auditd-config.c)

