### PR TITLE
Fix broken file update

### DIFF
--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -211,7 +211,7 @@ class Role(object):
         default_vars_remote_content = self.remote_repo.get_contents("defaults/main.yml")
         if default_vars_local_content != default_vars_remote_content.decoded_content:
             self.remote_repo.update_file(
-                "defaults/main.yml",
+                "/defaults/main.yml",
                 "Updates defaults/main.yml",
                 default_vars_local_content,
                 default_vars_remote_content.sha,
@@ -261,7 +261,7 @@ class Role(object):
 
         if self.tasks_local_content != tasks_remote_content.decoded_content:
             self.remote_repo.update_file(
-                "tasks/main.yml",
+                "/tasks/main.yml",
                 "Updates tasks/main.yml",
                 self.tasks_local_content,
                 tasks_remote_content.sha,
@@ -282,7 +282,7 @@ class Role(object):
         if vars_local_content != vars_remote_content.decoded_content and \
            vars_local_content.splitlines()[0] != "null":
             self.remote_repo.update_file(
-                "vars/main.yml",
+                "/vars/main.yml",
                 "Updates vars/main.yml",
                 vars_local_content,
                 vars_remote_content.sha,
@@ -326,7 +326,7 @@ class Role(object):
             print("Updating README.md in %s" % self.remote_repo.name)
 
             self.remote_repo.update_file(
-                "README.md",
+                "/README.md",
                 "Updates README.md",
                 local_readme_content,
                 remote_readme_file.sha,
@@ -370,7 +370,7 @@ class Role(object):
         if local_meta_content != remote_meta_file.decoded_content:
             print("Updating meta/main.yml in %s" % self.remote_repo.name)
             self.remote_repo.update_file(
-                "meta/main.yml",
+                "/meta/main.yml",
                 "Updates meta/main.yml",
                 local_meta_content,
                 remote_meta_file.sha,


### PR DESCRIPTION
With the conversation with @redhatrises, I learned that pyGithub has been changed. So, I think it is safe to assume that this change is implied by changes in the lib.

Addressing:
```
Traceback (most recent call last):
  File "utils/upload_ansible_roles_to_galaxy.py", line 533, in <module>
    main()
  File "utils/upload_ansible_roles_to_galaxy.py", line 523, in main
    Role(repo, playbook_full_path).update_repository(repo_status)
  File "utils/upload_ansible_roles_to_galaxy.py", line 403, in update_repository
    self._update_tasks_content_if_needed()
  File "utils/upload_ansible_roles_to_galaxy.py", line 271, in _update_tasks_content_if_needed
    GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
  File "/usr/lib/python2.9/site-packages/github/Repository.py", line 1510, in update_file
    input=put_parameters
  File "/usr/lib/python2.9/site-packages/github/Requester.py", line 185, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
  File "/usr/lib/python2.9/site-packages/github/Requester.py", line 198, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.UnknownObjectException: 404 {u'documentation_url': u'https://developer.github.com/v3', u'message': u'Not Found'}
https://api.github.com/repos/RedHatOfficial/ansible-role-rhel7-cui/contentstasks/main.yml
```
