### PR TITLE
Fix ansible/bash remediation for rule grub2_enable_selinux.

### DIFF
--- a/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
@@ -1,9 +1,26 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_fedora,multi_platform_ol,SUSE Linux Enterprise 15
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Ensure SELinux Not Disabled in /etc/default/grub
+{{% if product != "rhel6" -%}}
+- name: Find /etc/grub.d/ files
+  find:
+    paths:
+      - /etc/grub.d/
+    follow: yes
+  register: grub
+{{%- endif %}}
+
+- name: Ensure SELinux Not Disabled in grub files
   replace:
-    dest: /etc/default/grub
-    regexp: selinux=0
+    dest: "{{ item.path }}"
+    regexp: (selinux|enforcing)=0
+  with_items:
+{{%- if product == "rhel6" %}}
+    - { path: /etc/grub.conf }
+{{%- else %}}
+    - "{{ grub.files }}"
+    - { path: /etc/grub2.cfg }
+    - { path: /etc/default/grub }
+{{%- endif -%}}

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/bash/shared.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/bash/shared.sh
@@ -1,9 +1,9 @@
-# platform = multi_platform_rhel,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_fedora,multi_platform_ol,SUSE Linux Enterprise 15
 
-{{% if product == "rhel7" -%}}
-sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
-sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
-{{%- elif product == "rhel6" -%}}
+{{% if product == "rhel6" -%}}
 sed -i --follow-symlinks "s/selinux=0//gI" /etc/grub.conf
 sed -i --follow-symlinks "s/enforcing=0//gI" /etc/grub.conf
+{{%- else -%}}
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
 {{%- endif -%}}

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled.fail.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_hipaa
+
+echo "GRUB_CMDLINE_LINUX=selinux=0 enforcing=0 audit=1" >> /etc/default/grub
+echo "selinux=0" >> /etc/grub2.cfg
+echo "enforcing=0" >> /etc/grub2.cfg
+echo "selinux=0" > /etc/grub.d/tmp_file
+echo "rubbish=0" >> /etc/grub.d/tmp_file
+echo "enforcing=0" >> /etc/grub.d/tmp_file

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_enable.pass.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_enable.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_hipaa
+
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*


### PR DESCRIPTION
#### Description:

- Fix ansible/bash remediation for rule [grub2_enable_selinux](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml).
- Make it applicable for relevant products.
- Enhance ansible remediation to look for all files similar to bash remediation
- Add a couple of test scenarios

#### Rationale:

- As you can see in the bash remediation, only `rhel7` and `rhel6` was being considered: [grub2_enable_selinux/bash/shared.sh](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/selinux/grub2_enable_selinux/bash/shared.sh). In other words, the remediation for `rhel8` for example was an empty bash script.

This rule is selected by many profiles:
`$ grep -R '\- grub2_enable_selinux' --include \*.profile | grep -v build`
```
rhv4/profiles/rhvh-stig.profile:    - grub2_enable_selinux
rhv4/profiles/rhvh-vpp.profile:    - grub2_enable_selinux
rhel8/profiles/hipaa.profile:    - grub2_enable_selinux
rhel8/profiles/cis.profile:    - grub2_enable_selinux
rhel7/profiles/docker-host.profile:    - grub2_enable_selinux
rhel7/profiles/C2S.profile:    - grub2_enable_selinux
rhel7/profiles/hipaa.profile:    - grub2_enable_selinux
rhel7/profiles/rhelh-stig.profile:    - grub2_enable_selinux
rhel7/profiles/ncp.profile:    - grub2_enable_selinux
rhel7/profiles/cis.profile:    - grub2_enable_selinux
rhel7/profiles/rhelh-vpp.profile:    - grub2_enable_selinux
ocp4/profiles/coreos-ncp.profile:    - grub2_enable_selinux
ocp4/profiles/moderate.profile:    - grub2_enable_selinux
sle15/profiles/cis.profile:    - grub2_enable_selinux
ol8/profiles/hipaa.profile:    - grub2_enable_selinux

```
