### PR TITLE
revert platform:machine for chronyd_or_ntpd_specify_remote_server

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -36,8 +36,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 27278-1
     cce@rhel8: 80765-1


### PR DESCRIPTION
Need to ensure proper config wherever time services are deployed.