### PR TITLE
Fix SSGTS when running with python3 and writing binary data to file.

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -168,8 +168,8 @@ def run_stage_remediation_ansible(run_type, formatting, verbose_path):
     command_string = ' '.join(command)
     returncode, output = common.run_cmd_local(command, verbose_path)
     # Appends output of ansible-playbook to the verbose_path file.
-    with open(verbose_path, 'a') as f:
-        f.write('Stdout of "{}":'.format(command_string))
+    with open(verbose_path, 'ab') as f:
+        f.write('Stdout of "{}":'.format(command_string).encode("utf-8"))
         f.write(output.encode("utf-8"))
     if returncode != 0:
         msg = (
@@ -197,8 +197,8 @@ def run_stage_remediation_bash(run_type, formatting, verbose_path):
     returncode, output = common.run_cmd_remote(
         command_string, formatting['domain_ip'], verbose_path)
     # Appends output of script execution to the verbose_path file.
-    with open(verbose_path, 'a') as f:
-        f.write('Stdout of "{}":'.format(command_string))
+    with open(verbose_path, 'ab') as f:
+        f.write('Stdout of "{}":'.format(command_string).encode("utf-8"))
         f.write(output.encode("utf-8"))
     if returncode != 0:
         msg = (


### PR DESCRIPTION
#### Description:

- Fix execution of SSGTS when running with python3 and writing encoded data to file.

#### Rationale:

- The change from here: https://github.com/ComplianceAsCode/content/pull/5625/files#diff-6e5d767ae2de1548e098d7a79e306d88R173 broke the compatibility with python3. Only python2 was working.
