### PR TITLE
Remove grub documentation links from RHEL7 rationale

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_admin_username/rule.yml
@@ -24,13 +24,6 @@ description: |-
 
 rationale: |-
     Having a non-default grub superuser username makes password-guessing attacks less effective.
-    {{% if product == "rhel7" %}}
-    For more information on how to configure the grub2 superuser account and password,
-    please refer to
-    <ul>
-    <li>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Protecting_GRUB_2_with_a_Password.html") }}}</li>.
-    </ul>
-    {{% endif %}}
 
 severity: low
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_password/rule.yml
@@ -23,13 +23,6 @@ rationale: |-
     users with physical access cannot trivially alter
     important bootloader settings. These include which kernel to use,
     and whether to enter single-user mode.
-    {{% if product == "rhel7" %}}
-    For more information on how to configure the grub2 superuser account and password,
-    please refer to
-    <ul>
-    <li>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Protecting_GRUB_2_with_a_Password.html") }}}</li>.
-    </ul>
-    {{% endif %}}
 
 severity: high
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/rule.yml
@@ -23,13 +23,6 @@ rationale: |-
     users with physical access cannot trivially alter
     important bootloader settings. These include which kernel to use,
     and whether to enter single-user mode.
-    {{% if product == "rhel7" %}}
-    For more information on how to configure the grub2 superuser account and password,
-    please refer to
-    <ul>
-    <li>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Protecting_GRUB_2_with_a_Password.html") }}}</li>.
-    </ul>
-    {{% endif %}}
 
 severity: medium
 


### PR DESCRIPTION
#### Description:

- Remove grub documentation links from RHEL7 rationale

#### Rationale:

- Links are failing and having documentation links for a rationale is not really a rationale.
