### PR TITLE
Fail the build when some of html guides was not generated properly

### DIFF
--- a/build-scripts/build_all_guides.py
+++ b/build-scripts/build_all_guides.py
@@ -96,6 +96,9 @@ def main():
     for worker in workers:
         worker.join()
 
+    if queue.unfinished_tasks > 0:
+        raise RuntimeError("Some of the guides were not exported successfully")
+
     index_source = ssg.build_guides.build_index(benchmarks, input_basename,
                                                 index_links, index_options,
                                                 index_initial_src)

--- a/ssg/build_guides.py
+++ b/ssg/build_guides.py
@@ -80,7 +80,6 @@ def builder(queue):
                 "Fatal error encountered when generating guide '%s'. "
                 "Error details:\n%s\n\n" % (guide_path, error)
             )
-            queue.task_done()
             with queue.mutex:
                 queue.queue.clear()
             raise error


### PR DESCRIPTION
In order to understand this change, let me please drive your attention to the cmake macro called `ssg_build_html_guides`. The said macro builds all the HTML guides for a given product and the guide index. The existence of the guide index makes the `make` command skip the macro and hence, we need to ensure all the guides are generated properly, before ever generating the guide index.

Previously, when guide generation failed no error was reported. But more importantly, subsequent run of the `make` did not generate the guide as the index was well in place.

Looking at the code, I get a feeling that original authors wanted to make the build error out on failure (given the exception handling code in the thread main).

:flamingo: 