### PR TITLE
fix filename in configure_openssl_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -11,7 +11,7 @@
   changed_when: False
   check_mode: no
 
-- name: "Add .include for openssl.config to crypto_policy section"
+- name: "Add .include for opensslcnf.config to crypto_policy section"
   lineinfile:
     create: yes
     insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
@@ -21,7 +21,7 @@
     - test_crypto_policy_group.stdout is defined
     - test_crypto_policy_group.stdout | length > 0
 
-- name: "Add crypto_policy group and set include openssl.config"
+- name: "Add crypto_policy group and set include opensslcnf.config"
   lineinfile:
     create: yes
     line: "[crypto_policy]\n.include /etc/crypto-policies/back-ends/opensslcnf.config"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -15,7 +15,7 @@
   lineinfile:
     create: yes
     insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
-    line: ".include /etc/crypto-policies/back-ends/openssl.config"
+    line: ".include /etc/crypto-policies/back-ends/opensslcnf.config"
     path: /etc/pki/tls/openssl.cnf
   when:
     - test_crypto_policy_group.stdout is defined
@@ -24,7 +24,7 @@
 - name: "Add crypto_policy group and set include openssl.config"
   lineinfile:
     create: yes
-    line: "[crypto_policy]\n.include /etc/crypto-policies/back-ends/openssl.config"
+    line: "[crypto_policy]\n.include /etc/crypto-policies/back-ends/opensslcnf.config"
     path: /etc/pki/tls/openssl.cnf
   when:
     - test_crypto_policy_group.stdout is defined

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
@@ -2,8 +2,8 @@
 
 OPENSSL_CRYPTO_POLICY_SECTION='[ crypto_policy ]'
 OPENSSL_CRYPTO_POLICY_SECTION_REGEX='\[\s*crypto_policy\s*\]'
-OPENSSL_CRYPTO_POLICY_INCLUSION='.include /etc/crypto-policies/back-ends/openssl.config'
-OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*/etc/crypto-policies/back-ends/openssl.config$'
+OPENSSL_CRYPTO_POLICY_INCLUSION='.include /etc/crypto-policies/back-ends/opensslcnf.config'
+OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*/etc/crypto-policies/back-ends/opensslcnf.config$'
 
 function remediate_openssl_crypto_policy() {
 	CONFIG_FILE="/etc/pki/tls/openssl.cnf"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
@@ -20,7 +20,7 @@
   <ind:textfilecontent54_object id="object_configure_openssl_crypto_policy"
   version="1">
     <ind:filepath>/etc/pki/tls/openssl.cnf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*\[\s*crypto_policy\s*\]\s*\n*\s*\.include\s*/etc/crypto-policies/back-ends/openssl.config\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[\s*crypto_policy\s*\]\s*\n*\s*\.include\s*/etc/crypto-policies/back-ends/opensslcnf.config\s*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -11,7 +11,7 @@ description: |-
     To check that Crypto Policies settings are configured correctly, you have to examine the OpenSSL config file
     available under <tt>/etc/pki/tls/openssl.cnf</tt>.
     This file has the <tt>ini</tt> format, and it enables crypto policy support
-    if there is a <tt>[ crypto_policy ]</tt> section that contains the <tt>.include /etc/crypto-policies/back-ends/openssl.config</tt> directive.
+    if there is a <tt>[ crypto_policy ]</tt> section that contains the <tt>.include /etc/crypto-policies/back-ends/opensslcnf.config</tt> directive.
 
 rationale: |-
     Overriding the system crypto policy makes the behavior of the Java runtime violates expectations,
@@ -29,11 +29,11 @@ references:
 
 ocil_clause: |-
     the OpenSSL config file doesn't contain the whole section,
-    or that the section doesn't have the <pre>.include /etc/crypto-policies/back-ends/openssl.config</pre> directive
+    or that the section doesn't have the <pre>.include /etc/crypto-policies/back-ends/opensslcnf.config</pre> directive
 
 ocil: |-
-    To verify that OpenSSL uses the system crypro policy, check out that the OpenSSL config file
+    To verify that OpenSSL uses the system crypto policy, check out that the OpenSSL config file
     <pre>/etc/pki/tls/openssl.cnf</pre> contains the <pre>[ crypto_policy ]</pre> section with the
-    <pre>.include /etc/crypto-policies/back-ends/openssl.config</pre> directive:
-    <pre>grep '\.include\s* /etc/crypto-policies/back-ends/openssl.config$' /etc/pki/tls/openssl.cnf</pre>.
+    <pre>.include /etc/crypto-policies/back-ends/opensslcnf.config</pre> directive:
+    <pre>grep '\.include\s* /etc/crypto-policies/back-ends/opensslcnf.config$' /etc/pki/tls/openssl.cnf</pre>.
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/wrong.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/wrong.fail.sh
@@ -6,5 +6,5 @@
 
 create_config_file_with "[ crypto_policy ]
 
-.include /etc/crypto-policies/back-ends/opensslcnf.config
+.include /etc/crypto-policies/back-ends/openssl.config
 "


### PR DESCRIPTION
#### Description:

Rewrite openssl.config to opensslcnf.config in description, ocil, oval, bash, ansible, tests.

#### Rationale:

The file openssl.config is not expected to be included into openssl.cnf config file. The correct file is opensslcnf.config. Remediation of this rule was causing problems with openssl.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1847697
