### PR TITLE
Fix python2 python3 sanity check test

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -271,7 +271,7 @@ macro(ssg_build_ansible_playbooks PRODUCT)
     set(ANSIBLE_PLAYBOOKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/playbooks")
     add_custom_command(
         OUTPUT "${ANSIBLE_PLAYBOOKS_DIR}"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --ssg-root "${CMAKE_SOURCE_DIR}" --product "${PRODUCT}"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --ssg-root "${CMAKE_SOURCE_DIR}" --product "${PRODUCT}" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --output-dir "${ANSIBLE_PLAYBOOKS_DIR}"
         DEPENDS "${ANSIBLE_FIXES_DIR}"
         DEPENDS generate-internal-${PRODUCT}-ansible-all-fixes
         DEPENDS "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py"

--- a/shared/transforms/xccdf-get-only-remediations-sorted.xslt
+++ b/shared/transforms/xccdf-get-only-remediations-sorted.xslt
@@ -54,6 +54,24 @@
 					<xsl:with-param name="type">ANACONDA</xsl:with-param>
 				</xsl:call-template>
 			</xsl:for-each>
+
+			<xsl:for-each select="//xccdf:fix[@system='urn:xccdf:fix:script:ignition']">
+				<xsl:sort select="../@id" data-type="text" order="ascending" />
+				<xsl:call-template name="fix-template">
+					<xsl:with-param name="fix"><xsl:value-of select="." /></xsl:with-param>
+					<xsl:with-param name="id"><xsl:value-of select="../@id" /></xsl:with-param>
+					<xsl:with-param name="type">IGNITION</xsl:with-param>
+				</xsl:call-template>
+			</xsl:for-each>
+
+			<xsl:for-each select="//xccdf:fix[@system='urn:xccdf:fix:script:kubernetes']">
+				<xsl:sort select="../@id" data-type="text" order="ascending" />
+				<xsl:call-template name="fix-template">
+					<xsl:with-param name="fix"><xsl:value-of select="." /></xsl:with-param>
+					<xsl:with-param name="id"><xsl:value-of select="../@id" /></xsl:with-param>
+					<xsl:with-param name="type">KUBERNETES</xsl:with-param>
+				</xsl:call-template>
+			</xsl:for-each>
 		</benchmark>
 	</xsl:template>
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -305,7 +305,7 @@ class AnsibleRemediation(Remediation):
             else:
                 reboot_tag = "no_reboot_needed"
             tags.append(reboot_tag)
-        to_update["tags"] = tags
+        to_update["tags"] = sorted(tags)
 
     def update_tags_from_rule(self, to_update):
         if not self.associated_rule:
@@ -321,7 +321,7 @@ class AnsibleRemediation(Remediation):
 
         refs = self.get_references()
         tags.extend(refs)
-        to_update["tags"] = tags
+        to_update["tags"] = sorted(tags)
 
     def _get_cce(self):
         return self.associated_rule.identifiers.get("cce", None)

--- a/utils/compare_generated.sh
+++ b/utils/compare_generated.sh
@@ -199,7 +199,7 @@ function save_find_results_to_filenames_array() {
 # $1: First build directory
 function operate_on_builddirs() {
 	local first_directory="$1" second_directory="$2" first_file second_file rc
-	save_find_results_to_filenames_array "$first_directory" "*-ds.xml"
+	save_find_results_to_filenames_array "$first_directory" "ssg-*-ds*.xml"
 
 	for first_file in "${filenames[@]}"; do
 		second_file="$(same_file_in_second_directory "$first_file" "$first_directory" "$second_directory")"


### PR DESCRIPTION
#### Description:

- Fix CMake File to proper work with custom build directories
- Update `utils/compare_generated.sh` to consider SCAP1.2 datastreams
- Add Ignition/Kubernetes remediation to the file :`shared/transforms/xccdf-get-only-remediations-sorted.xslt` which extracts remediation content from the datastream to be compared.
- Sort tags before including into ansible playbooks

#### Rationale:

- I stumbled upon this test `tests/python2_vs_python3_sanity.sh` and it was not working because it uses a custom build directory and our cmake file was missing some inputs to work better with custom build directories. The test aims to detect deviations between content generated by python2 and python3. It has detected one issue with tags on ansible playbooks where the content was not being sorted leading to differences.
