### PR TITLE
Add k8s remediations for several audit rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20sethostname%2Csetdomainname%20-F%20key%3Daudit_rules_networkconfig_modification%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20sethostname%2Csetdomainname%20-F%20key%3Daudit_rules_networkconfig_modification%0A-w%20/etc/issue%20-p%20wa%20-k%20audit_rules_networkconfig_modification%0A-w%20/etc/issue.net%20-p%20wa%20-k%20audit_rules_networkconfig_modification%0A-w%20/etc/hosts%20-p%20wa%20-k%20audit_rules_networkconfig_modification%0A-w%20/etc/sysconfig/network%20-p%20wa%20-k%20audit_rules_networkconfig_modification%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-audit_rules_networkconfig_modification.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-audit_rules_usergroup_modification.rules

--- a/shared/templates/template_KUBERNETES_audit_rules_dac_modification
+++ b/shared/templates/template_KUBERNETES_audit_rules_dac_modification
@@ -1,0 +1,19 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20{{{ ATTR }}}%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dperm_mod%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20{{{ ATTR }}}%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dperm_mod%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-{{{ ATTR }}}_dac_modification.rules

--- a/shared/templates/template_KUBERNETES_audit_rules_login_events
+++ b/shared/templates/template_KUBERNETES_audit_rules_login_events
@@ -1,0 +1,19 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,-w%20{{{ PATH }}}%20-p%20wa%20-k%20logins%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-{{{ NAME }}}_login_events.rules

--- a/shared/templates/template_KUBERNETES_audit_rules_privileged_commands
+++ b/shared/templates/template_KUBERNETES_audit_rules_privileged_commands
@@ -1,0 +1,19 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,-a%20always%2Cexit%20-F%20path%3D{{{ PATH }}}%20-F%20perm%3Dx%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-{{{ NORMALIZED_PATH }}}_execution.rules

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -55,7 +55,7 @@ def auditd_lineinfile(data, lang):
     return data
 
 
-@template(["ansible", "bash", "oval"])
+@template(["ansible", "bash", "oval", "kubernetes"])
 def audit_rules_dac_modification(data, lang):
     return data
 

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -85,7 +85,7 @@ def audit_rules_path_syscall(data, lang):
     return data
 
 
-@template(["ansible", "bash", "oval"])
+@template(["ansible", "bash", "oval", "kubernetes"])
 def audit_rules_privileged_commands(data, lang):
     path = data["path"]
     name = re.sub(r"[-\./]", "_", os.path.basename(path))
@@ -94,6 +94,11 @@ def audit_rules_privileged_commands(data, lang):
         data["id"] = data["_rule_id"]
         data["title"] = "Record Any Attempts to Run " + name
         data["path"] = path.replace("/", "\\/")
+    elif lang == "kubernetes":
+        npath = path.replace("/", "_")
+        if npath[0] == '_':
+            npath = npath[1:]
+        data["normalized_path"] = npath
     return data
 
 @template(["ansible", "bash", "oval"])

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -65,7 +65,7 @@ def audit_rules_file_deletion_events(data, lang):
     return data
 
 
-@template(["ansible", "bash", "oval"])
+@template(["ansible", "bash", "oval", "kubernetes"])
 def audit_rules_login_events(data, lang):
     path = data["path"]
     name = re.sub(r'[-\./]', '_', os.path.basename(os.path.normpath(path)))


### PR DESCRIPTION
#### Description:

- Implements k8s templates for audit_rules_dac_modification and
  audit_rules_privileged_commands, this creates several remediations
  automatically
- adds handcrafted remediations for audit_rules_networkconfig_modification
  and audit_rules_usergroup_modification as those unfortunately have no
  template

#### Rationale:

- More content!