### PR TITLE
Add RHEL datastream to ocp4 content image

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -7,8 +7,10 @@ COPY . .
 
 RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 
-RUN ./build_product --debug ocp4
+RUN ./build_product --debug ocp4 rhel7 rhel8
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /content/build/ssg-ocp4-ds.xml .
+COPY --from=builder /content/build/ssg-rhel7-ds.xml .
+COPY --from=builder /content/build/ssg-rhel8-ds.xml .


### PR DESCRIPTION
RHEL nodes can be OCP4 worker nodes, so let's add those datastreams to
the container image so they can be taken into use.