### PR TITLE
revert platform:machine in service_chronyd_or_ntpd_enabled

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -35,8 +35,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 27444-9
     cce@rhel8: 80874-1


### PR DESCRIPTION
Containers run services too. Looks like the underlying check needs to be updated, not removed.