### PR TITLE
ocp4: Fix ignition remediation to disable user coredumps

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ignition/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/ignition/shared.yml
@@ -11,4 +11,4 @@ spec:
           source: data:,%2A%20%20%20%20%20hard%20%20%20core%20%20%20%200
         filesystem: root
         mode: 0644
-        path: /etc/limits.d/disable_users_coredumps.conf
+        path: /etc/security/limits.d/75-disable_users_coredumps.conf


### PR DESCRIPTION
It had the wrong path