### PR TITLE
Update unowned user rule warning

### DIFF
--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -56,6 +56,11 @@ ocil: |-
     <pre>$ sudo chown <tt>user</tt> <tt>file</tt></pre>
 
 warnings:
-    - general: |-
-        This rule only considers local users.
-        If you have your users defined outside <code>/etc/passwd</code>, the rule won't consider those.
+    - functionality: |-
+        For this rule to evaluate centralized user accounts, <tt>getent</tt> must be working properly
+        so that running the command <pre>getent passwd</pre> returns a list of all users in your organization.
+        If using the System Security Services Daemon (SSSD), <pre>enumerate = true</pre> must be configured
+        in your organization's domain to return a complete list of users
+    - performance: |-
+        Enabling this rule will result in slower scan times depending on the size of your organization
+        and number of centralized users.


### PR DESCRIPTION
#### Description:

- Update warning for the `no_files_unowned_by_user` rule. 

#### Rationale:

- Current warning is incomplete and doesn't take into account the usage of password_object
