### PR TITLE
profile_tool.py: Measure gap in Ansible parity

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -188,16 +188,21 @@ def main():
             'missing_kubernetes_fixes',
             'missing_puppet_fixes',
             'missing_anaconda_fixes',
-            'missing_cces'
+            'missing_cces',
+            'ansible_parity'
             ]
         link = """<a href="{}"><div style="height:100%;width:100%">{}</div></a>"""
 
         for profile in ret:
+            bash_fixes_count = profile['rules_count'] - profile['missing_bash_fixes_count']
             for content in content_list:
                 content_file = "{}_{}.txt".format(profile['profile_id'], content)
                 content_filepath = os.path.join("content", content_file)
                 count = len(profile[content])
                 if count > 0:
+                    if content == "ansible_parity":
+                        #custom text link for ansible parity
+                        count = link.format(content_filepath, "{} out of {} ({}%)".format(bash_fixes_count-count, bash_fixes_count, int(((bash_fixes_count-count)/bash_fixes_count)*100)))
                     count_href_element = link.format(content_filepath, count)
                     profile['{}_count'.format(content)] = count_href_element
                     with open(os.path.join(content_path, content_file), 'w+') as f:

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -97,6 +97,7 @@ def parse_args():
         if args.all:
             args.implemented = True
             args.missing = True
+            args.ansible_parity = True
 
         if args.implemented:
             args.implemented_ovals = True

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -64,6 +64,10 @@ def parse_args():
                         action="store_true",
                         help="Equivalent of --missing-ovals, --missing-fixes"
                         " and --missing-cces all being set.")
+    parser_stats.add_argument("--ansible-parity",
+                        action="store_true",
+                        help="Show IDs of rules with Bash fix which miss Ansible fix."
+                        " Rules missing both Bash and Ansible are not shown.")
     parser_stats.add_argument("--all", default=False,
                         action="store_true", dest="all",
                         help="Show all available statistics.")

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -104,6 +104,7 @@ class XCCDFBenchmark(object):
             'assigned_cces_pct': 0,
             'missing_cces': [],
             'missing_stig_ids': [],
+            'ansible_parity': [],
         }
 
         rule_stats = []
@@ -251,6 +252,13 @@ class XCCDFBenchmark(object):
             profile_stats['rules_count'] * 100
         profile_stats['missing_cces'] = \
             [x.dict['id'] for x in rule_stats if x.dict['cce'] is None]
+
+        profile_stats['ansible_parity'] = \
+            [rule_id for rule_id in profile_stats["missing_ansible_fixes"] if rule_id not in profile_stats["missing_bash_fixes"]]
+        profile_stats['ansible_parity_pct'] = \
+            float(len(profile_stats['implemented_bash_fixes']) -
+                  len(profile_stats['ansible_parity'])) / \
+            len(profile_stats['implemented_bash_fixes']) * 100
 
         return profile_stats
 
@@ -449,6 +457,15 @@ class XCCDFBenchmark(object):
                       (rules_count - impl_cces_count, rules_count,
                        profile_stats['assigned_cces_pct']))
                 self.console_print(profile_stats['missing_cces'],
+                                   console_width)
+
+            if options.ansible_parity:
+                print("*** rules of '%s' profile with bash fix which miss "
+                      "ansible fix scripts: %d of %d [%d%% complete]"
+                      % (profile, impl_bash_fixes_count - len(profile_stats['ansible_parity']),
+                         impl_bash_fixes_count,
+                         profile_stats['ansible_parity_pct']))
+                self.console_print(profile_stats['ansible_parity'],
                                    console_width)
 
         elif options.format == "html":

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -460,8 +460,8 @@ class XCCDFBenchmark(object):
                                    console_width)
 
             if options.ansible_parity:
-                print("*** rules of '%s' profile with bash fix which miss "
-                      "ansible fix scripts: %d of %d [%d%% complete]"
+                print("*** rules of '%s' profile with bash fix that implement "
+                      "ansible fix scripts: %d out of %d [%d%% complete]"
                       % (profile, impl_bash_fixes_count - len(profile_stats['ansible_parity']),
                          impl_bash_fixes_count,
                          profile_stats['ansible_parity_pct']))
@@ -498,6 +498,7 @@ class XCCDFBenchmark(object):
             del profile_stats['implemented_anaconda_fixes_pct']
             del profile_stats['assigned_cces_pct']
             del profile_stats['ssg_version']
+            del profile_stats['ansible_parity_pct']
 
             return profile_stats
         else:


### PR DESCRIPTION
#### Description:

- Enhance `profile_tool.py` to measure gap in Ansible-Bash parity.
- By @ggbecker: Implement HTML ansible parity statistics so it will show up in the jenkins job: https://jenkins.complianceascode.io/job/scap-security-guide-stats/Statistics/

#### Rationale:

- Data is power
