### PR TITLE
add ocp_allowed_registries_for_import to profiles

### DIFF
--- a/ocp4/profiles/e8.profile
+++ b/ocp4/profiles/e8.profile
@@ -13,3 +13,4 @@ description: |-
 
 selections:
     - ocp_idp_no_htpasswd
+    - ocp_allowed_registries_for_import

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -29,3 +29,4 @@ description: |-
 
 selections:
     - ocp_idp_no_htpasswd
+    - ocp_allowed_registries_for_import


### PR DESCRIPTION
#### Description:

Add the `ocp_allowed_registries_for_import` test to the NIST 800-53 Moderate and Essential 8 profiles.

#### Rationale:

The `ocp_allowed_registries_for_import` test aligns with both the NIST 800-53 Moderate and Essential 8 profiles.
