### PR TITLE
rsyslog: Improve OVAL and Bash handling of include() syntax

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
@@ -86,7 +86,17 @@
     -->
     <ind:pattern operation="pattern match">^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_groupownership_ignore_include_paths</filter>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_groupownership_ignore_include_paths" comment="ignore" version="1">
+    <!-- Among the paths matched in object_rfp_log_files_paths there can be paths from
+         include() or $IncludeConfig statements.
+         These paths are conf files, not log files. Their groupownership don't need to be as
+         required for log files, thus, lets exclude them from the list of objects found
+    -->
+    <ind:text operation="pattern match">(?:file="[^\s;]+"|\$IncludeConfig[\s]+[^\s;]+)</ind:text>
+  </ind:textfilecontent54_state>
 
   <!-- Define OVAL variable to hold all the various system log files locations
        retrieved from the different rsyslog configuration files

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
@@ -83,7 +83,17 @@
     -->
     <ind:pattern operation="pattern match">^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_owner_ignore_include_paths</filter>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_owner_ignore_include_paths" comment="ignore" version="1">
+    <!-- Among the paths matched in object_rfp_log_files_paths there can be paths from
+         include() or $IncludeConfig statements.
+         These paths are conf files, not log files. Their owner don't need to be as
+         required for log files, thus, lets exclude them from the list of objects found
+    -->
+    <ind:text operation="pattern match">(?:file="[^\s;]+"|\$IncludeConfig[\s]+[^\s;]+)</ind:text>
+  </ind:textfilecontent54_state>
 
   <!-- Define OVAL variable to hold all the various system log files locations
        retrieved from the different rsyslog configuration files

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -6,7 +6,7 @@ RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
 readarray -t RSYSLOG_INCLUDE_CONFIG < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
-readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub(".*file=\"(\\S+)\".*","\\1",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
+readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
 
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -6,12 +6,14 @@ RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
 readarray -t RSYSLOG_INCLUDE_CONFIG < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
+readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub(".*file=\"(\\S+)\".*","\\1",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
+
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS
 
 # Browse each file selected above as containing paths of log files
 # ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)
-for LOG_FILE in "${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}"
+for LOG_FILE in "${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}"
 do
 	# From each of these files extract just particular log file path(s), thus:
 	# * Ignore lines starting with space (' '), comment ('#"), or variable syntax ('$') characters,

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -87,10 +87,10 @@
     -->
     <ind:pattern operation="pattern match">^[^\s#\$]+[\s]+.*[\s]+-?(/+[^:;\s]+);*.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    <filter action="exclude">state_ignore_include_paths</filter>
+    <filter action="exclude">state_permissions_ignore_include_paths</filter>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_ignore_include_paths" comment="ignore" version="1">
+  <ind:textfilecontent54_state id="state_permissions_ignore_include_paths" comment="ignore" version="1">
     <!-- Among the paths matched in object_rfp_log_files_paths there can be paths from
          include() or $IncludeConfig statements.
          These paths are conf files, not log files. Their permissions don't need to be as

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -87,7 +87,17 @@
     -->
     <ind:pattern operation="pattern match">^[^\s#\$]+[\s]+.*[\s]+-?(/+[^:;\s]+);*.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_ignore_include_paths</filter>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_ignore_include_paths" comment="ignore" version="1">
+    <!-- Among the paths matched in object_rfp_log_files_paths there can be paths from
+         include() or $IncludeConfig statements.
+         These paths are conf files, not log files. Their permissions don't need to be as
+         required for log files, thus, lets exclude them from the list of objects found
+    -->
+    <ind:text operation="pattern match">(?:file="[^\s;]+"|\$IncludeConfig[\s]+[^\s;]+)</ind:text>
+  </ind:textfilecontent54_state>
 
   <!-- Define OVAL variable to hold all the various system log files locations
        retrieved from the different rsyslog configuration files


### PR DESCRIPTION
#### Description:

- Fix OVAL check to not consider paths refering to `.conf` files as `.log` files. (179cf6b)
  - Assumes that `.conf` files are accompanied by `include` or `$IncludeConfig`.
- Improves remediation to fix permissions of `.log` files referenced via `include()` syntax.
  - Previously only `.log` files referenced via `$IncludeConfig` were fixed.

#### Notes:

- Fixes item 3 of #5213
