### PR TITLE
Change the CPE identifier for RHCOS to indicate it's an OS

### DIFF
--- a/rhcos4/cpe/rhcos4-cpe-dictionary.xml
+++ b/rhcos4/cpe/rhcos4-cpe-dictionary.xml
@@ -2,7 +2,7 @@
 <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd">
-      <cpe-item name="cpe:/a:redhat:enterprise_linux_coreos:4">
+      <cpe-item name="cpe:/o:redhat:enterprise_linux_coreos:4">
             <title xml:lang="en-us">Red Hat Enterprise Linux CoreOS 4</title>
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_OS_is_rhcos4</check>

--- a/shared/checks/oval/installed_OS_is_rhcos4.xml
+++ b/shared/checks/oval/installed_OS_is_rhcos4.xml
@@ -5,7 +5,7 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/a:redhat:enterprise_linux_coreos:4" source="CPE" />
+      <reference ref_id="cpe:/o:redhat:enterprise_linux_coreos:4" source="CPE" />
       <description>The operating system installed on the system is
       Red Hat Enterprise Linux CoreOS release 4</description>
     </metadata>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -258,7 +258,7 @@ PRODUCT_TO_CPE_MAPPING = {
         "cpe:/a:redhat:openshift_container_platform:4.1",
     ],
     "rhcos4": [
-        "cpe:/a:redhat:enterprise_linux_coreos:4",
+        "cpe:/o:redhat:enterprise_linux_coreos:4",
     ],
     "ol7": [
         "cpe:/o:oracle:linux:7",


### PR DESCRIPTION
#### Description:
The "part" after the cpe:// "uri" identifier was set to "a" which means
"application", but should probably say "o" to indicate that RHCOS is in
fact an OS.

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:
This would help the Compliance Operator add proper metadata to the
objects it uses to represents profiles.