### PR TITLE
Warn about only local user backends being considered

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -53,3 +53,8 @@ ocil: |-
     Either remove all files and directories from the system that do not have a valid group,
     or assign a valid group with the chgrp command:
     <pre>$ sudo chgrp <i>group</i> <i>file</i></pre>
+
+warnings:
+    - general: |-
+        This rule only considers local groups.
+        If you have your groups defined outside <code>/etc/group</code>, the rule won't consider those.

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -54,3 +54,8 @@ ocil: |-
     valid user, or assign a valid user to all unowned files and directories on
     the system with the <tt>chown</tt> command:
     <pre>$ sudo chown <tt>user</tt> <tt>file</tt></pre>
+
+warnings:
+    - general: |-
+        This rule only considers local users.
+        If you have your users defined outside <code>/etc/passwd</code>, the rule won't consider those.


### PR DESCRIPTION
Rules that deal with uids/gids don't take into account remote user backends s.a. AD or general LDAP setups.

In the ideal case, the scanner and the content would work together to work even with remote users, but as it is not the case, let's at least display a warning.

As more rule may be affected by this, I have made it a macro.