### PR TITLE
Fix incomplete temporary file

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -275,6 +275,7 @@ def datastream_in_stash(current_location):
     tfile = tempfile.NamedTemporaryFile(prefix="ssgts-ds-")
 
     tfile.write(open(current_location, "rb").read())
+    tfile.flush()
     yield tfile.name
 
 


### PR DESCRIPTION
Ensure all the data has been written before reusing the temporary
file. Occurred with Python 2 only.

Fixes: #5730
