### PR TITLE
Ansible template mount options: avoid duplicating options and extend system default when appropriate

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1574,7 +1574,7 @@ mount_option::
 ** *mountoption* - mount option, eg. `nosuid`
 ** *filesystem* - filesystem in `/etc/fstab`, eg. `tmpfs`. Used only in Bash remediation.
 ** *type* - filesystem type. Used only in Bash remediation.
-** *mount_has_to_exist* - Used only in Bash remediation. Specifies if the *mountpoint* entry has to exist in `/etc/fstab` before the remediation is executed. If set to `yes` and the *mountpoint* entry is not present in `/etc/fstab` the Bash remediation terminates. If set to `no` the *mountpoint* entry will be created in `/etc/fstab`.
+** *mount_has_to_exist* - Specifies if the *mountpoint* entry has to exist in `/etc/fstab` before the remediation is executed. If set to `yes` and the *mountpoint* entry is not present in `/etc/fstab` the Bash remediation terminates. If set to `no` the *mountpoint* entry will be created in `/etc/fstab`.
 * Languages: Anaconda, Ansible, Bash, OVAL
 
 mount_option_remote_filesystems::

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/entry_in_fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/entry_in_fstab.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "tmpfs /dev/shm tmpfs rw,seclabel,nodev,nosuid 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/multiple_entries_in_mtab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/multiple_entries_in_mtab.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cat /etc/mtab > /etc/mtab.old
 # destroy symlink

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/no_entry_in_fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/no_entry_in_fstab.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# make sure there is no entry for /dev/shm
+sed -i '/\/dev\/shm/d' /etc/fstab

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -3,21 +3,18 @@
 # strategy = configure
 # complexity = low
 # disruption = high
-- name: Check fstab information associated to mountpoint
-  command: findmnt --fstab '{{{ MOUNTPOINT }}}'
-  register: device_name
-  failed_when: device_name.rc > 1
-  changed_when: False
 
 {{% if MOUNT_HAS_TO_EXIST == "no" %}}
-- name: Check mtab information associated to mountpoint
-  command: findmnt --mtab '{{{ MOUNTPOINT }}}'
+   {{% set TABFILE="" %}}
+{{% else %}}
+   {{% set TABFILE="--fstab" %}}
+{{% endif %}}
+
+- name: Check information associated to mountpoint
+  command: findmnt {{{ TABFILE }}} '{{{ MOUNTPOINT }}}'
   register: device_name
   failed_when: device_name.rc > 1
   changed_when: False
-  when:
-    - device_name.stdout is defined and device_name.stdout == ""
-{{% endif %}}
 
 - name: Create mount_info dictionary variable
   set_fact:

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -27,5 +27,6 @@
     state: "mounted"
     fstype: "{{ mount_info.fstype }}"
   when:
+    - mount_info is defined and "{{{ MOUNTOPTION }}}" not in mount_info.options
     - device_name.stdout is defined
     - (device_name.stdout | length > 0)

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -3,7 +3,7 @@
 # strategy = configure
 # complexity = low
 # disruption = high
-- name: get back mount information associated to mountpoint
+- name: Check fstab information associated to mountpoint
   command: findmnt --fstab '{{{ MOUNTPOINT }}}'
   register: device_name
   failed_when: device_name.rc > 1
@@ -19,7 +19,7 @@
     - device_name.stdout is defined and device_name.stdout == ""
 {{% endif %}}
 
-- name: create mount_info dictionary variable
+- name: Create mount_info dictionary variable
   set_fact:
     mount_info: "{{ mount_info|default({})|combine({item.0: item.1}) }}"
   with_together:

--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -9,6 +9,16 @@
   failed_when: device_name.rc > 1
   changed_when: False
 
+{{% if MOUNT_HAS_TO_EXIST == "no" %}}
+- name: Check mtab information associated to mountpoint
+  command: findmnt --mtab '{{{ MOUNTPOINT }}}'
+  register: device_name
+  failed_when: device_name.rc > 1
+  changed_when: False
+  when:
+    - device_name.stdout is defined and device_name.stdout == ""
+{{% endif %}}
+
 - name: create mount_info dictionary variable
   set_fact:
     mount_info: "{{ mount_info|default({})|combine({item.0: item.1}) }}"


### PR DESCRIPTION
#### Description:

- Fix Ansible template for mount options:
  - Do not duplicate mount options
  - When appropriate, extend mount options from `mtab`

#### Rationale:
- Fixes remediation failures in rule `mount_option_dev_shm_noexec`
- Inspired by #4335
