### PR TITLE
revert platform:machine for network_sniffer_disabled

### DIFF
--- a/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/rule.yml
@@ -22,8 +22,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The oscap interface probe doesn't support offline mode
-
 identifiers:
     cce@rhel6: 27152-8
     cce@rhel7: 80174-6


### PR DESCRIPTION
Still applicable to containers. Looks like a different OVAL technique must be used.