### PR TITLE
Attribute credit for CIS content

### DIFF
--- a/rhel7/profiles/cis.profile
+++ b/rhel7/profiles/cis.profile
@@ -3,9 +3,11 @@ documentation_complete: true
 title: 'CIS Red Hat Enterprise Linux 7 Benchmark'
 
 description: |-
-    This baseline aligns to the Center for Internet Security
-    Red Hat Enterprise Linux 7 Benchmark, v2.2.0, released
-    12-27-2017.
+    This profile defines a baseline that aligns to the Center for Internet Security®
+    Red Hat Enterprise Linux 7 Benchmark, v2.2.0, released 12-27-2017.
+
+    This profile includes Center for Internet Security®
+    Red Hat Enterprise Linux 7 CIS Benchmarks™ content.
 
 selections:
     # Necessary for dconf rules

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -3,9 +3,11 @@ documentation_complete: true
 title: 'CIS Red Hat Enterprise Linux 8 Benchmark'
 
 description: |-
-    This baseline aligns to the Center for Internet Security
-    Red Hat Enterprise Linux 8 Benchmark, v1.0.0, released
-    09-30-2019.
+    This profile defines a baseline that aligns to the Center for Internet Security®
+    Red Hat Enterprise Linux 8 Benchmark™, v1.0.0, released 09-30-2019.
+
+    This profile includes Center for Internet Security®
+    Red Hat Enterprise Linux 8 CIS Benchmarks™ content.
 
 selections:
     # Necessary for dconf rules


### PR DESCRIPTION

#### Description:

- Attribute credit to Center for Internet Security for Benchmark contents
- Update the description text a bit.

This gets correctly rendered in OAA, and in HTML Guides.
![trademarks](https://user-images.githubusercontent.com/7460169/82584310-9d9d0580-9b94-11ea-9c80-6122e54e9752.png)

![guide_trademarks](https://user-images.githubusercontent.com/7460169/82584834-59f6cb80-9b95-11ea-835b-e0c15a1b7990.png)
