### PR TITLE
OCP4: Add remediation equality unit tests

### DIFF
--- a/tests/unit/kubernetes/Makefile
+++ b/tests/unit/kubernetes/Makefile
@@ -1,6 +1,7 @@
 PROFILE?=
 CONTENT_IMAGE?=
 export ROOT_DIR=$(shell git rev-parse --show-toplevel)
+export GOFLAGS=-mod=vendor
 TEST_DIR=$(ROOT_DIR)/tests/unit/kubernetes
 TEST_FLAGS?=-v
 

--- a/tests/unit/kubernetes/Makefile
+++ b/tests/unit/kubernetes/Makefile
@@ -3,7 +3,7 @@ CONTENT_IMAGE?=
 export ROOT_DIR=$(shell git rev-parse --show-toplevel)
 export GOFLAGS=-mod=vendor
 TEST_DIR=$(ROOT_DIR)/tests/unit/kubernetes
-TEST_FLAGS?=-v
+TEST_FLAGS?=-v -count=1
 
 .PHONY: all
 all: unit

--- a/tests/unit/kubernetes/go.mod
+++ b/tests/unit/kubernetes/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 // indirect
-	github.com/coreos/ignition v0.35.0 // indirect
+	github.com/coreos/ignition v0.35.0
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50 // indirect

--- a/tests/unit/kubernetes/unit_test.go
+++ b/tests/unit/kubernetes/unit_test.go
@@ -7,11 +7,15 @@ import (
 func TestUnit(t *testing.T) {
 	ctx := newUnitTestContext(t)
 	t.Run("Verify kubernetes files are correct", func(t *testing.T) {
+		filesTouchedByMCs := make(map[string]fileTracker)
 		ctx.assertWithRelevantContentFiles(func(path string) {
 			obj := ctx.assertObjectIsValid(path)
 
 			if isMachineConfig(obj) {
-				ctx.assertMachineConfigIsValid(obj, path)
+				mcfg := ctx.assertMachineConfigIsValid(obj, path)
+				if mcfgChangesFile(mcfg, ctx.t) {
+					ctx.assertFileDoesntDiffer(mcfg, path, filesTouchedByMCs)
+				}
 			}
 		})
 	})

--- a/tests/unit/kubernetes/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go
+++ b/tests/unit/kubernetes/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go
@@ -30,8 +30,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -45,8 +45,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -82,8 +82,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {


### PR DESCRIPTION
The tests check that remediations don't change files in inconsistent ways. This way we can keep a golden configuration for a specific service, and so remediations will work in the way that machine-config-operator expects.