### PR TITLE
introduce macro for ansible remediation of audit watch rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/ansible/shared.yml
@@ -4,6 +4,6 @@
 # complexity = low
 # disruption = low
 
-{{{ remediate_audit_watch_rules_d(path="/etc/selinux/", permissions="wa", key="MAC-policy") }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path="/etc/selinux/", permissions="wa", key="MAC-policy") }}}
 
-{{{ remediate_audit_watch_audit_rules(path="/etc/selinux/", permissions="wa", key="MAC-policy") }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path="/etc/selinux/", permissions="wa", key="MAC-policy") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/ansible/shared.yml
@@ -4,65 +4,6 @@
 # complexity = low
 # disruption = low
 
-#
-# check if rules already exist
-#
+{{{ remediate_audit_watch_rules_d(path="/etc/selinux/", permissions="wa", key="MAC-policy") }}}
 
-- name: Check if rule already exists in /etc/audit/rules.d/*
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: '^\s*-w\s+/etc/selinux/\s+-p\s+wa(\s|$)+'
-    patterns: "*.rules"
-  register: find_existing_mac_rules_d
-
-- name: Check if rule already exists in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit/"
-    contains: '^\s*-w\s+/etc/selinux/\s+-p\s+wa(\s|$)+'
-    patterns: "audit.rules"
-  register: find_existing_mac_audit_rules
-
-
-#
-# Inserts/replaces the rule in /etc/audit/rules.d
-#
-- name: Search /etc/audit/rules.d for other rules with MAC-policy key
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: "-k MAC-policy$"
-    patterns: "*.rules"
-  register: find_mac_key
-  when: find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
-
-- name: If existing MAC modification ruleset not found, use /etc/audit/rules.d/MAC-policy.rules as the recipient for the rule
-  set_fact:
-    all_files:
-      - /etc/audit/rules.d/MAC-policy.rules
-  when: find_mac_key.matched is defined and find_mac_key.matched == 0 and find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-      - "{{ find_mac_key.files | map(attribute='path') | list | first }}"
-  when: find_mac_key.matched is defined and find_mac_key.matched > 0 and find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
-
-- name: Inserts/replaces the MAC modification rule in rules.d
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "-w /etc/selinux/ -p wa -k MAC-policy"
-    create: yes
-  when: find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
-
-
-#   
-# Inserts/replaces the rule in /etc/audit/audit.rules
-#
-- name: Inserts/replaces the MAC modifications rule in /etc/audit/audit.rules
-  lineinfile:
-    line: "-w /etc/selinux/ -p wa -k MAC-policy"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  when: find_existing_mac_audit_rules.matched is defined and find_existing_mac_audit_rules.matched == 0
+{{{ remediate_audit_watch_audit_rules(path="/etc/selinux/", permissions="wa", key="MAC-policy") }}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -277,7 +277,14 @@ regex_replace("\(n\)\*", "\\n")
 {{% macro ansible_deregexify_banner_backslash() -%}}
 regex_replace("\\", "")
 {{%- endmacro %}}
-
+{{#
+The following macro remediates one audit watch rule in /etc/audit/rules.d directory.
+The macro requires following parameters:
+- path: path to watch
+- permissions: permissions changes to watch for
+- key: key to use as identifier. Note that if there exists any other rule with the same find_mac_key
+in some file within /etc/audit/rules.d/, the new rule will be appended to this file.
+#}}
 {{% macro remediate_audit_watch_rules_d(path='', permissions='', key='') -%}}
 - name: Check if rule already exists in /etc/audit/rules.d/*
   find:
@@ -285,49 +292,57 @@ regex_replace("\\", "")
     recurse: no
     contains: '^\s*-w\s+{{{ path }}}\s+-p\s+{{{ permissions }}}(\s|$)+'
     patterns: "*.rules"
-  register: find_existing_mac_rules_d
+  register: find_existing_watch_rules_d
+
 - name: Search /etc/audit/rules.d for other rules with specified key
   find:
     paths: "/etc/audit/rules.d"
     recurse: no
     contains: "^.*(-F key=)(|-k ){{{ key }}}$"
     patterns: "*.rules"
-  register: find_mac_key
-  when: find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+  register: find_watch_key
+  when: find_existing_watch_rules_d.matched is defined and find_existing_watch_rules_d.matched == 0
 
 - name: If existing ruleset with key {{{ key }}} not found, use /etc/audit/rules.d/{{{ key }}}.rules as the recipient for the rule
   set_fact:
     all_files:
       - /etc/audit/rules.d/{{{ key }}}.rules
-  when: find_mac_key.matched is defined and find_mac_key.matched == 0 and find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+  when: find_watch_key.matched is defined and find_watch_key.matched == 0 and find_existing_watch_rules_d.matched is defined and find_existing_watch_rules_d.matched == 0
 
 - name: Use matched file as the recipient for the rule
   set_fact:
     all_files:
-      - "{{ find_mac_key.files | map(attribute='path') | list | first }}"
-  when: find_mac_key.matched is defined and find_mac_key.matched > 0 and find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+      - "{{ find_watch_key.files | map(attribute='path') | list | first }}"
+  when: find_watch_key.matched is defined and find_watch_key.matched > 0 and find_existing_watch_rules_d.matched is defined and find_existing_watch_rules_d.matched == 0
 
 - name: Inserts/replaces the rule in rules.d
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-w {{{ path }}} -p {{{ permissions }}} -k {{{ key }}}"
     create: yes
-  when: find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+  when: find_existing_watch_rules_d.matched is defined and find_existing_watch_rules_d.matched == 0
 {{%- endmacro %}}
 
+{{#
+The following macro remediates one audit watch rule in /etc/audit/audit.rules.
+The macro requires following parameters:
+- path: path to watch
+- permissions: permissions changes to watch for
+- key: key to use as identifier. 
+#}}
 {{% macro remediate_audit_watch_audit_rules(path='', permissions='', key='') -%}}
 - name: Check if rule already exists in /etc/audit/audit.rules
   find:
     paths: "/etc/audit/"
     contains: '^\s*-w\s+{{{ path }}}\s+-p\s+{{{ permissions }}}(\s|$)+'
     patterns: "audit.rules"
-  register: find_existing_mac_audit_rules
+  register: find_existing_watch_audit_rules
 
-- name: Inserts/replaces the MAC modifications rule in /etc/audit/audit.rules
+- name: Inserts/replaces the rule in /etc/audit/audit.rules
   lineinfile:
     line: "-w {{{ path }}} -p {{{ permissions }}} -k {{{ key }}}"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-  when: find_existing_mac_audit_rules.matched is defined and find_existing_mac_audit_rules.matched == 0
+  when: find_existing_watch_audit_rules.matched is defined and find_existing_watch_audit_rules.matched == 0
 {{%- endmacro %}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -285,8 +285,8 @@ The macro requires following parameters:
 - key: key to use as identifier. Note that if there exists any other rule with the same find_mac_key
 in some file within /etc/audit/rules.d/, the new rule will be appended to this file.
 #}}
-{{% macro remediate_audit_watch_rules_d(path='', permissions='', key='') -%}}
-- name: Check if rule already exists in /etc/audit/rules.d/*
+{{% macro ansible_audit_augenrules_add_watch_rule(path='', permissions='', key='') -%}}
+- name: Check if watch rule for {{{ path }}} already exists in /etc/audit/rules.d/
   find:
     paths: "/etc/audit/rules.d"
     recurse: no
@@ -294,7 +294,7 @@ in some file within /etc/audit/rules.d/, the new rule will be appended to this f
     patterns: "*.rules"
   register: find_existing_watch_rules_d
 
-- name: Search /etc/audit/rules.d for other rules with specified key
+- name: Search /etc/audit/rules.d for other rules with specified key {{{ key }}}
   find:
     paths: "/etc/audit/rules.d"
     recurse: no
@@ -303,7 +303,7 @@ in some file within /etc/audit/rules.d/, the new rule will be appended to this f
   register: find_watch_key
   when: find_existing_watch_rules_d.matched is defined and find_existing_watch_rules_d.matched == 0
 
-- name: If existing ruleset with key {{{ key }}} not found, use /etc/audit/rules.d/{{{ key }}}.rules as the recipient for the rule
+- name: Use /etc/audit/rules.d/{{{ key }}}.rules as the recipient for the rule
   set_fact:
     all_files:
       - /etc/audit/rules.d/{{{ key }}}.rules
@@ -315,7 +315,7 @@ in some file within /etc/audit/rules.d/, the new rule will be appended to this f
       - "{{ find_watch_key.files | map(attribute='path') | list | first }}"
   when: find_watch_key.matched is defined and find_watch_key.matched > 0 and find_existing_watch_rules_d.matched is defined and find_existing_watch_rules_d.matched == 0
 
-- name: Inserts/replaces the rule in rules.d
+- name: Add watch rule for {{{ path }}} in /etc/audit/rules.d/
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-w {{{ path }}} -p {{{ permissions }}} -k {{{ key }}}"
@@ -330,15 +330,15 @@ The macro requires following parameters:
 - permissions: permissions changes to watch for
 - key: key to use as identifier. 
 #}}
-{{% macro remediate_audit_watch_audit_rules(path='', permissions='', key='') -%}}
-- name: Check if rule already exists in /etc/audit/audit.rules
+{{% macro ansible_audit_auditctl_add_watch_rule(path='', permissions='', key='') -%}}
+- name: Check if watch rule for {{{ path }}} already exists in /etc/audit/audit.rules
   find:
     paths: "/etc/audit/"
     contains: '^\s*-w\s+{{{ path }}}\s+-p\s+{{{ permissions }}}(\s|$)+'
     patterns: "audit.rules"
   register: find_existing_watch_audit_rules
 
-- name: Inserts/replaces the rule in /etc/audit/audit.rules
+- name: Add watch rule for {{{ path }}} in /etc/audit/audit.rules
   lineinfile:
     line: "-w {{{ path }}} -p {{{ permissions }}} -k {{{ key }}}"
     state: present

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -277,3 +277,57 @@ regex_replace("\(n\)\*", "\\n")
 {{% macro ansible_deregexify_banner_backslash() -%}}
 regex_replace("\\", "")
 {{%- endmacro %}}
+
+{{% macro remediate_audit_watch_rules_d(path='', permissions='', key='') -%}}
+- name: Check if rule already exists in /etc/audit/rules.d/*
+  find:
+    paths: "/etc/audit/rules.d"
+    recurse: no
+    contains: '^\s*-w\s+{{{ path }}}\s+-p\s+{{{ permissions }}}(\s|$)+'
+    patterns: "*.rules"
+  register: find_existing_mac_rules_d
+- name: Search /etc/audit/rules.d for other rules with specified key
+  find:
+    paths: "/etc/audit/rules.d"
+    recurse: no
+    contains: "^.*(-F key=)(|-k ){{{ key }}}$"
+    patterns: "*.rules"
+  register: find_mac_key
+  when: find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+
+- name: If existing ruleset with key {{{ key }}} not found, use /etc/audit/rules.d/{{{ key }}}.rules as the recipient for the rule
+  set_fact:
+    all_files:
+      - /etc/audit/rules.d/{{{ key }}}.rules
+  when: find_mac_key.matched is defined and find_mac_key.matched == 0 and find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+
+- name: Use matched file as the recipient for the rule
+  set_fact:
+    all_files:
+      - "{{ find_mac_key.files | map(attribute='path') | list | first }}"
+  when: find_mac_key.matched is defined and find_mac_key.matched > 0 and find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+
+- name: Inserts/replaces the rule in rules.d
+  lineinfile:
+    path: "{{ all_files[0] }}"
+    line: "-w {{{ path }}} -p {{{ permissions }}} -k {{{ key }}}"
+    create: yes
+  when: find_existing_mac_rules_d.matched is defined and find_existing_mac_rules_d.matched == 0
+{{%- endmacro %}}
+
+{{% macro remediate_audit_watch_audit_rules(path='', permissions='', key='') -%}}
+- name: Check if rule already exists in /etc/audit/audit.rules
+  find:
+    paths: "/etc/audit/"
+    contains: '^\s*-w\s+{{{ path }}}\s+-p\s+{{{ permissions }}}(\s|$)+'
+    patterns: "audit.rules"
+  register: find_existing_mac_audit_rules
+
+- name: Inserts/replaces the MAC modifications rule in /etc/audit/audit.rules
+  lineinfile:
+    line: "-w {{{ path }}} -p {{{ permissions }}} -k {{{ key }}}"
+    state: present
+    dest: /etc/audit/audit.rules
+    create: yes
+  when: find_existing_mac_audit_rules.matched is defined and find_existing_mac_audit_rules.matched == 0
+{{%- endmacro %}}


### PR DESCRIPTION
#### Description:

This PR introduces 2 new Jinja2 macros to be used in Ansible remediations.
remediate_audit_watch_rules_d remediates one audit watch line within files located in /etc/audit/rules.d/ directory.
remediate_audit_watch_audit_rules remediates one audit watch rule within /etc/audit/audit.rules file.
The macro is also used within one rule to demonstrate its functionality.

#### Rationale:

Remediating Audit watches is something which repeats often so it deserves a macro. It will decrease chance of errors and code duplication.
