### PR TITLE
Add checks and remediation for password_quality_pamcracklib

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit/bash/shared.sh
@@ -1,0 +1,16 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platorm_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+if grep -q "dcredit=" /etc/pam.d/system-auth; then
+	sed -i --follow-symlink "s/\(dcredit *= *\).*/\1-1/" /etc/pam.d/system-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ dcredit=-1/" /etc/pam.d/system-auth
+fi
+
+if grep -q "dcredit=" /etc/pam.d/password-auth; then
+	sed -i --follow-symlink "s/\(dcredit *= *\).*/\1-1/" /etc/pam.d/password-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ dcredit=-1/" /etc/pam.d/password-auth
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit/oval/shared.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="cracklib_accounts_password_pam_dcredit" version="1">
+    <metadata>
+      <title>The system must require passwords to contain at least one numeric character.</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description></description>
+    </metadata>
+    <!-- password requires a digit ... -->
+    <criteria>
+	  <criterion comment="Check password requires a digit" test_ref="test_cracklib_accounts_password_pam_dcredit_system" />
+	  <criterion comment="Check password requires a digit" test_ref="test_cracklib_accounts_password_pam_dcredit_passwd" />	
+	</criteria>
+  </definition>
+  
+  <ind:textfilecontent54_test check="all" comment="Check password requires a digit" id="test_cracklib_accounts_password_pam_dcredit_system" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_dcredit_system" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_dcredit_system" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*dcredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" comment="Check password requires a digit" id="test_cracklib_accounts_password_pam_dcredit_passwd" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_dcredit_passwd" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_dcredit_passwd" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*dcredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>  
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok/bash/shared.sh
@@ -1,0 +1,18 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platorm_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+
+if grep -q "difok=" /etc/pam.d/system-auth; then   
+	sed -i --follow-symlink "s/\(difok *= *\).*/\18/" /etc/pam.d/system-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ difok=8/" /etc/pam.d/system-auth
+fi
+
+
+if grep -q "difok=" /etc/pam.d/password-auth; then   
+	sed -i --follow-symlink "s/\(difok *= *\).*/\18/" /etc/pam.d/password-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ difok=8/" /etc/pam.d/password-auth
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok/oval/shared.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="cracklib_accounts_password_pam_difok" version="1">
+    <metadata>
+      <title>The system must require at least eight characters be changed between the old and new passwords.</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description></description>
+    </metadata>
+    <!-- eight characters be changed between the old and new passwords ... -->
+    <criteria>
+	  <criterion comment="Check eight characters changed between old and new passwords" test_ref="test_cracklib_accounts_password_pam_difok_system" />
+	  <criterion comment="Check eight characters changed between old and new passwords" test_ref="test_cracklib_accounts_password_pam_difok_passwd" />	
+	</criteria>
+  </definition>
+  
+  <ind:textfilecontent54_test check="all" comment="Check eight characters changed between old and new passwords" id="test_cracklib_accounts_password_pam_difok_system" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_difok_system" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_difok_system" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*difok=8</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" comment="Check eight characters changed between old and new passwords" id="test_cracklib_accounts_password_pam_difok_passwd" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_difok_passwd" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_difok_passwd" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*difok=8</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>  
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit/bash/shared.sh
@@ -1,0 +1,16 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platorm_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+if grep -q "lcredit=" /etc/pam.d/system-auth; then
+	sed -i --follow-symlink "s/\(lcredit *= *\).*/\1-1/" /etc/pam.d/system-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ lcredit=-1/" /etc/pam.d/system-auth
+fi
+
+if grep -q "lcredit=" /etc/pam.d/password-auth; then
+	sed -i --follow-symlink "s/\(lcredit *= *\).*/\1-1/" /etc/pam.d/password-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ lcredit=-1/" /etc/pam.d/password-auth
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit/oval/shared.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="cracklib_accounts_password_pam_lcredit" version="1">
+    <metadata>
+      <title>The system must require passwords to contain at least one lower-case alphabetic character.</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description></description>
+    </metadata>
+    <!-- password requires a lower case alphabetic char ... -->
+    <criteria>
+	  <criterion comment="Check password requires a lower case alphabetic char" test_ref="test_cracklib_accounts_password_pam_lcredit_system" />
+	  <criterion comment="Check password requires a lower case alphabetic char" test_ref="test_cracklib_accounts_password_pam_lcredit_passwd" />	
+	</criteria>
+  </definition>
+  
+  <ind:textfilecontent54_test check="all" comment="Check password requires a lower case alphabetic char" id="test_cracklib_accounts_password_pam_lcredit_system" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_lcredit_system" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_lcredit_system" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*lcredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" comment="Check password requires a lower case alphabetic char" id="test_cracklib_accounts_password_pam_lcredit_passwd" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_lcredit_passwd" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_lcredit_passwd" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*lcredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>  
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_maxrepeat/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_maxrepeat/bash/shared.sh
@@ -1,0 +1,18 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platorm_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+
+if grep -q "maxrepeat=" /etc/pam.d/system-auth; then   
+	sed -i --follow-symlink "s/\(maxrepeat *= *\).*/\13/" /etc/pam.d/system-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ maxrepeat=3/" /etc/pam.d/system-auth
+fi
+
+
+if grep -q "maxrepeat=" /etc/pam.d/password-auth; then   
+	sed -i --follow-symlink "s/\(maxrepeat *= *\).*/\13/" /etc/pam.d/password-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ maxrepeat=3/" /etc/pam.d/password-auth
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_maxrepeat/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_maxrepeat/oval/shared.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="cracklib_accounts_password_pam_maxrepeat" version="1">
+    <metadata>
+      <title>The system must require passwords to contain no more than three consecutive repeating characters.</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description></description>
+    </metadata>
+    <!-- require passwords to contain no more than three consecutive repeating characters ... -->
+    <criteria>
+	  <criterion comment="Check passwords contain no more than three consecutive repeating characters" test_ref="test_cracklib_accounts_password_pam_maxrepeat_system" />
+	  <criterion comment="Check passwords contain no more than three consecutive repeating characters" test_ref="test_cracklib_accounts_password_pam_maxrepeat_passwd" />	
+	</criteria>
+  </definition>
+  
+  <ind:textfilecontent54_test check="all" comment="Check passwords contain no more than three consecutive repeating characters" id="test_cracklib_accounts_password_pam_maxrepeat_system" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_maxrepeat_system" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_maxrepeat_system" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*maxrepeat=3</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" comment="Check passwords contain no more than three consecutive repeating characters" id="test_cracklib_accounts_password_pam_maxrepeat_passwd" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_maxrepeat_passwd" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_maxrepeat_passwd" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*maxrepeat=3</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>  
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit/bash/shared.sh
@@ -1,0 +1,16 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platorm_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+if grep -q "ocredit=" /etc/pam.d/system-auth; then
+	sed -i --follow-symlink "s/\(ocredit *= *\).*/\1-1/" /etc/pam.d/system-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ ocredit=-1/" /etc/pam.d/system-auth
+fi
+
+if grep -q "ocredit=" /etc/pam.d/password-auth; then
+	sed -i --follow-symlink "s/\(ocredit *= *\).*/\1-1/" /etc/pam.d/password-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ ocredit=-1/" /etc/pam.d/password-auth
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit/oval/shared.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="cracklib_accounts_password_pam_ocredit" version="1">
+    <metadata>
+      <title>The system must require passwords to contain at least one special character.</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description></description>
+    </metadata>
+    <!-- password requires a special character ... -->
+    <criteria>
+	  <criterion comment="Check password requires a special char" test_ref="test_cracklib_accounts_password_pam_ocredit_system" />
+	  <criterion comment="Check password requires a special char" test_ref="test_cracklib_accounts_password_pam_ocredit_passwd" />	
+	</criteria>
+  </definition>
+  
+  <ind:textfilecontent54_test check="all" comment="Check password requires a special char" id="test_cracklib_accounts_password_pam_ocredit_system" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_ocredit_system" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_ocredit_system" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*ocredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" comment="Check password requires a special char" id="test_cracklib_accounts_password_pam_ocredit_passwd" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_ocredit_passwd" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_ocredit_passwd" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*ocredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>  
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit/bash/shared.sh
@@ -1,0 +1,16 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platorm_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+if grep -q "ucredit=" /etc/pam.d/system-auth; then
+	sed -i --follow-symlink "s/\(ucredit *= *\).*/\1-1/" /etc/pam.d/system-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ ucredit=-1/" /etc/pam.d/system-auth
+fi
+
+if grep -q "ucredit=" /etc/pam.d/password-auth; then
+	sed -i --follow-symlink "s/\(ucredit *= *\).*/\1-1/" /etc/pam.d/password-auth
+else
+	sed -i --follow-symlink "/pam_cracklib.so/ s/$/ ucredit=-1/" /etc/pam.d/password-auth
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit/oval/shared.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="cracklib_accounts_password_pam_ucredit" version="1">
+    <metadata>
+      <title>The system must require passwords to contain at least one upper-case alphabetic character.</title>
+      <affected family="unix">
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description></description>
+    </metadata>
+    <!-- password requires an upper-case char ... -->
+    <criteria>
+	  <criterion comment="Check password requires an upper case character" test_ref="test_cracklib_accounts_password_pam_ucredit_system" />
+	  <criterion comment="Check password requires an upper case character" test_ref="test_cracklib_accounts_password_pam_ucredit_passwd" />	
+	</criteria>
+  </definition>
+  
+  <ind:textfilecontent54_test check="all" comment="Check password requires an upper case character" id="test_cracklib_accounts_password_pam_ucredit_system" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_ucredit_system" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_ucredit_system" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*ucredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" comment="Check password requires an upper case character" id="test_cracklib_accounts_password_pam_ucredit_passwd" version="1">
+    <ind:object object_ref="object_cracklib_accounts_password_pam_ucredit_passwd" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_cracklib_accounts_password_pam_ucredit_passwd" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">.*pam_cracklib.so.*ucredit=-1</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>  
+</def-group>

--- a/rhel6/profiles/stig.profile
+++ b/rhel6/profiles/stig.profile
@@ -41,6 +41,11 @@ selections:
     - gid_passwd_group_same
     - account_unique_name
     - account_temp_expire_date
+    - cracklib_accounts_password_pam_dcredit
+    - cracklib_accounts_password_pam_lcredit
+    - cracklib_accounts_password_pam_ocredit
+    - cracklib_accounts_password_pam_ucredit
+    - cracklib_accounts_password_pam_difok
     - cracklib_accounts_password_pam_maxrepeat
     - no_files_unowned_by_user
     - file_permissions_ungroupowned
@@ -97,6 +102,7 @@ selections:
     - var_password_pam_ucredit=1
     - var_password_pam_ocredit=1
     - var_password_pam_lcredit=1
+    - var_password_pam_dcredit=1
     - sshd_idle_timeout_value=15_minutes
     - gconf_gnome_disable_ctrlaltdel_reboot
     - postfix_client_configure_mail_alias


### PR DESCRIPTION

#### Description:

- _Add oval and bash content to pam dcredit, difok, lcredit, maxrepeat, ocredit and ucredit. Add references to rhel6 stig profile._

#### Rationale:

- _Previously no content to check or remediate for these stig requirements_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
