### PR TITLE
Add error message to the crypto policy remediation

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/bash/shared.sh
@@ -5,4 +5,17 @@
 
 populate var_system_crypto_policy
 
-update-crypto-policies --set ${var_system_crypto_policy}
+stderr_of_call=$(update-crypto-policies --set ${var_system_crypto_policy} 2>&1 > /dev/null)
+rc=$?
+
+if test "$rc" = 127; then
+	echo "$stderr_of_call" >&2
+	echo "Make sure that the script is installed on the remediated system." >&2
+	echo "See output of the 'dnf provides update-crypto-policies' command" >&2
+	echo "to see what package to (re)install" >&2
+
+	false  # end with an error code
+elif test "$rc" != 0; then
+	echo "Error invoking the update-crypto-policies script: $stderr_of_call" >&2
+	false  # end with an error code
+fi


### PR DESCRIPTION
We have noticed that recently, the `update-crypto-policies` script has been rewritten into Python, which means that it is not available on systems without the Python environment (e.g. containers). Therefore, it may happen that the remediation for this rule can fail in many use cases.

So this PR introduces these changes to the update-crypto-policies invocation handling:

- If the script is not there, come up with a specific warning:
![image](https://user-images.githubusercontent.com/2823847/83885781-1c727080-a747-11ea-8860-872d92b312d3.png)

- If another error occurs, just make it clear that it happened during update-crypto-policies invocation:
![image](https://user-images.githubusercontent.com/2823847/83885899-36ac4e80-a747-11ea-9ca8-fbe06acd9601.png)
