### PR TITLE
ocp4: Fix platform check helper script

### DIFF
--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -223,7 +223,7 @@ def createTestProfile(rule):
 
 
 def clusterTestFunc(args):
-    build_cmd = 'utils/build_ds_container.sh ocp4'
+    build_cmd = 'utils/build_ds_container.sh'
 
     if which('oc') is None:
         print('oc is required to test a rule in-cluster.')


### PR DESCRIPTION
A recent change modified the `utils/build_ds_container.sh` script's
arguments. This makes the needed changes to the helper script as well.