### PR TITLE
revert platform:machine for service_systemd-coredump_disabled

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
@@ -16,8 +16,6 @@ rationale: |-
 
 severity: unknown
 
-platform: machine
-
 identifiers:
     cce@rhel8: 82881-4
     cce@ocp4: 82530-7


### PR DESCRIPTION
Containers run services too. Looks like OVAL technique needs to be updated.