### PR TITLE
pkgname@debian auditd

### DIFF
--- a/linux_os/guide/system/auditing/package_audit_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audit_installed/rule.yml
@@ -29,3 +29,6 @@ template:
         pkgname@ubuntu1404: auditd
         pkgname@ubuntu1604: auditd
         pkgname@ubuntu1804: auditd
+        pkgname@debian8: auditd
+        pkgname@debian9: auditd
+        pkgname@debian10: auditd


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

#### Description:

- The audit system package is called `auditd` on Debian, https://packages.debian.org/buster/auditd

#### Rationale:

- `xccdf_org.ssgproject.content_rule_package_audit_installed` fails.

```
- name: Ensure audit is installed
  package:
    name: audit
    state: present
```
