### PR TITLE
revert platform:machine for sssd_enable_smartcards

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -27,8 +27,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel7: 80570-5
     cce@rhel8: 80909-5


### PR DESCRIPTION
Need to ensure proper configuration of the service however/wherever it is deployed. Looks like the underlying OVAL needs to be updated - but this rule is still applicable. 