### PR TITLE
revert platform:machine for service_cockpit_disabled

### DIFF
--- a/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
@@ -14,8 +14,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine
-
 ocil: '{{{ ocil_service_disabled(service="cockpit") }}}'
 
 ocil_clause: 'it is not disabled'


### PR DESCRIPTION
Services run inside containers

eg
`````
# cat Dockerfile

FROM fedora

RUN dnf -y install cockpit; dnf clean all; systemctl enable cockpit

EXPOSE 80

CMD [ "/sbin/init" ]
`````

see also https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container/