### PR TITLE
ocp4/utils: Enable build_ds_container.sh to create images in other namespaces

### DIFF
--- a/ocp-resources/ds-build.yaml
+++ b/ocp-resources/ds-build.yaml
@@ -2,13 +2,11 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
   name: "openscap-$PRODUCT-ds" 
-  namespace: openshift-compliance
 ---
 kind: BuildConfig
 apiVersion: build.openshift.io/v1
 metadata:
   name: "openscap-$PRODUCT-ds" 
-  namespace: openshift-compliance
 spec:
   runPolicy: "Serial" 
   triggers: 

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -2,6 +2,10 @@
 
 product=$1
 
+# Build container in specified namespace. Else default to
+# "openshift-compliance"
+namespace=${2:-"openshift-compliance"}
+
 root_dir=$(git rev-parse --show-toplevel)
 
 pushd $root_dir
@@ -9,33 +13,36 @@ pushd $root_dir
 # build the product's content
 "$root_dir/build_product" "$product"
 
-# Ensure openshift-compliance namespace exists. If it already exists, this is
-# not a problem.
-oc apply -f "$root_dir/ocp-resources/compliance-operator-ns.yaml"
+if [ "$namespace" == "openshift-compliance" ]; then
+    # Ensure openshift-compliance namespace exists. If it already exists, this
+    # is not a problem.
+    oc apply -f "$root_dir/ocp-resources/compliance-operator-ns.yaml"
+fi
 
 # Create buildconfig and ImageStream
 # This enables us to create a configuration so we can build a container
 # with the datastream
 # If they already exist, this is not a problem
-cat "$root_dir/ocp-resources/ds-build.yaml" | sed "s/\$PRODUCT/$product/" | oc apply -f -
+cat "$root_dir/ocp-resources/ds-build.yaml" | sed "s/\$PRODUCT/$product/" | \
+    oc apply -n "$namespace" -f -
 
 # Start build
-oc start-build -n openshift-compliance "openscap-$product-ds" \
+oc start-build -n "$namespace" "openscap-$product-ds" \
     --from-file="$root_dir/build/ssg-$product-ds.xml"
 
 # Wait some seconds until the object gets persisted
 sleep 5
 
-latest_build=$(oc get -n openshift-compliance --no-headers buildconfigs "openscap-$product-ds" | awk '{print $4}')
+latest_build=$(oc get -n "$namespace" --no-headers buildconfigs "openscap-$product-ds" | awk '{print $4}')
 
 popd
 
 while true; do
-    build_status=$(oc get builds -n openshift-compliance --no-headers "openscap-$product-ds-$latest_build" | awk '{print $4}')
+    build_status=$(oc get builds -n "$namespace" --no-headers "openscap-$product-ds-$latest_build" | awk '{print $4}')
 
     if [ "$build_status" == "Complete" ]; then
         # Get built image
-        image=$(oc get imagestreams -n openshift-compliance --no-headers "openscap-$product-ds" | awk '{printf "%s:%s",$2, $3}')
+        image=$(oc get imagestreams -n "$namespace" --no-headers "openscap-$product-ds" | awk '{printf "%s:%s",$2, $3}')
 
         echo "Success!"
         echo "********"


### PR DESCRIPTION
Right now the script is hardcoded to use the `openshift-compliance`
namespace. This makes it so that the aforementioned namespace is taken
as a default, but if you give a second parameter to the script, it'll
use that namespace.

e.g.

    ./utils/build_ds_container.sh ocp4 other-namespace

Will build the content for ocp4, and push the container image to the
namespace called "other-namespace".