### PR TITLE
Add Ansible for ensure_logrotate_activated

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -1,0 +1,33 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+- name: Configure daily log rotation in /etc/logrotate.conf
+  lineinfile:
+    create: yes
+    dest: "/etc/logrotate.conf"
+    regexp: "^daily$"
+    line: "daily"
+
+- name: Make sure daily log rotation setting is not overriden in /etc/logrotate.conf
+  lineinfile:
+    create: no
+    dest: "/etc/logrotate.conf"
+    regexp: "^(weekly|monthly|yearly)$"
+    state: absent
+
+- name: Configure cron.daily if not already
+  block:
+    - name: Add shebang
+      lineinfile:
+        path: "/etc/cron.daily/logrotate"
+        line: "#!/bin/sh"
+        insertbefore: BOF
+        create: yes
+    - name: Add logrotate call
+      lineinfile:
+        path: "/etc/cron.daily/logrotate"
+        line: '/usr/sbin/logrotate /etc/logrotate.conf'
+        regexp: '^[\s]*/usr/sbin/logrotate[\s\S]*/etc/logrotate.conf$'

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_extra_monthly.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_extra_monthly.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i "s/weekly/daily/g" /etc/logrotate.conf
+echo "monthly" >> /etc/logrotate.conf


### PR DESCRIPTION
#### Description:

- Just adds Ansible remediation mimicing bash behavior

#### Notes:
- This doesn't make use of Ansible `cron` module because it doesn't play well with default `/etc/cron.daily/logrotate`. Ansible adds its own managed line into the file.
