### PR TITLE
Add support for blacklisting directories when doing system-wide file scans

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -2,13 +2,7 @@
   <definition class="compliance" id="file_permissions_unauthorized_world_writable" version="1">
     <metadata>
       <title>Find Unauthorized World-Writable Files</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_opensuse</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
+      {{{- oval_affected(products) }}}
       <description>The world-write permission should be disabled for all files.</description>
     </metadata>
     <criteria>
@@ -31,6 +25,7 @@
     <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_special_selinux_files</filter>
     <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_proc</filter>
     <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_sys</filter>
+    <filter action="exclude">state_files_in_blacklisted_dirs</filter>
   </unix:file_object>
   <unix:file_state id="state_file_permissions_unauthorized_world_write" version="1">
     <unix:type operation="equals">regular</unix:type>
@@ -45,4 +40,24 @@
   <unix:file_state id="state_file_permissions_unauthorized_world_write_exclude_sys" version="1">
     <unix:filepath operation="pattern match">^/sys/.*$</unix:filepath>
   </unix:file_state>
+
+  <linux:rpmverifyfile_state id="state_files_in_blacklisted_dirs" version="1">
+    <linux:filepath operation="pattern match" var_ref="var_blacklisted_dirs_patterns" var_check="at least one"/>
+  </linux:rpmverifyfile_state>
+
+  <local_variable id="var_blacklisted_dirs_patterns" datatype="string" version="1" comment="Blacklisted directories as filepath regexes">
+    <concat>
+      <literal_component>^</literal_component>
+      <variable_component var_ref="var_blacklisted_dirs"/>
+      <literal_component>.*</literal_component>
+    </concat>
+  </local_variable>
+
+  <local_variable id="var_blacklisted_dirs" datatype="string" version="1" comment="Blacklisted directories">
+    <split delimiter=":">
+      <variable_component var_ref="var_blacklisted_paths"/>
+    </split>
+  </local_variable>
+
+  <external_variable comment="List of blacklisted paths" datatype="string" id="var_blacklisted_paths" version="1" />
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/rule.yml
@@ -11,6 +11,9 @@ description: |-
     this applies to real files and not virtual files that are a part of
     pseudo file systems such as <tt>sysfs</tt> or <tt>procfs</tt>.
 
+    You can use the <code>var_blacklisted_paths</code> XCCDF value to specify a colon-separated list of directories to avoid.
+    For this profile, that would be: {{{ sub_var_value("var_blacklisted_paths") }}}
+
 rationale: |-
     Data in world-writable files can be modified by any
     user on the system. In almost all circumstances, files can be

--- a/linux_os/guide/system/var_blacklisted_paths.var
+++ b/linux_os/guide/system/var_blacklisted_paths.var
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Blacklisted paths'
+
+description: |-
+    Colon-separated list of paths not to scan.
+    Some rules that scan the whole filesystem may use this variable - refer to individual rule description.
+
+type: string
+
+interactive: false
+
+options:
+    default: "/sys:/tmp:/proc"
+


### PR DESCRIPTION
Initial support added to rpm_verify_ownership via the var_blacklisted_paths XCCDF value.

The PR **doesn't work out of the box - please help**: for some reason, the build system doesn't add the `check-export` element to the rule XCCDF, without which the external variable used in the OVAL doesn't work. If I add the `check-export` manually into the datastream, it starts to work.

I think that this mechanism could be ported to macros and used in more rules to enable users to e.g. exclude `/proc` etc. What I don't know is whether this filtering could prevent scanning (which would be really nice), or just collecting, i.e. the scanner would scan, but throw away findings and not eat more RAM, or neither, when the scanner scans, collects and waits for the end to throw everything away.
The fix would be beneficial even for the last case, as  `/proc` may cause false positives.