### PR TITLE
revert platform:machine on sssd_memcache_timeout

### DIFF
--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
@@ -22,8 +22,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 82445-8
     cce@rhel7: 80364-3


### PR DESCRIPTION
Need to ensure service is properly configured wherever/however it is deployed. 