### PR TITLE
Extend bls_entries_options to check for runtime and $kernelopts 

### DIFF
--- a/linux_os/guide/system/auditing/bls_audit_option/rule.yml
+++ b/linux_os/guide/system/auditing/bls_audit_option/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4
+prodtype: fedora,rhcos4,rhel8
 
 title: 'Enable Auditing for Processes Which Start Prior to the Audit Daemon'
 

--- a/shared/templates/template_OVAL_bls_entries_option
+++ b/shared/templates/template_OVAL_bls_entries_option
@@ -8,6 +8,8 @@
     <criteria operator="AND">
         <criterion test_ref="test_bls_{{{ SANITIZED_ARG_NAME }}}_options"
         comment="Check if {{{ ARG_NAME_VALUE }}} is present in the 'options' line in /boot/loader/entries/*" />
+        <criterion test_ref="test_runtime_{{{ SANITIZED_ARG_NAME }}}_option"
+        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the /proc/cmdline" />
     </criteria>
   </definition>
 
@@ -15,9 +17,8 @@
   comment="check for kernel option {{{ ARG_NAME_VALUE }}} for all snippets in /boot/loader/entries"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_bls_{{{ SANITIZED_ARG_NAME }}}_options" />
-    <ind:state state_ref="state_bls_{{{ SANITIZED_ARG_NAME }}}_option" />
+    <ind:state state_ref="state_{{{ SANITIZED_ARG_NAME }}}_option" />
   </ind:textfilecontent54_test>
-
   <ind:textfilecontent54_object id="object_bls_{{{ SANITIZED_ARG_NAME }}}_options"
   version="1">
     <ind:filepath operation="pattern match">^/boot/loader/entries/.*\.conf$</ind:filepath>
@@ -25,7 +26,20 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_bls_{{{ SANITIZED_ARG_NAME }}}_option"
+  <ind:textfilecontent54_test id="test_runtime_{{{ SANITIZED_ARG_NAME }}}_option"
+  comment="check for kernel runtime option {{{ ARG_NAME_VALUE }}} in /proc/cmdline"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_runtime_{{{ SANITIZED_ARG_NAME }}}_option" />
+    <ind:state state_ref="state_{{{ SANITIZED_ARG_NAME }}}_option" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_runtime_{{{ SANITIZED_ARG_NAME }}}_option"
+  version="1">
+    <ind:filepath operation="pattern match">^/proc/cmdline$</ind:filepath>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ SANITIZED_ARG_NAME }}}_option"
   version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>

--- a/shared/templates/template_OVAL_bls_entries_option
+++ b/shared/templates/template_OVAL_bls_entries_option
@@ -6,23 +6,59 @@
       <description>Ensure {{{ ARG_NAME_VALUE }}} option is configured in the 'options' line in /boot/loader/entries/*.conf.</description>
     </metadata>
     <criteria operator="AND">
-        <criterion test_ref="test_bls_{{{ SANITIZED_ARG_NAME }}}_options"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the 'options' line in /boot/loader/entries/*" />
-        <criterion test_ref="test_runtime_{{{ SANITIZED_ARG_NAME }}}_option"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the /proc/cmdline" />
+      <criteria operator="OR" comment="Check if BLS entries are configured with {{{ SANITIZED_ARG_NAME }}} option">
+        <criterion test_ref="test_bls_all_entries_{{{ SANITIZED_ARG_NAME }}}_options"
+        comment="Check that all boot entries have {{{ SANITIZED_ARG_NAME }}}" />
+        <criteria operator="AND">
+          <criterion test_ref="test_bls_entries_without_{{{ SANITIZED_ARG_NAME }}}_option"
+          comment="Check that entries wihout option {{{ ARG_NAME_VALUE }}} have $kernelopts" />
+          <criterion test_ref="test_grubenv_{{{ SANITIZED_ARG_NAME }}}_option"
+          comment="Check if /boot/grub2/grubenv contains {{{ SANITIZED_ARG_NAME }}} option" />
+        </criteria>
+      </criteria>
+      <criterion test_ref="test_runtime_{{{ SANITIZED_ARG_NAME }}}_option"
+      comment="Check if {{{ ARG_NAME_VALUE }}} is present in the /proc/cmdline" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_bls_{{{ SANITIZED_ARG_NAME }}}_options"
-  comment="check for kernel option {{{ ARG_NAME_VALUE }}} for all snippets in /boot/loader/entries"
-  check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_bls_{{{ SANITIZED_ARG_NAME }}}_options" />
+  <ind:textfilecontent54_test id="test_bls_all_entries_{{{ SANITIZED_ARG_NAME }}}_options"
+  comment="Check that entries with option {{{ ARG_NAME_VALUE }}} exist"
+  check="all" version="1">
+    <ind:object object_ref="object_bls_all_entries_{{{ SANITIZED_ARG_NAME }}}_options" />
     <ind:state state_ref="state_{{{ SANITIZED_ARG_NAME }}}_option" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_bls_{{{ SANITIZED_ARG_NAME }}}_options"
+
+  <ind:textfilecontent54_object id="object_bls_all_entries_{{{ SANITIZED_ARG_NAME }}}_options"
   version="1">
     <ind:filepath operation="pattern match">^/boot/loader/entries/.*\.conf$</ind:filepath>
     <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_bls_entries_without_{{{ SANITIZED_ARG_NAME }}}_option"
+  comment="Check that entries wihout option {{{ ARG_NAME_VALUE }}} have $kernelopts"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_bls_entries_without_{{{ SANITIZED_ARG_NAME }}}_option" />
+    <ind:state state_ref="state_kernelopts_option" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_bls_entries_without_{{{ SANITIZED_ARG_NAME }}}_option"
+  version="1">
+    <ind:filepath operation="pattern match">^/boot/loader/entries/.*\.conf$</ind:filepath>
+    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_{{{ SANITIZED_ARG_NAME }}}_option</filter>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_grubenv_{{{ SANITIZED_ARG_NAME }}}_option"
+  comment="Make sure kernel updates retain {{{ ARG_NAME_VALUE }}} option"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_grubenv_{{{ SANITIZED_ARG_NAME }}}_option" />
+    <ind:state state_ref="state_{{{ SANITIZED_ARG_NAME }}}_option" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_grubenv_{{{ SANITIZED_ARG_NAME }}}_option"
+  version="1">
+    <ind:filepath operation="pattern match">^/boot/grub2/grubenv$</ind:filepath>
+    <ind:pattern operation="pattern match">^kernelopts=(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -42,5 +78,10 @@
   <ind:textfilecontent54_state id="state_{{{ SANITIZED_ARG_NAME }}}_option"
   version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_kernelopts_option"
+  version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?\$kernelopts(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>
 </def-group>

--- a/shared/templates/template_OVAL_bls_entries_option
+++ b/shared/templates/template_OVAL_bls_entries_option
@@ -18,6 +18,11 @@
       </criteria>
       <criterion test_ref="test_runtime_{{{ SANITIZED_ARG_NAME }}}_option"
       comment="Check if {{{ ARG_NAME_VALUE }}} is present in the /proc/cmdline" />
+{{% if product in ["rhel8", "fedora"] %}}
+      <!-- This ensures that running grub2-mkconfig won't remove any required options from /boot/grub2/grubenv -->
+      <criterion test_ref="test_kernel_update_{{{ SANITIZED_ARG_NAME }}}_option"
+      comment="Make sure kernel updates will retain {{{ ARG_NAME_VALUE }}} option" />
+{{% endif %}}
     </criteria>
   </definition>
 
@@ -74,6 +79,21 @@
     <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+{{% if product in ["rhel8", "fedora"] %}}
+  <ind:textfilecontent54_test id="test_kernel_update_{{{ SANITIZED_ARG_NAME }}}_option"
+  comment="Check for option {{{ ARG_NAME_VALUE }}} in /etc/default/grub"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_kernel_update_{{{ SANITIZED_ARG_NAME }}}_option" />
+    <ind:state state_ref="state_{{{ SANITIZED_ARG_NAME }}}_option" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_kernel_update_{{{ SANITIZED_ARG_NAME }}}_option"
+  version="1">
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
 
   <ind:textfilecontent54_state id="state_{{{ SANITIZED_ARG_NAME }}}_option"
   version="1">


### PR DESCRIPTION
#### Description:

- Add check for runtime kernel options (`/proc/cmdline`)
- Extend set of checks to support `$kernelopts`
  - Fedora and RHEL8 may not have the kernel options directly in the entries in `/boot/loader/entries/*.conf`, but rather be defined by `$kernelopts` which are sourced via `/boot/grub2/grubenv`.
- Also make sure that `/boot/grub2/grubenv` will retain the configured kernel options.
  - Running `grub2-mkconfig` or kernel update may update `/boot/grub2/grubenv` and strip kernel options away if they are not set in `/etc/default/grub` (`GRUB_CMDLINE_LINUX`).

