### PR TITLE
ocp4: Test amount of check results for scans

### DIFF
--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -27,10 +27,17 @@ func TestE2e(t *testing.T) {
 		ctx.resetClientMappings()
 	})
 
+	// Remediations
 	var numberOfRemediationsInit int
-	var numberOfFailuresInit int
 	var numberOfRemediationsEnd int
+
+	// Failures
+	var numberOfFailuresInit int
 	var numberOfFailuresEnd int
+
+	// Check Results
+	var numberOfCheckResultsInit int
+	var numberOfCheckResultsEnd int
 
 	t.Run("Run first compliance scan", func(t *testing.T) {
 		// Create suite and auto-apply remediations
@@ -38,6 +45,7 @@ func TestE2e(t *testing.T) {
 		ctx.waitForComplianceSuite(suite)
 		numberOfRemediationsInit = ctx.getRemediationsForSuite(suite, false)
 		numberOfFailuresInit = ctx.getFailuresForSuite(suite, false)
+		numberOfCheckResultsInit = ctx.getCheckResultsForSuite(suite)
 	})
 
 	t.Run("Wait for Remediations to apply", func(t *testing.T) {
@@ -52,6 +60,17 @@ func TestE2e(t *testing.T) {
 		ctx.waitForComplianceSuite(suite)
 		numberOfRemediationsEnd = ctx.getRemediationsForSuite(suite, true)
 		numberOfFailuresEnd = ctx.getFailuresForSuite(suite, true)
+		numberOfCheckResultsEnd = ctx.getCheckResultsForSuite(suite)
+	})
+
+	t.Run("We should have the same number of check results in each scan", func(t *testing.T) {
+		if numberOfCheckResultsInit != numberOfCheckResultsEnd {
+			t.Errorf("The amount of check results are NOT the same: init -> %d  end %d",
+				numberOfCheckResultsInit, numberOfCheckResultsEnd)
+		} else {
+			t.Logf("There amount of check results are the same: init -> %d  end %d",
+				numberOfCheckResultsInit, numberOfCheckResultsEnd)
+		}
 	})
 
 	t.Run("We should have less remediations to apply", func(t *testing.T) {

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -393,6 +393,18 @@ func (ctx *e2econtext) getFailuresForSuite(s *cmpv1alpha1.ComplianceSuite, displ
 	return len(failList.Items)
 }
 
+func (ctx *e2econtext) getCheckResultsForSuite(s *cmpv1alpha1.ComplianceSuite) int {
+	failList := &cmpv1alpha1.ComplianceCheckResultList{}
+	matchLabels := dynclient.MatchingLabels{
+		cmpv1alpha1.SuiteLabel: s.Name,
+	}
+	err := ctx.dynclient.List(goctx.TODO(), failList, matchLabels)
+	if err != nil {
+		ctx.t.Fatalf("Couldn't get remediation list")
+	}
+	return len(failList.Items)
+}
+
 func isNodeReady(node corev1.Node) bool {
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == corev1.NodeReady &&


### PR DESCRIPTION
As a sanity check, we check that the test results are indeed the same
between the first and second scans.

This also helps us compare this number between different test runs.