### PR TITLE
revert platform:machine on chronyd_no_chronyc_network

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/rule.yml
@@ -15,8 +15,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: 82840-0
     cce@ocp4: 82466-4


### PR DESCRIPTION
This check evaluates a configuration item. What if chrony is running inside a container? Need to ensure it is configured properly.