### PR TITLE
ocp4: Check for diminishing failures in e2e test

### DIFF
--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -28,13 +28,16 @@ func TestE2e(t *testing.T) {
 	})
 
 	var numberOfRemediationsInit int
+	var numberOfFailuresInit int
 	var numberOfRemediationsEnd int
+	var numberOfFailuresEnd int
 
 	t.Run("Run first compliance scan", func(t *testing.T) {
 		// Create suite and auto-apply remediations
 		suite := ctx.createComplianceSuiteForProfile("1", true)
 		ctx.waitForComplianceSuite(suite)
 		numberOfRemediationsInit = ctx.getRemediationsForSuite(suite, false)
+		numberOfFailuresInit = ctx.getFailuresForSuite(suite, false)
 	})
 
 	t.Run("Wait for Remediations to apply", func(t *testing.T) {
@@ -48,6 +51,7 @@ func TestE2e(t *testing.T) {
 		suite := ctx.createComplianceSuiteForProfile("2", false)
 		ctx.waitForComplianceSuite(suite)
 		numberOfRemediationsEnd = ctx.getRemediationsForSuite(suite, true)
+		numberOfFailuresEnd = ctx.getFailuresForSuite(suite, true)
 	})
 
 	t.Run("We should have less remediations to apply", func(t *testing.T) {
@@ -57,6 +61,13 @@ func TestE2e(t *testing.T) {
 		} else {
 			t.Logf("There are less remediations now: init -> %d  end %d",
 				numberOfRemediationsInit, numberOfRemediationsEnd)
+		}
+		if numberOfFailuresInit <= numberOfFailuresEnd {
+			t.Errorf("The failures didn't diminish: init -> %d  end %d",
+				numberOfFailuresInit, numberOfFailuresEnd)
+		} else {
+			t.Logf("There are less failures now: init -> %d  end %d",
+				numberOfFailuresInit, numberOfFailuresEnd)
 		}
 	})
 }

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -370,6 +370,27 @@ func (ctx *e2econtext) getRemediationsForSuite(s *cmpv1alpha1.ComplianceSuite, d
 	return len(remList.Items)
 }
 
+func (ctx *e2econtext) getFailuresForSuite(s *cmpv1alpha1.ComplianceSuite, display bool) int {
+	failList := &cmpv1alpha1.ComplianceCheckResultList{}
+	matchLabels := dynclient.MatchingLabels{
+		cmpv1alpha1.SuiteLabel:                               s.Name,
+		string(cmpv1alpha1.ComplianceCheckResultStatusLabel): string(cmpv1alpha1.CheckResultFail),
+	}
+	err := ctx.dynclient.List(goctx.TODO(), failList, matchLabels)
+	if err != nil {
+		ctx.t.Fatalf("Couldn't get remediation list")
+	}
+	if display {
+		if len(failList.Items) > 0 {
+			ctx.t.Logf("Failures from ComplianceSuite: %s", s.Name)
+		}
+		for _, rem := range failList.Items {
+			ctx.t.Logf("- %s", rem.Name)
+		}
+	}
+	return len(failList.Items)
+}
+
 func isNodeReady(node corev1.Node) bool {
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == corev1.NodeReady &&


### PR DESCRIPTION
We used to only check that there were less remediations, but we also
want to know what failures didn't get addressed for a specific profile.