### PR TITLE
disable_host_auth rule edit

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
@@ -52,7 +52,7 @@ references:
 template:
     name: sshd_lineinfile
     vars:
-        missing_parameter_pass: 'true'
+        missing_parameter_pass: 'false'
         parameter: HostbasedAuthentication
         rule_id: disable_host_auth
         value: 'no'


### PR DESCRIPTION

#### Description:

- _Changed missing_parameter_pass value to true._

#### Rationale:

- _STIG explicitly calls for the parameter to be present even though the OS default configuration is secure. STIG scans will continuously fail without it._

