### PR TITLE
Add xwindows runlevel target to STIG profile

### DIFF
--- a/rhel7/profiles/rhelh-stig.profile
+++ b/rhel7/profiles/rhelh-stig.profile
@@ -430,6 +430,7 @@ selections:
     - package_tftp-server_removed
     - tftpd_uses_secure_mode
     - package_xorg-x11-server-common_removed
+    - xwindows_runlevel_target
     - sssd_enable_pam_services
     - mount_option_noexec_remote_filesystems
     - auditd_audispd_network_failure_action

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -273,6 +273,7 @@ selections:
     - sshd_enable_x11_forwarding
     - tftpd_uses_secure_mode
     - package_xorg-x11-server-common_removed
+    - xwindows_runlevel_target
     - sysctl_net_ipv4_ip_forward
     - mount_option_krb_sec_remote_filesystems
     - snmpd_not_default_password

--- a/rhv4/profiles/rhvh-stig.profile
+++ b/rhv4/profiles/rhvh-stig.profile
@@ -428,6 +428,7 @@ selections:
     - package_tftp-server_removed
     - tftpd_uses_secure_mode
     - package_xorg-x11-server-common_removed
+    - xwindows_runlevel_target
     - sssd_enable_pam_services
     - mount_option_noexec_remote_filesystems
     - auditd_audispd_network_failure_action


### PR DESCRIPTION
#### Description:
- Based on #5625
- Contains additional commit that adds xwindows runlevel target to STIG profiles

#### Rationale:

- This PR adds one commit which select the rule  xwindows_runlevel_target in STIG profiles

- It's a derivative of #5625, contains the same commit plus the one mentioned by the message above
