### PR TITLE
revert platform:machine for service_usbguard_enabled

### DIFF
--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
@@ -14,8 +14,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine
-
 identifiers:
     cce@rhel8: 82853-3
     cce@ocp4: 82537-2


### PR DESCRIPTION
Containers run services too. Looks like underlying OVAL needs to be updated, but this rule is still applicable to containers.