### PR TITLE
Add Ansible for audit_rules_system_shutdown

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
@@ -17,7 +17,7 @@
     state: absent
   loop: "{{ find_rules_d.files | map(attribute='path') | list + ['/etc/audit/audit.rules'] }}"
 
-- name: Insert configuration into /etc/audit/rules.d/immutable.rules and /etc/audit/audit.rules
+- name: Add Audit -e option into /etc/audit/rules.d/immutable.rules and /etc/audit/audit.rules
   lineinfile:
     path: "{{ item }}"
     create: True

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/ansible/shared.yml
@@ -1,0 +1,28 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Collect all files from /etc/audit/rules.d with .rules extension
+  find:
+    paths: "/etc/audit/rules.d/"
+    patterns: "*.rules"
+  register: find_rules_d
+
+- name: Remove the -f option from all Audit config files
+  lineinfile:
+    path: "{{ item }}"
+    regexp: '^\s*(?:-f)\s+.*$'
+    state: absent
+  loop: "{{ find_rules_d.files | map(attribute='path') | list + ['/etc/audit/audit.rules'] }}"
+
+- name: Add Audit -f option into /etc/audit/rules.d/immutable.rules and /etc/audit/audit.rules
+  lineinfile:
+    path: "{{ item }}"
+    create: True
+    line: "-f 2"
+  loop:
+    - "/etc/audit/audit.rules"
+    - "/etc/audit/rules.d/immutable.rules"
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
@@ -8,7 +8,7 @@
 # files to check if '-f .*' setting is present in that '*.rules' file already.
 # If found, delete such occurrence since auditctl(8) manual page instructs the
 # '-f 2' rule should be placed as the last rule in the configuration
-find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -exec sed -i '/-e[[:space:]]\+.*/d' {} ';'
+find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -exec sed -i '/-f[[:space:]]\+.*/d' {} ';'
 
 # Append '-f 2' requirement at the end of both:
 # * /etc/audit/audit.rules file 		(for auditctl case)

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
@@ -4,15 +4,7 @@
 #
 # /etc/audit/audit.rules,			(for auditctl case)
 # /etc/audit/rules.d/*.rules			(for augenrules case)
-#
-# files to check if '-f .*' setting is present in that '*.rules' file already.
-# If found, delete such occurrence since auditctl(8) manual page instructs the
-# '-f 2' rule should be placed as the last rule in the configuration
 find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -exec sed -i '/-f[[:space:]]\+.*/d' {} ';'
-
-# Append '-f 2' requirement at the end of both:
-# * /etc/audit/audit.rules file 		(for auditctl case)
-# * /etc/audit/rules.d/immutable.rules		(for augenrules case)
 
 for AUDIT_FILE in "/etc/audit/audit.rules" "/etc/audit/rules.d/immutable.rules"
 do

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_correct.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "-e 2" > /etc/audit/rules.d/immutable.rules
+echo "-f 2" >> /etc/audit/rules.d/immutable.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_e_2_immutable.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_e_2_immutable.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "-e 2" > /etc/audit/rules.d/immutable.rules


### PR DESCRIPTION
#### Description:

- Fix mistake in Bash remediation for `audit_rules_system_shutdown`
- Add Ansible remediation for `audit_rules_system_shutdown` (inspired by remediation for `audit_rules_immutable`)
- Clarify task name in Ansible for `audit_rules_immutable` 
