### PR TITLE
revert platform:machine for chronyd_or_ntpd_set_maxpoll

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -21,8 +21,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 80439-3
     cce@ocp4: 82684-2


### PR DESCRIPTION
Need to ensure chrony configuration is properly set, even when running in containers.