### PR TITLE
Made the rule sshd_rekey_limit parametrized.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_all                                                                                                                                                                                                                                                                                        [0/453]
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("var_rekey_limit_size", "var_rekey_limit_time") }}}
+
+{{{ ansible_sshd_set(parameter="RekeyLimit", value="{{ var_rekey_limit_size}} {{var_rekey_limit_time}}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+populate var_rekey_limit_size
+populate var_rekey_limit_time
+
+{{{ bash_sshd_config_set(parameter='RekeyLimit', value="$var_rekey_limit_size $var_rekey_limit_time") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/bash/shared.sh
@@ -3,7 +3,6 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-populate var_rekey_limit_size
-populate var_rekey_limit_time
+{{{ bash_instantiate_variables("var_rekey_limit_size", "var_rekey_limit_time") }}}
 
 {{{ bash_sshd_config_set(parameter='RekeyLimit', value="$var_rekey_limit_size $var_rekey_limit_time") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
@@ -1,5 +1,4 @@
-{{% set filepath = "/etc/ssh/sshd_config" %}}
-{{% set parameter = "RekeyLimit" %}}
+{{% set filepath = "/etc/ssh/sshd_config" -%}}
 
 
 <def-group>
@@ -7,7 +6,7 @@
     <metadata>
       <title>{{{ rule_title }}}</title>
       {{{- oval_affected(products) }}}
-      <description>Ensure '{{{ RekeyLimit }}}' is configured with the correct value in '{{{ filepath }}}'</description>
+      <description>Ensure 'RekeyLimit' is configured with the correct value in '{{{ filepath }}}'</description>
     </metadata>
     <criteria comment="sshd is configured correctly or is not installed" operator="OR">
         {{{- application_not_required_or_requirement_unset() }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
@@ -1,0 +1,43 @@
+{{% set filepath = "/etc/ssh/sshd_config" %}}
+{{% set parameter = "RekeyLimit" %}}
+
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    <metadata>
+      <title>{{{ rule_title }}}</title>
+      {{{- oval_affected(products) }}}
+      <description>Ensure '{{{ RekeyLimit }}}' is configured with the correct value in '{{{ filepath }}}'</description>
+    </metadata>
+    <criteria comment="sshd is configured correctly or is not installed" operator="OR">
+        {{{- application_not_required_or_requirement_unset() }}}
+        {{{- application_required_or_requirement_unset() }}}
+        {{{- oval_line_in_file_criterion(filepath, "RekeyLimit") }}}
+    </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="tests the value of RekeyLimit setting in the  file" id="test_sshd_rekey_limit" version="1">
+     <ind:object object_ref="obj_sshd_rekey_limit"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_sshd_rekey_limit" version="1">
+     <ind:filepath>{{{ filepath }}}</ind:filepath>
+     <ind:pattern var_ref="sshd_line_regex" operation="pattern match"></ind:pattern>
+     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="sshd_line_regex" datatype="string" comment="The regex of the directive" version="1">
+    <concat>
+      <literal_component>^[\s]*RekeyLimit[\s]+</literal_component>
+      <variable_component var_ref="var_rekey_limit_size"/>
+      <literal_component>[\s]+</literal_component>
+      <variable_component var_ref="var_rekey_limit_time"/>
+      <literal_component>[\s]*$</literal_component>
+    </concat>
+  </local_variable>
+
+  <external_variable comment="Size component of the rekey limit" datatype="string" id="var_rekey_limit_size" version="1" />
+  <external_variable comment="Time component of the rekey limit" datatype="string" id="var_rekey_limit_time" version="1" />
+</def-group>
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/rule.yml
@@ -7,7 +7,7 @@ description: |-
     the session key of the is renegotiated, both in terms of
     amount of data that may be transmitted and the time
     elapsed. To decrease the default limits, put line
-    <tt>RekeyLimit 512M 1h</tt> to file <tt>/etc/ssh/sshd_config</tt>.
+    <tt>RekeyLimit {{{ sub_var_value("var_rekey_limit_size") }}} {{{ sub_var_value("var_rekey_limit_time") }}}</tt> to file <tt>/etc/ssh/sshd_config</tt>.
 
 rationale: |-
     By decreasing the limit based on the amount of data and enabling
@@ -30,12 +30,4 @@ ocil: |-
     following command:
     <pre>$ sudo grep RekeyLimit /etc/ssh/sshd_config</pre>
     If configured properly, output should be
-    <pre>RekeyLimit 512M 1h</pre>
-
-template:
-    name: sshd_lineinfile
-    vars:
-        missing_parameter_pass: 'false'
-        parameter: RekeyLimit
-        rule_id: sshd_rekey_limit
-        value: 512M 1h
+    <pre>RekeyLimit {{{ sub_var_value("var_rekey_limit_size") }}} {{{ sub_var_value("var_rekey_limit_time") }}}</pre>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_size.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_size.fail.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_all
+
+sed -e '/RekeyLimit/d' /etc/ssh/sshd_config
+echo "RekeyLimit 812M 1h" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_time.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_time.fail.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_all
+
+sed -e '/RekeyLimit/d' /etc/ssh/sshd_config
+echo "RekeyLimit 512M 2h" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/no_line.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/no_line.fail.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_all
+
+sed -e '/RekeyLimit/d' /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/ok.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/ok.pass.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_all
+
+sed -e '/RekeyLimit/d' /etc/ssh/sshd_config
+echo "RekeyLimit 512M 1h" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/var_rekey_limit_size.var
+++ b/linux_os/guide/services/ssh/ssh_server/var_rekey_limit_size.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'SSH RekeyLimit - size'
+
+description: 'Specify the size component of the rekey limit.'
+
+type: string
+
+operator: equals
+
+options:
+    sshd_default: "default"
+    default: "512M"
+    "512M": "512M"

--- a/linux_os/guide/services/ssh/ssh_server/var_rekey_limit_time.var
+++ b/linux_os/guide/services/ssh/ssh_server/var_rekey_limit_time.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'SSH RekeyLimit - size'
+
+description: 'Specify the size component of the rekey limit.'
+
+type: string
+
+operator: equals
+
+options:
+    sshd_default: "none"
+    default: "1h"
+    "1hour": "1h"

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -58,6 +58,8 @@ selections:
     - sshd_set_keepalive
     - sshd_enable_warning_banner
     - sshd_rekey_limit
+    - var_rekey_limit_size=512M
+    - var_rekey_limit_time=1hour
     - sshd_use_strong_rng
     - openssl_use_strong_entropy
 

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -1,4 +1,18 @@
 {{#
+Pass strings that correspond to XCCDF value names as arguments to this macro:
+ansible_instantiate_variables("varname1", "varname2")
+
+Then, assume that the task that follows can work with the variable by referencing it, e.g.
+value: "Setting={{ varname1 }}"
+
+#}}
+{{%- macro ansible_instantiate_variables() -%}}
+{{%- for name in varargs -%}}
+- (xccdf-var {{{ name }}})
+{{% endfor -%}}
+{{%- endmacro -%}}
+
+{{#
   A wrapper over the Ansible lineinfile module. This handles the most common
   options for us. regex is optional and when blank, it won't be included in
   the Ansible script; this allows arbitrary additions to files. new_line will

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1,5 +1,20 @@
 {{# ##### High level macros ##### #}}
 
+{{#
+Pass strings that correspond to XCCDF value names as arguments to this macro:
+bash_instantiate_variables("varname1", "varname2")
+
+Then, assume that variables of that names are defined and contain the correct value, e.g.
+echo "Setting=$varname1" >> config_file
+
+#}}
+{{%- macro bash_instantiate_variables() -%}}
+{{%- for name in varargs -%}}
+populate {{{ name }}}
+{{# this line is intentionally left blank #}}
+{{% endfor -%}}
+{{%- endmacro -%}}
+
 {{%- macro bash_shell_file_set(path, parameter, value, no_quotes=false) -%}}
 {{% if no_quotes -%}}
   {{% if "$" in value %}}

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -214,6 +214,8 @@ selections:
 - timer_dnf-automatic_enabled
 - usbguard_allow_hid_and_hub
 - var_sshd_set_keepalive=0
+- var_rekey_limit_size=512M
+- var_rekey_limit_time=1hour
 - var_accounts_user_umask=027
 - var_password_pam_difok=4
 - var_password_pam_maxrepeat=3

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -21,7 +21,6 @@ description: 'This profile contains configuration checks that align to the
 
     - Red Hat Containers with a Red Hat Enterprise Linux 8 image'
 documentation_complete: true
-extends: ospp
 selections:
 - account_disable_post_pw_expiration
 - account_temp_expire_date
@@ -243,6 +242,8 @@ selections:
 - timer_dnf-automatic_enabled
 - usbguard_allow_hid_and_hub
 - var_sshd_set_keepalive=0
+- var_rekey_limit_size=512M
+- var_rekey_limit_time=1hour
 - var_accounts_user_umask=027
 - var_password_pam_difok=4
 - var_password_pam_maxrepeat=3


### PR DESCRIPTION
Introduce the rekey_limit_size and rekey_limit_time XCCDF values to make the rule more flexible.

There is one problem: The rule uses **two** XCCDF values, and I think that this is not supported at least for Bash remediations. The remediation code is a wild jungle, is anybody here who knows what buttons to push to make it work? The solution is probably to edit https://github.com/ComplianceAsCode/content/blob/master/ssg/build_remediations.py#L671, but I don't want to mash another hack into a nested-nested-nested if block.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1813066