### PR TITLE
Fix ansible upload script to not break when capitalization of profile changes

### DIFF
--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -501,7 +501,7 @@ def main():
     github_repositories = [repo.name for repo in github_org.get_repos()]
 
     # Create empty repositories
-    github_new_repos = sorted(list(set(selected_roles.keys()) - set(github_repositories)))
+    github_new_repos = sorted(list(set(map(str.lower, selected_roles.keys())) - set(map(unicode.lower, github_repositories))))
     if github_new_repos:
         create_empty_repositories(github_new_repos, github_org)
 


### PR DESCRIPTION
Addressing:
```
Creating new Github repository: ansible-role-rhel7-C2S
Traceback (most recent call last):
  File "utils/upload_ansible_roles_to_galaxy.py", line 536, in <module>
    main()
  File "utils/upload_ansible_roles_to_galaxy.py", line 508, in main
    create_empty_repositories(github_new_repos, github_org)
  File "utils/upload_ansible_roles_to_galaxy.py", line 92, in create_empty_repositories
    has_downloads=False)
  File "/usr/lib/python2.9/site-packages/github/Organization.py", line 441, in create_repo
    input=post_parameters
  File "/usr/lib/python2.9/site-packages/github/Requester.py", line 185, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
  File "/usr/lib/python2.9/site-packages/github/Requester.py", line 198, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.GithubException: 422 {u'documentation_url': u'https://developer.github.com/v3/repos/#create', u'message': u'Repository creation failed.', u'errors': [{u'field': u'name', u'message': u'name already exists on this account', u'code': u'custom', u'resource': u'Repository'}]}
```
