### PR TITLE
Flush the write buffers after write.

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -275,6 +275,8 @@ def datastream_in_stash(current_location):
     tfile = tempfile.NamedTemporaryFile(prefix="ssgts-ds-")
 
     tfile.write(open(current_location, "rb").read())
+    # We don't want to close the file right away, as close => delete
+    tfile.flush()
     yield tfile.name
 
 


### PR DESCRIPTION
Flushing doesn't seem to be needed in Python3, but the code doesn't always work for Python2.
Closing the temp file makes it deleted, so that's why flushing is used instead.

Fixes: #5730