### PR TITLE
Include OCP4 CPE check only into OCP4 datastream.

### DIFF
--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -3,7 +3,7 @@
     <metadata>
       <title>Red Hat OpenShift Container Platform</title>
       <affected family="unix">
-        <platform>multi_platform_all</platform>
+        <platform>Red Hat OpenShift Container Platform 4</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform:4.1" source="CPE" />
       <description>The application installed installed on the system is OpenShift 4.</description>


### PR DESCRIPTION
#### Description:

- This OVAL check requires yamlfilecontent probe and that might not be
available for certain versions of OpenSCAP and it can cause the content
to fail the validation.

#### Rationale:

- Keep this check out of other datastreams than OCP4 one.