### PR TITLE
revert platform:machine in sssd_ssh_known_hosts_timeout

### DIFF
--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
@@ -20,8 +20,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 82441-7
     cce@rhel7: 80366-8


### PR DESCRIPTION
Need to ensure proper configuration however/wherever services are deployed. Looks like underlying OVAL needs to be updated, but rule is still applicable.