### PR TITLE
Update RHEL7 documentation link for grub2_uefi_admin_username.

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/rule.yml
@@ -28,7 +28,7 @@ rationale: |-
     For more information on how to configure the grub2 superuser account and password,
     please refer to
     <ul>
-    <li>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Protecting_GRUB_2_with_a_Password.html") }}}</li>.
+    <li>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-working_with_the_grub_2_boot_loader#sec-Protecting_GRUB_2_with_a_Password") }}}</li>.
     </ul>
     {{% endif %}}
 


### PR DESCRIPTION
#### Rationale:

- Old link doesn't redirect to new documentation page

- Fixes jenkins job: https://jenkins.complianceascode.io/job/scap-security-guide-linkcheck/
