### PR TITLE
test_parse_affected.py: Handle empty rendered content

### DIFF
--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -67,6 +67,8 @@ def parse_affected(cur_dir, env_yaml):
             xml_content = ssg.jinja.process_file_with_macros(oval, env_yaml)
             # Some OVAL definitions may render to an empty definition
             # when building OVAL 5.10 only content
+            # Macros may leave empty new lines behind, lets strip them.
+            xml_content = xml_content.strip()
             if not xml_content:
                 continue
 
@@ -80,7 +82,8 @@ def parse_affected(cur_dir, env_yaml):
                 assert isinstance(results[1], int)
 
             except ValueError as e:
-                print("No <affected> element found in file {}".format(oval))
+                print("No <affected> element found in file {}. "
+                      " Parsed XML was:\n{}".format(oval, xml_content))
                 raise e
 
 


### PR DESCRIPTION
#### Description:

- Updates the test to strip newlines from rendered content before checking if not empty.

#### Rationale:

After Jinja rendering content, macros may leave empty lines behind.
When 5.10 OVAL content is built it can happen that a rendered OVAL check contains only empty lines.
The build system handles that nicely, but `test_parse_affected.py` test doesn't.

Fixes [scap-security-guide-nightly-oval510-zip](https://jenkins.complianceascode.io/view/All%20Green/job/scap-security-guide-nightly-oval510-zip/646/console), which started to fail after #5326.