### PR TITLE
Add several more Kubernetes templates and audit rule remediations for the e8 and moderate profiles

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1527,6 +1527,14 @@ audit_rules_usergroup_modification::
 ** *path* - path that should be part of the audit rule as a value of `-w` argument, eg. `/etc/group`.
 * Languages: Ansible, Bash, OVAL
 
+audit_add_watch_rule::
+* Ensure there is an audit rule that records access to particular files or directories
+* Parameters:
+** *files* - an array of files to set up audit rules for
+** *key* - the key field to identify the meaning of the audit rule
+** *permissions* - the permissions to watch for, please see `man 7 audit.rules` for an example
+* Languages: Kubernetes
+
 file_groupowner::
 * Check group that owns the given file.
 * Parameters:

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1488,6 +1488,12 @@ audit_file_contents::
 ** *contents* - expected contents of the file
 * Languages: Ansible, Bash, OVAL
 
+audit_rules_time::
+* Ensure there is an audit rule that records time-related syscalls. The syscall would be logged using the `audit_time_rules` key
+* Parameters:
+** *syscall* - name of the system call, e.g. `settimeofday`
+* Languages: Kubernetes
+
 audit_rules_unsuccessful_file_modification::
 * Ensure there is an Audit rule to record unsuccessful attempts to access files
 * Parameters:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
@@ -55,3 +55,10 @@ ocil: |-
     configuration, a line should be returned (including
     <tt>perm=wa</tt> indicating permissions that are watched).
 
+template:
+  name: audit_add_watch_rule
+  vars:
+    key: MAC-policy
+    permissions: wa
+    files:
+      - /etc/selinux/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
@@ -63,3 +63,13 @@ ocil: |-
     If the system is configured to watch for network configuration changes, a line should be returned for
     each file specified (and <tt>perm=wa</tt> should be indicated for each).
 
+template:
+  name: audit_add_watch_rule
+  vars:
+    key: audit_rules_networkconfig_modification
+    permissions: wa
+    files:
+      - /etc/issue
+      - /etc/issue.net
+      - /etc/hosts
+      - /etc/sysconfig/network

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/rule.yml
@@ -49,3 +49,12 @@ references:
     iso27001-2013: A.11.2.6,A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.7.1,A.13.1.1,A.13.2.1,A.14.1.3,A.14.2.7,A.15.2.1,A.15.2.2,A.16.1.4,A.16.1.5,A.16.1.7,A.6.2.1,A.6.2.2
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
 
+template:
+  name: audit_add_watch_rule
+  vars:
+    key: session
+    permissions: wa
+    files:
+      - /var/log/utmp
+      - /var/log/btmp
+      - /var/log/wtmp

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
@@ -59,3 +59,7 @@ ocil_clause: 'the system is not configured to audit time changes'
 
 {{{ complete_ocil_entry_audit_syscall(syscall="adjtimex") }}}
 
+template:
+  name: audit_rules_time
+  vars:
+      syscall: adjtimex

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/ignition/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/ignition/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_ocp
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20clock_settime%20-F%20a0%3D0x0%20-k%20time-change%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20clock_settime%20-F%20a0%3D0x0%20-k%20time-change%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-time_clock_settime.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
@@ -59,3 +59,7 @@ ocil_clause: 'the system is not configured to audit time changes'
 
 {{{ complete_ocil_entry_audit_syscall(syscall="settimeofday") }}}
 
+template:
+  name: audit_rules_time
+  vars:
+      syscall: settimeofday

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
@@ -66,3 +66,7 @@ ocil: |-
     If the system is 64-bit only, this is not applicable<br />
     {{{ complete_ocil_entry_audit_syscall(syscall="stime") }}}
 
+template:
+  name: audit_rules_time
+  vars:
+      syscall: stime

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/rule.yml
@@ -58,3 +58,10 @@ ocil: |-
     <pre>$ sudo auditctl -l | grep "watch=/etc/localtime"</pre>
     If the system is configured to audit this activity, it will return a line.
 
+template:
+  name: audit_add_watch_rule
+  vars:
+     permissions: wa
+     key: audit_time_rules
+     files:
+      - /etc/localtime

--- a/shared/templates/template_KUBERNETES_audit_add_watch_rule
+++ b/shared/templates/template_KUBERNETES_audit_add_watch_rule
@@ -1,0 +1,20 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,{{% for FILE in FILES -%}}
+          -w%20{{{ FILE }}}%20-p%20{{{ PERMISSIONS }}}%20-k%20{{{ KEY }}}%0A{{% endfor %}}
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-watch_{{{ _RULE_ID }}}.rules

--- a/shared/templates/template_KUBERNETES_audit_rules_time
+++ b/shared/templates/template_KUBERNETES_audit_rules_time
@@ -1,0 +1,19 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20{{{ SYSCALL }}}%20-F%20key%3Daudit_time_rules%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20{{{ SYSCALL }}}%20-F%20key%3Daudit_time_rules%0A
+        filesystem: root
+        mode: 0644
+        path: /etc/audit/rules.d/75-time_{{{ SYSCALL }}}.rules

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -155,6 +155,11 @@ def audit_rules_time(data, lang):
     return data
 
 
+@template(["kubernetes"])
+def audit_add_watch_rule(data, lang):
+    return data
+
+
 def _file_owner_groupowner_permissions_regex(data):
     data["is_directory"] = data["filepath"].endswith("/")
     if "missing_file_pass" not in data:

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -150,6 +150,11 @@ def audit_file_contents(data, lang):
     return data
 
 
+@template(["kubernetes"])
+def audit_rules_time(data, lang):
+    return data
+
+
 def _file_owner_groupowner_permissions_regex(data):
     data["is_directory"] = data["filepath"].endswith("/")
     if "missing_file_pass" not in data:


### PR DESCRIPTION
#### Description:

- Adds audit rule remediations for auditing of time-related syscalls
- Adds a Kubernetes template for generating audit rules that watch certain files
- Add a Kubernetes remediation that audits the clock_settime syscall

#### Rationale:

- We wanted to have the e8 profile covered for a demo this week, these patches
are leftovers I had in tree. They are also useful for the moderate profile
anyway.