### PR TITLE
fixes for build under Python 3.9

### DIFF
--- a/build-scripts/sds_move_ocil_to_checks.py
+++ b/build-scripts/sds_move_ocil_to_checks.py
@@ -106,7 +106,7 @@ def move_ocil_content_from_ds_extended_component_to_ds_component(datastreamtree,
     timestamp = extendedcomp.get('timestamp')
 
     # Get children elements of <ds:extended-component> containing OCIL content
-    extchildren = extendedcomp.getchildren()
+    extchildren = list(extendedcomp)
     # There should be just one OCIL subcomponent in <ds:extended-component>
     if len(extchildren) != 1:
         sys.stderr.write("ds:extended-component contains more than one element!"

--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -179,7 +179,7 @@ def main():
     check_content_refs = xccdftree.findall(".//{%s}check-content-ref"
                                            % xccdf_ns)
 
-    xccdf_parent_map = dict((c, p) for p in xccdftree.getiterator() for c in p)
+    xccdf_parent_map = dict((c, p) for p in xccdftree.iter() for c in p)
     # now we can actually do the verification work here
     if options.rules_with_invalid_checks or options.all_checks:
         for check_content_ref in check_content_refs:

--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -179,7 +179,13 @@ def main():
     check_content_refs = xccdftree.findall(".//{%s}check-content-ref"
                                            % xccdf_ns)
 
-    xccdf_parent_map = dict((c, p) for p in xccdftree.iter() for c in p)
+    # decide on usage of .iter or .getiterator method of elementtree class.
+    # getiterator is deprecated in Python 3.9, but iter is not available in
+    # older versions
+    if getattr(xccdftree, 'iter', None) == None:
+        xccdf_parent_map = dict((c, p) for p in xccdftree.getiterator() for c in p)
+    else:
+        xccdf_parent_map = dict((c, p) for p in xccdftree.iter() for c in p)
     # now we can actually do the verification work here
     if options.rules_with_invalid_checks or options.all_checks:
         for check_content_ref in check_content_refs:

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -20,7 +20,10 @@
 #      Martin Preisler <mpreisle@redhat.com>
 
 import logging
-from xml.etree import cElementTree as ElementTree
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    from xml.etree import ElementTree as ElementTree
 import json
 import sys
 import os

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -111,7 +111,7 @@ def main():
             benchmark.findall(".//{%s}Value" % (XCCDF_NAMESPACE)):
         values.append(value)
 
-    parent_map = dict((c, p) for p in benchmark.getiterator() for c in p)
+    parent_map = dict((c, p) for p in benchmark.iter() for c in p)
     for rule in \
             benchmark.findall(".//{%s}Rule" % (XCCDF_NAMESPACE)):
         parent_map[rule].remove(rule)

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -111,7 +111,13 @@ def main():
             benchmark.findall(".//{%s}Value" % (XCCDF_NAMESPACE)):
         values.append(value)
 
-    parent_map = dict((c, p) for p in benchmark.iter() for c in p)
+    # decide on usage of .iter or .getiterator method of elementtree class.
+    # getiterator is deprecated in Python 3.9, but iter is not available in
+    # older versions
+    if getattr(benchmark, "iter", None) == None:
+        parent_map = dict((c, p) for p in benchmark.getiterator() for c in p)
+    else:
+        parent_map = dict((c, p) for p in benchmark.iter() for c in p)
     for rule in \
             benchmark.findall(".//{%s}Rule" % (XCCDF_NAMESPACE)):
         parent_map[rule].remove(rule)

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -17,7 +17,7 @@ def extract_subelement(objects, sub_elem_type):
     """
 
     for obj in objects:
-        for subelement in obj.getiterator():
+        for subelement in obj.iter():
             if subelement.get(sub_elem_type):
                 sub_element = subelement.get(sub_elem_type)
                 return sub_element
@@ -44,12 +44,12 @@ def extract_referred_nodes(tree_with_refs, tree_with_ids, attrname):
     reflist = []
     elementlist = []
 
-    for element in tree_with_refs.getiterator():
+    for element in tree_with_refs.iter():
         value = element.get(attrname)
         if value is not None:
             reflist.append(value)
 
-    for element in tree_with_ids.getiterator():
+    for element in tree_with_ids.iter():
         if element.get("id") in reflist:
             elementlist.append(element)
 

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -17,7 +17,14 @@ def extract_subelement(objects, sub_elem_type):
     """
 
     for obj in objects:
-        for subelement in obj.iter():
+        # decide on usage of .iter or .getiterator method of elementtree class.
+        # getiterator is deprecated in Python 3.9, but iter is not available in
+        # older versions
+        if getattr(obj, "iter", None) == None:
+            obj_iterator = obj.getiterator()
+        else:
+            obj_iterator = obj.iter()
+        for subelement in obj_iterator:
             if subelement.get(sub_elem_type):
                 sub_element = subelement.get(sub_elem_type)
                 return sub_element
@@ -44,12 +51,27 @@ def extract_referred_nodes(tree_with_refs, tree_with_ids, attrname):
     reflist = []
     elementlist = []
 
-    for element in tree_with_refs.iter():
+
+    # decide on usage of .iter or .getiterator method of elementtree class.
+    # getiterator is deprecated in Python 3.9, but iter is not available in
+    # older versions
+    if getattr(tree_with_refs, "iter", None) == None:
+        tree_with_refs_iterator = tree_with_refs.getiterator()
+    else:
+        tree_with_refs_iterator = tree_with_refs.iter()
+    for element in tree_with_refs_iterator:
         value = element.get(attrname)
         if value is not None:
             reflist.append(value)
 
-    for element in tree_with_ids.iter():
+    # decide on usage of .iter or .getiterator method of elementtree class.
+    # getiterator is deprecated in Python 3.9, but iter is not available in
+    # older versions
+    if getattr(tree_with_ids, "iter", None) == None:
+        tree_with_ids_iterator = tree_with_ids.getiterator()
+    else:
+        tree_with_ids_iterator = tree_with_ids.iter()
+    for element in tree_with_ids_iterator:
         if element.get("id") in reflist:
             elementlist.append(element)
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -735,7 +735,7 @@ def expand_xccdf_subs(fix, remediation_type, remediation_functions):
         # First concat output form of modified fix text (including text appended
         # to all children of the fix)
         modfix = [fix.text]
-        for child in fix.getchildren():
+        for child in list(fix):
             if child is not None and child.text is not None:
                 modfix.append(child.text)
         modfixtext = "".join(modfix)

--- a/ssg/build_stig.py
+++ b/ssg/build_stig.py
@@ -38,7 +38,7 @@ def add_references(reference, destination):
         for ref in refs:
             if (ref.get('href').startswith(stig_refs) and
                     ref.text in dictionary):
-                index = rule.getchildren().index(ref)
+                index = list(rule).index(ref)
                 new_ref = ET.Element(
                     '{%s}reference' % XCCDF11_NS, {'href': stig_ns})
                 new_ref.text = dictionary[ref.text]

--- a/ssg/id_translate.py
+++ b/ssg/id_translate.py
@@ -64,7 +64,14 @@ class IDTranslator(object):
         )
 
     def translate(self, tree, store_defname=False):
-        for element in tree.iter():
+        # decide on usage of .iter or .getiterator method of elementtree class.
+        # getiterator is deprecated in Python 3.9, but iter is not available in
+        # older versions
+        if getattr(tree, "iter", None) == None:
+            tree_iterator = tree.getiterator()
+        else:
+            tree_iterator = tree.iter()
+        for element in tree_iterator:
             idname = element.get("id")
             if idname:
                 # store the old name if requested (for OVAL definitions)

--- a/ssg/id_translate.py
+++ b/ssg/id_translate.py
@@ -64,7 +64,7 @@ class IDTranslator(object):
         )
 
     def translate(self, tree, store_defname=False):
-        for element in tree.getiterator():
+        for element in tree.iter():
             idname = element.get("id")
             if idname:
                 # store the old name if requested (for OVAL definitions)

--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -9,7 +9,7 @@ from .constants import xml_version, oval_header, timestamp, PREFIX_TO_NS
 try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
-    import cElementTree as ElementTree
+    from xml.etree import ElementTree as ElementTree
 
 
 def oval_generated_header(product_name, schema_version, ssg_version):


### PR DESCRIPTION
#### Description:

If cElementTree module is not found, import ElementTree.
Also replace instances of element.getchildren() with list(element) and element.getiterator() with element.iter().

#### Rationale:

Build on Fedora Rawhide failed. Fixes were applied based on deprecation info here:
https://docs.python.org/3.8/library/xml.etree.elementtree.html

- Fixes #5816
