### PR TITLE
Remove outdated OSPP metadata from test scenario for audit_rules_privileged_commands.

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_pci-dss
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # Remediation for this rule cannot remove the duplicates
 # remediation = none
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8


### PR DESCRIPTION
#### Description:

- Remove outdated profile metadata in test scenario for audit_rules_privileged_commands