### PR TITLE
Edit checks and remediation for set_password_hashing_algorithm_systemauth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -8,4 +8,7 @@ do
 	if ! grep -q "^password.*sufficient.*pam_unix.so.*sha512" $pamFile; then
 		sed -i --follow-symlinks "/^password.*sufficient.*pam_unix.so/ s/$/ sha512/" $pamFile
 	fi
+	if grep -q "^password.*sufficient.*pam_unix.so.*\(md5\|sha256\|bigcrypt\|blowfish\)" $pamFile; then
+		sed -i --follow-symlinks "/^password.*sufficient.*pam_unix.so/ s/ \(md5\|sha256\|bigcrypt\|blowfish\)//g" $pamFile
+	fi
 done

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
@@ -13,17 +13,49 @@
     </metadata>
     <criteria operator="AND">
       <criterion test_ref="test_pam_unix_sha512" />
+	  <criterion test_ref="test_pam_unix_noncompliant_hash" negate="true" />
+	  <criterion test_ref="test_password_auth_pam_unix_sha512" />
+	  <criterion test_ref="test_password_auth_pam_unix_noncompliant_hash" negate="true" />
     </criteria>
   </definition>
 
+<!-- test system-auth -->
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="check /etc/pam.d/system-auth for correct settings" id="test_pam_unix_sha512" version="1">
     <ind:object object_ref="object_pam_unix_sha512" />
+    <ind:state state_ref="state_pam_unix_sha512" />
   </ind:textfilecontent54_test>
-
   <ind:textfilecontent54_object comment="check /etc/pam.d/system-auth for correct settings" id="object_pam_unix_sha512" version="1">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+.*sha512.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+(.*)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_pam_unix_sha512" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*sha512.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="check /etc/pam.d/system-auth for correct settings" id="test_pam_unix_noncompliant_hash" version="1">
+    <ind:object object_ref="object_pam_unix_sha512" />
+    <ind:state state_ref="state_pam_unix_noncompliant_hash" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_state id="state_pam_unix_noncompliant_hash" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^.*(?:md5|sha256|bigcrypt|blowfish)(?:\s|$)</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+<!-- duplicate tests for password-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="check /etc/pam.d/password-auth for correct settings" id="test_password_auth_pam_unix_sha512" version="1">
+    <ind:object object_ref="object_password_auth_pam_unix_sha512" />
+    <ind:state state_ref="state_pam_unix_sha512" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object comment="check /etc/pam.d/password-auth for correct settings" id="object_password_auth_pam_unix_sha512" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+(.*)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="check /etc/pam.d/password-auth for correct settings" id="test_password_auth_pam_unix_noncompliant_hash" version="1">
+    <ind:object object_ref="object_password_auth_pam_unix_sha512" />
+    <ind:state state_ref="state_pam_unix_noncompliant_hash" />
+  </ind:textfilecontent54_test>
+  
 
 </def-group>


### PR DESCRIPTION

#### Description:

- _Added check for password-auth per STIG. Added check for existing noncompliant hashes. Added remediation for removal of non-compliant hashes._

#### Rationale:

- _Previously did not check password-auth. Previously allowed the presence of MD5 hash_

