### PR TITLE
revert platform:machine for service_sssd_enabled

### DIFF
--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -17,8 +17,6 @@ identifiers:
     cce@rhel7: 80363-5
     cce@rhel8: 82440-9
 
-platform: machine
-
 references:
     nist: CM-6(a),IA-5(10)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7


### PR DESCRIPTION
containers run services too. Underlying OVAL may need updating, but the rule is still applicable.