### PR TITLE
revert platform:machine in chronyd_or_ntpd_specify_multiple_servers

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -37,8 +37,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 27012-4
     cce@rhel8: 80764-4


### PR DESCRIPTION
Need to ensure proper configuration no matter where chrony or ntp is deployed.