### PR TITLE
Allow each product to build with different set of remediation languages

### DIFF
--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -27,7 +27,7 @@ def parse_args():
         help="YAML file with information about the product we are building. "
         "e.g.: ~/scap-security-guide/rhel7/product.yml"
     )
-    parser.add_argument("--bash-remediation-fns", required=True,
+    parser.add_argument("--bash-remediation-fns",
                         help="XML with the XCCDF Group containing all bash "
                         "remediation functions stored as values."
                         "e.g.: build/bash-remediation-functions.xml")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -295,7 +295,11 @@ endmacro()
 
 macro(ssg_build_remediations PRODUCT)
     message(STATUS "Scanning for dependencies of ${PRODUCT} fixes (bash, ansible, puppet, anaconda, ignition and kubernetes)...")
-    _ssg_build_remediations_for_language(${PRODUCT} "bash;ansible;puppet;anaconda;ignition;kubernetes")
+
+    if(NOT DEFINED PRODUCT_REMEDIATION_LANGUAGES)
+        set(PRODUCT_REMEDIATION_LANGUAGES "bash;ansible;puppet;anaconda;ignition;kubernetes")
+    endif()
+    _ssg_build_remediations_for_language(${PRODUCT} "${PRODUCT_REMEDIATION_LANGUAGES}")
 
     # only enable the ansible syntax checks if we are using openscap 1.2.17 or higher
     # older openscap causes syntax errors, see https://github.com/OpenSCAP/openscap/pull/977

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -328,24 +328,19 @@ endmacro()
 macro(ssg_build_xccdf_with_remediations PRODUCT)
     # we have to encode spaces in paths before passing them as stringparams to xsltproc
     string(REPLACE " " "%20" CMAKE_CURRENT_BINARY_DIR_NO_SPACES "${CMAKE_CURRENT_BINARY_DIR}")
+    set(PRODUCT_XSLT_LANGUAGE_PARAMS "")
+    set(PRODUCT_LANGUAGE_DEPENDS "")
+    foreach(LANGUAGE ${PRODUCT_REMEDIATION_LANGUAGES})
+        list(APPEND PRODUCT_XSLT_LANGUAGE_PARAMS --stringparam ${LANGUAGE}_remediations ${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/${LANGUAGE}-fixes.xml )
+        list(APPEND PRODUCT_LANGUAGE_DEPENDS generate-internal-${PRODUCT}-${LANGUAGE}-fixes.xml ${CMAKE_CURRENT_BINARY_DIR}/${LANGUAGE}-fixes.xml )
+    endforeach()
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam bash_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/bash-fixes.xml" --stringparam ansible_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ansible-fixes.xml" --stringparam puppet_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/puppet-fixes.xml" --stringparam anaconda_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/anaconda-fixes.xml" --stringparam ignition_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ignition-fixes.xml" --stringparam kubernetes_remediations "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/kubernetes-fixes.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" ${PRODUCT_XSLT_LANGUAGE_PARAMS} --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
         DEPENDS generate-internal-${PRODUCT}-xccdf-unlinked-ocilrefs.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-ocilrefs.xml"
-        DEPENDS generate-internal-${PRODUCT}-bash-fixes.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/bash-fixes.xml"
-        DEPENDS generate-internal-${PRODUCT}-ansible-fixes.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ansible-fixes.xml"
-        DEPENDS generate-internal-${PRODUCT}-puppet-fixes.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/puppet-fixes.xml"
-        DEPENDS generate-internal-${PRODUCT}-anaconda-fixes.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/anaconda-fixes.xml"
-        DEPENDS generate-internal-${PRODUCT}-ignition-fixes.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ignition-fixes.xml"
-        DEPENDS generate-internal-${PRODUCT}-kubernetes-fixes.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/kubernetes-fixes.xml"
+        DEPENDS ${PRODUCT_LANGUAGE_DEPENDS}
         DEPENDS "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt"
         COMMENT "[${PRODUCT}-content] generating xccdf-unlinked.xml"
     )

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1202,7 +1202,15 @@ This ensures consistent, high quality OVAL checks that we can edit in one place 
 
 === Remediations
 
-Remediations, also called fixes, are used to change the state of the machine, so that previously non-passing rules can pass. There can be multiple versions of the same remediation meant to be executed by different applications, more specifically Ansible, Bash, Anaconda, Puppet, Ignition and Kubernetes.
+Remediations, also called fixes, are used to change the state of the machine, so that previously non-passing rules can pass. There can be multiple versions of the same remediation meant to be executed by different applications, more specifically Ansible, Bash, Anaconda, Puppet, Ignition and Kubernetes. By default all remediation languages are built and included in the DataStream.
+
+But each product can specify its own set of remediation to include in the DataStream via a CMake Variable in the product's `CMakeLists.txt`.
+See example below, from OCP4 product, `ocp4/CMakeLists.txt`:
+
+----
+set(PRODUCT_REMEDIATION_LANGUAGES "ignition;kubernetes")
+----
+
 They also have to be idempotent, meaning that they must be able to be executed multiple times without causing the fixes to accumulate. The Ansible's language works in such a way that this behavior is built-in, however, for the other versions, the remediations must have it implemented explicitly.
 Remediations also carry metadata that should be present at the beginning of the files. This meta data will be converted in link:https://scap.nist.gov/specifications/xccdf/xccdf_element_dictionary.html#fixType[XCCDF tags] during the building process. That is how it looks like and what it means:
 

--- a/ocp4/CMakeLists.txt
+++ b/ocp4/CMakeLists.txt
@@ -5,5 +5,6 @@ endif()
 
 set(PRODUCT "ocp4")
 set(DISA_SRG_TYPE "os")
+set(PRODUCT_REMEDIATION_LANGUAGES "ignition;kubernetes")
 
 ssg_build_product(${PRODUCT})

--- a/rhcos4/CMakeLists.txt
+++ b/rhcos4/CMakeLists.txt
@@ -5,5 +5,6 @@ endif()
 
 set(PRODUCT "rhcos4")
 set(DISA_SRG_TYPE "os")
+set(PRODUCT_REMEDIATION_LANGUAGES "ignition;kubernetes")
 
 ssg_build_product(${PRODUCT})

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -130,29 +130,6 @@
 </xsl:template>
 
 <xsl:template match="xccdf:Benchmark">
-  <xsl:if test="$bash_remediations='' or not($bash_remediations_doc)">
-    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$bash_remediations"/>".</xsl:message>
-  </xsl:if>
-
-  <xsl:if test="$ansible_remediations='' or not($ansible_remediations_doc)">
-    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$ansible_remediations"/>".</xsl:message>
-  </xsl:if>
-
-  <xsl:if test="$anaconda_remediations='' or not($anaconda_remediations_doc)">
-    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$anaconda_remediations"/>".</xsl:message>
-  </xsl:if>
-
-  <xsl:if test="$puppet_remediations='' or not($puppet_remediations_doc)">
-    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$puppet_remediations"/>".</xsl:message>
-  </xsl:if>
-
-  <xsl:if test="$ignition_remediations='' or not($ignition_remediations_doc)">
-    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$ignition_remediations"/>".</xsl:message>
-  </xsl:if>
-
-  <xsl:if test="$kubernetes_remediations='' or not($kubernetes_remediations_doc)">
-    <xsl:message terminate="yes">Fatal error while loading "<xsl:value-of select="$kubernetes_remediations"/>".</xsl:message>
-  </xsl:if>
 
   <xsl:copy>
     <!-- plain-text elements must appear in sequence -->

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -419,7 +419,11 @@ def write_fixes_to_xml(remediation_type, build_dir, output_path, fixes):
                                      xmlns="http://checklists.nist.gov/xccdf/1.1")
     fixgroup = get_fixgroup_for_type(fixcontent, remediation_type)
 
-    remediation_functions = get_available_functions(build_dir)
+    if remediation_type == "bash":
+        # (bash_)remediation_functions are really only used for bash
+        remediation_functions = get_available_functions(build_dir)
+    else:
+        remediation_functions = None
 
     for fix_name in fixes:
         fix_contents, config = fixes[fix_name]

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -506,6 +506,10 @@ class Benchmark(object):
                 print(dir_item_path)
 
     def add_bash_remediation_fns_from_file(self, action, file_):
+        if not file_:
+            # bash-remediation-functions.xml doens't exist
+            return
+
         if action == "list-inputs":
             print(file_)
         else:


### PR DESCRIPTION
#### Description:

- Add a CMake variable to set remediation languages to include in a product DS.
  - By default it builds all of them, same as before.
- Products that want to restrict remediation languages can set them via `PRODUCT_REMEDIATION_LANGUAGES` in the product's CMakefile.
  - See OCP4 product as an example.
- [x] Documentation to be added.

#### Rationale:
- Products not interested in a remediation technology can opt-out of it.
- Slightly reduces DS size.
   - The OCP4 DS went from 8.6MB to 8.3 MB (honestly I expected difference to be larger, :unamused: )
