### PR TITLE
Ansible mount_option: split mount and option task

### DIFF
--- a/shared/templates/template_ANSIBLE_mount_option
+++ b/shared/templates/template_ANSIBLE_mount_option
@@ -26,14 +26,19 @@
     - device_name.stdout is defined and device_name.stdout_lines is defined
     - (device_name.stdout | length > 0)
 
-- name: Ensure permission {{{ MOUNTOPTION }}} are set on {{{ MOUNTPOINT }}}
+- name: Make sure {{{ MOUNTOPTION }}} option is part of the to {{{ MOUNTPOINT }}} options
+  set_fact:
+    mount_info: "{{ mount_info | combine( {'options':''~mount_info.options~',{{{ MOUNTOPTION }}}' }) }}"
+  when:
+    - mount_info is defined and "{{{ MOUNTOPTION }}}" not in mount_info.options
+
+- name: Ensure {{{ MOUNTPOINT }}} is mounted with {{{ MOUNTOPTION }}} option
   mount:
     path: "{{{ MOUNTPOINT }}}"
     src: "{{ mount_info.source }}"
-    opts: "{{ mount_info.options }},{{{ MOUNTOPTION }}}"
+    opts: "{{ mount_info.options }}"
     state: "mounted"
     fstype: "{{ mount_info.fstype }}"
   when:
-    - mount_info is defined and "{{{ MOUNTOPTION }}}" not in mount_info.options
     - device_name.stdout is defined
     - (device_name.stdout | length > 0)


### PR DESCRIPTION
#### Description:

- Separate task that adds mount options mounts the mountpoint into two tasks.
  - Now there is one task to "add" the mount point, and another to make sure the mount point is mounted

#### Rationale:

-  Test scenario `separate.fail.sh` for `mount_option_var_tmp_noexec` started to fail after #5752 
  - Conditioning the "mount" task on the absence of the target mount option caused the task to always be skipped when mount option was alredy present, and could result in the mount point not 
being mounted.
