### PR TITLE
Add ignition and kubernetes remediation type into html statistics page.

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -180,6 +180,8 @@ def main():
             'missing_ovals',
             'missing_bash_fixes',
             'missing_ansible_fixes',
+            'missing_ignition_fixes',
+            'missing_kubernetes_fixes',
             'missing_puppet_fixes',
             'missing_anaconda_fixes',
             'missing_cces'


### PR DESCRIPTION
#### Description:

- Consider new remediation types (`ignition` and `kubernetes`) when generating HTML statistics from `profile_tool.py` script.

#### Rationale:

- Make statistics job nice again: https://jenkins.complianceascode.io/job/scap-security-guide-stats/Statistics/rhel8/product-statistics/statistics.html
