### PR TITLE
revert platform:machine for smartcard_auth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -32,8 +32,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel6: 27440-7
     cce@rhel7: 80207-4


### PR DESCRIPTION
Underlying OVAL needs to be rewritten, but the rule is still applicable to containers.