### PR TITLE
fix grub2_bootloader_argument template

### DIFF
--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel7.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel7.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7
+
+# Break the audit argument in kernel command line in /boot/grub2/grub.cfg
+file="/boot/grub2/grub.cfg"
+if grep -q '^.*audit=.*'  "$file" ; then
+	# modify the GRUB command-line if an audit= arg already exists
+	sed -i 's/\(^.*\)audit=[^[:space:]]*\(.*\)/\1 audit=11 \2/'  "$file"
+else
+	# no audit=arg is present, append it
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 audit=11/'  "$file"
+fi
+

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 8
+
+# Break the audit argument in kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*audit=.*'  "$file" ; then
+	# modify the GRUB command-line if an audit= arg already exists
+	sed -i 's/\(^.*\)audit=[^[:space:]]*\(.*\)/\1 audit=11 \2/'  "$file"
+else
+	# no audit=arg is present, append it
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 audit=11/'  "$file"
+fi

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/correct_grubby.pass.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/correct_grubby.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7
+
+# Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby
+if grep -q '^GRUB_CMDLINE_LINUX=.*audit_backlog_limit=.*"'  '/etc/default/grub' ; then
+	# modify the GRUB command-line if an audit_backlog_limit= arg already exists
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit_backlog_limit=[^[:space:]]*\(.*"\)/\1 audit_backlog_limit=8192 \2/'  '/etc/default/grub'
+else
+	# no audit_backlog_limit=arg is present, append it
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 audit_backlog_limit=8192"/'  '/etc/default/grub'
+fi
+
+grubby --update-kernel=ALL --args="audit_backlog_limit=8192"

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/correct_grubenv.pass.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/correct_grubenv.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) audit_backlog_limit=8192"

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_etcdefaultgrub.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7
+
+# Break the audit_backlog_limit argument in kernel command line in /etc/default/grub
+if grep -q '^GRUB_CMDLINE_LINUX=.*audit_backlog_limit=.*"'  '/etc/default/grub' ; then
+	# modify the GRUB command-line if an audit_backlog_limit= arg already exists
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)audit_backlog_limit=[^[:space:]]*\(.*"\)/\1 audit_backlog_limit=123 \2/'  '/etc/default/grub'
+else
+	# no audit_backlog_limit=arg is present, append it
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 audit_backlog_limit=123"/'  '/etc/default/grub'
+fi

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_rhel8.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+# Break the audit_backlog_limit argument in kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*audit_backlog_limit=.*'  "$file" ; then
+	# modify the GRUB command-line if an audit_backlog_limit= arg already exists
+	sed -i 's/\(^.*\)audit_backlog_limit=[^[:space:]]*\(.*\)/\1 audit_backlog_limit=123 \2/'  "$file"
+else
+	# no audit_backlog_limit=arg is present, append it
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 audit_backlog_limit=123/'  "$file"
+fi

--- a/shared/templates/template_ANSIBLE_grub2_bootloader_argument
+++ b/shared/templates/template_ANSIBLE_grub2_bootloader_argument
@@ -40,5 +40,6 @@
   when:
     - kernelopts.stdout_lines is defined
     - kernelopts.stdout_lines | length > 0
+    - kernelopts.stdout | regex_search('^kernelopts=.*{{{ ARG_NAME_VALUE }}}.*$', multiline=True) is none
 
 {{% endif %}}

--- a/shared/templates/template_ANSIBLE_grub2_bootloader_argument
+++ b/shared/templates/template_ANSIBLE_grub2_bootloader_argument
@@ -40,6 +40,6 @@
   when:
     - kernelopts.stdout_lines is defined
     - kernelopts.stdout_lines | length > 0
-    - kernelopts.stdout | regex_search('^kernelopts=.*{{{ ARG_NAME_VALUE }}}.*$', multiline=True) is none
+    - kernelopts.stdout | regex_search('^kernelopts(?:=|=.*\s){{{ ARG_NAME_VALUE }}}(?:$|\s).*$', multiline=True) is none
 
 {{% endif %}}

--- a/shared/templates/template_ANSIBLE_grub2_bootloader_argument
+++ b/shared/templates/template_ANSIBLE_grub2_bootloader_argument
@@ -40,6 +40,6 @@
   when:
     - kernelopts.stdout_lines is defined
     - kernelopts.stdout_lines | length > 0
-    - kernelopts.stdout | regex_search('^kernelopts(?:=|=.*\s){{{ ARG_NAME_VALUE }}}(?:$|\s).*$', multiline=True) is none
+    - kernelopts.stdout | regex_search('^kernelopts=(?:.*\s)?{{{ ARG_NAME_VALUE }}}(?:\s.*)?$', multiline=True) is none
 
 {{% endif %}}

--- a/shared/templates/template_ANSIBLE_grub2_bootloader_argument
+++ b/shared/templates/template_ANSIBLE_grub2_bootloader_argument
@@ -13,7 +13,7 @@
 - name: replace existing {{{ ARG_NAME }}} argument
   replace:
       path: /etc/default/grub
-      regexp: '{{{ ARG_NAME }}}=.'
+      regexp: '{{{ ARG_NAME }}}=\w+'
       replace: '{{{ ARG_NAME_VALUE }}}'
   when: argcheck.rc == 0
 

--- a/shared/templates/template_BASH_grub2_bootloader_argument
+++ b/shared/templates/template_BASH_grub2_bootloader_argument
@@ -14,7 +14,7 @@ fi
 grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"
 {{% else %}}
 # Correct grub2 kernelopts value using grub2-editenv
-if ! grub2-editenv - list | grep -qE '^kernelopts(=|=.*\s){{{ ARG_NAME_VALUE }}}($|\s).*$'; then
+if ! grub2-editenv - list | grep -qE '^kernelopts=(.*\s)?{{{ ARG_NAME_VALUE }}}(\s.*)?$'; then
   grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) {{{ ARG_NAME_VALUE }}}"
 fi
 {{% endif %}}

--- a/shared/templates/template_BASH_grub2_bootloader_argument
+++ b/shared/templates/template_BASH_grub2_bootloader_argument
@@ -14,5 +14,7 @@ fi
 grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"
 {{% else %}}
 # Correct grub2 kernelopts value using grub2-editenv
-grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) {{{ ARG_NAME_VALUE }}}"
+if ! grub2-editenv - list | grep -qE '^kernelopts(=|=.*\s){{{ ARG_NAME_VALUE }}}($|\s).*$'; then
+  grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) {{{ ARG_NAME_VALUE }}}"
+fi
 {{% endif %}}

--- a/shared/templates/template_OVAL_grub2_bootloader_argument
+++ b/shared/templates/template_OVAL_grub2_bootloader_argument
@@ -92,7 +92,7 @@
 
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
   version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^.*{{{ ESCAPED_ARG_NAME_VALUE }}}.*$</ind:subexpression>
+    <ind:subexpression datatype="string" operation="pattern match">^.*(?:^|\s){{{ ESCAPED_ARG_NAME_VALUE }}}(?:$|\s).*$</ind:subexpression>
   </ind:textfilecontent54_state>
 
 </def-group>

--- a/shared/templates/template_OVAL_grub2_bootloader_argument
+++ b/shared/templates/template_OVAL_grub2_bootloader_argument
@@ -92,7 +92,7 @@
 
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
   version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^.*(?:^|\s){{{ ESCAPED_ARG_NAME_VALUE }}}(?:$|\s).*$</ind:subexpression>
+    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>
 
 </def-group>


### PR DESCRIPTION
#### Description:

- fix regex in ansible remediation for rhel7

- add limiting condition to rhel8 version of ansible and bash remediation

- add tests for the rule grub2_audit_backlog_limit_argument to catch the case where argument and its value were there, but directly after the value there were extra characters, effectively changing the value. See rationale.

- modify regular expression in oval state to be strict. Argument together with value have to be surrounded by white space characters, or eventually begining / end of line.

#### Rationale:

This fixes several problems:

- ansible and bash remediation of grub2 arguments through grub2-editenv command did not check if the correct value is already there, creating duplicate entries. Multiple remediations could exhaust grubenv name space.

- ansible remediation of /etc/default/grub performed wrong replacement of characters. For example, in case we were remediating audit_backlog_limit=8192 and the value was already present there, the result would be audit_backlog_limit=8192192.

- the previous problem let to the fix of error in oval check. The regex used in the check was correctly checking for the arg=value, but it did not care about surroundings. So audit=1 was correct, myaudit=1 was correct, audit=10 was correct... but we want only audit=1 to be correct.

- Fixes #5754
