### PR TITLE
Use cmake variable SSG_PRODUCT_DEFAULT for VSEL product

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ option(SSG_PRODUCT_SLE15 "If enabled, the SLE15 SCAP content will be built" ${SS
 option(SSG_PRODUCT_UBUNTU1404 "If enabled, the Ubuntu 14.04 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_UBUNTU1604 "If enabled, the Ubuntu 16.04 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_UBUNTU1804 "If enabled, the Ubuntu 18.04 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
-option(SSG_PRODUCT_VSEL "If enabled, the McAfee VSEL SCAP content will be built" TRUE)
+option(SSG_PRODUCT_VSEL "If enabled, the McAfee VSEL SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_WRLINUX8 "If enabled, the WRLinux8 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_WRLINUX1019 "If enabled, the WRLinux1019 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 


### PR DESCRIPTION
#### Rationale:

- better align with `build_product.sh` script otherwise the content for this product is always built.

Additional info:
From the documentation (new product example) it is correct:
https://github.com/ComplianceAsCode/content/blame/master/example/README.md#L47