### PR TITLE
ocp4: Add missing AC-1 checks to moderate profile

### DIFF
--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: rhel6,rhel7,rhel8,rhv4,sle15,ocp4
 
 title: 'Verify Group Who Owns SSH Server config file'
 

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: rhel6,rhel7,rhel8,rhv4,sle15,ocp4
 
 title: 'Verify Owner on SSH Server config file'
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: rhel6,rhel7,rhel8,rhv4,sle15,ocp4
 
 title: 'Verify Permissions on SSH Server config file'
 

--- a/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel6,rhel7,rhel8,rhv4
+prodtype: fedora,rhel6,rhel7,rhel8,rhv4,ocp4
 
 title: 'Disable Bluetooth Service'
 

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -520,6 +520,21 @@ selections:
     #- mount_option_nodev_removable_partitions
     #- mount_option_noexec_removable_partitions
 
+    # AC-1
+    - configure_ssh_crypto_policy
+    - service_bluetooth_disabled
+    #- sshd_use_approved_macs
+    #- sshd_use_approved_ciphers
+    #- sshd_set_loglevel_verbose
+    #- sshd_set_loglevel_info
+    #- sshd_disable_compression
+    #- sshd_allow_only_protocol2
+    - file_permissions_sshd_pub_key
+    - file_permissions_sshd_private_key
+    - file_permissions_sshd_config
+    - file_owner_sshd_config
+    - file_groupowner_sshd_config
+
     # AC-3
     - sshd_limit_user_access
     - sshd_disable_rhosts


### PR DESCRIPTION
These checks are enabled for RHEL, but are also valid for RHCOS. So
let's enable these checks.

Note that the sshd-related checks have been commented out since we still
need to come up with a remediation strategy, given that those touch the
same file.