### PR TITLE
Fix db in which Ansible remediation sets banner_enable

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Enable GNOME3 Login Warning Banner"
   ini_file:
-    dest: "/etc/dconf/db/local.d/00-security-settings"
+    dest: "/etc/dconf/db/gdm.d/00-security-settings"
     section: "org/gnome/login-screen"
     option: banner-message-enable
     value: "true"
@@ -13,7 +13,7 @@
 
 - name: "Prevent user modification of GNOME banner-message-enabled"
   lineinfile:
-    path: /etc/dconf/db/local.d/locks/00-security-settings-lock
+    path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/login-screen/banner-message-enable'
     line: '/org/gnome/login-screen/banner-message-enable'
     create: yes

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: banner-message-enable
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME banner-message-enabled"
   lineinfile:


### PR DESCRIPTION
#### Description:

- Ansible remediation was configuring different db than OVAL checks

#### Notes:

- Caught by test scenario!