### PR TITLE
Edit remediation for use_approved_ciphers

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/rhel6.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/rhel6.sh
@@ -1,6 +1,0 @@
-# platform = Red Hat Enterprise Linux 6
-grep -q ^Ciphers /etc/ssh/sshd_config && \
-  sed -i "s/Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc/g" /etc/ssh/sshd_config
-if ! [ $? -eq 0 ]; then
-    echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc" >> /etc/ssh/sshd_config
-fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Oracle Linux 7
+# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 6,Oracle Linux 7
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -11,5 +11,10 @@ operator: equals
 interactive: false
 
 options:
+    {{#- STIG is product-dependent, so the selector has to be made available for individual products selectively -#}}
+    {{%- if product in ("rhel7", "ol7") %}}
     stig: aes128-ctr,aes192-ctr,aes256-ctr
+    {{%- elif product in ("rhel6", "ol6") %}}
+    stig: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc
+    {{%- endif %}}
     default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -11,5 +11,8 @@ operator: equals
 interactive: false
 
 options:
+    {{#- STIG is product-dependent, so the selector has to be made available for individual products selectively -#}}
+    {{%- if product in ("rhel6", "rhel7", "ol6", "ol7") %}}
     stig: hmac-sha2-512,hmac-sha2-256
+    {{%- endif %}}
     default: hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -11,8 +11,5 @@ operator: equals
 interactive: false
 
 options:
-    {{#- STIG is product-dependent, so the selector has to be made available for individual products selectively -#}}
-    {{%- if product in ("rhel6", "rhel7", "ol6", "ol7") %}}
     stig: hmac-sha2-512,hmac-sha2-256
-    {{%- endif %}}
     default: hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com

--- a/rhel6/profiles/stig.profile
+++ b/rhel6/profiles/stig.profile
@@ -106,3 +106,4 @@ selections:
     - configure_user_data_backups
     - var_postfix_inet_interfaces=localhost
     - postfix_network_listening_disabled
+    - sshd_approved_ciphers=stig


### PR DESCRIPTION

#### Description:

- _Added RHEL6 remediation to shared.sh rather than having separate rhel6.sh_

#### Rationale:

- _The separate rhel6 remediation script shouldnt be necessary in this case._

