### PR TITLE
revert platform:machine for sssd_offline_cred_expiration

### DIFF
--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
@@ -19,8 +19,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 82447-4
     cce@rhel7: 80365-0


### PR DESCRIPTION
Need to ensure service is properly configured however/wherever it is deployed. Looks like underlying OVAL must be updated, but this rule is still applicable.