### PR TITLE
Warn about findings from rpm_verify_permissions and rpm_verify_ownership

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
@@ -58,8 +58,10 @@ ocil: |-
     is expected by the RPM database:
     <pre>$ rpm -Va | rpm -Va --nofiledigest | awk '{ if (substr($0,6,1)=="U" || substr($0,7,1)=="G") print $NF }'</pre>
 
-{{% if product == "rhel6" %}}
 warnings:
+    - general: |-
+        Profiles may require that specific files be owned by root while the default owner defined by the vendor is different. Such files will be reported as a finding and need to be evaluated according to your policy and deployment environment.
+{{% if product == "rhel6" %}}
     - general: |-
         <b>Note: Due to a bug in the <tt>gdm</tt> package,
         the RPM verify command may continue to fail even after file permissions have

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
@@ -60,7 +60,10 @@ ocil: |-
 
 warnings:
     - general: |-
-        Profiles may require that specific files be owned by root while the default owner defined by the vendor is different. Such files will be reported as a finding and need to be evaluated according to your policy and deployment environment.
+        Profiles may require that specific files be owned by root while the default owner defined
+        by the vendor is different.
+        Such files will be reported as a finding and need to be evaluated according to your policy
+        and deployment environment.
 {{% if product == "rhel6" %}}
     - general: |-
         <b>Note: Due to a bug in the <tt>gdm</tt> package,

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -69,7 +69,10 @@ ocil: |-
 
 warnings:
     - general: |-
-        Profiles may require that specific files have stricter file permissions than defined by the vendor. Such files will be reported as a finding and need to be evaluated according to your policy and deployment environment.
+        Profiles may require that specific files have stricter file permissions than defined by the
+        vendor.
+        Such files will be reported as a finding and need to be evaluated according to your policy
+        and deployment environment.
 {{% if product == "rhel6" %}}
     - general: |-
         <b>Note: Due to a bug in the <tt>gdm</tt> package,

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -67,8 +67,10 @@ ocil: |-
     is expected by the RPM database:
     <pre>$ rpm -Va | awk '{ if (substr($0,2,1)=="M") print $NF }'</pre>
 
-{{% if product == "rhel6" %}}
 warnings:
+    - general: |-
+        Profiles may require that specific files have stricter file permissions than defined by the vendor. Such files will be reported as a finding and need to be evaluated according to your policy and deployment environment.
+{{% if product == "rhel6" %}}
     - general: |-
         <b>Note: Due to a bug in the <tt>gdm</tt> package,
         the RPM verify command may continue to fail even after file permissions have


### PR DESCRIPTION
#### Description:
There can be cases in which a Profile requires that a file permission be
more strict than package default permissions, or a file be owned by root.
In these cases this rule will report the file changed by the Profile itself as a finding.

#### Rationale:
Not all permission or ownership requirements make sense to be incorporated by the
package, and currently there is no mechanism to waive these findings.
