### PR TITLE
Change oval check to verify if we're in OCP4

### DIFF
--- a/applications/openshift/ocp_data_root.var
+++ b/applications/openshift/ocp_data_root.var
@@ -14,4 +14,4 @@ operator: equals
 interactive: false
 
 options:
-    default: /tmp
+    default: /kubernetes-api-resources

--- a/applications/openshift/ocp_idp_no_htpasswd/tests/correct.pass.sh
+++ b/applications/openshift/ocp_idp_no_htpasswd/tests/correct.pass.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-mkdir -p /tmp/apis/config.openshift.io/v1/oauths
+mkdir -p /kubernetes-api-resources/apis/config.openshift.io/v1/oauths
 
-cat << EOF > /tmp/apis/config.openshift.io/v1/oauths/cluster
+cat << EOF > /kubernetes-api-resources/apis/config.openshift.io/v1/oauths/cluster
 spec:
   identityProviders:
   - foo: bar

--- a/applications/openshift/ocp_idp_no_htpasswd/tests/htpasswd.fail.sh
+++ b/applications/openshift/ocp_idp_no_htpasswd/tests/htpasswd.fail.sh
@@ -2,9 +2,9 @@
 
 # remediation = none
 
-mkdir -p /tmp/apis/config.openshift.io/v1/oauths
+mkdir -p /kubernetes-api-resources/apis/config.openshift.io/v1/oauths
 
-cat << EOF > /tmp/apis/config.openshift.io/v1/oauths/cluster
+cat << EOF > /kubernetes-api-resources/apis/config.openshift.io/v1/oauths/cluster
 spec:
   identityProviders:
   - foo: bar

--- a/applications/openshift/ocp_idp_no_htpasswd/tests/no_file.fail.sh
+++ b/applications/openshift/ocp_idp_no_htpasswd/tests/no_file.fail.sh
@@ -2,4 +2,4 @@
 
 # remediation = none
 
-rm -rf /tmp/apis/config.openshift.io/v1/oauths
+rm -rf /kubernetes-api-resources/apis/config.openshift.io/v1/oauths

--- a/applications/openshift/ocp_idp_no_htpasswd/tests/nothing_wrong.pass.sh
+++ b/applications/openshift/ocp_idp_no_htpasswd/tests/nothing_wrong.pass.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-mkdir -p /tmp/apis/config.openshift.io/v1/oauths
+mkdir -p /kubernetes-api-resources/apis/config.openshift.io/v1/oauths
 
-cat << EOF > /tmp/apis/config.openshift.io/v1/oauths/cluster
+cat << EOF > /kubernetes-api-resources/apis/config.openshift.io/v1/oauths/cluster
 spec:
    nothing: here
 EOF

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -93,7 +93,10 @@ def main():
                     variables.clear()
                     variables.append(local_var)
                     env_obj = ssg.build_cpe.extract_env_obj(env_objects, local_var)
-                    objects.append(env_obj)
+                    # env_obj will return no objects if the local variable doesn't
+                    # reference any object via object_ref
+                    if env_obj:
+                        objects.append(env_obj)
         else:
             ovaltree.remove(variables)
 

--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -20,11 +20,7 @@
   </ind:yamlfilecontent_test>
 
   <local_variable id="ocp4_dump_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
-      <concat>
-              <!--<variable_component var_ref="ocp_data_root"/>-->
-          <variable_component var_ref="ocp_data_root"/>
-          <literal_component>/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver</literal_component>
-      </concat>
+      <literal_component>/kubernetes-api-resources/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver</literal_component>
   </local_variable>
 
   <unix:file_test id="test_file_for_ocp4" check="only one" comment="Find the actual file to be scanned." version="1">
@@ -43,6 +39,4 @@
   <ind:yamlfilecontent_state id="state_ocp4" version="1">
       <ind:value_of datatype="string" operation="pattern match">4\..*</ind:value_of>
   </ind:yamlfilecontent_state>
-
-  <external_variable comment="Root of downloaded API objects" datatype="string" id="ocp_data_root" version="1" />
 </def-group>

--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -8,8 +8,41 @@
       <reference ref_id="cpe:/a:redhat:openshift_container_platform:4.1" source="CPE" />
       <description>The application installed installed on the system is OpenShift 4.</description>
     </metadata>
-    <criteria>
-      <extend_definition comment="RHEL8 OS installed" definition_ref="installed_OS_is_rhel8" />
+    <criteria operator="AND">
+      <criterion comment="cluster is OpenShift 4" test_ref="test_ocp4" />
+      <criterion comment="Make sure OCP4 clusteroperators file is present" test_ref="test_file_for_ocp4"/>
     </criteria>
   </definition>
+
+  <ind:yamlfilecontent_test id="test_ocp4" check="at least one" comment="Find one match" version="1">
+      <ind:object object_ref="object_ocp4"/>
+      <ind:state state_ref="state_ocp4"/>
+  </ind:yamlfilecontent_test>
+
+  <local_variable id="ocp4_dump_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
+      <concat>
+              <!--<variable_component var_ref="ocp_data_root"/>-->
+          <variable_component var_ref="ocp_data_root"/>
+          <literal_component>/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver</literal_component>
+      </concat>
+  </local_variable>
+
+  <unix:file_test id="test_file_for_ocp4" check="only one" comment="Find the actual file to be scanned." version="1">
+      <unix:object object_ref="object_file_for_ocp4"/>
+  </unix:file_test>
+
+  <unix:file_object id="object_file_for_ocp4" version="1">
+      <unix:filepath var_ref="ocp4_dump_location"/>
+  </unix:file_object>
+
+  <ind:yamlfilecontent_object id="object_ocp4" version="1">
+      <ind:filepath var_ref="ocp4_dump_location"/>
+      <ind:yamlpath>.status.versions[:].version</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
+  <ind:yamlfilecontent_state id="state_ocp4" version="1">
+      <ind:value_of datatype="string" operation="pattern match">4\..*</ind:value_of>
+  </ind:yamlfilecontent_state>
+
+  <external_variable comment="Root of downloaded API objects" datatype="string" id="ocp_data_root" version="1" />
 </def-group>

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -27,12 +27,19 @@ def extract_env_obj(objects, local_var):
     """
     From a collection of objects, return the object with id matching
     the object_ref of the local variable.
+
+    NOTE: This assumes that a local variable can only reference one object.
+    Which is not true, variables can reference multiple objects.
+    But this assumption should work for OVAL checks for CPEs,
+    as they are not that complicated.
     """
 
     for obj in objects:
         env_id = extract_subelement(local_var, 'object_ref')
         if env_id == obj.get('id'):
             return obj
+
+    return None
 
 
 def extract_referred_nodes(tree_with_refs, tree_with_ids, attrname):


### PR DESCRIPTION
The check used to verify if it was a RHEL node, but this is not ideal.
This changes it so that we rely on an object fetched from the cluster
that contains the version, and we check that the version is correct.

This effectively makes the OCP4 product only usable for API/platform
checks (meaning, kubernetes checks).