### PR TITLE
Allow regex checks with yamlfile_value template, update add_platform_rule.py

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1732,6 +1732,7 @@ yamlfile_value::
 ** *value* - the value to check.
 ** *type* (SimpleDatatypeEnumeration) - datatype for state's value_of, optional.
 ** *entity_check* (CheckEnumeration) - entity_check value for state's value_of, optional.
+** *pattern_check* - if set to `"true"`, the value is handled as a pattern match for state's value_of, optional.
 ** *negate* - if set to `"true"` the meaning of the value check criterion would be inverted, optional.
 ** *ocp_data* - if set to `"true"` then the filepath would be treated as a part of the dump of OCP configuration with the `ocp_data_root` prefix; optional.
 * Languages: OVAL

--- a/shared/templates/template_OVAL_yamlfile_value
+++ b/shared/templates/template_OVAL_yamlfile_value
@@ -48,7 +48,7 @@
   </ind:yamlfilecontent_object>
 
   <ind:yamlfilecontent_state id="state_{{{ rule_id }}}" version="1">
-    <ind:value_of{{% if TYPE %}} datatype="{{{ TYPE }}}"{{% endif %}}{{% if ENTITY_CHECK %}} entity_check="{{{ ENTITY_CHECK }}}"{{% endif %}}>{{{ VALUE }}}</ind:value_of>
+    <ind:value_of{{% if TYPE %}} datatype="{{{ TYPE }}}"{{% endif %}}{{% if PATTERN_CHECK %}} operation="pattern match"{{% endif %}}{{% if ENTITY_CHECK %}} entity_check="{{{ ENTITY_CHECK }}}"{{% endif %}}>{{{ VALUE }}}</ind:value_of>
   </ind:yamlfilecontent_state>
 
   {{% if OCP_DATA %}}

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -361,6 +361,7 @@ def timer_enabled(data, lang):
 def yamlfile_value(data, lang):
     data["negate"] = data.get("negate", "false") == "true"
     data["ocp_data"] = data.get("ocp_data", "false") == "true"
+    data["pattern_check"] = data.get("pattern_check", "false") == "true"
     return data
 
 


### PR DESCRIPTION
This PR adds pattern_check input to the template, which gives you a pattern match operation type. It also fixes the helper utility to accommodate recent changes and to begin using the template, with an added --regex flag to set pattern_check in the rule definition. I can split these up into different PR's if that's preferred.