### PR TITLE
Make OCP4 CPE check more lax

### DIFF
--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -8,16 +8,10 @@
       <reference ref_id="cpe:/a:redhat:openshift_container_platform:4.1" source="CPE" />
       <description>The application installed installed on the system is OpenShift 4.</description>
     </metadata>
-    <criteria operator="AND">
-      <criterion comment="cluster is OpenShift 4" test_ref="test_ocp4" />
+    <criteria>
       <criterion comment="Make sure OCP4 clusteroperators file is present" test_ref="test_file_for_ocp4"/>
     </criteria>
   </definition>
-
-  <ind:yamlfilecontent_test id="test_ocp4" check="at least one" comment="Find one match" version="1">
-      <ind:object object_ref="object_ocp4"/>
-      <ind:state state_ref="state_ocp4"/>
-  </ind:yamlfilecontent_test>
 
   <local_variable id="ocp4_dump_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
       <literal_component>/kubernetes-api-resources/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver</literal_component>
@@ -30,13 +24,4 @@
   <unix:file_object id="object_file_for_ocp4" version="1">
       <unix:filepath var_ref="ocp4_dump_location"/>
   </unix:file_object>
-
-  <ind:yamlfilecontent_object id="object_ocp4" version="1">
-      <ind:filepath var_ref="ocp4_dump_location"/>
-      <ind:yamlpath>.status.versions[:].version</ind:yamlpath>
-  </ind:yamlfilecontent_object>
-
-  <ind:yamlfilecontent_state id="state_ocp4" version="1">
-      <ind:value_of datatype="string" operation="pattern match">4\..*</ind:value_of>
-  </ind:yamlfilecontent_state>
 </def-group>


### PR DESCRIPTION
The check was verifying the version contained in the clusteroperators
resource. While this correct, it doesn't hold true in some CI
environments. This resulted in us struggling to do checks in CI...

Talking to the team in charge of building this component, they mentioned
that it's sufficient to check for the existence of this object in order
to verify that the cluster is indeed OpenShift 4.x. So this is what
we're checking now for the cpe.