### PR TITLE
Quick fixes to utils/deploy_compliance_operator.sh script

### DIFF
--- a/ocp-resources/compliance-operator-operator-group.yaml
+++ b/ocp-resources/compliance-operator-operator-group.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  generateName: openshift-compliance-
+  name: openshift-compliance
   namespace: openshift-compliance
 spec:
   targetNamespaces:

--- a/utils/deploy_compliance_operator.sh
+++ b/utils/deploy_compliance_operator.sh
@@ -4,23 +4,19 @@ root_dir=$(git rev-parse --show-toplevel)
 
 echo "Ensuring openshift-compliance namespace exists."
 # If it already exists, this is not a problem.
-oc create -f "$root_dir/ocp-resources/compliance-operator-ns.yaml" || true
+oc apply -f "$root_dir/ocp-resources/compliance-operator-ns.yaml"
 
 echo "Creating OperatorSource"
 # Create operator source so we can install the latest available release which
 # is available from an "external datastore"; meaning, it's our upstream release
 # which is not yet in OperatorHub
-oc create -f "$root_dir/ocp-resources/compliance-operator-source.yaml"
-
-echo "Creating CatalogSourceConfig"
-# This allows us to create subscriptions
-oc create -f "$root_dir/ocp-resources/compliance-operator-csc.yaml"
+oc apply -f "$root_dir/ocp-resources/compliance-operator-source.yaml"
 
 echo "Creating OperatorGroup"
 # Create operator group (defines which namespaces are targetted by the
 # operator)
-oc create -f "$root_dir/ocp-resources/compliance-operator-operator-group.yaml"
+oc apply -f "$root_dir/ocp-resources/compliance-operator-operator-group.yaml"
 
 echo "Creating Subscription"
 # Create subscription (which installs the operator)
-oc create -f "$root_dir/ocp-resources/compliance-operator-alpha-subscription.yaml"
+oc apply -f "$root_dir/ocp-resources/compliance-operator-alpha-subscription.yaml"

--- a/utils/deploy_compliance_operator.sh
+++ b/utils/deploy_compliance_operator.sh
@@ -2,7 +2,7 @@
 
 root_dir=$(git rev-parse --show-toplevel)
 
-echo "Ensuring openshift-compliance namespace exists."
+echo "* Ensuring openshift-compliance namespace exists."
 # If it already exists, this is not a problem.
 oc apply -f "$root_dir/ocp-resources/compliance-operator-ns.yaml"
 
@@ -10,17 +10,21 @@ oc apply -f "$root_dir/ocp-resources/compliance-operator-ns.yaml"
 # namespace
 sleep 5
 
-echo "Creating OperatorSource"
+echo "* Creating OperatorSource"
 # Create operator source so we can install the latest available release which
 # is available from an "external datastore"; meaning, it's our upstream release
 # which is not yet in OperatorHub
 oc apply -f "$root_dir/ocp-resources/compliance-operator-source.yaml"
 
-echo "Creating OperatorGroup"
+echo "* Creating OperatorGroup"
 # Create operator group (defines which namespaces are targetted by the
 # operator)
 oc apply -f "$root_dir/ocp-resources/compliance-operator-operator-group.yaml"
 
-echo "Creating Subscription"
+echo "* Creating Subscription"
 # Create subscription (which installs the operator)
 oc apply -f "$root_dir/ocp-resources/compliance-operator-alpha-subscription.yaml"
+
+echo "* The compliance-operator is now installing."
+echo "* To take it into use, do:"
+echo -e "\t$ oc project openshift-compliance"

--- a/utils/deploy_compliance_operator.sh
+++ b/utils/deploy_compliance_operator.sh
@@ -6,6 +6,10 @@ echo "Ensuring openshift-compliance namespace exists."
 # If it already exists, this is not a problem.
 oc apply -f "$root_dir/ocp-resources/compliance-operator-ns.yaml"
 
+# Some clusters may be slow... so let's wait til Kubernetes persists the new
+# namespace
+sleep 5
+
 echo "Creating OperatorSource"
 # Create operator source so we can install the latest available release which
 # is available from an "external datastore"; meaning, it's our upstream release


### PR DESCRIPTION
This:

* Makes the script idempotent by using the `oc apply` command instead of
  `oc create`

* Removes the deprecated resource `csc`.