### PR TITLE
Policy source data format proposal

### DIFF
--- a/docs/policy_source_format.adoc
+++ b/docs/policy_source_format.adoc
@@ -1,0 +1,233 @@
+= Policy source data format
+
+The policy source data format will help us to align policy with an SCAP profile.
+Being able to understand the alignment between policy and the implementing
+profile is important for both developers and SMEs.
+
+The policy source data format adds another layer on top of profiles which stores
+the metadata for security controls and, more importantly, concentrates the
+mapping from requirement to rule at a single place.
+
+We will explain the format using the expected workflow and we will show examples
+of the format.
+
+== Storing controls data
+
+When we develop a new SCAP profile, we first get a PDF with a policy that
+consists of controls (requirements). For example NIST 800-53 controls, ANSSI
+requirements, CIS Benchmark, etc.
+
+To add the policy to SCAP Security Guide git repository, we will create a YAML
+file that represents this policy. There will be a special directory, called
+`controls`, in the repository to store these files. These files serve as a
+database of controls (requirements). They are independent from profiles and
+products. We can extract the interesting data from the PDF and save them in a
+YAML file. We can also create this file manually, or it can be converted from
+some other format (XML, OpenControl) if available.
+
+There can be one YAML file that represents the whole policy. Another option is
+that the file can be splitted into multiple small files to ease orientation. The
+YAML file can look like this:
+
+----
+$ cat controls/abcd.yml
+
+policy: ABCD Benchmark for securing Linux systems
+id: abcd
+version: 1.2.3
+source: https://www.abcd.com/linux.pdf
+controls:
+  - id: R1
+    title: User session timeout
+    description: |-
+      Remote user sessions must be closed after a certain
+      period of inactivity.
+  - id: R2
+    title: Minimization of configuration
+    description: |-
+      The features configured at the level of launched services
+      should be limited to the strict minimum.
+  - id: R3
+    title: Enabling SELinux targeted Policy
+    description: |-
+      It is recommended to enable SELinux in enforcing mode
+      and to use the targeted policy.
+----
+
+Title and description elements can be optional. In future, we can introduce more
+metadata keys if we find it convenient.
+
+In the real world, controls (requirements) can be nested. For example, PCI-DSS
+has tree structure, within requirement 2.3 we can find 2.3.a, 2.3.b, etc.
+Therefore, each item in controls list can contain a controls list.
+
+Once we have the file, we can read through the policy requirements and assess
+each requirement. For the controls we will have to identify whether it can be
+automated by SCAP. If yes, we should look if we already have existing XCCDF
+rules in SCAP Security Guide. 
+
+For example, let’s say that we identified that:
+
+* R1 can be automatically scanned by SCAP and we already have 3 existing rules
+in our repository. However, we want one of them to be selected only on RHEL 9,
+but the rule is applicable to all platforms.
+* R2 is up to manual checking, but we have systemd_target_multi_user which is
+related to this control.
+* R3 can be automatically scanned by SCAP but unfortunately we don’t have any
+rules and checks implemented yet.
+
+For each control we will add the `automated` key, which describes whether the
+control requirement can be automated by SCAP and scanning. Possible values are:
+`yes`, `no`, `partially`.
+
+When XCCDF rules exist, we will assign them to the controls. We will distinguish
+between XCCDF rules which directly implement the given controls (represented by
+`rules` YAML key) and rules that are only related or relevant to the control
+(represented by `related_rules` YAML key).
+
+The rules and related_rules keys consist of a list of rule IDs. If a rule needs
+to be chosen only in some of products despite its `prodtype` we can use Jinja
+macros inside the controls file to choose products.
+
+After we insert our findings to the controls file, the file will look like this:
+
+----
+$ cat controls/abcd.yml
+ 
+policy: ABCD Benchmark for securing Linux systems
+id: abcd
+version: 1.2.3
+source: https://www.abcd.com/linux.pdf
+controls:
+  - id: R1
+    title: User session timeout
+    description: |-
+      Remote user sessions must be closed after a certain
+      period of inactivity.
+    automated: yes
+    rules:
+    - sshd_set_idle_timeout
+    - accounts_tmout
+    - var_accounts_tmout=10_min
+{{% if product == “rhel9” %}}
+    - cockpit_session_timeout
+{{% endif %}}
+  - id: R2
+    title: Minimization of configuration
+    description: |-
+      The features configured at the level of launched services
+      should be limited to the strict minimum.
+    automated: no
+    note: |- 
+      This is individual depending on the system workload
+      therefore needs to be audited manually.
+    related_rules:
+       - systemd_target_multi_user
+  - id: R3
+    title: Enabling SELinux targeted Policy
+    description: |-
+      It is recommended to enable SELinux in enforcing mode
+      and to use the targeted policy.
+    automated: yes
+----
+
+Notice that the `rules` key in control R1 references the rules. Therefore we can
+use the controls YAML file to assign references instead of adding references to
+each `rule.yml` file.
+
+== Using controls in profiles
+
+Later, we can use the policy requirements in profile YAML. Let’s say that we
+will define a “High” profile built from the controls.
+
+We can order the alignment in the same way as the source policy.
+
+----
+$ cat rhel8/profiles/abcd-high.profile
+ 
+documentation_complete: true
+title: ABCD High for Red Hat Enterprise Linux 8
+description: |-
+  This profile contains configuration checks that align to
+  the ABCD benchmark.
+policies:
+- id: abcd
+  controls:
+  - R1
+  - R2
+  - R3
+selections:
+  - security_patches_uptodate
+----
+
+In a similar way, we could define a “Low” profile that selects only some of the
+requirements.
+
+In the example we have selected all controls from `controls/abcd.yml` by listing
+them explicitly. It is possible to shorten it using the “all” value which means
+that all controls will be selected. Let’s show how it will be easier:
+
+----
+$ cat rhel8/profiles/abcd-high.profile
+ 
+documentation_complete: true
+title: ABCD High for Red Hat Enterprise Linux 8
+description: |-
+  This profile contains configuration checks that align to
+  the ABCD benchmark.
+policies:
+- id: abcd
+  controls: all
+selections:
+  - security_patches_uptodate
+----
+
+Finally, when we build the content we will automatically get a SCAP profile
+which contains all XCCDF rules from all controls selected in profile YAML. The
+relevant rules are not selected automatically. In our example, the generated
+profile will contain rules `sshd_set_idle_timeout`, `accounts_tmout` and
+`security_patches_uptodate`. The profile will be compiled to a canonical form.
+
+Example of a compiled profile:
+
+----
+$ cat build/rhel8/profiles/abcd-high.profile
+
+documentation_complete: true
+title: ABCD High for Red Hat Enterprise Linux 8
+description: |-
+  This profile contains configuration checks that align to
+  the ABCD benchmark.
+selections:
+# From abcd control R1:
+  - sshd_set_idle_timeout
+  - accounts_tmout
+  - var_accounts_tmout=10_min
+# other selections:
+  - security_patches_uptodate
+----
+
+== Presentation of data
+
+We will be able to generate policy statistics to discover the state of our
+profile: A script that reads the profile file and policies directory can produce
+the following output:
+
+----
+$ python3 utils/policy_coverage.py rhel8/profiles/abcd-high.profile
+
+SCAP coverage of policy requirements for abcd-high.profile:
+Total requirements: 3
+Implemented: 1 / 3 (33.3 %)
+- R1
+Not Implemented: 1 / 3 (33.3 %)
+- R3
+Not Applicable: 1 / 3 (33.3 %)
+- R2
+----
+
+This can be extended to show also statistics about OVALs, Bash and Ansible
+coverage.
+
+Second option is to generate the precompiled profile file. This will generate
+you a detailed view on the profile.


### PR DESCRIPTION
This is the policy source data format that we will use to improve
development of our profiles. It will allow us to store security controls
and requirements in the repository and then define profiles by using
their IDs instead of separate rules.

This is done in order to solve the problem that there is no easy way to
demonstrate to profile stakeholder the status of their profile.

Intended workflow:

* SME identifies security controls the policy consists of. Those
  controls serve as direct input for our profiles.
* SME goes through controls, and makes sure that they are sufficiently
  covered by rules.
* SME fine-tunes the profile by overriding a couple of individual rules
  in the profile file.

Once the format is accepted we can start developing tools that support
this new workflow.

In future, we can also use it for further refactoring, for example
streamlining the generation of HTML tables.

Add comments as if you review the code.

