### PR TITLE
ocp4 e2e: Enable testing for different products

### DIFF
--- a/tests/ocp4e2e/Makefile
+++ b/tests/ocp4e2e/Makefile
@@ -1,5 +1,7 @@
 PROFILE?=
-TEST_TYPE?=
+# Defines the product that the test aims to test
+# Since we already have test for RHCOS4, this is the default for now.
+PRODUCT?=rhcos4
 CONTENT_IMAGE?=
 export ROOT_DIR=$(shell git rev-parse --show-toplevel)
 TEST_DIR=$(ROOT_DIR)/tests/ocp4e2e
@@ -13,9 +15,9 @@ INSTALL_OPERATOR?=true
 all: e2e
 
 .PHONY: e2e
-e2e: image-to-cluster ## Run the e2e tests. This requires that the PROFILE environment variable be set. This will upload images to the cluster as part of the run with the `image-to-cluster` target.
+e2e: image-to-cluster ## Run the e2e tests. This requires that the PROFILE and PRODUCT environment variables be set. This will upload images to the cluster as part of the run with the `image-to-cluster` target.
 	pushd $(TEST_DIR) && \
-	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -type="$(TEST_TYPE)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
+	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -product="$(PRODUCT)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
 
 .PHONY: image-to-cluster
 image-to-cluster: ## Upload a content image to the cluster. The SKIP_CONTAINER_PUSH environment variable skips this step; the CONTENT_IMAGE environment variable takes a pre-uploaded image into use.

--- a/tests/ocp4e2e/Makefile
+++ b/tests/ocp4e2e/Makefile
@@ -1,4 +1,5 @@
 PROFILE?=
+TEST_TYPE?=
 CONTENT_IMAGE?=
 export ROOT_DIR=$(shell git rev-parse --show-toplevel)
 TEST_DIR=$(ROOT_DIR)/tests/ocp4e2e
@@ -14,7 +15,7 @@ all: e2e
 .PHONY: e2e
 e2e: image-to-cluster ## Run the e2e tests. This requires that the PROFILE environment variable be set. This will upload images to the cluster as part of the run with the `image-to-cluster` target.
 	pushd $(TEST_DIR) && \
-	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
+	go test $(TEST_FLAGS) . -profile="$(PROFILE)" -type="$(TEST_TYPE)" -content-image="$(CONTENT_IMAGE)" -install-operator=$(INSTALL_OPERATOR)
 
 .PHONY: image-to-cluster
 image-to-cluster: ## Upload a content image to the cluster. The SKIP_CONTAINER_PUSH environment variable skips this step; the CONTENT_IMAGE environment variable takes a pre-uploaded image into use.

--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -7,19 +7,10 @@ import (
 
 func TestE2e(t *testing.T) {
 	ctx := newE2EContext(t)
-	Setup(t, ctx)
-	switch ctx.testtype {
-	case "rhcos4":
-		RHCOS4Tests(ctx)
-	case "ocp4":
-		OCP4Tests(ctx)
-	}
-}
-
-func Setup(t *testing.T, ctx *e2econtext) {
 	t.Run("Parameter setup and validation", func(t *testing.T) {
 		ctx.assertRootdir()
 		ctx.assertProfile()
+		ctx.assertScanType()
 		ctx.assertContentImage()
 		ctx.assertKubeClient()
 	})
@@ -36,9 +27,7 @@ func Setup(t *testing.T, ctx *e2econtext) {
 		}
 		ctx.resetClientMappings()
 	})
-}
 
-func RHCOS4Tests(ctx *e2econtext) {
 	// Remediations
 	var numberOfRemediationsInit int
 	var numberOfRemediationsEnd int
@@ -51,64 +40,68 @@ func RHCOS4Tests(ctx *e2econtext) {
 	var numberOfCheckResultsInit int
 	var numberOfCheckResultsEnd int
 
-	ctx.t.Run("Run first compliance scan", func(t *testing.T) {
+	// Invalid check results
+	var numberOfInvalidResults int
+
+	t.Run("Run first compliance scan", func(t *testing.T) {
 		// Create suite and auto-apply remediations
 		suite := ctx.createComplianceSuiteForProfile("1", true)
 		ctx.waitForComplianceSuite(suite)
 		numberOfRemediationsInit = ctx.getRemediationsForSuite(suite, false)
 		numberOfFailuresInit = ctx.getFailuresForSuite(suite, false)
 		numberOfCheckResultsInit = ctx.getCheckResultsForSuite(suite)
+		numberOfInvalidResults = ctx.getInvalidResultsFromSuite(suite, true)
 	})
 
-	ctx.t.Run("Wait for Remediations to apply", func(t *testing.T) {
-		// Lets wait for the MachineConfigs to start applying
-		time.Sleep(30 * time.Second)
-		ctx.waitForNodesToBeReady()
-	})
+	if numberOfRemediationsInit > 0 {
+		t.Run("Wait for Remediations to apply", func(t *testing.T) {
+			// Lets wait for the MachineConfigs to start applying
+			time.Sleep(30 * time.Second)
+			ctx.waitForNodesToBeReady()
+		})
 
-	ctx.t.Run("Run second compliance scan", func(t *testing.T) {
-		// Create suite and auto-apply remediations
-		suite := ctx.createComplianceSuiteForProfile("2", false)
-		ctx.waitForComplianceSuite(suite)
-		numberOfRemediationsEnd = ctx.getRemediationsForSuite(suite, true)
-		numberOfFailuresEnd = ctx.getFailuresForSuite(suite, true)
-		numberOfCheckResultsEnd = ctx.getCheckResultsForSuite(suite)
-	})
+		t.Run("Run second compliance scan", func(t *testing.T) {
+			// Create suite and auto-apply remediations
+			suite := ctx.createComplianceSuiteForProfile("2", false)
+			ctx.waitForComplianceSuite(suite)
+			numberOfRemediationsEnd = ctx.getRemediationsForSuite(suite, true)
+			numberOfFailuresEnd = ctx.getFailuresForSuite(suite, true)
+			numberOfCheckResultsEnd = ctx.getCheckResultsForSuite(suite)
+		})
 
-	ctx.t.Run("We should have the same number of check results in each scan", func(t *testing.T) {
-		if numberOfCheckResultsInit != numberOfCheckResultsEnd {
-			t.Errorf("The amount of check results are NOT the same: init -> %d  end %d",
-				numberOfCheckResultsInit, numberOfCheckResultsEnd)
-		} else {
-			t.Logf("There amount of check results are the same: init -> %d  end %d",
-				numberOfCheckResultsInit, numberOfCheckResultsEnd)
-		}
-	})
+		t.Run("We should have the same number of check results in each scan", func(t *testing.T) {
+			if numberOfCheckResultsInit != numberOfCheckResultsEnd {
+				t.Errorf("The amount of check results are NOT the same: init -> %d  end %d",
+					numberOfCheckResultsInit, numberOfCheckResultsEnd)
+			} else {
+				t.Logf("There amount of check results are the same: init -> %d  end %d",
+					numberOfCheckResultsInit, numberOfCheckResultsEnd)
+			}
+		})
 
-	ctx.t.Run("We should have less remediations to apply", func(t *testing.T) {
-		if numberOfRemediationsInit <= numberOfRemediationsEnd {
-			t.Errorf("The remediations didn't diminish: init -> %d  end %d",
-				numberOfRemediationsInit, numberOfRemediationsEnd)
-		} else {
-			t.Logf("There are less remediations now: init -> %d  end %d",
-				numberOfRemediationsInit, numberOfRemediationsEnd)
-		}
-		if numberOfFailuresInit <= numberOfFailuresEnd {
-			t.Errorf("The failures didn't diminish: init -> %d  end %d",
-				numberOfFailuresInit, numberOfFailuresEnd)
-		} else {
-			t.Logf("There are less failures now: init -> %d  end %d",
-				numberOfFailuresInit, numberOfFailuresEnd)
-		}
-	})
-}
+		t.Run("We should have less remediations to apply", func(t *testing.T) {
+			if numberOfRemediationsInit <= numberOfRemediationsEnd {
+				t.Errorf("The remediations didn't diminish: init -> %d  end %d",
+					numberOfRemediationsInit, numberOfRemediationsEnd)
+			} else {
+				t.Logf("There are less remediations now: init -> %d  end %d",
+					numberOfRemediationsInit, numberOfRemediationsEnd)
+			}
+			if numberOfFailuresInit <= numberOfFailuresEnd {
+				t.Errorf("The failures didn't diminish: init -> %d  end %d",
+					numberOfFailuresInit, numberOfFailuresEnd)
+			} else {
+				t.Logf("There are less failures now: init -> %d  end %d",
+					numberOfFailuresInit, numberOfFailuresEnd)
+			}
+		})
+	} else {
+		t.Logf("No remediations were generated from this profile")
+	}
 
-func OCP4Tests(ctx *e2econtext) {
-	ctx.t.Run("Run platform compliance scan", func(t *testing.T) {
-		suite := ctx.createComplianceSuiteForPlatformProfile("1")
-		ctx.waitForComplianceSuite(suite)
-		if n := ctx.getBadResultsFromSuite(suite, true); n > 0 {
-			ctx.t.Errorf("Expected Pass, Fail, Info, or Skip results from platform scans. Got %d Error/None results", n)
+	t.Run("We should have no errors or invalid resutls", func(t *testing.T) {
+		if numberOfInvalidResults > 0 {
+			t.Errorf("Expected Pass, Fail, Info, or Skip results from platform scans. Got %d Error/None results", numberOfInvalidResults)
 		}
 	})
 }

--- a/tests/ocp4e2e/go.mod
+++ b/tests/ocp4e2e/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/openshift/compliance-operator v0.1.9
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver v0.17.1
 	k8s.io/apimachinery v0.17.2


### PR DESCRIPTION
This generalizes the e2e test to be able to run tests for different products.

The logic is as follows:

* If the product uses the `linux_os/guide` benchmark, it's marked as a node scan
* If the product uses the `application` benchmark, it's marked as a paltform scan

The intent is to start checking for OCP4 checks as well in its own test.

This also starts verifying that no invalid or errored checks happen. The assertion is that any check throwing an Error or None is an unexpected result.  

Co-Authored-By: @JAORMX 