### PR TITLE
Add RHEL content to quay_publish container image

### DIFF
--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -3,9 +3,11 @@ FROM fedora:latest as builder
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content
 WORKDIR /content
-RUN ./build_product --debug ocp4 rhcos4
+RUN ./build_product --debug ocp4 rhel7 rhel8 rhcos4
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /content/build/ssg-ocp4-ds.xml .
+COPY --from=builder /content/build/ssg-rhel7-ds.xml .
+COPY --from=builder /content/build/ssg-rhel8-ds.xml .
 COPY --from=builder /content/build/ssg-rhcos4-ds.xml .


### PR DESCRIPTION
This is needed to have parity with the ocp4_content image.