### PR TITLE
Fix test scenarios for mount partitions rules

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/separate.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
+# Remediating would mount /tmp, which would break the test environment.
+# remediation = none
+
 . $SHARED/partition.sh
 
 umount /home || true  # no problem if not mounted

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/separate.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S
 
+# Remediating would mount /tmp, which would break the test environment.
+# remediation = none
+
 . $SHARED/partition.sh
 
 clean_up_partition /var/tmp


### PR DESCRIPTION
Updated the rest of the `separate.fail.sh` test scenarios to not
run remediation as it breaks test environemnt. This is aligned
with the `mount_option_tmp_noexec/tests/separate.fail.sh` scenario.

Discussion related to this happened in the https://github.com/ComplianceAsCode/content/pull/5566