### PR TITLE
revert platform:machine on chronyd_client_only

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
@@ -15,8 +15,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: 82988-7
     cce@ocp4: 82465-6


### PR DESCRIPTION
This rule is for a configuration check. What if the container is running a chrony service? Needs to ensure it's configured properly.