### PR TITLE
change sshd rekey limit to 1G 1 hour in rhel8 ospp

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/var_rekey_limit_size.var
+++ b/linux_os/guide/services/ssh/ssh_server/var_rekey_limit_size.var
@@ -12,3 +12,4 @@ options:
     sshd_default: "default"
     default: "512M"
     "512M": "512M"
+    "1G": "1G"

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -58,7 +58,7 @@ selections:
     - sshd_set_keepalive
     - sshd_enable_warning_banner
     - sshd_rekey_limit
-    - var_rekey_limit_size=512M
+    - var_rekey_limit_size=1G
     - var_rekey_limit_time=1hour
     - sshd_use_strong_rng
     - openssl_use_strong_entropy

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -44,6 +44,3 @@ selections:
     - package_rsyslog-gnutls_installed
     - rsyslog_remote_tls
     - rsyslog_remote_tls_cacert
-    - sshd_rekey_limit
-    - var_rekey_limit_size=512M
-    - var_rekey_limit_time=1hour

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -44,3 +44,6 @@ selections:
     - package_rsyslog-gnutls_installed
     - rsyslog_remote_tls
     - rsyslog_remote_tls_cacert
+    - sshd_rekey_limit
+    - var_rekey_limit_size=512M
+    - var_rekey_limit_time=1hour

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -214,7 +214,7 @@ selections:
 - timer_dnf-automatic_enabled
 - usbguard_allow_hid_and_hub
 - var_sshd_set_keepalive=0
-- var_rekey_limit_size=512M
+- var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
 - var_accounts_user_umask=027
 - var_password_pam_difok=4

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -242,7 +242,7 @@ selections:
 - timer_dnf-automatic_enabled
 - usbguard_allow_hid_and_hub
 - var_sshd_set_keepalive=0
-- var_rekey_limit_size=512M
+- var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
 - var_accounts_user_umask=027
 - var_password_pam_difok=4


### PR DESCRIPTION
#### Description:

Add 1G to the var_rekey_limit_size.
Add changes to ospp.
Do not propagate changes to derived stig profile.

#### Rationale:

CC requirements.