### PR TITLE
Reference should not point to OS version.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
@@ -33,7 +33,7 @@ references:
     disa: '58'
     nist: CM-6(a)
     nist-csf: PR.AC-7
-    rhel7: FMT_MOF_EXT.1
+    ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000030-GPOS-00011
     vmmsrg: SRG-OS-000030-VMM-000110
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'


### PR DESCRIPTION
#### Description:

- Reference should not point to OS version.

#### Rationale:

- All other references point to standards, not to products.
