### PR TITLE
fix rhel8 hipaa ansible playbook

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
@@ -3,13 +3,9 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Test for existence of /etc/securetty
-  stat:
-    path: /etc/securetty
-  register: securetty_empty
+
 
 - name: "Direct root Logins Not Allowed"
   copy:
     dest: /etc/securetty
     content: ""
-  when: securetty_empty.stat.size > 1

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/tests/missing.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/tests/wrong.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "something" > /etc/securetty

--- a/shared/templates/template_ANSIBLE_sebool
+++ b/shared/templates/template_ANSIBLE_sebool
@@ -13,11 +13,17 @@
 {{% else %}}
 - (xccdf-var var_{{{ SEBOOLID }}})
 
+{{% if product == "rhel8" %}}
+- name: Ensure python3-libsemanage installed
+  package:
+    name: python3-libsemanage
+    state: present
+{{% else %}}
 - name: Ensure libsemanage-python installed
   package:
     name: libsemanage-python
     state: present
-
+{{% endif %}}
 - name: Set SELinux boolean {{{ SEBOOLID }}} accordingly
   seboolean:
     name: {{{ SEBOOLID }}}


### PR DESCRIPTION
#### Description:

- simplify and fix ansible remediation of no_direct_root_logins

- add tests for no_direct_root_logins

- change package name for rhel8 in ansible template for sebool

#### Rationale:

Ansible playbook for rhel8 hipaa profile did not finish successfully. This PR fixes problematic remediations.