### PR TITLE
Fix release documentation and fix generation of release notes

### DIFF
--- a/release_tools/README.adoc
+++ b/release_tools/README.adoc
@@ -21,13 +21,14 @@ authentication tokens for these services.
 * Your Jenkins user - your User ID is probably the same as your GitHub handle, to be sure,
   check your *profile page* in Jenkins.
 * A Jenkins token - generate a token on *Configure page* in Jenkins
-  While generating the token, make sure that your Jenkins user has build permissions in Jenkins.
 
 * Create `.env.yml` file in `release_tools` directory, to hold your tokens:
 +
    github_token: '<your github token here>'
    jenkins_user: '<you jenkins user ID>'
    jenkins_token: '<you jenkins token here>'
+
+Your Jenkins user needs to have a special permission to perform the build successfully. This permission is not granted automatically to all users. If you want to perform build and you don't have this permission, please contact one of link:https://github.com/orgs/ComplianceAsCode/teams/trusted-developers[trusted developers].
 
 [NOTE]
 ====

--- a/release_tools/README.adoc
+++ b/release_tools/README.adoc
@@ -1,6 +1,6 @@
 = How to perform a semi-automatic release =
 
-The scripts in this folder automates some processes of the release.
+The scripts in this folder automate some processes of the release.
 
 === Dependencies ===
 
@@ -21,24 +21,26 @@ authentication tokens for these services.
 * Your Jenkins user - your User ID is probably the same as your GitHub handle, to be sure,
   check your *profile page* in Jenkins.
 * A Jenkins token - generate a token on *Configure page* in Jenkins
+  While generating the token, make sure that your Jenkins user has build permissions in Jenkins.
 
-* Create `.env` file in `release_tools` directory, to hold your tokens:
+* Create `.env.yml` file in `release_tools` directory, to hold your tokens:
 +
-   GITHUB_TOKEN='<your github token here>'
-   JENKINS_USER='<you jenkins user ID>'
-   JENKINS_TOKEN='<you jenkins token here>'
+   github_token: '<your github token here>'
+   jenkins_user: '<you jenkins user ID>'
+   jenkins_token: '<you jenkins token here>'
 
 [NOTE]
 ====
 You can also use your own fork of the project to test and debug the release tools, define in `.env` file the owner and name of the repo to use.
 
-   OWNER="--owner <owner of repo>" # your github user name
-   REPO="--repo <name of repo>"    # your clone's repo name
+   owner: "--owner <owner of repo>" # your github user name
+   repo: "--repo <name of repo>"    # your clone's repo name
 
 ====
 
 === Before the release ===
 
+* Make sure that the `build` directory is empty
 * Make sure the version in `CMakeLists.txt` is correct, i.e.: the version corresponds to an unreleased version number.
 * Run `PYTHONPATH=. utils/generate_contributors.py` to update the contributors list.
 +
@@ -60,7 +62,7 @@ The script will verify the status of a few Jenkins jobs:
 * link:https://jenkins.complianceascode.io/job/scap-security-guide-scapval-scap-1.2/[SCAPVal 1.2]
 * link:https://jenkins.complianceascode.io/job/scap-security-guide-scapval-scap-1.3/[SCAPVal 1.3]
 * link:https://jenkins.complianceascode.io/job/scap-security-guide-nightly-zip/[Nightly zip]
-* https://jenkins.complianceascode.io/job/scap-security-guide-nightly-oval510-zip/[Nightly OVAl 5.10 zip]
+* link:https://jenkins.complianceascode.io/job/scap-security-guide-nightly-oval510-zip/[Nightly OVAl 5.10 zip]
 
 Although these jobs probably have run against `master`, they are a good indicator of problems in the project.
 

--- a/release_tools/content_gh.py
+++ b/release_tools/content_gh.py
@@ -101,7 +101,9 @@ def generate_release_notes(repo, args):
         for changed_file in changed_files:
             changed_filename = changed_file.filename
 
-            if ".profile" in changed_filename:
+            # do not include files from profile_stability folder
+            # they are part of testing mechanisms
+            if ".profile" in changed_filename and "profile_stability" not in changed_filename:
                 # Track changes to product:profile
                 profile_match = re.match(r"(\w+)/profiles/([\w-]+).profile", changed_filename)
                 product, profile = profile_match.groups()


### PR DESCRIPTION
#### Description:

Fix wrong or not exact parts of release documentation.
During generation of release notes, files ending in ..rofile within profile_stability folder are skipped.

#### Rationale:

The  release documentation was not exact.
If there were any changes done to profile files within profile_stability folder, they caused an exception during generation of release notes.