### PR TITLE
Add dev_shm rules to rhel7 stig profile

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -26,6 +26,7 @@ references:
     cis@rhel8: 1.1.5
     cis@ubuntu1804: 1.1.14
     stigid@ol7: "021022"
+    stigid@rhel7: "021022"
     disa: "1764"
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -29,6 +29,7 @@ references:
     cis@rhel8: 1.1.17
     cis@ubuntu1804: 1.1.16
     stigid@ol7: "021024"
+    stigid@rhel7: "021024"
     disa: "1764"
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -26,6 +26,7 @@ references:
     cis@rhel8: 1.1.16
     cis@ubuntu1804: 1.1.15
     stigid@ol7: "021023"
+    stigid@rhel7: "021023"
     disa: "1764"
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -293,3 +293,6 @@ selections:
     - audit_rules_usergroup_modification_opasswd
     - sysctl_net_ipv4_conf_all_accept_redirects
     - wireless_disable_interfaces
+    - mount_option_dev_shm_nodev
+    - mount_option_dev_shm_noexec
+    - mount_option_dev_shm_nosuid


### PR DESCRIPTION
#### Description:

- The following rules are all DISA stig requirements but are not included in the rhel7 stig profile, this adds them:
  - mount_option_dev_shm_nodev (https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-02-26/finding/V-81009)
  - mount_option_dev_shm_noexec (https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-02-26/finding/V-81013)
  - mount_option_dev_shm_nosuid (https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-02-26/finding/V-81011)

#### Rationale:

- OL7 references already existed, add the rhel7 references and include the in the rhel7 stig.profile
- Fixes #3374, fixes #3375, and fixes #3376