### PR TITLE
Use specific OVAL check to verify that a system is RHCOS4

### DIFF
--- a/shared/checks/oval/installed_OS_is_rhcos4.xml
+++ b/shared/checks/oval/installed_OS_is_rhcos4.xml
@@ -7,10 +7,39 @@
       </affected>
       <reference ref_id="cpe:/a:redhat:enterprise_linux_coreos:4" source="CPE" />
       <description>The operating system installed on the system is
-      Red Hat Enterprise Linux CoreOS</description>
+      Red Hat Enterprise Linux CoreOS release 4</description>
     </metadata>
     <criteria>
-      <extend_definition comment="RHEL8 OS installed" definition_ref="installed_OS_is_rhel8" />
+      <criteria operator="AND">
+        <criterion comment="RHCOS is installed" test_ref="test_rhcos" />
+        <criterion comment="RHCOS version 4 is installed" test_ref="test_rhcos4" />
+      </criteria>
     </criteria>
   </definition>
+
+  <ind:textfilecontent54_test check="all" comment="os-release is rhcos" id="test_rhcos" version="1">
+    <ind:object object_ref="obj_rhcos" />
+    <ind:state state_ref="state_rhcos" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhcos" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^ID=&quot;(\w+)&quot;$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhcos" version="1">
+    <ind:subexpression operation="pattern match">rhcos</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" comment="rhcoreos is version 4" id="test_rhcos4" version="1">
+    <ind:object object_ref="obj_rhcos4" />
+    <ind:state state_ref="state_rhcos4" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhcos4" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=&quot;(\d)\.\d+&quot;$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhcos4" version="1">
+    <ind:subexpression operation="pattern match">4</ind:subexpression>
+  </ind:textfilecontent54_state>
 </def-group>

--- a/shared/checks/oval/installed_OS_is_rhel8.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8.xml
@@ -16,7 +16,6 @@
       test_ref="test_rhel8_unix_family" />
       <criteria operator="OR">
         <criterion comment="RHEL 8 is installed" test_ref="test_rhel8" />
-        <criterion comment="RHEL 8 CoreOS is installed" test_ref="test_rhel8_coreos" />
         <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
           <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
           <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 8" test_ref="test_rhevh_rhel8_version" />
@@ -44,19 +43,6 @@
   <linux:rpminfo_object id="obj_rhel8" version="1">
     <linux:name>redhat-release</linux:name>
   </linux:rpminfo_object>
-
-  <ind:textfilecontent54_test check="all" comment="redhat-release-coreos is version 8" id="test_rhel8_coreos" version="1">
-    <ind:object object_ref="obj_rhel8_coreos" />
-    <ind:state state_ref="state_rhel8_coreos" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_rhel8_coreos" version="1">
-    <ind:filepath>/etc/os-release</ind:filepath>
-    <ind:pattern operation="pattern match">^PRETTY_NAME=&quot;Red Hat Enterprise Linux CoreOS \d+\.(\d)\d+\.[\d\.\-]+ \([\w\s]+\)&quot;$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_rhel8_coreos" version="1">
-    <ind:subexpression operation="pattern match">8</ind:subexpression>
-  </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 8" id="test_rhevh_rhel8_version" version="1">
     <ind:object object_ref="obj_rhevh_rhel8_version" />


### PR DESCRIPTION
We used to bundle the check into the RHEL8 checks. However, we've
noticed that the same checks for RHCOS won't be the same as for RHEL. So
let's separate them.

On the other hand, the RHCOS checks were broken by a recent change on
the `PRETTY_NAME` format in the `/etc/os-release` file we were checking.
So instead, we switch to checking the `ID` key to match `rhcos` and
`VERSION_ID` to match `4`.