### PR TITLE
macro for remediating audit syscall rules requires arch to be specified

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -3,11 +3,31 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+#
+# What architecture are we on?
+#
+- name: Set architecture for audit tasks
+  set_fact:
+    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-{{% if product == "rhel6" %}}
-{{{ ansible_audit_augenrules_add_syscall_rule(syscalls=["init_module", "delete_module"], key="modules") }}}
-{{{ ansible_audit_auditctl_add_syscall_rule(syscalls=["init_module", "delete_module"], key="modules") }}}
-{{% else %}}
-{{{ ansible_audit_augenrules_add_syscall_rule(syscalls=["init_module", "finit_module", "delete_module"], key="modules") }}}
-{{{ ansible_audit_auditctl_add_syscall_rule(syscalls=["init_module", "finit_module", "delete_module"], key="modules") }}}
-{{% endif %}}
+
+- name: perform remediation of Audit rules for kernel module loading for x86 platform
+  block:
+  {{% if product == "rhel6" %}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
+  {{% else %}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
+  {{% endif %}}
+
+- name: perform remediation of Audit rules for kernel module loading for x86_64 platform
+  block:
+  {{% if product == "rhel6" %}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
+  {{% else %}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
+  {{% endif %}}
+  when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -11,7 +11,7 @@
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
 
-- name: perform remediation of Audit rules for kernel module loading for x86 platform
+- name: Perform remediation of Audit rules for kernel module loading for x86 platform
   block:
   {{% if product == "rhel6" %}}
     {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
@@ -21,7 +21,7 @@
     {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
   {{% endif %}}
 
-- name: perform remediation of Audit rules for kernel module loading for x86_64 platform
+- name: Perform remediation of Audit rules for kernel module loading for x86_64 platform
   block:
   {{% if product == "rhel6" %}}
     {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -10,24 +10,20 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
+# set list of syscalls based on rhel version
+{{% if product == "rhel6" %}}
+{{% set audit_syscalls = ["init_module", "delete_module"] %}}
+{{% else %}}
+{{% set audit_syscalls = ["init_module", "delete_module", "finit_module"] %}}
+{{% endif %}}
 
 - name: Perform remediation of Audit rules for kernel module loading for x86 platform
   block:
-  {{% if product == "rhel6" %}}
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
-  {{% else %}}
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
-  {{% endif %}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=audit_syscalls, key="modules")|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=audit_syscalls, key="modules")|indent(4) }}}
 
 - name: Perform remediation of Audit rules for kernel module loading for x86_64 platform
   block:
-  {{% if product == "rhel6" %}}
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["init_module", "delete_module"], key="modules")|indent(4) }}}
-  {{% else %}}
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["init_module", "finit_module", "delete_module"], key="modules")|indent(4) }}}
-  {{% endif %}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=audit_syscalls, key="modules")|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=audit_syscalls, key="modules")|indent(4) }}}
   when: audit_arch == "b64"

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -349,21 +349,12 @@ The macro requires following parameters:
 {{#
 The following macro remediates Audit syscall rule in /etc/audit/rules.d directory.
 The macro requires following parameters:
+- arch: an architecture to be used in the Audit rule (b32, b64)
 - syscalls: list of syscalls supplied as a list ["syscall1", "syscall2"] etc.
 - key: a key to use as rule identifier.
 Note that if there  already exists a rule wit the same key in the /etc/audit/rules.d directory, the rule will be placed in the same file.
-The rule determines the architecture of the system and apply appropriate remediations.
-It utilizes b32 for X86 architecture and both b32 and b64 for x86_64 architecture.
 #}}
-
-{{% macro ansible_audit_augenrules_add_syscall_rule(syscalls=[], key="") -%}}
-#
-# What architecture are we on?
-#
-- name: Set architecture for audit tasks
-  set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
-
+{{% macro ansible_audit_augenrules_add_syscall_rule(arch="", syscalls=[], key="") -%}}
 - name: Declare list of syscals
   set_fact:
     syscalls: {{{ syscalls }}}
@@ -371,27 +362,16 @@ It utilizes b32 for X86 architecture and both b32 and b64 for x86_64 architectur
 - name: Declare number of syscalls
   set_fact: audit_syscalls_number_of_syscalls="{{ syscalls|length|int }}"
 
-- name: Check existence of syscalls for 32 bit architecture in /etc/audit/rules.d/
+- name: Check existence of syscalls for architecture {{{ arch }}} in /etc/audit/rules.d/
   find:
     paths: "/etc/audit/rules.d"
-    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
+    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch={{{ arch }}}[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
     patterns: "*.rules"
-  register: audit_syscalls_found_32_rules_d
+  register: audit_syscalls_found_{{{ arch }}}_rules_d
   loop: "{{ syscalls }}"
 
-- name: Get number of matched 32 bit syscalls in /etc/audit/rules.d/
-  set_fact: audit_syscalls_matched_32_rules_d="{{audit_syscalls_found_32_rules_d.results|sum(attribute='matched')|int }}"
-
-- name: Check existence of syscalls for 64 bit architecture in /etc/audit/rules.d/
-  find:
-    paths: "/etc/audit/rules.d"
-    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
-    patterns: "*.rules"
-  register: audit_syscalls_found_64_rules_d
-  loop: "{{ syscalls }}"
-
-- name: Get number of matched 64 bit syscalls in /etc/audit/rules.d/
-  set_fact: audit_syscalls_matched_64_rules_d="{{audit_syscalls_found_64_rules_d.results|sum(attribute='matched')|int }}"
+- name: Get number of matched syscalls for architecture {{{ arch }}}in /etc/audit/rules.d/
+  set_fact: audit_syscalls_matched_{{{ arch }}}_rules_d="{{audit_syscalls_found_{{{ arch }}}_rules_d.results|sum(attribute='matched')|int }}"
 
 - name: Search /etc/audit/rules.d for other rules with the key {{{ key }}}
   find:
@@ -412,13 +392,13 @@ It utilizes b32 for X86 architecture and both b32 and b64 for x86_64 architectur
       - "{{ find_syscalls_files.files | map(attribute='path') | list | first }}"
   when: find_syscalls_files.matched is defined and find_syscalls_files.matched > 0
 
-- name: "Insert the syscall rule in {{ all_files[0] }} when on x86"
+- name: "Insert the syscall rule in {{ all_files[0] }}"
   block:
     - name: "Construct rule: add rule list, action and arch"
-      set_fact: tmpline="-a always,exit -F arch=b32 "
+      set_fact: tmpline="-a always,exit -F arch={{{ arch }}} "
     - name: "Construct rule: add syscalls"
       set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
-      loop: "{{ audit_syscalls_found_32_rules_d.results }}"
+      loop: "{{ audit_syscalls_found_{{{ arch }}}_rules_d.results }}"
       when: item.matched is defined and item.matched == 0
     - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k {{{ key }}}' }}"
@@ -428,43 +408,17 @@ It utilizes b32 for X86 architecture and both b32 and b64 for x86_64 architectur
         line: "{{ tmpline }}"
         create: true
         state: present
-  when: audit_syscalls_matched_32_rules_d < audit_syscalls_number_of_syscalls
-
-- name: "Insert the syscall rule in {{ all_files[0] }} when on x86_64"
-  block:
-    - name: "Construct rule: add rule list, action and arch"
-      set_fact: tmpline="-a always,exit -F arch=b64 "
-    - name: "Construct rule: add syscalls"
-      set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
-      loop: "{{ audit_syscalls_found_64_rules_d.results }}"
-      when: item.matched is defined and item.matched == 0
-    - name: "Construct rule: add key"
-      set_fact: tmpline="{{ tmpline + '-k {{{ key }}}' }}"
-    - name: "Insert the line in {{ all_files[0] }}"
-      lineinfile:
-        path: "{{ all_files[0] }}"
-        line: "{{ tmpline }}"
-        create: true
-        state: present
-  when: audit_syscalls_matched_64_rules_d < audit_syscalls_number_of_syscalls and audit_arch is defined and audit_arch == 'b64'
+  when: audit_syscalls_matched_{{{ arch }}}_rules_d < audit_syscalls_number_of_syscalls
 {{%- endmacro %}}
 
 {{#
 The following macro remediates Audit syscall rule in /etc/audit/audit.rules file.
 The macro requires following parameters:
+- arch: an architecture to be used in the Audit rule (b32, b64)
 - syscalls: list of syscalls supplied as a list ["syscall1", "syscall2"] etc.
 - key: a key to use as rule identifier.
-The rule determines the architecture of the system and apply appropriate remediations.
-It utilizes b32 for X86 architecture and both b32 and b64 for x86_64 architecture.
 #}}
-{{% macro ansible_audit_auditctl_add_syscall_rule(syscalls=[], key="") -%}}
-#
-# What architecture are we on?
-#
-- name: Set architecture for audit tasks
-  set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
-
+{{% macro ansible_audit_auditctl_add_syscall_rule(arch="", syscalls=[], key="") -%}}
 - name: Declare list of syscals
   set_fact:
     syscalls: {{{ syscalls }}}
@@ -472,35 +426,24 @@ It utilizes b32 for X86 architecture and both b32 and b64 for x86_64 architectur
 - name: Declare number of syscalls
   set_fact: audit_syscalls_number_of_syscalls="{{ syscalls|length|int }}"
 
-- name: Check existence of syscalls for 32 bit architecture in /etc/audit/audit.rules
+- name: Check existence of syscalls for architecture {{{ arch }}} in /etc/audit/audit.rules
   find:
     paths: "/etc/audit"
-    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
+    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch={{{ arch }}}[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
     patterns: "audit.rules"
-  register: audit_syscalls_found_32_audit_rules
+  register: audit_syscalls_found_{{{ arch }}}_audit_rules
   loop: "{{ syscalls }}"
 
-- name: Get number of matched 32 bit syscalls in /etc/audit/audit.rules
-  set_fact: audit_syscalls_matched_32_audit_rules="{{audit_syscalls_found_32_audit_rules.results|sum(attribute='matched')|int }}"
+- name: Get number of matched syscalls for architecture {{{ arch }}} in /etc/audit/audit.rules
+  set_fact: audit_syscalls_matched_{{{ arch }}}_audit_rules="{{audit_syscalls_found_{{{ arch }}}_audit_rules.results|sum(attribute='matched')|int }}"
 
-- name: Check existence of syscalls for 64 bit architecture in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit"
-    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
-    patterns: "audit.rules"
-  register: audit_syscalls_found_64_audit_rules
-  loop: "{{ syscalls }}"
-
-- name: Get number of matched 64 bit syscalls in /etc/audit/rules.d/*
-  set_fact: audit_syscalls_matched_64_audit_rules="{{audit_syscalls_found_64_audit_rules.results|sum(attribute='matched')|int }}"
-
-- name: Insert the syscall rule in /etc/audit/audit.rules when on x86
+- name: Insert the syscall rule in /etc/audit/audit.rules
   block:
     - name: "Construct rule: add rule list, action and arch"
-      set_fact: tmpline="-a always,exit -F arch=b32 "
+      set_fact: tmpline="-a always,exit -F arch={{{ arch }}} "
     - name: "Construct rule: add syscalls"
       set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
-      loop: "{{ audit_syscalls_found_32_audit_rules.results }}"
+      loop: "{{ audit_syscalls_found_{{{ arch }}}_audit_rules.results }}"
       when: item.matched is defined and item.matched == 0
     - name: "Construct rule: add key"
       set_fact: tmpline="{{ tmpline + '-k {{{ key }}}' }}"
@@ -510,23 +453,5 @@ It utilizes b32 for X86 architecture and both b32 and b64 for x86_64 architectur
         line: "{{ tmpline }}"
         create: true
         state: present
-  when: audit_syscalls_matched_32_audit_rules < audit_syscalls_number_of_syscalls
-
-- name: Insert the syscall rule in /etc/audit/rules.d when on x86_64
-  block:
-    - name: "Construct rule: add rule list, action and arch"
-      set_fact: tmpline="-a always,exit -F arch=b64 "
-    - name: "Construct rule: add syscalls"
-      set_fact: tmpline="{{tmpline + '-S ' + item.item + ' ' }}"
-      loop: "{{ audit_syscalls_found_64_audit_rules.results }}"
-      when: item.matched is defined and item.matched == 0
-    - name: "Construct rule: add key"
-      set_fact: tmpline="{{ tmpline + '-k {{{ key }}}' }}"
-    - name: Insert the line in /etc/audit/audit.rules
-      lineinfile:
-        path: "/etc/audit/audit.rules"
-        line: "{{ tmpline }}"
-        create: true
-        state: present
-  when: audit_syscalls_matched_64_audit_rules < audit_syscalls_number_of_syscalls and audit_arch is defined and audit_arch == 'b64'
+  when: audit_syscalls_matched_{{{ arch }}}_audit_rules < audit_syscalls_number_of_syscalls
 {{%- endmacro %}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -370,7 +370,7 @@ Note that if there  already exists a rule wit the same key in the /etc/audit/rul
   register: audit_syscalls_found_{{{ arch }}}_rules_d
   loop: "{{ syscalls }}"
 
-- name: Get number of matched syscalls for architecture {{{ arch }}}in /etc/audit/rules.d/
+- name: Get number of matched syscalls for architecture {{{ arch }}} in /etc/audit/rules.d/
   set_fact: audit_syscalls_matched_{{{ arch }}}_rules_d="{{audit_syscalls_found_{{{ arch }}}_rules_d.results|sum(attribute='matched')|int }}"
 
 - name: Search /etc/audit/rules.d for other rules with the key {{{ key }}}


### PR DESCRIPTION
#### Description:

Modified macros for ansible remediation of Audit syscalls to require parameter arch to be set.
Rewrite rule audit_rules_kernel_module_loading to use this new way.

#### Rationale:

Currently the macro is "smart" and determines if the rule should be remediated for 32 bit syscalls or both 32 and 64 bit syscalls. Unfortunately, this is not always desired. Fore example the stime syscall is not defined for 64 bit architecture and current macro would therefore produce wrong Audit configuration.