### PR TITLE
Remove result files when test scenarios pass.

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -368,6 +368,19 @@ class GenericRunner(object):
 
         if result:
             LogHelper.log_preloaded('pass')
+            if self.clean_files:
+                files_to_remove = [self.verbose_path]
+                if stage in ['initial', 'final']:
+                    files_to_remove.append(self.results_path)
+
+                for fname in tuple(files_to_remove):
+                    try:
+                        if os.path.exists(fname):
+                            os.remove(fname)
+                    except OSError:
+                        logging.error(
+                            "Failed to cleanup file '{0}'"
+                            .format(fname))
         else:
             LogHelper.log_preloaded('fail')
             if self.manual_debug:


### PR DESCRIPTION
#### Description:

- Removes result `xml` files from `initial` and `final` steps of SSG Test Suite when **no** option `--dontclean` is selected.

#### Rationale:

- Saves up disk space.

#### Additional information:

It was a little bit confusing to identify exactly which files to remove... but deleting `self.results_path` seems to be a good start. Also I don't know exactly when `remediation` phase generates files, so if anyone knows which other files can be safely removed, feedback is welcomed.