### PR TITLE
Add Ansible for kernel_module_ipv6_option_disabled

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/ansible/shared.yml
@@ -1,0 +1,22 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+
+- name: Disable IPv6 Networking kernel module
+  lineinfile:
+    create: yes
+    dest: "/etc/modprobe.d/ipv6.conf"
+    regexp: "^options\\s+ipv6\\s+disable=\\d"
+    line: "options ipv6 disable=1"
+
+- name: Ensure disable_ipv6 (all and default) is set to 1
+  sysctl:
+    name: "{{ item }}"
+    value: "1"
+    state: present
+    reload: yes
+  with_items:
+    - "net.ipv6.conf.all.disable_ipv6"
+    - "net.ipv6.conf.default.disable_ipv6"

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_disabled.pass.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_disabled.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7
+
+echo "options ipv6 disable=1" > /etc/modprobe.d/ipv6.conf

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_enabled.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_enabled.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7
+
+echo "options ipv6 disable=0" > /etc/modprobe.d/ipv6.conf


### PR DESCRIPTION
#### Description:

- Add Ansible remediation for `kernel_module_ipv6_option_disabled` that closely follows behavior of Bash remediation.

#### Notes:
- The remediation of this rule also sets sysctl `disable_ipv6` to `1`, as some other module may be pulling in the module as a dependency.
  Reference: https://access.redhat.com/solutions/72733.

- The remediation does more than disabling only one kernel module, so it is not suitable for "templation" (use of templating system).
