### PR TITLE
Refactor & clean-up & tidy-up the ansible roles generator

### DIFF
--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -139,7 +139,6 @@ class PlaybookToRoleConverter():
 
         self.role_data = ssg.yaml.ordered_load(filedata)
         self.default_vars_data = self.role_data[0]["vars"] if "vars" in self.role_data[0] else []
-        self.tasks_data = self.role_data[0]["tasks"] if "tasks" in self.role_data[0] else []
         self.added_variables = set()
 
         # ansible language doesn't allow pre_tasks for roles, if the only pre task
@@ -183,6 +182,11 @@ class PlaybookToRoleConverter():
         root, _ = os.path.splitext(os.path.basename(self._local_playbook_filename))
         product, _, profile = root.split("-", 2)
         return "%s_%s" % (product, profile.replace("-", "_"))
+
+    @property
+    @memoize
+    def tasks_data(self):
+        return self.role_data[0]["tasks"] if "tasks" in self.role_data[0] else []
 
     def _reformat_local_content(self):
         description = ""

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -314,7 +314,7 @@ class RoleGithubUpdater(object):
         new_content = self.role.file(filepath)
 
         if filepath == 'README.md':
-            remote_readme_file = self._remote_content("README.md")
+            remote_readme_file, _ = self._remote_content("README.md")
             if not remote_readme_file:
                 return new_content
 
@@ -325,7 +325,7 @@ class RoleGithubUpdater(object):
                           "%s.%s" % (ORGANIZATION_NAME, self.role.name),
                           local_readme_content)
         elif filepath == 'meta/main.yml':
-            remote_meta_file = self._remote_content(filepath)
+            remote_meta_file, _ = self._remote_content(filepath)
             if not remote_meta_file:
                 return new_content
 
@@ -353,20 +353,21 @@ class RoleGithubUpdater(object):
         return new_content
 
     def _remote_content(self, filepath):
-        content = self.remote_repo.get_contents(filepath).decoded_content
+        remote = self.remote_repo.get_contents(filepath)
+        content = remote.decoded_content
         if filepath == 'README.md':
-            content =  content.decode("utf-8")
-        return content
+            content = content.decode("utf-8")
+        return content, remote.sha
 
     def _update_content_if_needed(self, filepath):
-        remote_content = self._remote_content(filepath)
+        remote_content, sha = self._remote_content(filepath)
 
         if self._local_content(filepath) != remote_content:
             self.remote_repo.update_file(
                 "/" + filepath,
                 "Updates " + filepath,
                 self._local_content(filepath),
-                remote_content.sha,
+                sha,
                 author=InputGitAuthor(
                     GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
             )

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -160,11 +160,6 @@ class PlaybookToRoleConverter():
         self.description = description
         self._add_variables_to_tasks()
 
-        self.tasks_local_content = yaml.dump(
-            self.tasks_data, width=120, default_flow_style=False)
-        # Add \n in between tasks to increase readability
-        self.tasks_local_content = self.tasks_local_content.replace('\n- ', '\n\n- ')
-
         self._reformat_local_content()
         try:
             self.title = re.search(
@@ -187,6 +182,12 @@ class PlaybookToRoleConverter():
     @memoize
     def tasks_data(self):
         return self.role_data[0]["tasks"] if "tasks" in self.role_data[0] else []
+
+    @property
+    @memoize
+    def tasks_local_content(self):
+        return yaml.dump(self.tasks_data, width=120, default_flow_style=False) \
+            .replace('\n- ', '\n\n- ')
 
     def _reformat_local_content(self):
         description = ""

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -347,7 +347,7 @@ class Role(object):
         local_meta_content = local_meta_content.replace("@DESCRIPTION@", self.title)
         return local_meta_content.replace("@MIN_ANSIBLE_VERSION@", ssg.ansible.min_ansible_version)
 
-    def update_repository(self, repo_status):
+    def update_repository(self):
         print("Processing %s..." % self.remote_repo.name)
 
         self.gather_data()
@@ -476,16 +476,11 @@ def main():
 
     # Update repositories
     for repo in sorted(github_org.get_repos(), key=lambda repo: repo.name):
-        if repo.name in github_new_repos:
-            repo_status = "new"
-        else:
-            repo_status = "update"
-
         if repo.name in selected_roles:
             playbook_filename = "%s-playbook-%s.yml" % selected_roles[repo.name]
             playbook_full_path = os.path.join(
                 args.build_playbooks_dir, playbook_filename)
-            Role(repo, playbook_full_path).update_repository(repo_status)
+            Role(repo, playbook_full_path).update_repository()
             if args.tag_release:
                 update_repo_release(github, repo)
         elif repo.name not in potential_roles:

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -150,6 +150,11 @@ class PlaybookToRoleConverter():
         self.description = description
         self._add_variables_to_tasks()
 
+        self.tasks_local_content = yaml.dump(
+            self.tasks_data, width=120, default_flow_style=False)
+        # Add \n in between tasks to increase readability
+        self.tasks_local_content = self.tasks_local_content.replace('\n- ', '\n\n- ')
+
     def _get_description_from_filedata(self, filedata):
         separator = "#" * 79
         offset_from_separator = 3
@@ -198,17 +203,12 @@ class Role(object):
         self.tasks_data = self.role.tasks_data
         self.added_variables = self.role.added_variables
 
-        self.tasks_local_content = None
-
         self.description = self.role.description
         self.title = None
         self.role_name = None
         self._init()
 
     def _init(self):
-        self.tasks_local_content = yaml.dump(
-            self.tasks_data, width=120, default_flow_style=False)
-
         self._reformat_local_content()
         try:
             self.title = re.search(
@@ -222,8 +222,6 @@ class Role(object):
 
     def _reformat_local_content(self):
         description = ""
-        # Add \n in between tasks to increase readability
-        self.tasks_local_content = self.tasks_local_content.replace('\n- ', '\n\n- ')
 
         self.description = self.description.replace('# ', '')
         self.description = self.description.replace('#', '')
@@ -243,7 +241,7 @@ class Role(object):
 
     def _local_content(self, filepath):
         if filepath == 'tasks/main.yml':
-            return self.tasks_local_content
+            return self.role.tasks_local_content
         elif filepath == 'vars/main.yml':
             if len(self.vars_data) < 1:
                 return "---\n# defaults file for {role_name}\n".format(role_name=self.role_name)

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -132,6 +132,9 @@ def update_repo_release(github, repo):
 
 
 class PlaybookToRoleConverter():
+    PRODUCED_FILES = ('defaults/main.yml', 'meta/main.yml', 'tasks/main.yml', 'vars/main.yml',
+                      'README.md')
+
     def __init__(self, local_playbook_filename):
         self._local_playbook_filename = local_playbook_filename
 
@@ -363,7 +366,7 @@ class Role(object):
     def update_repository(self):
         print("Processing %s..." % self.remote_repo.name)
 
-        for path in ('defaults/main.yml', 'meta/main.yml', 'tasks/main.yml', 'vars/main.yml', 'README.md'):
+        for path in PlaybookToRoleConverter.PRODUCED_FILES:
             self._update_content_if_needed(path)
 
         repo_description = (

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -134,10 +134,8 @@ def update_repo_release(github, repo):
 class PlaybookToRoleConverter():
     def __init__(self, local_playbook_filename):
         self._local_playbook_filename = local_playbook_filename
-        with io.open(local_playbook_filename, 'r', encoding="utf-8") as f:
-            filedata = f.read()
 
-        self.role_data = ssg.yaml.ordered_load(filedata)
+        self.role_data = ssg.yaml.ordered_load(self._raw_playbook)
         self.default_vars_data = self.role_data[0]["vars"] if "vars" in self.role_data[0] else []
         self.added_variables = set()
 
@@ -156,7 +154,7 @@ class PlaybookToRoleConverter():
                     "pre_tasks are not supported for ansible roles and "
                     "will be skipped!.\n")
 
-        description = self._get_description_from_filedata(filedata)
+        description = self._get_description_from_filedata(self._raw_playbook)
         self.description = description
         self._add_variables_to_tasks()
         self._reformat_local_content()
@@ -195,6 +193,12 @@ class PlaybookToRoleConverter():
 
         # Fix the description format for markdown so that it looks pretty
         return description.replace('\n', '  \n')
+
+    @property
+    @memoize
+    def _raw_playbook(self):
+        with io.open(self._local_playbook_filename, 'r', encoding="utf-8") as f:
+            return f.read()
 
     def _reformat_local_content(self):
         description = ""

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -256,19 +256,23 @@ class Role(object):
 
         return description
 
-    def _update_tasks_content_if_needed(self):
-        tasks_remote_content = self.remote_repo.get_contents("tasks/main.yml")
+    def _local_content(self, filepath):
+        if filepath == 'tasks/main.yml':
+            return self.tasks_local_content
 
-        if self.tasks_local_content != tasks_remote_content.decoded_content:
+    def _update_content_if_needed(self, filepath):
+        remote_content = self.remote_repo.get_contents(filepath)
+
+        if self._local_content(filepath) != remote_content.decoded_content:
             self.remote_repo.update_file(
-                "/tasks/main.yml",
-                "Updates tasks/main.yml",
-                self.tasks_local_content,
-                tasks_remote_content.sha,
+                "/" + filepath,
+                "Updates " + filepath,
+                self._local_content(filepath),
+                remote_content.sha,
                 author=InputGitAuthor(
                     GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
             )
-            print("Updating tasks/main.yml in %s" % self.remote_repo.name)
+            print("Updating %s in %s" % (filepath, self.remote_repo.name))
 
     def _update_vars_content_if_needed(self):
         if len(self.vars_data) < 1:
@@ -398,7 +402,7 @@ class Role(object):
         # Fix the description format for markdown so that it looks pretty
         self.description = self.description.replace('\n', '  \n')
 
-        self._update_tasks_content_if_needed()
+        self._update_content_if_needed('tasks/main.yml')
         self._update_vars_content_if_needed()
         self._update_readme_content_if_needed(repo_status)
         self._update_meta_content_if_needed(repo_status)

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -135,14 +135,13 @@ class PlaybookToRoleConverter():
     def __init__(self, local_playbook_filename):
         self._local_playbook_filename = local_playbook_filename
 
-        self.role_data = ssg.yaml.ordered_load(self._raw_playbook)
         self.added_variables = set()
 
         # ansible language doesn't allow pre_tasks for roles, if the only pre task
         # is the ansible version check we can ignore it because the minimal version
         # is in role metadata
-        if "pre_tasks" in self.role_data[0]:
-            pre_tasks_data = self.role_data[0]["pre_tasks"]
+        if "pre_tasks" in self._playbook[0]:
+            pre_tasks_data = self._playbook[0]["pre_tasks"]
             if len(pre_tasks_data) == 1 and \
                     pre_tasks_data[0]["name"] == \
                     ssg.ansible.ansible_version_requirement_pre_task_name:
@@ -164,7 +163,7 @@ class PlaybookToRoleConverter():
     @property
     @memoize
     def tasks_data(self):
-        return self.role_data[0]["tasks"] if "tasks" in self.role_data[0] else []
+        return self._playbook[0]["tasks"] if "tasks" in self._playbook[0] else []
 
     @property
     @memoize
@@ -175,7 +174,7 @@ class PlaybookToRoleConverter():
     @property
     @memoize
     def default_vars_data(self):
-        return self.role_data[0]["vars"] if "vars" in self.role_data[0] else []
+        return self._playbook[0]["vars"] if "vars" in self._playbook[0] else []
 
     @property
     @memoize
@@ -194,6 +193,11 @@ class PlaybookToRoleConverter():
 
         # Fix the description format for markdown so that it looks pretty
         return description.replace('\n', '  \n')
+
+    @property
+    @memoize
+    def _playbook(self):
+        return ssg.yaml.ordered_load(self._raw_playbook)
 
     @property
     @memoize

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -229,7 +229,14 @@ class PlaybookToRoleConverter():
     @property
     @memoize
     def _description(self):
-        description = self._get_description_from_filedata(self._raw_playbook)
+        separator = "#" * 79
+        offset_from_separator = 3
+        first_separator_pos = self._raw_playbook.find(separator)
+        second_separator_pos = self._raw_playbook.find(separator,
+                                                       first_separator_pos + len(separator))
+        description_start = first_separator_pos + len(separator) + offset_from_separator
+        description_stop = second_separator_pos - offset_from_separator
+        description = self._raw_playbook[description_start:description_stop]
         description = description.replace('# ', '')
         description = description.replace('#', '')
 
@@ -241,19 +248,6 @@ class PlaybookToRoleConverter():
             else:
                 desc += (line + "\n")
         return desc.strip("\n\n")
-
-    def _get_description_from_filedata(self, filedata):
-        separator = "#" * 79
-        offset_from_separator = 3
-
-        first_separator_pos = filedata.find(
-            separator)
-        second_separator_pos = filedata.find(
-            separator, first_separator_pos + len(separator))
-
-        description_start = first_separator_pos + len(separator) + offset_from_separator
-        description_stop = second_separator_pos - offset_from_separator
-        return filedata[description_start:description_stop]
 
     def _tag_is_valid_variable(self, tag):
         return '-' not in tag and tag != 'always'

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -136,7 +136,6 @@ class PlaybookToRoleConverter():
         self._local_playbook_filename = local_playbook_filename
 
         self.role_data = ssg.yaml.ordered_load(self._raw_playbook)
-        self.default_vars_data = self.role_data[0]["vars"] if "vars" in self.role_data[0] else []
         self.added_variables = set()
 
         # ansible language doesn't allow pre_tasks for roles, if the only pre task
@@ -172,6 +171,11 @@ class PlaybookToRoleConverter():
     def tasks_local_content(self):
         return yaml.dump(self.tasks_data, width=120, default_flow_style=False) \
             .replace('\n- ', '\n\n- ')
+
+    @property
+    @memoize
+    def default_vars_data(self):
+        return self.role_data[0]["vars"] if "vars" in self.role_data[0] else []
 
     @property
     @memoize
@@ -256,7 +260,6 @@ class Role(object):
         self.local_playbook_filename = local_playbook_filename
 
         self.vars_data = []
-        self.default_vars_data = self.role.default_vars_data
         self.added_variables = self.role.added_variables
 
         self.title = self.role.title
@@ -353,7 +356,7 @@ class Role(object):
 
     def _generate_defaults_content(self):
         default_vars_to_add = sorted(self.added_variables)
-        default_vars_local_content = yaml.dump(self.default_vars_data, width=120, indent=4,
+        default_vars_local_content = yaml.dump(self.role.default_vars_data, width=120, indent=4,
                                                default_flow_style=False)
         header = [
             "---", "# defaults file for {role_name}\n".format(role_name=self.role.name),

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -183,11 +183,7 @@ class PlaybookToRoleConverter():
         self.added_variables.update(variables_to_add)
 
     def _tag_is_valid_variable(self, tag):
-        if "-" in tag:
-            return False
-        if tag == "always":
-            return False
-        return True
+        return '-' not in tag and tag != 'always'
 
 
 class Role(object):

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -241,10 +241,8 @@ class Role(object):
         self.role = PlaybookToRoleConverter(local_playbook_filename)
         self.local_playbook_filename = local_playbook_filename
 
-        self.role_data = self.role.role_data
         self.vars_data = []
         self.default_vars_data = self.role.default_vars_data
-        self.tasks_data = self.role.tasks_data
         self.added_variables = self.role.added_variables
 
         self.description = self.role.description

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -256,7 +256,7 @@ class PlaybookToRoleConverter():
         return '-' not in tag and tag != 'always'
 
 
-class Role(object):
+class RoleGithubUpdater(object):
     def __init__(self, repo, local_playbook_filename):
         self.remote_repo = repo
         self.role = PlaybookToRoleConverter(local_playbook_filename)
@@ -478,7 +478,7 @@ def main():
             playbook_filename = "%s-playbook-%s.yml" % selected_roles[repo.name]
             playbook_full_path = os.path.join(
                 args.build_playbooks_dir, playbook_filename)
-            Role(repo, playbook_full_path).update_repository()
+            RoleGithubUpdater(repo, playbook_full_path).update_repository()
             if args.tag_release:
                 update_repo_release(github, repo)
         elif repo.name not in potential_roles:

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -265,11 +265,28 @@ class Role(object):
             else:
                  return yaml.dump(self.vars_data, width=120, indent=4,
                                   default_flow_style=False)
+        elif filepath == 'README.md':
+            remote_readme_file = self._remote_content("README.md")
+            if not remote_readme_file:
+                return self._generate_readme_content()
+
+            local_readme_content = re.sub(r'Ansible version (\d*\.\d+|\d+)',
+                                          "Ansible version %s" % ssg.ansible.min_ansible_version,
+                                          remote_readme_file)
+            return re.sub(r'%s\.[a-zA-Z0-9\-_]+' % ORGANIZATION_NAME,
+                          "%s.%s" % (ORGANIZATION_NAME, self.role_name),
+                          local_readme_content)
+
+    def _remote_content(self, filepath):
+        content = self.remote_repo.get_contents(filepath).decoded_content
+        if filepath == 'README.md':
+            content =  content.decode("utf-8")
+        return content
 
     def _update_content_if_needed(self, filepath):
-        remote_content = self.remote_repo.get_contents(filepath)
+        remote_content = self._remote_content(filepath)
 
-        if self._local_content(filepath) != remote_content.decoded_content:
+        if self._local_content(filepath) != remote_content:
             self.remote_repo.update_file(
                 "/" + filepath,
                 "Updates " + filepath,
@@ -296,31 +313,6 @@ class Role(object):
         local_readme_content = local_readme_content.replace(
             "@ROLE_NAME@", self.role_name)
         return local_readme_content
-
-    def _update_readme_content_if_needed(self, repo_status):
-        local_readme_content = self._generate_readme_content()
-        remote_readme_file = self.remote_repo.get_contents("README.md")
-
-        if repo_status == "update":
-            local_readme_content = remote_readme_file.decoded_content.decode("utf-8")
-            local_readme_content = re.sub(r'Ansible version (\d*\.\d+|\d+)',
-                                          "Ansible version %s" % ssg.ansible.min_ansible_version,
-                                          local_readme_content)
-            local_readme_content = re.sub(r'%s\.[a-zA-Z0-9\-_]+' % ORGANIZATION_NAME,
-                                          "%s.%s" % (ORGANIZATION_NAME, self.role_name),
-                                          local_readme_content)
-
-        if local_readme_content != remote_readme_file.decoded_content.decode("utf-8"):
-            print("Updating README.md in %s" % self.remote_repo.name)
-
-            self.remote_repo.update_file(
-                "/README.md",
-                "Updates README.md",
-                local_readme_content,
-                remote_readme_file.sha,
-                author=InputGitAuthor(
-                    GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_AUTHOR_EMAIL)
-            )
 
     def _update_meta_content_if_needed(self, repo_status):
         remote_meta_file = self.remote_repo.get_contents("meta/main.yml")
@@ -386,9 +378,8 @@ class Role(object):
         # Fix the description format for markdown so that it looks pretty
         self.description = self.description.replace('\n', '  \n')
 
-        for path in ('tasks/main.yml', 'vars/main.yml'):
+        for path in ('tasks/main.yml', 'vars/main.yml', 'README.md'):
             self._update_content_if_needed(path)
-        self._update_readme_content_if_needed(repo_status)
         self._update_meta_content_if_needed(repo_status)
         self.add_task_variables_to_default_variables_if_needed()
 

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -172,7 +172,6 @@ class Role(object):
         self.vars_data = []
         self.default_vars_data = self.role.default_vars_data
         self.tasks_data = self.role.tasks_data
-        self.pre_tasks_data = []
         self.added_variables = set()
 
         self.tasks_local_content = None

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -159,14 +159,7 @@ class PlaybookToRoleConverter():
         description = self._get_description_from_filedata(filedata)
         self.description = description
         self._add_variables_to_tasks()
-
         self._reformat_local_content()
-        try:
-            self.title = re.search(
-                r'Profile Title:\s+(.+)$', self.description, re.MULTILINE).group(1)
-        except AttributeError:
-            self.title = re.search(
-                r'Ansible Playbook for\s+(.+)$', self.description, re.MULTILINE).group(1)
 
     @property
     @memoize
@@ -185,6 +178,14 @@ class PlaybookToRoleConverter():
     def tasks_local_content(self):
         return yaml.dump(self.tasks_data, width=120, default_flow_style=False) \
             .replace('\n- ', '\n\n- ')
+
+    @property
+    @memoize
+    def title(self):
+        try:
+            return re.search(r'Profile Title:\s+(.+)$', self.description, re.MULTILINE).group(1)
+        except AttributeError:
+            return re.search(r'Ansible Playbook for\s+(.+)$', self.description, re.MULTILINE).group(1)
 
     @property
     @memoize

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -138,6 +138,24 @@ class Role(object):
         self.description = None
         self.title = None
         self.role_name = None
+        self._init()
+
+    def _init(self):
+        self.gather_data()
+        self.add_variables_to_tasks()
+        self.tasks_local_content = yaml.dump(
+            self.tasks_data, width=120, default_flow_style=False)
+
+        self._reformat_local_content()
+        try:
+            self.title = re.search(
+                r'Profile Title:\s+(.+)$', self.description, re.MULTILINE).group(1)
+        except AttributeError:
+            self.title = re.search(
+                r'Ansible Playbook for\s+(.+)$', self.description, re.MULTILINE).group(1)
+
+        # Fix the description format for markdown so that it looks pretty
+        self.description = self.description.replace('\n', '  \n')
 
     def gather_data(self):
         with io.open(self.local_playbook_filename, 'r', encoding="utf-8") as f:
@@ -337,23 +355,6 @@ class Role(object):
 
     def update_repository(self):
         print("Processing %s..." % self.remote_repo.name)
-
-        self.gather_data()
-
-        self.add_variables_to_tasks()
-        self.tasks_local_content = yaml.dump(
-            self.tasks_data, width=120, default_flow_style=False)
-
-        self._reformat_local_content()
-        try:
-            self.title = re.search(
-                r'Profile Title:\s+(.+)$', self.description, re.MULTILINE).group(1)
-        except AttributeError:
-            self.title = re.search(
-                r'Ansible Playbook for\s+(.+)$', self.description, re.MULTILINE).group(1)
-
-        # Fix the description format for markdown so that it looks pretty
-        self.description = self.description.replace('\n', '  \n')
 
         for path in ('defaults/main.yml', 'meta/main.yml', 'tasks/main.yml', 'vars/main.yml', 'README.md'):
             self._update_content_if_needed(path)

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -168,9 +168,6 @@ class PlaybookToRoleConverter():
             self.title = re.search(
                 r'Ansible Playbook for\s+(.+)$', self.description, re.MULTILINE).group(1)
 
-        # Fix the description format for markdown so that it looks pretty
-        self.description = self.description.replace('\n', '  \n')
-
     @property
     @memoize
     def name(self):
@@ -188,6 +185,15 @@ class PlaybookToRoleConverter():
     def tasks_local_content(self):
         return yaml.dump(self.tasks_data, width=120, default_flow_style=False) \
             .replace('\n- ', '\n\n- ')
+
+    @property
+    @memoize
+    def description_md(self):
+        # This is for a role and not a playbook
+        description = re.sub(r'Playbook', "Role", self.description)
+
+        # Fix the description format for markdown so that it looks pretty
+        return description.replace('\n', '  \n')
 
     def _reformat_local_content(self):
         description = ""
@@ -250,7 +256,6 @@ class Role(object):
         self.default_vars_data = self.role.default_vars_data
         self.added_variables = self.role.added_variables
 
-        self.description = self.role.description
         self.title = self.role.title
 
     def _local_content(self, filepath):
@@ -325,11 +330,8 @@ class Role(object):
         with io.open(README_TEMPLATE_PATH, 'r',  encoding="utf-8") as f:
             readme_template = f.read()
 
-        # This is for a role and not a playbook
-        self.description = re.sub(r'Playbook', "Role", self.description)
-
         local_readme_content = readme_template.replace(
-            "@DESCRIPTION@", self.description)
+            "@DESCRIPTION@", self.description_md)
         local_readme_content = local_readme_content.replace(
             "@TITLE@", self.title)
         local_readme_content = local_readme_content.replace(

--- a/utils/upload_ansible_roles_to_galaxy.py
+++ b/utils/upload_ansible_roles_to_galaxy.py
@@ -154,9 +154,6 @@ class Role(object):
             self.title = re.search(
                 r'Ansible Playbook for\s+(.+)$', self.description, re.MULTILINE).group(1)
 
-        # Fix the description format for markdown so that it looks pretty
-        self.description = self.description.replace('\n', '  \n')
-
     def gather_data(self):
         with io.open(self.local_playbook_filename, 'r', encoding="utf-8") as f:
             filedata = f.read()
@@ -184,7 +181,8 @@ class Role(object):
                     "will be skipped!.\n")
 
         description = self.get_description_from_filedata(filedata)
-        self.description = description
+        # Fix the description format for markdown so that it looks pretty
+        self.description = description.replace('\n', '  \n')
 
     def add_variables_to_tasks(self):
         for task in self.tasks_data:


### PR DESCRIPTION
These changes have no functional effect. It is only rewiring of the script to be more easily comprehended by humans.

 * split monster spaghetti class to two shorter ones, split is done to avoid feature creep, generation of ansible role is separated from github update logic
 * make code more declarative and thus easier to read and assess what is what