### PR TITLE
Fix possible collision of remediations of file permissions

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -700,6 +700,11 @@ class Group(object):
         # audit_rules_privileged_commands, othervise the rule
         # does not catch newly installed screeen binary during remediation
         # and report fail
+        # the software group should come before the
+        # bootloader-grub2 group because of conflict between
+        # rules rpm_verify_permissions and file_permissions_grub2_cfg
+        # specific rules concerning permissions should
+        # be applied after the general rpm_verify_permissions
         # The FIPS group should come before Crypto - if we want to set a different (stricter) Crypto Policy than FIPS.
         # the firewalld_activation must come before ruleset_modifications, othervise
         # remediations for ruleset_modifications won't work
@@ -707,6 +712,7 @@ class Group(object):
         # otherwise the remediation prints error although it is successful
         priority_order = [
             "accounts", "auditing",
+            "software", "bootloader-grub2",
             "fips", "crypto",
             "firewalld_activation", "ruleset_modifications",
             "disabling_ipv6", "configuring_ipv6"


### PR DESCRIPTION
#### Description:

Force ordering of "software" group before "bootloader-grub2" group.

#### Rationale:

If the "software" group is ordered after the "bootloader-grub2" group and certain profiles are remediated with Ansible playbooks, it happens that rules requesting file permissions different from the ones dictated by packagers start failing.
This problem is fixed by this PR in the following profiles:
- rhel7 cis

- rhel7 hipaa

- rhel7 ncp

- rhel7 rhelh-stig

- rhel8 cis

- rhel8 hipaa
