### PR TITLE
Add rules to configure zIPL

### DIFF
--- a/linux_os/guide/system/bootloader-zipl/group.yml
+++ b/linux_os/guide/system/bootloader-zipl/group.yml
@@ -1,0 +1,11 @@
+documentation_complete: true
+
+title: 'zIPL bootloader configuration'
+
+description: |-
+    During the boot process, the bootloader is
+    responsible for starting the execution of the kernel and passing
+    options to it.
+    The default {{{ full_name }}} boot loader for s390x systems is called zIPL.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
@@ -1,0 +1,40 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Enable Auditing to Start Prior to the Audit Daemon in zIPL'
+
+description: |-
+    To ensure all processes can be audited, even those which start prior to the audit daemon,
+    check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>audit=1</tt>
+    included in its options.
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
+    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+
+    To ensure that new kernels and boot entries continue to enable audit,
+    add <pre>audit=1</pre> to <tt>/etc/kernel/cmdline</tt>.
+
+rationale: |-
+    Each process on the system carries an "auditable" flag which indicates whether
+    its activities can be audited. Although <tt>auditd</tt> takes care of enabling
+    this for all processes which launch after it does, adding the kernel argument
+    ensures it is set for every process during boot.
+
+severity: medium
+
+ocil_clause: 'auditing is not enabled at boot time'
+
+ocil: |-
+  To check that audit is enabled at boot time, check all boot entries with following command:
+  <pre>sudo grep -L "^options\s+.*\baudit=1\b" /boot/loader/entries/*.conf</pre>
+  No line should be returned, each line returned is a boot entry that doesn't enable audit.
+
+  Check that no image file is specified in <tt>/etc/zipl.conf</tt>:
+  <pre>grep -R "^image\s*=" /etc/zipl.conf</pre>
+  No line should be returned, if a line is returned zipl may load a different kernel than intended.
+
+  And make sure that <tt>/boot/bootmap</tt> is newer than <tt>/boot/loader/entries/*.conf</tt>
+  and <tt>/etc/zipl.conf</tt>:
+  <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
+  No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
@@ -7,13 +7,13 @@ title: 'Enable Auditing to Start Prior to the Audit Daemon in zIPL'
 description: |-
     To ensure all processes can be audited, even those which start prior to the audit daemon,
     check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>audit=1</tt>
-    included in its options.
-    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
-    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
-    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+    included in its options.<br />
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).<br />
+    And run <tt>zipl</tt> command so that <tt>/boot/bootmap</tt> is updated.<br /><br />
 
     To ensure that new kernels and boot entries continue to enable audit,
-    add <pre>audit=1</pre> to <tt>/etc/kernel/cmdline</tt>.
+    add <tt>audit=1</tt> to <tt>/etc/kernel/cmdline</tt>.
 
 rationale: |-
     Each process on the system carries an "auditable" flag which indicates whether

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Extend Audit Backlog Limit for the Audit Daemon in zIPL'
+
+description: |-
+    To improve the kernel capacity to queue all log events, even those which start prior to the audit daemon,
+    check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>audit_backlog_limit=8192</tt>
+    included in its options.
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
+    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+
+    To ensure that new kernels and boot entries continue to extend the audit log events queue,
+    add <pre>audit_backlog_limit=8192</pre> to <tt>/etc/kernel/cmdline</tt>.
+
+rationale: |-
+    audit_backlog_limit sets the queue length for audit events awaiting transfer
+    to the audit daemon. Until the audit daemon is up and running, all log messages
+    are stored in this queue.  If the queue is overrun during boot process, the action
+    defined by audit failure flag is taken.
+
+severity: medium
+
+ocil_clause: 'audit backlog limit is not configured'
+
+ocil: |-
+  To check that all boot entries extend the backlog limit;
+  Check that all boot entries extend the log events queue:
+  <pre>sudo grep -L "^options\s+.*\baudit_backlog_limit=0\b" /boot/loader/entries/*.conf</pre>
+  No line should be returned, each line returned is a boot entry that does not extend the log events queue.
+
+  Check that no image file is specified in <tt>/etc/zipl.conf</tt>:
+  <pre>grep -R "^image\s*=" /etc/zipl.conf</pre>
+  No line should be returned, if a line is returned zipl may load a different kernel than intended.
+
+  And make sure that <tt>/boot/bootmap</tt> is newer than <tt>/boot/loader/entries/*.conf</tt>
+  and <tt>/etc/zipl.conf</tt>:
+  <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
+  No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
@@ -7,13 +7,13 @@ title: 'Extend Audit Backlog Limit for the Audit Daemon in zIPL'
 description: |-
     To improve the kernel capacity to queue all log events, even those which start prior to the audit daemon,
     check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>audit_backlog_limit=8192</tt>
-    included in its options.
-    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
-    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
-    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+    included in its options.<br />
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).<br />
+    And run <tt>zipl</tt> command so that <tt>/boot/bootmap</tt> is updated.<br /><br />
 
     To ensure that new kernels and boot entries continue to extend the audit log events queue,
-    add <pre>audit_backlog_limit=8192</pre> to <tt>/etc/kernel/cmdline</tt>.
+    add <tt>audit_backlog_limit=8192</tt> to <tt>/etc/kernel/cmdline</tt>.
 
 rationale: |-
     audit_backlog_limit sets the queue length for audit events awaiting transfer

--- a/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
@@ -7,10 +7,10 @@ title: 'Ensure SELinux Not Disabled in zIPL'
 description: |-
     To ensure SELinux is not disabled at boot time,
     check that no boot entry in <tt>/boot/loader/entries/*.conf</tt> has <tt>selinux=0</tt>
-    included in its options.
-    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
-    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
-    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+    included in its options.<br />
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).<br />
+    And run <tt>zipl</tt> command so that <tt>/boot/bootmap</tt> is updated.<br /><br />
 
 rationale: |-
     Disabling a major host protection feature, such as SELinux, at boot time prevents

--- a/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Ensure SELinux Not Disabled in zIPL'
+
+description: |-
+    To ensure SELinux is not disabled at boot time,
+    check that no boot entry in <tt>/boot/loader/entries/*.conf</tt> has <tt>selinux=0</tt>
+    included in its options.
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
+    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+
+rationale: |-
+    Disabling a major host protection feature, such as SELinux, at boot time prevents
+    it from confining system services at boot time.  Further, it increases
+    the chances that it will remain off during system operation.
+
+severity: medium
+
+ocil_clause: 'SELinux is disabled at boot time'
+
+ocil: |-
+    To check that selinux is not disabled at boot time;
+    Check that no boot entry disables selinux:
+    <pre>sudo grep -L "^options\s+.*\bselinux=0\b" /boot/loader/entries/*.conf</pre>
+    No line should be returned, each line returned is a boot entry that disables SELinux.
+
+    Check that no image file is specified in <tt>/etc/zipl.conf</tt>:
+    <pre>grep -R "^image\s*=" /etc/zipl.conf</pre>
+    No line should be returned, if a line is returned zipl may load a different kernel than intended.
+
+    And make sure that <tt>/boot/bootmap</tt> is newer than <tt>/boot/loader/entries/*.conf</tt>
+    and <tt>/etc/zipl.conf</tt>:
+    <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
+    No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.

--- a/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Enable page allocator poisoning in zIPL'
+
+description: |-
+    To enable poisoning of free pages,
+    check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>page_poison=1</tt>
+    included in its options.
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
+    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+
+    To ensure that new kernels and boot entries continue to enable page poisoning,
+    add <pre>page_poison=1</pre> to <tt>/etc/kernel/cmdline</tt>.
+
+rationale: |-
+    Poisoning writes an arbitrary value to freed pages, so any modification or
+    reference to that page after being freed or before being initialized will be
+    detected and prevented.
+    This prevents many types of use-after-free vulnerabilities at little performance cost.
+    Also prevents leak of data and detection of corrupted memory.
+
+severity: medium
+
+ocil_clause: 'page allocator poisoning is not enabled'
+
+ocil: |-
+  To check that page poisoning is enabled at boot time, check all boot entries with following command:
+  <pre>sudo grep -L "^options\s+.*\bpage_poison=1\b" /boot/loader/entries/*.conf</pre>
+  No line should be returned, each line returned is a boot entry that doesn't enable page poisoning.
+
+  Check that no image file is specified in <tt>/etc/zipl.conf</tt>:
+  <pre>grep -R "^image\s*=" /etc/zipl.conf</pre>
+  No line should be returned, if a line is returned zipl may load a different kernel than intended.
+
+  And make sure that <tt>/boot/bootmap</tt> is newer than <tt>/boot/loader/entries/*.conf</tt>
+  and <tt>/etc/zipl.conf</tt>:
+  <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
+  No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.

--- a/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
@@ -7,13 +7,13 @@ title: 'Enable page allocator poisoning in zIPL'
 description: |-
     To enable poisoning of free pages,
     check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>page_poison=1</tt>
-    included in its options.
-    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
-    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
-    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+    included in its options.<br />
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).<br />
+    And run <tt>zipl</tt> command so that <tt>/boot/bootmap</tt> is updated.<br />
 
     To ensure that new kernels and boot entries continue to enable page poisoning,
-    add <pre>page_poison=1</pre> to <tt>/etc/kernel/cmdline</tt>.
+    add <tt>page_poison=1</tt> to <tt>/etc/kernel/cmdline</tt>.
 
 rationale: |-
     Poisoning writes an arbitrary value to freed pages, so any modification or

--- a/linux_os/guide/system/bootloader-zipl/zipl_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_pti_argument/rule.yml
@@ -7,13 +7,13 @@ title: 'Enable Kernel Page-Table Isolation (KPTI) in zIPL'
 description: |-
     To enable Kernel page-table isolation,
     check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>pti=on</tt>
-    included in its options.
-    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
-    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
-    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+    included in its options.<br />
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).<br />
+    And run <tt>zipl</tt> command so that <tt>/boot/bootmap</tt> is updated.<br /><br />
 
     To ensure that new kernels and boot entries continue to enable page-table isolation,
-    add <pre>pti=on</pre> to <tt>/etc/kernel/cmdline</tt>.
+    add <tt>pti=on</tt> to <tt>/etc/kernel/cmdline</tt>.
 
 rationale: |-
     Kernel page-table isolation is a kernel feature that mitigates

--- a/linux_os/guide/system/bootloader-zipl/zipl_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_pti_argument/rule.yml
@@ -1,0 +1,40 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Enable Kernel Page-Table Isolation (KPTI) in zIPL'
+
+description: |-
+    To enable Kernel page-table isolation,
+    check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>pti=on</tt>
+    included in its options.
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
+    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+
+    To ensure that new kernels and boot entries continue to enable page-table isolation,
+    add <pre>pti=on</pre> to <tt>/etc/kernel/cmdline</tt>.
+
+rationale: |-
+    Kernel page-table isolation is a kernel feature that mitigates
+    the Meltdown security vulnerability and hardens the kernel
+    against attempts to bypass kernel address space layout
+    randomization (KASLR).
+
+severity: medium
+
+ocil_clause: 'Kernel page-table isolation is not enabled'
+
+ocil: |-
+  To check that page-table isolation is enabled at boot time, check all boot entries with following command:
+  <pre>sudo grep -L "^options\s+.*\bpti=on\b" /boot/loader/entries/*.conf</pre>
+  No line should be returned, each line returned is a boot entry that doesn't enable page-table isolation .
+
+  Check that no image file is specified in <tt>/etc/zipl.conf</tt>:
+  <pre>grep -R "^image\s*=" /etc/zipl.conf</pre>
+  No line should be returned, if a line is returned zipl may load a different kernel than intended.
+
+  And make sure that <tt>/boot/bootmap</tt> is newer than <tt>/boot/loader/entries/*.conf</tt>
+  and <tt>/etc/zipl.conf</tt>:
+  <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
+  No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.

--- a/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
@@ -7,13 +7,13 @@ title: 'Enable SLUB/SLAB allocator poisoning in zIPL'
 description: |-
     To enable poisoning of SLUB/SLAB objects,
     check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>slub_debug=P</tt>
-    included in its options.
-    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
-    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
-    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+    included in its options.<br />
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).<br />
+    And run <tt>zipl</tt> command so that <tt>/boot/bootmap</tt> is updated.<br /><br />
 
     To ensure that new kernels and boot entries continue to extend the audit log events queue,
-    add <pre>slub_debug=P</pre> to <tt>/etc/kernel/cmdline</tt>.
+    add <tt>slub_debug=P</tt> to <tt>/etc/kernel/cmdline</tt>.
 
 rationale: |-
     Poisoning writes an arbitrary value to freed objects, so any modification or

--- a/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Enable SLUB/SLAB allocator poisoning in zIPL'
+
+description: |-
+    To enable poisoning of SLUB/SLAB objects,
+    check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>slub_debug=P</tt>
+    included in its options.
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
+    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+
+    To ensure that new kernels and boot entries continue to extend the audit log events queue,
+    add <pre>slub_debug=P</pre> to <tt>/etc/kernel/cmdline</tt>.
+
+rationale: |-
+    Poisoning writes an arbitrary value to freed objects, so any modification or
+    reference to that object after being freed or before being initialized will be
+    detected and prevented.
+    This prevents many types of use-after-free vulnerabilities at little performance cost.
+    Also prevents leak of data and detection of corrupted memory.
+
+severity: medium
+
+ocil_clause: 'SLUB/SLAB poisoning is not enabled'
+
+ocil: |-
+  To check that SLUB/SLAB poisoning is enabled, check all boot entries with following command;
+  <pre>sudo grep -L "^options\s+.*\bslub_debug=P\b" /boot/loader/entries/*.conf</pre>
+  No line should be returned, each line returned is a boot entry that does not enable poisoning.
+
+  Check that no image file is specified in <tt>/etc/zipl.conf</tt>:
+  <pre>grep -R "^image\s*=" /etc/zipl.conf</pre>
+  No line should be returned, if a line is returned zipl may load a different kernel than intended.
+
+  And make sure that <tt>/boot/bootmap</tt> is newer than <tt>/boot/loader/entries/*.conf</tt>
+  and <tt>/etc/zipl.conf</tt>:
+  <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
+  No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.

--- a/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Disable vsyscalls in zIPL'
+
+description: |-
+    To disable use of virtual syscalls,
+    check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>vsyscall=none</tt>
+    included in its options.
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
+    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+
+    To ensure that new kernels and boot entries continue to disable virtual syscalls,
+    add <pre>vsyscall=none</pre> to <tt>/etc/kernel/cmdline</tt>.
+
+rationale: |-
+    Poisoning writes an arbitrary value to freed pages, so any modification or
+    reference to that page after being freed or before being initialized will be
+    detected and prevented.
+    This prevents many types of use-after-free vulnerabilities at little performance cost.
+    Also prevents leak of data and detection of corrupted memory.
+
+severity: medium
+
+ocil_clause: 'vsyscalls are enabled'
+
+ocil: |-
+  To check that virtual syscalls are disabled at boot time, check all boot entries with following command:
+  <pre>sudo grep -L "^options\s+.*\bvsyscall=none\b" /boot/loader/entries/*.conf</pre>
+  No line should be returned, each line returned is a boot entry that doesn't disable virtual syscalls.
+
+  Check that no image file is specified in <tt>/etc/zipl.conf</tt>:
+  <pre>grep -R "^image\s*=" /etc/zipl.conf</pre>
+  No line should be returned, if a line is returned zipl may load a different kernel than intended.
+
+  And make sure that <tt>/boot/bootmap</tt> is newer than <tt>/boot/loader/entries/*.conf</tt>
+  and <tt>/etc/zipl.conf</tt>:
+  <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
+  No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.

--- a/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
@@ -16,11 +16,8 @@ description: |-
     add <tt>vsyscall=none</tt> to <tt>/etc/kernel/cmdline</tt>.
 
 rationale: |-
-    Poisoning writes an arbitrary value to freed pages, so any modification or
-    reference to that page after being freed or before being initialized will be
-    detected and prevented.
-    This prevents many types of use-after-free vulnerabilities at little performance cost.
-    Also prevents leak of data and detection of corrupted memory.
+    Virtual Syscalls provide an opportunity of attack for a user who has control
+    of the return instruction pointer.
 
 severity: medium
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
@@ -7,13 +7,13 @@ title: 'Disable vsyscalls in zIPL'
 description: |-
     To disable use of virtual syscalls,
     check that all boot entries in <tt>/boot/loader/entries/*.conf</tt> have <tt>vsyscall=none</tt>
-    included in its options.
-    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <pre>image = </pre> setting,
-    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).
-    And run <pre>zipl</pre> command so that <tt>/boot/bootmap</tt> is updated.
+    included in its options.<br />
+    Make sure <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt> setting,
+    as {{{ full_name }}} adheres to Boot Loader Specification (BLS).<br />
+    And run <tt>zipl</tt> command so that <tt>/boot/bootmap</tt> is updated.<br /><br />
 
     To ensure that new kernels and boot entries continue to disable virtual syscalls,
-    add <pre>vsyscall=none</pre> to <tt>/etc/kernel/cmdline</tt>.
+    add <tt>vsyscall=none</tt> to <tt>/etc/kernel/cmdline</tt>.
 
 rationale: |-
     Poisoning writes an arbitrary value to freed pages, so any modification or


### PR DESCRIPTION
#### Description:

- Add `bootloader-zip` group
- Add few rules for kernel options in zIPL
  - Ensure `audit=1` is set
  - Ensure `audit_backlog_limit=8192` is set
  - Ensure `selinux=0` is not set
