### PR TITLE
Remove ocp4 prodtype from applications/openshift/api-server rules

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
@@ -1,17 +1,13 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Disable the AlwaysAdmit Admission Control Plugin'
 
 description: |-
     To ensure OpenShift only responses to requests explicitly allowed by the
     admissions control plugin, edit the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master node(s)
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
-{{%- endif %}}
     and ensure the <tt>admissionConfig</tt> is not configured to include <tt>AlwaysAdmit</tt>.
 
 rationale: |-
@@ -27,9 +23,5 @@ ocil_clause: '<tt>admissionConfig</tt> is not set'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A4 AlwaysAdmit /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A4 AlwaysAdmit /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return no output.

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the AlwaysPullImages Admission Control Plugin'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_EventRateLimit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_EventRateLimit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the EventRateLimit Admission Control Plugin'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the NamespaceLifecyle Admission Control Plugin'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the NodeRestriction Admission Control Plugin'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_PodSecurityPolicy/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_PodSecurityPolicy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the PodSecurityPolicy Admission Control Plugin'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the SecurityContextDeny Admission Control Plugin'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the ServiceAccount Admission Control Plugin'
 

--- a/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Disable Anonymous Authentication to the API Server'
 
@@ -8,24 +8,11 @@ description: |-
     By default, anonymous access to the OpenShift API is enabled. This
     configuration check ensures that anonymous requests to the OpenShift
     API server are disabled. Edit the API server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master node(s)
-    and set the below parameter:
-    <pre>
-    "apiServerArguments":{
-      ...
-      "anonymous-auth":[
-        "false"
-      ],
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
     and set the below parameter:
     <pre>apiServerArguments:
       anonymous-auth:
       - 'false'</pre>
-{{%- endif %}}
 
 rationale: |-
     When enabled, requests that are not rejected by other configured
@@ -43,9 +30,5 @@ ocil_clause: '<tt>anonymous-auth</tt> is not set to <tt>false</tt>'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A1 anonymous-auth /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A1 anonymous-auth /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return <pre>false</pre>.

--- a/applications/openshift/api-server/api_server_audit_log_maxage/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxage/rule.yml
@@ -1,21 +1,11 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the Audit Log Maximum Retention Days (maximumFileRetentionDays)'
 
 description: |-
     To configure audit log retention, edit the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master node(s) and set
-    the <tt>maximumFileRetentionDays</tt> parameter to <tt>30</tt> or as appropriate for the number of days:
-    <pre>
-    "auditConfig":{
-      ...
-      "maximumFileRetentionDays":30,
-      ...
-     </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s) and set
     the <tt>maximumFileRetentionDays</tt> parameter to <tt>30</tt> or as appropriate for the number of days:
     <pre>auditConfig:
@@ -24,7 +14,6 @@ description: |-
       maximumFileRetentionDays: 30
       maximumFileSizeMegabytes: 10
       maximumRetainedFiles: 10</pre>
-{{%- endif %}}
 
 rationale: |-
     Retaining audit logs for a specified period of time allows OpenShift Operators
@@ -39,9 +28,5 @@ ocil_clause: '<tt>maximumFileRetentionDays</tt> is set less than <tt>30</tt> or 
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep maximumFileRetentionDays /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep maximumFileRetentionDays /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return a value of <pre>30</pre> or as appropriate.

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -1,22 +1,11 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the Maximum Retained Audit Logs'
 
 description: |-
     To configure how many rotations of audit logs are retained, edit the API Server
-{{%- if product == "ocp4" %}}
-    pod specification file <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt>
-    on the master node(s) and set the <tt>maximumRetainedFiles</tt> parameter to
-    <tt>10</tt> or to an organizationally appropriate value:
-       <pre>
-    "auditConfig":{
-      ...
-      "maximumRetainedFiles":10,
-      ...
-     </pre>
-{{% else %}}
     pod specification file <tt>/etc/origin/master/master-config.yaml</tt>
     on the master node(s) and set the <tt>maximumRetainedFiles</tt> parameter to
     <tt>10</tt> or to an organizationally appropriate value:
@@ -26,7 +15,6 @@ description: |-
       maximumFileRetentionDays: 30
       maximumFileSizeMegabytes: 10
       maximumRetainedFiles: 10</pre>
-{{%- endif %}}
 
 rationale: |-
     OpenShift automatically rotates the log files. Retaining old log files ensures
@@ -44,9 +32,5 @@ ocil_clause: '<tt>maximumRetainedFiles</tt> is set to <tt>10</tt> or as appropri
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep maximumRetainedFiles /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep maximumRetainedFiles /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return a value of <pre>10</pre> or as appropriate.

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -1,22 +1,11 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure Maximum Audit Log Size'
 
 description: |-
     To rotate audit logs upon reaching a maximum size, edit the API Server pod
-{{%- if product == "ocp4" %}}
-    specification file <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on
-    the master node(s) and set the <tt>maximumFileSizeMegabytes</tt> parameter to
-    an appropriate size in MB. For example, to set it to 100 MB:
-    <pre>
-    "auditConfig":{
-      ...
-      "maximumFileSizeMegabytes":100,
-      ...
-     </pre>
-{{% else %}}
     specification file <tt>/etc/origin/master/master-config.yaml</tt> on
     the master node(s) and set the <tt>maximumFileSizeMegabytes</tt> parameter to
     an appropriate size in MB. For example, to set it to 100 MB:
@@ -26,7 +15,6 @@ description: |-
       maximumFileRetentionDays: 30
       maximumFileSizeMegabytes: 100
       maximumRetainedFiles: 10</pre>
-{{%- endif %}}
 
 rationale: |-
     OpenShift automatically rotates log files. Retaining old log files ensures that
@@ -44,9 +32,5 @@ ocil_clause: '<tt>maximumFileSizeMegabytes</tt> is set to <tt>100</tt> or as app
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep maximumFileSizeMegabytes /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep maximumFileSizeMegabytes /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return a value of <pre>100</pre> or as appropriate.

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -1,23 +1,12 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the Audit Log Path'
 
 description: |-
     To enable auditing on the OpenShift API Server, the audit log path
     must be set. Edit the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master node(s)
-    and set the <tt>audit-log-path</tt> to a suitable path and file
-    where you would like audit logs to be written. For example:
-    <pre>
-    "auditConfig":{
-      ...
-      "auditFilePath":"/var/log/kube-apiserver/audit.log",
-      ...
-     </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
     and set the <tt>audit-log-path</tt> to a suitable path and file
     where you would like audit logs to be written. For example:
@@ -27,7 +16,6 @@ description: |-
       maximumFileRetentionDays: 30
       maximumFileSizeMegabytes: 10
       maximumRetainedFiles: 10</pre>
-{{%- endif %}}
 
 rationale: |-
     Auditing of the API Server is not enabled by default. Auditing the API Server
@@ -44,9 +32,5 @@ ocil_clause: '<tt>audit-log-path</tt> does not contain a valid audit file path'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep auditFilePath /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep auditFilePath /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return a valid audit log path.

--- a/applications/openshift/api-server/api_server_authorization_mode/rule.yml
+++ b/applications/openshift/api-server/api_server_authorization_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Ensure API Server authorization-mode is set to Webhook'
 
@@ -9,23 +9,11 @@ description: |-
     and the API Server <tt>authorization-mode</tt> is set to <tt>Webhook</tt>.
     To ensure that the API server requires authorization for API requests,
     validate that <tt>authorization-mode</tt> is configured to <tt>Webhook</tt>
-{{%- if product == "ocp4" %}}
-    in <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt>:
-    <pre>
-    "apiServerArguments":{
-      ...
-      "authorization-mode":[
-        "Webhook"
-      ],
-      ...
-    </pre>
-{{% else %}}
     in <tt>/etc/origin/master/master-config.yaml</tt>:
     <pre>kubernetesMasterConfig:
       apiServerArguments:
         authorization-mode:
         - Webhook</pre>
-{{%- endif %}}
 
 warnings:
   - functionality: |-
@@ -45,9 +33,5 @@ ocil_clause: '<tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A1 authorization-mode /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A1 authorization-mode /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     Verify that there is no output, or the output is set to <tt>Webhook</tt>.

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -1,31 +1,18 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Disable basic-auth-file for the API Server'
 
 description: |-
     Basic Authentication should not be used. Follow the OpenShift documentation
     and configure alternate mechanisms for authentication. Then, edit API
-{{%- if product == "ocp4" %}}
-    server pod specification file <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt>
-    on the master node and remove the <tt>basic-auth-file</tt> parameter.
-    <pre>
-    "apiServerArguments":{
-      ...
-      "basic-auth-file":[
-        "/path/to/any/file"
-      ],
-      ...
-    </pre>
-{{% else %}}
     server pod specification file <tt>/etc/origin/master/master-config.yaml</tt>
     on the master node and remove the <tt>basic-auth-file</tt> parameter.
     <pre>kubernetesMasterConfig:
       apiServerArguments:
         basic-auth-file:
         - /path/to/any/file</pre>
-{{%- endif %}}
 
     Alternate authentication mechanisms such as tokens and certificates will need to be
     used. Username and password for basic authentication will be disabled.
@@ -46,9 +33,5 @@ ocil_clause: 'basic-auth-file is configured and enabled on the master node'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A2 basic-auth-file /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A2 basic-auth-file /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return no output.

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the Client Certificate Authority for the API Server'
 
@@ -10,23 +10,12 @@ description: |-
     <tt>clientCA</tt> must be configured. Verify
     that <tt>servingInfo</tt> has the <tt>clientCA</tt> configured in 
     the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "servingInfo":{
-      ...
-      "clientCA":"/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt",
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) to something similar to:
     <pre>servingInfo:
       clientCA: ca.crt
       certFile: master.server.crt
       keyFile: master.server.key</pre>
-{{%- endif %}}
 
 rationale: |-
     API Server communication contains sensitive parameters that should remain
@@ -48,12 +37,6 @@ ocil_clause: '<tt>clientCA</tt> is not set as appropriate for <tt>servingInfo</t
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep clientCA /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"clientCA":"/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt",</pre>
-{{% else %}}
     <pre>$ sudo grep clientCA /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>clientCA: ca.crt</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the etcd Certificate Authority for the API Server'
 
@@ -8,18 +8,6 @@ description: |-
     To ensure etcd is configured to make use of TLS encryption for client
     connections, follow the OpenShift documentation and setup the TLS
     connection between the API Server and etcd. Then, verify
-{{%- if product == "ocp4" %}}
-    that <tt>storageConfig</tt> has the <tt>ca</tt> configured in 
-    the API Server pod specification file
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "storageConfig":{
-      ...
-      "ca":"/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt",
-      ...
-    </pre>
-{{% else %}}
     that <tt>etcdClientInfo</tt> has the <tt>ca</tt> configured in 
     the API Server pod specification file
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
@@ -28,7 +16,6 @@ description: |-
       ca: master.etcd-ca.crt
       certFile: master.etcd-client.crt
       keyFile: master.etcd-client.key</pre>
-{{%- endif %}}
 
 rationale: |-
     etcd is a highly-available key-value store used by OpenShift deployments
@@ -46,15 +33,9 @@ ocil_clause: '{{%- if product == "ocp4" %}}<tt>ca</tt> is not set as appropriate
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep ca /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"ca":"/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt",</pre>
-{{% else %}}
     <pre>$ sudo grep -A3 etcdClientInfo /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>etcdClientInfo:
       ca: master.etcd-ca.crt
       certFile: master.etcd-client.crt
       keyFile: master.etcd-client.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the etcd Certificate for the API Server'
 
@@ -8,18 +8,6 @@ description: |-
     To ensure etcd is configured to make use of TLS encryption for client
     communications, follow the OpenShift documentation and setup the TLS
     connection between the API Server and etcd. Then, verify
-{{%- if product == "ocp4" %}}
-    that <tt>storageConfig</tt> has the <tt>certFile</tt> configured in 
-    the API Server pod specification file
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "storageConfig":{
-      ...
-      "certFile":"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt",
-      ...
-    </pre>
-{{% else %}}
     that <tt>etcdClientInfo</tt> has the <tt>ca</tt> configured in 
     the API Server pod specification file
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
@@ -28,7 +16,6 @@ description: |-
       ca: master.etcd-ca.crt
       certFile: master.etcd-client.crt
       keyFile: master.etcd-client.key</pre>
-{{%- endif %}}
 
 rationale: |-
     etcd is a highly-available key-value store used by OpenShift deployments
@@ -46,15 +33,9 @@ ocil_clause: '<tt>certFile</tt> does not exist or is not configured to valid cer
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep certFile /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"certFile":"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt",</pre>
-{{% else %}}
     <pre>$ sudo grep -A3 etcdClientInfo /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>etcdClientInfo:
       ca: master.etcd-ca.crt
       certFile: master.etcd-client.crt
       keyFile: master.etcd-client.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the etcd Certificate Key for the API Server'
 
@@ -8,18 +8,6 @@ description: |-
     To ensure etcd is configured to make use of TLS encryption for client
     communications, follow the OpenShift documentation and setup the TLS
     connection between the API Server and etcd. Then, verify
-{{%- if product == "ocp4" %}}
-    that <tt>storageConfig</tt> has the <tt>keyFile</tt> configured in 
-    the API Server pod specification file
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "storageConfig":{
-      ...
-      "keyFile":"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key",
-      ...
-    </pre>
-{{% else %}}
     that <tt>etcdClientInfo</tt> has the <tt>ca</tt> configured in 
     the API Server pod specification file
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
@@ -28,7 +16,6 @@ description: |-
       ca: master.etcd-ca.crt
       certFile: master.etcd-client.crt
       keyFile: master.etcd-client.key</pre>
-{{%- endif %}}
 
 rationale: |-
     etcd is a highly-available key-value store used by OpenShift deployments
@@ -46,15 +33,9 @@ ocil_clause: '<tt>keyFile</tt> does not exist or is not configured to valid cert
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep keyFile /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"keyFile":"/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key",</pre>
-{{% else %}}
     <pre>$ sudo grep -A3 etcdClientInfo /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>etcdClientInfo:
       ca: master.etcd-ca.crt
       certFile: master.etcd-client.crt
       keyFile: master.etcd-client.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -1,24 +1,11 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Disable Use of the Insecure Bind Address'
 
 description: |-
     OpenShift should not bind to non-loopback insecure addresses. Edit the API
-{{%- if product == "ocp4" %}}
-    Server pod specification file <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt>
-    on the master node(s) and remove the <tt>insecure-bind-address</tt>
-    parameter.
-    <pre>
-    "apiServerArguments":{
-      ...
-      "insecure-bind-address":[
-        "127.0.0.1"
-      ],
-      ...
-    </pre>
-{{% else %}}
     Server pod specification file <tt>/etc/origin/master/master-config.yaml</tt>
     on the master node(s) and remove the <tt>insecure-bind-address</tt>
     parameter.
@@ -26,7 +13,6 @@ description: |-
       apiServerArguments:
         insecure-bind-address:
         - 127.0.0.1</pre>
-{{%- endif %}}
 
 rationale: |-
     If the API Server is bound to an insecure address the installation would
@@ -43,9 +29,5 @@ ocil_clause: 'insecure-bind-address is exists and has not been removed</tt>'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A2 insecure-bind-address /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A2 insecure-bind-address /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     No output should be returned.

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Prevent Insecure Port Access'
 
@@ -9,11 +9,7 @@ description: |-
     HTTPS with authentication and authorization, and the secure API endpoint
     is bound to 0.0.0.0:8443. To ensure that the insecure port configuration
     has not been enabled, the <tt>insecure-port</tt> setting should not exist
-{{%- if product == "ocp4" %}}
-    in <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master node(s).
-{{% else %}}
     in <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s).
-{{%- endif %}}
 
 rationale: |-
     Configuring the API Server on an insecure port would allow unauthenticated
@@ -31,9 +27,5 @@ ocil_clause: '<tt>insecure-port</tt> setting exists'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A2 insecure-port /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A2 insecure-port /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     There should be no output returned.

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the kubelet Certificate Authority for the API Server'
 
@@ -10,23 +10,12 @@ description: |-
     between the API Server and kubelets. Then, verify
     that <tt>kubeletClientInfo</tt> has the <tt>ca</tt> configured in 
     the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "kubeletClientInfo":{
-      ...
-      "ca":"/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt",
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) to something similar to:
     <pre>kubeletClientInfo:
       ca: ca-bundle.crt
       certFile: master.kubelet-client.crt
       keyFile: master.kubelet-client.key</pre>
-{{%- endif %}}
 
 rationale: |-
     Connections from the API Server to the kubelet are used for fetching logs
@@ -45,15 +34,9 @@ ocil_clause: '<tt>ca</tt> is not set as appropriate for <tt>kubeletClientInfo</t
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A3 kubeletClientInfo /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"ca":"/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt",</pre>
-{{% else %}}
     <pre>$ sudo grep -A3 kubeletClientInfo /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>kubeletClientInfo:
       ca: ca-bundle.crt
       certFile: master.kubelet-client.crt
       keyFile: master.kubelet-client.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the kubelet Certificate File for the API Server'
 
@@ -10,23 +10,12 @@ description: |-
     kubelets. Then, verify
     that <tt>kubeletClientInfo</tt> has the <tt>certFile</tt> configured in 
     the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "kubeletClientInfo":{
-      ...
-      "certFile":"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt",
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) to something similar to:
     <pre>kubeletClientInfo:
       ca: ca-bundle.crt
       certFile: master.kubelet-client.crt
       keyFile: master.kubelet-client.key</pre>
-{{%- endif %}}
 
 rationale: |-
     By default the API Server does not authenticate itself to the kublet's
@@ -43,15 +32,9 @@ ocil_clause: '<tt>certFile</tt> is not set as appropriate for <tt>kubeletClientI
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A3 kubeletClientInfo /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"certFile":"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt",</pre>
-{{% else %}}
     <pre>$ sudo grep -A3 kubeletClientInfo /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>kubeletClientInfo:
       ca: ca-bundle.crt
       certFile: master.kubelet-client.crt
       keyFile: master.kubelet-client.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the kubelet Certificate Key for the API Server'
 
@@ -10,23 +10,12 @@ description: |-
     kubelets. Then, verify
     that <tt>kubeletClientInfo</tt> has the <tt>keyFile</tt> configured in 
     the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "storageConfig":{
-      ...
-      "keyFile":"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key",
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) to something similar to:
     <pre>kubeletClientInfo:
       ca: ca-bundle.crt
       certFile: master.kubelet-client.crt
       keyFile: master.kubelet-client.key</pre>
-{{%- endif %}}
 
 rationale: |-
     By default the API Server does not authenticate itself to the kubelet's
@@ -43,15 +32,9 @@ ocil_clause: '<tt>keyFile</tt> is not set as appropriate for <tt>kubeletClientIn
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep keyFile /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"keyFile":"/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key",</pre>
-{{% else %}}
     <pre>$ sudo grep -A3 kubeletClientInfo /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>kubeletClientInfo:
       ca: ca-bundle.crt
       certFile: master.kubelet-client.crt
       keyFile: master.kubelet-client.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_kubelet_https/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_https/rule.yml
@@ -1,24 +1,11 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable kubelet HTTPS connections to the API Server'
 
 description: |-
     HTTPS should be used for connections between the API Server and Kubelets.
-{{%- if product == "ocp4" %}}
-    Edit the API Server pod specification file <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt>
-    on the master node(s) and remove the <tt>kubelet-https</tt> parameter. This will ensure communications
-    are encrypted using TLS (the default setting).
-    <pre>
-    "apiServerArguments":{
-      ...
-      "kubelet-https":[
-        "false"
-      ],
-      ...
-    </pre>
-{{% else %}}
     Edit the API Server pod specification file <tt>/etc/origin/master/master-config.yaml</tt>
     on the master node(s) and remove the <tt>kubelet-https</tt> parameter. This will ensure communications
     are encrypted using TLS (the default setting).
@@ -26,7 +13,6 @@ description: |-
       apiServerArguments:
         kubelet-https:
         - 'false'</pre>
-{{%- endif %}}
 
 rationale: |-
     Connections from the API Server to Kubelets could potentially carry
@@ -43,9 +29,5 @@ ocil_clause: 'kubelet-https is specified it must be set to <tt>true</tt>'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep kubelet-https /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep kubelet-https /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return no output.

--- a/applications/openshift/api-server/api_server_profiling/rule.yml
+++ b/applications/openshift/api-server/api_server_profiling/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Disable Profiling on the API server'
 

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the API Server Request Timeout'
 
@@ -8,25 +8,12 @@ description: |-
     All components that use the API should connect via the secured port,
     authenticate themselves, and be authorized to use the API. To ensure
     such a configuration, edit the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) and set the <tt>request-timeout</tt> to <tt>300</tt>:
-    <pre>
-    "apiServerArguments":{
-      ...
-      "request-timeout":[
-        "300"
-      ],
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) and set the <tt>request-timeout</tt> to <tt>300</tt>:
     <pre>kubernetesMasterConfig:
       apiServerArguments:
         request-timeout:
         - 300</pre>
-{{%- endif %}}
 
 rationale: |-
     Setting global request timout allows extending the API Server request
@@ -48,9 +35,5 @@ ocil_clause: '<tt>request-timeout</tt> is not set or is not set to an appropriat
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A2 request-timeout /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A2 request-timeout /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return <pre>300</pre>.

--- a/applications/openshift/api-server/api_server_secure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_secure_port/rule.yml
@@ -1,25 +1,11 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the Secure Port for the API Server'
 
 description: |-
     To ensure traffic is served over HTTPS, edit the API Server pod specification
-{{%- if product == "ocp4" %}}
-    file <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master node(s)
-    and either remove the <tt>secure-port</tt>  or set it to a different
-    (non-zero) desired port.
-        in <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt>:
-    <pre>
-    "apiServerArguments":{
-      ...
-      "secure-port":[
-        "8443"
-      ],
-      ...
-    </pre>
-{{% else %}}
     file <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
     and either remove the <tt>secure-port</tt>  or set it to a different
     (non-zero) desired port.
@@ -27,7 +13,6 @@ description: |-
       apiServerArguments:
         secure-port:
         - 8443</pre>
-{{%- endif %}}
 
 rationale: |-
     The secure port is used to serve HTTPS with authentication and authorization.
@@ -43,9 +28,5 @@ ocil_clause: '<tt>secure-port</tt> is set with a value greater than <tt>0</tt>'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A2 secure-port /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A2 secure-port /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should not return <pre>0</pre>.

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -1,24 +1,12 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the Service Account Public Key for the API Server'
 
 description: |-
     To ensure the API Server utilizes its own key pair, edit the
     API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master node(s)
-    and set the <tt>serviceAccountPublicKeyFiles</tt> parameter to the public
-    key file for service accounts:
-    <pre>
-    ...
-    "serviceAccountPublicKeyFiles":[
-      "/etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs"
-    ],
-    ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
     and set the <tt>publicKeyFiles</tt> parameter to the public
     key file for service accounts:
@@ -27,7 +15,6 @@ description: |-
       publicKeyFiles:
       - serviceaccounts.public.key
     ...</pre>
-{{%- endif %}}
 
 rationale: |-
     By default, if no <tt>privateKeyFile</tt> is specified to the
@@ -46,17 +33,7 @@ ocil_clause: '{{%- if product == "ocp4" %}}serviceAccountPublicKeyFiles is not c
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A3 serviceAccountPublicKeyFiles /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain a line similar to:
-    <pre>
-    "serviceAccountPublicKeyFiles":[
-      "/etc/kubernetes/static-pod-resources/configmaps/sa-token-signing-certs"
-    ],
-    </pre>
-{{% else %}}
     <pre>$ sudo grep -A9 serviceAccountConfig /etc/origin/master/master-config.yaml</pre>
     The output should contain a line similar to:
     <pre>publicKeyFiles:
       - serviceaccounts.public.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the Certificate for the API Server'
 
@@ -9,23 +9,12 @@ description: |-
     <tt>certFile</tt> must be configured. Verify
     that <tt>servingInfo</tt> has the <tt>certFile</tt> configured in 
     the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "servingInfo":{
-      ...
-      "certFile":"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) to something similar to:
     <pre>servingInfo:
       clientCA: ca.crt
       certFile: master.server.crt
       keyFile: master.server.key</pre>
-{{%- endif %}}
 
 rationale: |-
     API Server communication contains sensitive parameters that should remain
@@ -41,15 +30,9 @@ ocil_clause: '<tt>certFile</tt> is not set as appropriate for <tt>servingInfo</t
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A7 servingInfo /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-    The output should contain something similar to:
-    <pre>"certFile":"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",</pre>
-{{% else %}}
     <pre>$ sudo grep -A7 servingInfo /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>servingInfo:
       clientCA: ca.crt
       certFile: master.server.crt
       keyFile: master.server.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Use Strong Cryptographic Ciphers on the API Server'
 

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Configure the Certificate Key for the API Server'
 
@@ -9,23 +9,12 @@ description: |-
     <tt>keyFile</tt> must be configured. To, verify
     that <tt>servingInfo</tt> has the <tt>keyFile</tt> configured in 
     the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</tt> on the master
-    node(s) to something similar to:
-    <pre>
-    "servingInfo":{
-      ...
-      "keyFile":"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) to something similar to:
     <pre>servingInfo:
       clientCA: ca.crt
       certFile: master.server.crt
       keyFile: master.server.key</pre>
-{{%- endif %}}
 
 rationale: |-
     API Server communication contains sensitive parameters that should remain
@@ -41,8 +30,6 @@ ocil_clause: '<tt>keyFile</tt> is not set as appropriate for <tt>servingInfo</tt
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-{{% else %}}
     <pre>$ sudo grep -A7 servingInfo /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
     The output should contain something similar to:
     <pre>"keyFile":"/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key",</pre>
@@ -51,4 +38,3 @@ ocil: |-
       clientCA: ca.crt
       certFile: master.server.crt
       keyFile: master.server.key</pre>
-{{%- endif %}}

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Disable Token-based Authentication'
 
@@ -8,25 +8,12 @@ description: |-
     To ensure OpenShift does not accept token-based authentication,
     follow the OpenShift documentation and configure alternate mechanisms for
     authentication. Then, edit the API Server pod specification file
-{{%- if product == "ocp4" %}}
-    <tt>/etc/origin/master/master-config.yaml</tt> on the master
-    node(s) and remove the <tt>token-auth-file</tt> setting.
-    <pre>
-    "apiServerArguments":{
-      ...
-      "token-auth-file":[
-        "/path/to/file"
-      ],
-      ...
-    </pre>
-{{% else %}}
     <tt>/etc/origin/master/master-config.yaml</tt> on the master
     node(s) and remove the <tt>token-auth-file</tt> setting.
     <pre>kubernetesMasterConfig:
       apiServerArguments:
         token-auth-file:
         - /path/to/file</pre>
-{{%- endif %}}
 
 rationale: |-
     The token-based authentication utilizes static tokens to authenticate
@@ -43,9 +30,5 @@ ocil_clause: '<tt>token-auth-file</tt> argument is configured'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ sudo grep -A2 token-auth-file /etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</pre>
-{{% else %}}
     <pre>$ sudo grep -A2 token-auth-file /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should return no output.

--- a/applications/openshift/api-server/group.yml
+++ b/applications/openshift/api-server/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'OpenShift API Server'
 


### PR DESCRIPTION
The rules that are currently defined for OCP4 under applications/openshift are incorrect; It's not feasible to check or modify the underlying static-pod files because these resources are immutable and have no API guarantees. We'll need to replace these with YAML checks, but for now I think we should remove the existing definitions.