### PR TITLE
revert platform:machine for package_abrt-addon-kerneloops_removed

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
@@ -13,8 +13,6 @@ rationale: |-
 
 severity: low
 
-platform: machine
-
 identifiers:
     cce@rhel6: 82928-3
     cce@rhel7: 82927-5


### PR DESCRIPTION
Containers have packages too. Need to ensure forbidden ones are not included.