### PR TITLE
fix Ansible sebool template installing non-existing package on rhel8

### DIFF
--- a/shared/templates/template_ANSIBLE_sebool
+++ b/shared/templates/template_ANSIBLE_sebool
@@ -18,12 +18,14 @@
   package:
     name: python3-libsemanage
     state: present
+
 {{% else %}}
 - name: Ensure libsemanage-python installed
   package:
     name: libsemanage-python
     state: present
 {{% endif %}}
+
 - name: Set SELinux boolean {{{ SEBOOLID }}} accordingly
   seboolean:
     name: {{{ SEBOOLID }}}


### PR DESCRIPTION
#### Description:

During execution of Ansible remediation for sebool, install python3-libsemanage if the product is rhel8.

#### Rationale:

The libsemanage-python package got renamed in rhel8 to python3-libsemanage. The remediation was failing, potentially halting whole playbook when executed on rhel8.
