### PR TITLE
Ubuntu1804/cis kernel module rules

### DIFF
--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ocp4,ol7,ol8,rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ocp4,ol7,ol8,rhel6,rhel7,rhel8,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of cramfs'
 
@@ -30,6 +30,7 @@ identifiers:
 references:
     cis@rhel8: 1.1.1.1
     cis@sle15: 1.1.1.1
+    cis@ubuntu1804: 1.1.1.1
     cui: 3.4.6
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of freevxfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of hfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of hfsplus'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ocp4,rhel6,rhel7,rhel8,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of jffs2'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ocp4,rhel6,rhel7,rhel8,sle15
+prodtype: fedora,ocp4,rhel6,rhel7,rhel8,sle15,ubuntu1804
 
 title: 'Disable Mounting of udf'
 
@@ -31,6 +31,7 @@ identifiers:
 references:
     cis@rhel8: 1.1.1.4
     cis@sle15: 1.1.1.7
+    cis@ubuntu1804: 1.1.1.6
     cui: 3.4.6
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3

--- a/shared/templates/template_OVAL_kernel_module_disabled
+++ b/shared/templates/template_OVAL_kernel_module_disabled
@@ -8,7 +8,10 @@
     </metadata>
     <criteria operator="OR">
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.d" />
+
+{{% if product != "ubuntu1804" %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
+{{% endif %}}
 
 {{% if product != "rhel6" %}}
 

--- a/shared/templates/template_OVAL_kernel_module_disabled
+++ b/shared/templates/template_OVAL_kernel_module_disabled
@@ -13,7 +13,7 @@
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
 {{% endif %}}
 
-{{% if product != "rhel6" %}}
+{{% if (product != "rhel6") and (product != "ubuntu1804") %}}
 
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d" />
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d" />


### PR DESCRIPTION
#### Description:

Enable kernel module rules for ubuntu 1804 according CIS profile:
cramfs, freevxfs, jffs2, hfs, hfsplus, udf.

Remove tests-criteria for Ubuntu1804:

#### Rationale:
- Adding these rules to complete the cis- hardening profile. 
- Remove testcriteria only for Ubuntu1804, because I only tested it on this version (Desktop version). 

  according the man-pages from ubuntu, /etc/modprobe.conf is still deprecated. But when tested, this rule is still not working. /etc/modprobe.d/[myfilename].conf is still working correctly. 
