### PR TITLE
Use https and .com for openssh website.

### DIFF
--- a/linux_os/guide/services/ssh/group.yml
+++ b/linux_os/guide/services/ssh/group.yml
@@ -9,7 +9,7 @@ description: |-
     authentication, through the use of public key cryptography. The
     implementation included with the system is called OpenSSH, and more
     detailed documentation is available from its website,
-    {{{ weblink(link="http://www.openssh.org") }}}.
+    {{{ weblink(link="https://www.openssh.com") }}}.
     Its server program is called <tt>sshd</tt> and provided by the RPM package
     <tt>openssh-server</tt>.
 


### PR DESCRIPTION
#### Description:

- Update the weblink to `https` and uses `.com` extension which is the correct one nowadays.

Relates to https://jenkins.complianceascode.io/job/scap-security-guide-linkcheck/605/console even though it is probably not the cause but it'll help without a doubt to prevent future faults.
