### PR TITLE
Edit audit rules auid values (from unset to STIG required values)

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
@@ -8,15 +8,15 @@ description: |-
     use the <tt>augenrules</tt> program to read audit rules during daemon startup
     (the default), add the following line to a file with suffix <tt>.rules</tt> in
     the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S chmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S chmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S chmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S chmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S chmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
@@ -8,15 +8,15 @@ description: |-
     use the <tt>augenrules</tt> program to read audit rules during daemon startup
     (the default), add the following line to a file with suffix <tt>.rules</tt> in
     the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S chown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S chown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S chown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S chown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
@@ -8,15 +8,15 @@ description: |-
     use the <tt>augenrules</tt> program to read audit rules during daemon startup
     (the default), add the following line to a file with suffix <tt>.rules</tt> in
     the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmod -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
@@ -8,15 +8,15 @@ description: |-
     use the <tt>augenrules</tt> program to read audit rules during daemon startup
     (the default), add the following line to a file with suffix <tt>.rules</tt> in
     the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmodat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
@@ -8,18 +8,18 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S fchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/correct_rules.pass.sh
@@ -2,6 +2,6 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
-echo "-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-echo "-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
@@ -8,15 +8,15 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fchownat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -10,18 +10,18 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -8,15 +8,15 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
@@ -8,15 +8,15 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S lchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S lchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S lchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S lchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S lchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S lchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S lchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S lchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -10,18 +10,18 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -8,15 +8,15 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -9,18 +9,18 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
     program to read audit rules during daemon startup (the default), add the
     following line to a file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     <br /><br />
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -8,15 +8,15 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 
 rationale: |-
     The changing of file permissions could indicate that a user is attempting to

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/group.yml
@@ -11,12 +11,12 @@ description: |-
     still achieving the desired effect. An example of this is that the "-S" calls
     could be split up and placed on separate lines, however, this is less efficient.
     Add the following to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod
-        -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod
-        -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod
+        -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod
+        -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
     If your system is 64 bit then these lines should be duplicated and the
     arch=b32 replaced with arch=b64 as follows:
-    <pre>-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod
-        -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod
-        -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    <pre>-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod
+        -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod
+        -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=perm_mod</pre>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -10,11 +10,11 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -56,7 +56,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/bin/chcon" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -10,11 +10,11 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -54,7 +54,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/restorecon" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -10,11 +10,11 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -56,7 +56,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/semanage" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -10,11 +10,11 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -47,7 +47,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/setfiles" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -10,11 +10,11 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -56,7 +56,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/setsebool" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
@@ -10,11 +10,11 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -45,7 +45,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/seunshare" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=privileged-priv_change</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
@@ -9,10 +9,10 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -F auid>={{{ auid }}} -F auid!=unset -k *"
+	PATTERN="-a always,exit -F arch=$ARCH -S .* -F auid>={{{ auid }}} -F auid!=4294967295 -k *"
 	# Use escaped BRE regex to specify rule group
 	GROUP="\(rmdir\|unlink\|rename\)"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>={{{ auid }}} -F auid!=unset -k delete"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>={{{ auid }}} -F auid!=4294967295 -k delete"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
@@ -9,12 +9,12 @@ description: |-
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename,renameat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename,renameat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename -S renameat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename -S renameat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
 
 rationale: |-
     Auditing file deletions will create an audit trail for files that are removed

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -9,12 +9,12 @@ description: |-
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rename -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rename -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rename -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rename -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
 
 rationale: |-
     Auditing file deletions will create an audit trail for files that are removed

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/correct_rules.pass.sh
@@ -2,5 +2,5 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
-echo "-a always,exit -F arch=b32 -S rename -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
-echo "-a always,exit -F arch=b64 -S rename -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a always,exit -F arch=b32 -S rename -F auid>=1000 -F auid!=4294967295 -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a always,exit -F arch=b64 -S rename -F auid>=1000 -F auid!=4294967295 -F key=delete" >> /etc/audit/rules.d/delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -9,12 +9,12 @@ description: |-
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S renameat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S renameat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S renameat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S renameat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
 
 rationale: |-
     Auditing file deletions will create an audit trail for files that are removed

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -9,12 +9,12 @@ description: |-
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rmdir -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rmdir -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rmdir -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rmdir -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
 
 rationale: |-
     Auditing file deletions will create an audit trail for files that are removed

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -9,12 +9,12 @@ description: |-
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S unlink -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S unlink -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S unlink -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S unlink -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
 
 rationale: |-
     Auditing file deletions will create an audit trail for files that are removed

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -9,12 +9,12 @@ description: |-
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S unlinkat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S unlinkat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S unlinkat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S unlinkat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
 
 rationale: |-
     Auditing file deletions will create an audit trail for files that are removed

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/group.yml
@@ -9,9 +9,9 @@ description: |-
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename,renameat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename,renameat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
     appropriate for your system:
-    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename,renameat -F auid&gt;={{{ auid }}} -F auid!=unset -F key=delete</pre>
+    <pre>-a always,exit -F arch=ARCH -S rmdir,unlink,unlinkat,rename,renameat -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=delete</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chmod/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S chmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chown/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S chown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File ownership attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_creat/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
 rationale: |-
     File access attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmod/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmod -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmodat/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmodat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchown/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File ownership attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchownat/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchownat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File ownership attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fremovexattr/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fsetxattr/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_ftruncate/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S ftruncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
 rationale: |-
     File access attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lchown/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lchown -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File ownership attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lremovexattr/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lremovexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lsetxattr/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lsetxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S open -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
 rationale: |-
     File access attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
 rationale: |-
     File access attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_creat/rule.yml
@@ -22,12 +22,12 @@ description: |-
     <tt>/etc/audit/audit.rules</tt> file.
 
     <pre>
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create
     </pre>
 
 rationale: |-
@@ -49,4 +49,4 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open_by_handle_at,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create</pre>
+        <pre>-a always,exit -F arch=b32 -S open_by_handle_at,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
@@ -23,12 +23,12 @@ description: |-
     <tt>/etc/audit/audit.rules</tt> file.
 
     <pre>
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification
     </pre>
 
 rationale: |-
@@ -50,4 +50,4 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification</pre>
+        <pre>-a always,exit -F arch=b32 -S open,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_creat/rule.yml
@@ -22,12 +22,12 @@ description: |-
     <tt>/etc/audit/audit.rules</tt> file.
 
     <pre>
-    -a always,exit -F arch=b32 -S open -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create
+    -a always,exit -F arch=b32 -S open -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create
+    -a always,exit -F arch=b64 -S open -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create
     </pre>
 
 rationale: |-
@@ -49,4 +49,4 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open,open -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create</pre>
+        <pre>-a always,exit -F arch=b32 -S open,open -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_trunc_write/rule.yml
@@ -23,12 +23,12 @@ description: |-
     <tt>/etc/audit/audit.rules</tt> file.
 
     <pre>
-    -a always,exit -F arch=b32 -S open -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification
+    -a always,exit -F arch=b32 -S open -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification
+    -a always,exit -F arch=b64 -S open -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification
     </pre>
 
 rationale: |-
@@ -50,4 +50,4 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open,openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification</pre>
+        <pre>-a always,exit -F arch=b32 -S open,openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S openat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
 rationale: |-
     File access attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_creat/rule.yml
@@ -22,12 +22,12 @@ description: |-
     <tt>/etc/audit/audit.rules</tt> file.
 
     <pre>
-    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create
+    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create
+    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create
     </pre>
 
 rationale: |-
@@ -49,4 +49,4 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-create</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-create</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_trunc_write/rule.yml
@@ -23,12 +23,12 @@ description: |-
     <tt>/etc/audit/audit.rules</tt> file.
 
     <pre>
-    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification
+    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification
+    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification
     </pre>
 
 rationale: |-
@@ -50,4 +50,4 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open,openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=unset -F key=successful-modification</pre>
+        <pre>-a always,exit -F arch=b32 -S open,openat -F a2&amp;01003 -F success=1 -F auid>={{{ auid }}} -F auid!=4294967295 -F key=successful-modification</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_removexattr/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S removexattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File permission changes could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_rename/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S rename -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
 rationale: |-
     File deletion attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_renameat/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S renameat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
 rationale: |-
     File deletion attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_setxattr/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S setxattr -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-perm-change</pre>
 
 rationale: |-
     File deletion attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_truncate/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b32 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-access</pre>
+    <pre>-a always,exit -F arch=b64 -S truncate -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-access</pre>
 
 rationale: |-
     File access attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlink/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S unlink -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
 rationale: |-
     File deletion attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlinkat/rule.yml
@@ -11,18 +11,18 @@ description: |-
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
 
-    <pre>-a always,exit -F arch=b32 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=successful-delete</pre>
+    <pre>-a always,exit -F arch=b64 -S unlinkat -F success=1 -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=successful-delete</pre>
 
 rationale: |-
     File deletion attempts could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
@@ -11,18 +11,18 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 
 	# First fix the -EACCES requirement
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -k *"
+	PATTERN="-a always,exit -F arch=$ARCH -S .* -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -k *"
 	# Use escaped BRE regex to specify rule group
 	GROUP="\(creat\|open\|truncate\)"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -k access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -k access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 
 	# Then fix the -EPERM requirement
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -k *"
+	PATTERN="-a always,exit -F arch=$ARCH -S .* -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -k *"
 	# No need to change content of $GROUP variable - it's the same as for -EACCES case above
-	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -k access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -k access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -8,21 +8,21 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/test_audit.rules
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/test_audit.rules
@@ -1,39 +1,39 @@
 # WARNING: Do not remove the comments in this file
 # one per line
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
 
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
 
 # multiple per arg
--a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
 
 # one per arg
--a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S chmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S chmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S chmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S chmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S chmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S chmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S chmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S chmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S chown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S chown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S chown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S chown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S chown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S chown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S chown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S chown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/default.pass.sh
@@ -2,7 +2,7 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/one_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/one_filter.fail.sh
@@ -2,7 +2,7 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -10,21 +10,21 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmod/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S fchmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S fchmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fchmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S fchmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmod -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fchmod -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmodat/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S fchmodat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S fchmodat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchmodat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fchmodat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchmodat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S fchmodat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchmodat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fchmodat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S fchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S fchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S fchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S fchownat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fchownat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S fchownat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fchownat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fremovexattr/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S fremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S fremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S fremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fsetxattr/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S fsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S fsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S fsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S fsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -10,24 +10,24 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S ftruncate -F exiu=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S ftruncate -F exiu=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
@@ -17,12 +17,12 @@ description: |-
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
 
-    <pre>-a always,exit -F arch=b32 -S lchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S lchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S lchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S lchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lchown -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S lchown -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -50,7 +50,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lremovexattr/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S lremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S lremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S lremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S lremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lremovexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S lremovexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lsetxattr/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S lsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S lsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S lsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S lsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S lsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S lsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S lsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S lsetxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -10,24 +10,24 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -10,21 +10,21 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/rule.yml
@@ -22,14 +22,14 @@ description: |-
     utility to read audit rules during daemon startup, add the rules below to
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
     </pre>
 
 rationale: |-
@@ -69,7 +69,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create</pre>
 
 template:
     vars:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
@@ -21,14 +21,14 @@ description: |-
     utility to read audit rules during daemon startup, add the rules below to
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
     </pre>
 
 rationale: |-
@@ -68,7 +68,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification</pre>
 
 template:
     vars:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/rule.yml
@@ -21,21 +21,21 @@ description: |-
     utility to read audit rules during daemon startup, check the order of rules below in
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
-    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
     </pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
-    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
     </pre>
 
 rationale: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
@@ -22,14 +22,14 @@ description: |-
     utility to read audit rules during daemon startup, add the rules below to
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
     </pre>
 
 rationale: |-
@@ -69,7 +69,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create</pre>
+        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create</pre>
 
 template:
     vars:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
@@ -18,13 +18,13 @@ description: |-
     utility to read audit rules during daemon startup, add the rules below to
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
     </pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
     </pre>
 
 rationale: |-
@@ -64,7 +64,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification</pre>
+        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification</pre>
 
 template:
     vars:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/rule.yml
@@ -21,21 +21,21 @@ description: |-
     utility to read audit rules during daemon startup, check the order of rules below in
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
-    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
     </pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
-    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
     </pre>
 
 rationale: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -10,24 +10,24 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/rule.yml
@@ -22,14 +22,14 @@ description: |-
     utility to read audit rules during daemon startup, add the rules below to
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
     </pre>
 
 rationale: |-
@@ -69,7 +69,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create</pre>
 
 template:
     vars:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rule.yml
@@ -21,14 +21,14 @@ description: |-
     utility to read audit rules during daemon startup, add the rules below to
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
     </pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
     </pre>
 
 rationale: |-
@@ -68,7 +68,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification</pre>
 
 template:
     vars:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/rule.yml
@@ -21,21 +21,21 @@ description: |-
     utility to read audit rules during daemon startup, check the order of rules below in
     <tt>/etc/audit/audit.rules</tt> file.
     <pre>
-    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
-    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
+    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
     </pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-create
-    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-modification
-    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
-    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S openat -F a2&amp;0100 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-create
+    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S openat -F a2&amp;01003 -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-modification
+    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
+    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-access
     </pre>
 
 rationale: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_removexattr/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S removexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S removexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S removexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S removexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S removexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S removexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S removexattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S removexattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -13,12 +13,12 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S rename -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b32 -S rename -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S rename -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S rename -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S rename -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b64 -S rename -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    -a always,exit -F arch=b64 -S rename -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S rename -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
 
 rationale: |-
     Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
@@ -57,7 +57,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
+        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-delete</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -13,12 +13,12 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S renameat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b32 -S renameat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S renameat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S renameat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S renameat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b64 -S renameat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    -a always,exit -F arch=b64 -S renameat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S renameat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
 
 rationale: |-
     Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
@@ -57,7 +57,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
+        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-delete</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_setxattr/rule.yml
@@ -14,11 +14,11 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S setxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b32 -S setxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b32 -S setxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b32 -S setxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
     If the system is 64 bit then also add the following lines:
-    <pre>-a always,exit -F arch=b64 -S setxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change
-    -a always,exit -F arch=b64 -S setxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+    <pre>-a always,exit -F arch=b64 -S setxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change
+    -a always,exit -F arch=b64 -S setxattr -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 
 rationale: |-
@@ -46,7 +46,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the audit rule checks a
         system call independently of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-perm-change</pre>
+        <pre>-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-perm-change</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -10,24 +10,24 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-    -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+    -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
 
 rationale: |-
     Unsuccessful attempts to access files could be an indicator of malicious activity on a system. Auditing

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -14,13 +14,13 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    -a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
 
 rationale: |-
     Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
@@ -59,7 +59,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
+        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-delete</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/default.pass.sh
@@ -2,7 +2,7 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/one_sys_with_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/one_sys_with_filter.fail.sh
@@ -2,7 +2,7 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b64 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b32 -S unlink -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b64 -S unlink -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/only_eacces.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/only_eacces.fail.sh
@@ -2,5 +2,5 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/two_sys_with_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/two_sys_with_filter.fail.sh
@@ -2,7 +2,7 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b64 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b32 -S unlink,unlinkat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
-echo "-a always,exit -F arch=b64 -S unlink,unlinkat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b32 -S unlink,unlinkat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
+echo "-a always,exit -F arch=b64 -S unlink,unlinkat -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -14,13 +14,13 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file.
-    <pre>-a always,exit -F arch=b32 -S unlinkat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b32 -S unlinkat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    <pre>-a always,exit -F arch=b32 -S unlinkat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b32 -S unlinkat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
 
     If the system is 64 bit then also add the following lines:
     <pre>
-    -a always,exit -F arch=b64 -S unlinkat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete
-    -a always,exit -F arch=b64 -S unlinkat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=unsuccessful-delete</pre>
+    -a always,exit -F arch=b64 -S unlinkat -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete
+    -a always,exit -F arch=b64 -S unlinkat -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=unsuccessful-delete</pre>
 
 rationale: |-
     Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
@@ -59,7 +59,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
+        <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=unsuccesful-delete</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/group.yml
@@ -11,9 +11,9 @@ description: |-
     still achieving the desired effect. An example of this is that the "-S" calls
     could be split up and placed on separate lines, however, this is less efficient.
     Add the following to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-        -a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+        -a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>
     If your system is 64 bit then these lines should be duplicated and the
     arch=b32 replaced with arch=b64 as follows:
-    <pre>-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access
-        -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=unset -F key=access</pre>
+    <pre>-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access
+        -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=access</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/ansible/shared.yml
@@ -1,0 +1,42 @@
+# platform = multi_platform_rhel,multi_platform_rhv
+# reboot = false
+# complexity = low
+# disruption = low
+# strategy = configure
+
+# Inserts/replaces the rule in /etc/audit/rules.d
+
+- name: Search /etc/audit/rules.d for audit rule entries
+  find:
+    paths: /etc/audit/rules.d
+    recurse: false
+    contains: ^.*/usr/bin/kmod.*$
+    patterns: '*.rules'
+  register: find_kmod
+
+- name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
+  set_fact:
+    all_files:
+    - /etc/audit/rules.d/privileged.rules
+  when: find_kmod.matched is defined and find_kmod.matched == 0
+
+- name: Use matched file as the recipient for the rule
+  set_fact:
+    all_files:
+    - '{{ find_/usr/bin/kmod.files | map(attribute=''path'') | list | first }}'
+  when: find_kmod.matched is defined and find_kmod.matched > 0
+
+- name: Inserts/replaces the kmod rule in rules.d
+  lineinfile:
+    path: '{{ all_files[0] }}'
+    line: '-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change'
+    state: present
+    create: true
+
+# Inserts/replaces the init_modules rule in /etc/audit/audit.rules
+
+- name: Inserts/replaces the kmod rule in audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change'
+    create: true

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/bash/shared.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+PATTERN="-w \/usr\/bin\/kmod -p x -F auid!=4294967295 \(-F key=\|-k \).*"
+GROUP="modules"
+FULL_RULE="-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change"
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/oval/shared.xml
@@ -1,0 +1,50 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_kernel_module_kmod" version="1">
+    <metadata>
+      <title>Audit Kernel Module Loading and Unloading - kmod</title>
+      <affected family="unix">
+        <platform>multi_platform_wrlinux</platform>
+        <platform>multi_platform_rhel</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>The audit rules should be configured to log information about kernel module changes.</description>
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit augenrules kmod" test_ref="test_32bit_ardm_kmod_augenrules" />
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit auditctl kmod" test_ref="test_32bit_ardm_kmod_auditctl" />
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules kmod" id="test_32bit_ardm_kmod_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_kmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_kmod_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+\/usr\/bin\/kmod[\s]+-p[\s]+x[\s]+-F[\s]+auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl kmod" id="test_32bit_ardm_kmod_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_kmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_kmod_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+\/usr\/bin\/kmod[\s]+-p[\s]+x[\s]+-F[\s]+auid!=4294967295[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/rule.yml
@@ -1,0 +1,52 @@
+documentation_complete: true
+
+prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4,ocp4
+
+title: 'Ensure auditd Collects Information on Kernel Module Changes'
+
+description: |-
+    To capture kernel module loading events, use following line:
+    <pre>-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change</pre>
+
+    Place to add the line depends on a way <tt>auditd</tt> daemon is configured. If it is configured
+    to use the <tt>augenrules</tt> program (the default), add the line to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>.
+
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility,
+    add the line to file <tt>/etc/audit/audit.rules</tt>.
+
+rationale: |-
+    Changes to kernel modules can be used to alter the behavior of the kernel and 
+    potentially introduce malicious code into kernel space. It is important
+    to have an audit trail of modules that have been introduced into the kernel.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 80414-6
+    cce@rhel8: 80713-1
+
+references:
+    cis: 5.2.17
+    cui: 3.1.7
+    disa: "2777"
+    hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.312(b),164.312(d),164.312(e)
+    nist: AU-2(d),AU-12(c),AC-6(9),CM-6(a)
+    nist-csf: DE.AE-3,DE.AE-5,DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.AC-3,PR.PT-1,PR.PT-4,RS.AN-1,RS.AN-4
+    ospp: FAU_GEN.1.1.c
+    pcidss: Req-10.2.7
+    srg: SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222
+    vmmsrg: SRG-OS-000477-VMM-001970
+    stigid@rhel7: "030840"
+    isa-62443-2013: 'SR 1.13,SR 2.10,SR 2.11,SR 2.12,SR 2.6,SR 2.8,SR 2.9,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 6.1,SR 6.2,SR 7.1,SR 7.6'
+    isa-62443-2009: 4.2.3.10,4.3.2.6.7,4.3.3.3.9,4.3.3.5.8,4.3.3.6.6,4.3.4.4.7,4.3.4.5.6,4.3.4.5.7,4.3.4.5.8,4.4.2.1,4.4.2.2,4.4.2.4
+    cobit5: APO10.01,APO10.03,APO10.04,APO10.05,APO11.04,APO12.06,APO13.01,BAI03.05,BAI08.02,DSS01.03,DSS01.04,DSS02.02,DSS02.04,DSS02.07,DSS03.01,DSS03.05,DSS05.02,DSS05.03,DSS05.04,DSS05.05,DSS05.07,MEA01.01,MEA01.02,MEA01.03,MEA01.04,MEA01.05,MEA02.01
+    iso27001-2013: A.11.2.6,A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.7.1,A.13.1.1,A.13.2.1,A.14.1.3,A.14.2.7,A.15.2.1,A.15.2.2,A.16.1.4,A.16.1.5,A.16.1.7,A.6.2.1,A.6.2.2
+    cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+
+ocil: |-
+    To verify that auditing of privileged command use is configured, run the
+    following command:
+    <pre>$ sudo grep passwd /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    It should return a relevant line in the audit rules.
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/tests/correct_rules.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-a always,exit -F arch=b32 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b64 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_kmod/tests/default.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
@@ -18,8 +18,8 @@ do
         PATTERN="-a always,exit -F arch=$ARCH -S init_module -S delete_module \(-F key=\|-k \).*"
         FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -S delete_module -k modules"
 {{% else %}}
-        PATTERN="-a always,exit -F arch=$ARCH -S init_module -S delete_module -S finit_module \(-F key=\|-k \).*"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -S delete_module -S finit_module -k modules"
+        PATTERN="-a always,exit -F arch=$ARCH -S create_module -S init_module -S delete_module -S finit_module \(-F key=\|-k \).*"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S create_module -S delete_module -S init_module -S finit_module -k modules"
 {{% endif %}}
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/oval/shared.xml
@@ -16,6 +16,7 @@
       <extend_definition comment="audit init_module" definition_ref="audit_rules_kernel_module_loading_init" />
       <extend_definition comment="audit delete_module" definition_ref="audit_rules_kernel_module_loading_delete" />
 {{% if product != "rhel6" %}}
+      <extend_definition comment="audit create_module" definition_ref="audit_rules_kernel_module_loading_create" />
       <extend_definition comment="audit finit_module" definition_ref="audit_rules_kernel_module_loading_finit" />
 {{% endif %}}
     </criteria>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -9,7 +9,8 @@ description: |-
 {{% if product == "rhel6" %}}
     -a always,exit -F arch=<i>ARCH</i> -S init_module,delete_module -F key=modules
 {{% else %}}
-    -a always,exit -F arch=<i>ARCH</i> -S init_module,finit_module,delete_module -F key=modules
+    -a always,exit -F arch=<i>ARCH</i> -S create_module,init_module,finit_module,delete_module -F key=modules
+    -w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change
 {{% endif %}}
     </pre>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_multiple_per_arg.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+# Use auditctl, on RHEL7, default is to use augenrules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+rm -f /etc/audit/rules.d/*
+
+# cut out irrelevant rules for this test
+sed '1,10d' test_audit.rules > /etc/audit/audit.rules
+sed -i '5,8d' /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_arg.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+# Use auditctl, on RHEL7, default is to use augenrules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+rm -f /etc/audit/rules.d/*
+
+# cut out irrelevant rules for this test
+sed '1,14d' test_audit.rules > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/syscalls_one_per_line.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S
+# remediation = bash
+
+# Use auditctl, on RHEL7, default is to use augenrules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+
+rm -f /etc/audit/rules.d/*
+
+# cut out irrelevant rules for this test
+sed '11,18d' test_audit.rules > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
@@ -1,0 +1,63 @@
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv
+# reboot = false
+# complexity = low
+# disruption = low
+# strategy = configure
+
+# What architecture are we on?
+
+- name: Set architecture for audit create_module tasks
+  set_fact:
+    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+
+# Inserts/replaces the rule in /etc/audit/rules.d
+
+- name: Search /etc/audit/rules.d for audit rule entries
+  find:
+    paths: /etc/audit/rules.d
+    recurse: false
+    contains: ^.*create_module.*$
+    patterns: '*.rules'
+  register: find_create_module
+
+- name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
+  set_fact:
+    all_files:
+    - /etc/audit/rules.d/privileged.rules
+  when: find_create_module.matched is defined and find_create_module.matched == 0
+
+- name: Use matched file as the recipient for the rule
+  set_fact:
+    all_files:
+    - '{{ find_create_module.files | map(attribute=''path'') | list | first }}'
+  when: find_create_module.matched is defined and find_create_module.matched > 0
+
+- name: Inserts/replaces the create_module rule in rules.d
+  lineinfile:
+    path: '{{ all_files[0] }}'
+    line: '-a always,exit -F arch=b32 -S create_module -k module-change'
+    state: present
+    create: true
+
+- name: Inserts/replaces the create_module rule in rules.d on x86_64
+  lineinfile:
+    path: '{{ all_files[0] }}'
+    line: '-a always,exit -F arch=b64 -S create_module -k module-change'
+    state: present
+    create: true
+  when: audit_arch is defined and audit_arch == 'b64'
+
+# Inserts/replaces the create_modules rule in /etc/audit/audit.rules
+
+- name: Inserts/replaces the create_module rule in audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-a always,exit -F arch=b32 -S create_module -k module-change'
+    create: true
+
+- name: Inserts/replaces the create_module rule in audit.rules when on x86_64
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-a always,exit -F arch=b64 -S create_module -k module-change'
+    create: true
+  when: audit_arch is defined and audit_arch == 'b64'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/bash/shared.sh
@@ -1,0 +1,22 @@
+# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# First perform the remediation of the syscall rule
+# Retrieve hardware architecture of the underlying system
+# Note: 32-bit and 64-bit kernel syscall numbers not always line up =>
+#       it's required on a 64-bit system to check also for the presence
+#       of 32-bit's equivalent of the corresponding rule.
+#       (See `man 7 audit.rules` for details )
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
+	PATTERN="-a always,exit -F arch=$ARCH -S create_module \(-F key=\|-k \).*"
+	GROUP="modules"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S create_module -k modules"
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/oval/shared.xml
@@ -1,0 +1,81 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_kernel_module_loading_create" version="1">
+    <metadata>
+      <title>Audit Kernel Module Loading and Unloading - create_module</title>
+      <affected family="unix">
+        <platform>multi_platform_wrlinux</platform>
+        <platform>Red Hat Enterprise Linux 7</platform>
+        <platform>Red Hat Enterprise Linux 8</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_rhv</platform>
+        <platform>multi_platform_ol</platform>
+      </affected>
+      <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit augenrules 32-bit create_module" test_ref="test_32bit_ardm_create_module_augenrules" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of create_module audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of create_module audit DAC rule -->
+          <criterion comment="audit augenrules 64-bit create_module" test_ref="test_64bit_ardm_create_module_augenrules" />
+        </criteria>
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit auditctl 32-bit create_module" test_ref="test_32bit_ardm_create_module_auditctl" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the create_module audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of create_module audit DAC rule -->
+          <criterion comment="audit auditctl 64-bit create_module" test_ref="test_64bit_ardm_create_module_auditctl" />
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit create_module" id="test_32bit_ardm_create_module_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_create_module_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_create_module_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+create_module[\s]+|([\s]+|[,])create_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit create_module" id="test_64bit_ardm_create_module_augenrules" version="1">
+    <ind:object object_ref="object_64bit_ardm_create_module_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_create_module_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+create_module[\s]+|([\s]+|[,])create_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit create_module" id="test_32bit_ardm_create_module_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_create_module_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_create_module_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+create_module[\s]+|([\s]+|[,])create_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit create_module" id="test_64bit_ardm_create_module_auditctl" version="1">
+    <ind:object object_ref="object_64bit_ardm_create_module_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_create_module_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+create_module[\s]+|([\s]+|[,])create_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
@@ -1,0 +1,49 @@
+documentation_complete: true
+
+prodtype: wrlinux1019,rhel7,rhel8,fedora,ol7,ol8,rhv4,ocp4
+
+title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading - create_module'
+
+description: |-
+    If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt> program
+    to read audit rules during daemon startup (the default), add the following lines to a file
+    with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt> to capture kernel module
+    loading and unloading events, setting ARCH to either b32 or b64 as appropriate for your system:
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S create_module -F key=modules</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility to read audit
+    rules during daemon startup, add the following lines to <tt>/etc/audit/audit.rules</tt> file
+    in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
+    b64 as appropriate for your system:
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S create_module -F key=modules</pre>
+
+rationale: |-
+    The addition/removal of kernel modules can be used to alter the behavior of
+    the kernel and potentially introduce malicious code into kernel space. It is important
+    to have an audit trail of modules that have been introduced into the kernel.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 80547-3
+    cce@rhel8: 80712-3
+
+references:
+    cis: 5.2.17
+    cui: 3.1.7
+    disa: "172"
+    hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.312(b),164.312(d),164.312(e)
+    nist: AU-2(d),AU-12(c),AC-6(9),CM-6(a)
+    nist-csf: DE.AE-3,DE.AE-5,DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.AC-3,PR.PT-1,PR.PT-4,RS.AN-1,RS.AN-4
+    ospp: FAU_GEN.1.1.c
+    pcidss: Req-10.2.7
+    srg: SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222
+    vmmsrg: SRG-OS-000477-VMM-001970
+    stigid@rhel7: "030821"
+    isa-62443-2013: 'SR 1.13,SR 2.10,SR 2.11,SR 2.12,SR 2.6,SR 2.8,SR 2.9,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 6.1,SR 6.2,SR 7.1,SR 7.6'
+    isa-62443-2009: 4.2.3.10,4.3.2.6.7,4.3.3.3.9,4.3.3.5.8,4.3.3.6.6,4.3.4.4.7,4.3.4.5.6,4.3.4.5.7,4.3.4.5.8,4.4.2.1,4.4.2.2,4.4.2.4
+    cobit5: APO10.01,APO10.03,APO10.04,APO10.05,APO11.04,APO12.06,APO13.01,BAI03.05,BAI08.02,DSS01.03,DSS01.04,DSS02.02,DSS02.04,DSS02.07,DSS03.01,DSS03.05,DSS05.02,DSS05.03,DSS05.04,DSS05.05,DSS05.07,MEA01.01,MEA01.02,MEA01.03,MEA01.04,MEA01.05,MEA02.01
+    iso27001-2013: A.11.2.6,A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.7.1,A.13.1.1,A.13.2.1,A.14.1.3,A.14.2.7,A.15.2.1,A.15.2.2,A.16.1.4,A.16.1.5,A.16.1.7,A.6.2.1,A.6.2.2
+    cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+
+{{{ complete_ocil_entry_audit_syscall(syscall="create_module") }}}
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -28,7 +28,7 @@
 - name: Overwrites the rule in rules.d
   lineinfile:
     path: "{{ item.1.path }}"
-    line: '-a always,exit -F path={{ item.0.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.0.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes'
     create: no
     regexp: "^.*path={{ item.0.item }} .*$"
   with_subelements:
@@ -38,7 +38,7 @@
 - name: Adds the rule in rules.d
   lineinfile:
     path: /etc/audit/rules.d/privileged.rules
-    line: '-a always,exit -F path={{ item.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes'
     create: yes
   with_items:
     - "{{ files_result.results }}"
@@ -49,7 +49,7 @@
 - name: Inserts/replaces the rule in audit.rules
   lineinfile:
     path: /etc/audit/audit.rules
-    line: '-a always,exit -F path={{ item.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes'
     create: yes
     regexp: "^.*path={{ item.item }} .*$"
   with_items:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/rhel6.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/rhel6.sh
@@ -1,0 +1,8 @@
+# platform = Red Hat Enterprise Linux 6
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# Perform the remediation
+perform_audit_rules_privileged_commands_remediation "auditctl" "500"
+perform_audit_rules_privileged_commands_remediation "augenrules" "500"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -14,13 +14,13 @@ description: |-
     <tt>/etc/audit/rules.d</tt> for each setuid / setgid program on the system,
     replacing the <i>SETUID_PROG_PATH</i> part with the full path of that setuid /
     setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt> for each setuid / setgid program on the
     system, replacing the <i>SETUID_PROG_PATH</i> part with the full path of that
     setuid / setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -3,5 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -4,4 +4,4 @@
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -4,5 +4,5 @@
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -4,5 +4,5 @@
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/priv.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -4,5 +4,5 @@ AUID=$1
 KEY=$2
 RULEPATH=$3
 for file in $(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null); do
-     echo "-a always,exit -F path=$file -F perm=x -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
+     echo "-a always,exit -F path=$file -F perm=x -F auid>=$AUID -F auid!=4294967295 -k $KEY" >> $RULEPATH
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_default.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7
+
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_missing_rule.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7
+
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
+sed -i '/newgrp/d' /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_one_rule.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7
+
+echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_auditctl_rules_configured.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7
+
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_default.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+# augenrules is default for rhel7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_duplicated.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_ospp,xccdf_org.ssgproject.content_profile_pci-dss
+# Remediation for this rule cannot remove the duplicates
+# remediation = none
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+./generate_privileged_commands_rule.sh 1000 privileged /tmp/privileged.rules
+
+cp /tmp/privileged.rules /etc/audit/rules.d/privileged.rules
+sed 's/unset/4294967295/' /tmp/privileged.rules >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_missing_rule.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+ sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_one_rule.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7
+
+mkdir -p /etc/audit/rules.d
+echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_rules_configured.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+# change key of rules for binaries in /usr/sbin
+# A mixed conbination of -k and -F key= should be accepted
+sed -i '/sbin/s/-k /-F key=/g' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_two_rules_mixed_keys.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=4294967295 -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_augenrules_two_rules_sep_files.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+mkdir -p /etc/audit/rules.d
+echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=4294967295 -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel7_rules_with_own_key.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Fedora
+
+./generate_privileged_commands_rule.sh 1000 own_key /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/openssh/key-sign -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/openssh/key-sign -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
@@ -3,5 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
@@ -5,4 +5,4 @@
 
 mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
@@ -4,4 +4,4 @@
 # platform = Red Hat Enterprise Linux 7,Fedora
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/userhelper -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/userhelper -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=4294967295 -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 rationale: |-
     Creation of groups through direct edition of /etc/group could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open_by_handle_at/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 rationale: |-
     Creation of groups through direct edition of /etc/group could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_openat/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 rationale: |-
     Creation of groups through direct edition of /etc/group could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/group -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/gshadow could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open_by_handle_at/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/gshadow could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_openat/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/gshadow could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/gshadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/passwd could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+        <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
@@ -2,5 +2,5 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
@@ -2,5 +2,5 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open_by_handle_at/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/passwd could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/passwd could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=unset -F key=modify</pre>
+        <pre>-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
@@ -2,5 +2,5 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
@@ -2,5 +2,5 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
@@ -2,5 +2,5 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/shadow could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+        <pre>-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open_by_handle_at/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b64 -S open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/shadow could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+        <pre>-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_openat/rule.yml
@@ -10,13 +10,13 @@ description: |-
     to use the <tt>augenrules</tt> program to read audit rules during daemon
     startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b32 -S openat -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
     If the system is 64 bit then also add the following line:
-    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+    <pre>-a always,exit -F arch=b64 -S openat -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 rationale: |-
     Creation of users through direct edition of /etc/shadow could be an indicator of malicious activity on a system.
@@ -40,7 +40,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        <pre>-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=unset -F key=user-modify</pre>
+        <pre>-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ auid }}} -F auid!=4294967295 -F key=user-modify</pre>
 
 template:
     name: audit_rules_path_syscall

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/ansible/shared.yml
@@ -18,28 +18,28 @@
 - name: Check if the rule for x86_64 is already present in /etc/audit/rules.d/*
   find:
     paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=4294967295(\s|$)+'
     patterns: "*.rules"
   register: find_existing_media_export_64_rules_d
 
 - name: Check if the rule for x86 is already present in /etc/audit/rules.d/*
   find:
     paths: "/etc/audit/rules.d/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=4294967295(\s|$)+'
     patterns: "*.rules"
   register: find_existing_media_export_32_rules_d
 
 - name: Check if the rule for x86_64 is already present in /etc/audit/audit.rules
   find:
     paths: "/etc/audit/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b64\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=4294967295(\s|$)+'
     patterns: "audit.rules"
   register: find_existing_media_export_64_audit_rules
 
 - name: Check if the rule for x86 is already present in /etc/audit/rules.d/*
   find:
     paths: "/etc/audit/"
-    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=unset(\s|$)+'
+    contains: '^\s*-a\s+always,exit\s+-F\s+arch=b32\s+-S\s+mount\s+-F\s+auid>={{{ auid }}}\s+-F\s+auid!=4294967295(\s|$)+'
     patterns: "audit.rules"
   register: find_existing_media_export_32_audit_rules
 
@@ -71,14 +71,14 @@
 - name: Inserts/replaces the media export rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S mount -F auid>={{{ auid }}} -F auid!=unset -F key=export"
+    line: "-a always,exit -F arch=b32 -S mount -F auid>={{{ auid }}} -F auid!=4294967295 -F key=export"
     create: yes
   when: find_existing_media_export_32_rules_d is defined and find_existing_media_export_32_rules_d.matched == 0
 
 - name: Inserts/replaces the media export rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S mount -F auid>={{{ auid }}} -F auid!=unset -F key=export"
+    line: "-a always,exit -F arch=b64 -S mount -F auid>={{{ auid }}} -F auid!=4294967295 -F key=export"
     create: yes
   when: audit_arch is defined and audit_arch == 'b64' and find_existing_media_export_64_rules_d is defined and find_existing_media_export_64_rules_d.matched == 0
 #   
@@ -86,7 +86,7 @@
 #
 - name: Inserts/replaces the media export rule in /etc/audit/audit.rules when on x86
   lineinfile:
-    line: "-a always,exit -F arch=b32 -S mount -F auid>={{{ auid }}} -F auid!=unset -F key=export"
+    line: "-a always,exit -F arch=b32 -S mount -F auid>={{{ auid }}} -F auid!=4294967295 -F key=export"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
@@ -94,7 +94,7 @@
 
 - name: Inserts/replaces the media export rule in audit.rules when on x86_64
   lineinfile:
-    line: "-a always,exit -F arch=b64 -S mount -F auid>={{{ auid }}} -F auid!=unset -F key=export"
+    line: "-a always,exit -F arch=b64 -S mount -F auid>={{{ auid }}} -F auid!=4294967295 -F key=export"
     state: present
     dest: /etc/audit/audit.rules
     create: yes

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/bash/shared.sh
@@ -9,10 +9,21 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -F auid>={{{ auid }}} -F auid!=unset -k *"
+	PATTERN="-a always,exit -F arch=$ARCH -S .* -F auid>={{{ auid }}} -F auid!=4294967295 -k *"
 	GROUP="mount"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S mount -F auid>={{{ auid }}} -F auid!=unset -k export"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S mount -F auid>={{{ auid }}} -F auid!=4294967295 -k export"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 done
+
+{{% if product == "rhel7" %}}
+
+PATTERN="-a always,exit -F path=/usr/bin/mount -F auid>={{{ auid }}} -F auid!=4294967295 -k *"
+GROUP="mount"
+FULL_RULE="-a always,exit -F path=/usr/bin/mount -F auid>={{{ auid }}} -F auid!=4294967295 -k export"
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/oval/shared.xml
@@ -15,6 +15,9 @@
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of audit rule -->
           <criterion comment="audit augenrules 64-bit mount" test_ref="test_64bit_ardm_media_export_mount_augenrules" />
         </criteria>
+{{% if product == "rhel7" %}}
+        <criterion comment="audit augenrules mount command" test_ref="test_audit_rules_media_export_mount_command_augenrules" />
+{{% endif %}}
       </criteria>
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
@@ -25,6 +28,9 @@
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of audit rule -->
           <criterion comment="audit augenrules 64-bit mount" test_ref="test_64bit_ardm_media_export_mount_auditctl" />
         </criteria>
+{{% if product == "rhel7" %}}
+        <criterion comment="audit auditctl mount command" test_ref="test_audit_rules_media_export_mount_command_auditctl" />
+{{% endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -47,6 +53,17 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+{{% if product == "rhel7" %}}
+  <ind:textfilecontent54_test check="all" comment="audit augenrules mount command" id="test_audit_rules_media_export_mount_command_augenrules" version="1">
+    <ind:object object_ref="object_audit_rules_media_export_mount_command_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_media_export_mount_command_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-a\s+always,exit\s+(?:(-F[\s]+path=\/usr\/bin\/mount[\s]+))(?:-F\s+auid>={{{ auid }}}\s+\-F\s+auid!=(?:4294967295|unset)\s+)(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
+
   <ind:textfilecontent54_test check="all" comment="audit auditctl mount 32-bit" id="test_audit_rules_media_export_mount_auditctl" version="1">
     <ind:object object_ref="object_audit_rules_media_export_mount_auditctl" />
   </ind:textfilecontent54_test>
@@ -64,4 +81,16 @@
     <ind:pattern operation="pattern match">^\-a\s+always,exit\s+(\-F\s+arch=b64\s+)(?:.*(-S[\s]+mount[\s]+|([\s]+|[,])mount([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}\s+\-F\s+auid!=(?:4294967295|unset)\s+)(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+{{% if product == "rhel7" %}}
+  <ind:textfilecontent54_test check="all" comment="audit auditctl mount command" id="test_audit_rules_media_export_mount_command_auditctl" version="1">
+    <ind:object object_ref="object_audit_rules_media_export_mount_command_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_media_export_mount_command_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-a\s+always,exit\s+(?:(-F[\s]+path=\/usr\/bin\/mount[\s]+))(?:-F\s+auid>={{{ auid }}}\s+\-F\s+auid!=(?:4294967295|unset)\s+)(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
+
 </def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/correct_rules.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+echo "-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/issue -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/hosts -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_privileged_functions/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_privileged_functions/bash/shared.sh
@@ -1,0 +1,27 @@
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# Perform the remediation for the syscall rule
+# Retrieve hardware architecture of the underlying system
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
+	PATTERN="-a always,exit -F arch=$ARCH -S execve -C uid!=euid -F euid=0 -k setuid"
+	# Use escaped BRE regex to specify rule group
+	GROUP="execve"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S execve -C uid!=euid -F euid=0 -k setuid"
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+
+	PATTERN="-a always,exit -F arch=$ARCH -S execve -C gid!=egid -F egid=0 -k setgid"
+	# Use escaped BRE regex to specify rule group
+	GROUP="execve"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S execve -C gid!=egid -F egid=0 -k setgid"
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_privileged_functions/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_privileged_functions/oval/shared.xml
@@ -1,0 +1,124 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_privileged_functions" version="1">
+    <metadata>
+      <title>Audit Privileged Functions</title>
+      <affected family="unix">
+        <platform>Red Hat Virtualization 4</platform>
+        <platform>multi_platform_fedora</platform>
+        <platform>multi_platform_ol</platform>
+        <platform>multi_platform_rhel</platform>
+      </affected>
+      <description>Audit privilged execution events.</description>
+    </metadata>
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit augenrules 32-bit privileged functions" test_ref="test_32bit_ardm_audit_privileged_functions_augenrules_gid" />
+        <criterion comment="audit augenrules 32-bit privileged functions" test_ref="test_32bit_ardm_audit_privileged_functions_augenrules_uid" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of privileged functions audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of privileged functions audit DAC rule -->
+          <criteria operator="AND">
+            <criterion comment="audit augenrules 64-bit privileged functions" test_ref="test_64bit_ardm_audit_privileged_functions_augenrules_gid" />
+            <criterion comment="audit augenrules 64-bit privileged functions" test_ref="test_64bit_ardm_audit_privileged_functions_augenrules_uid" />
+          </criteria>
+        </criteria>
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit auditctl 32-bit privileged functions" test_ref="test_32bit_ardm_audit_privileged_functions_auditctl_gid" />
+        <criterion comment="audit auditctl 32-bit privileged functions" test_ref="test_32bit_ardm_audit_privileged_functions_auditctl_uid" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the privileged functions audit DAC rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of privileged functions audit DAC rule -->
+          <criteria operator="AND">
+            <criterion comment="audit auditctl 64-bit privileged functions" test_ref="test_64bit_ardm_audit_privileged_functions_auditctl_gid" />
+            <criterion comment="audit auditctl 64-bit privileged functions" test_ref="test_64bit_ardm_audit_privileged_functions_auditctl_uid" />
+          </criteria>
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit privileged functions" id="test_32bit_ardm_audit_privileged_functions_augenrules_uid" version="1">
+    <ind:object object_ref="object_32bit_ardm_audit_privileged_functions_augenrules_uid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_audit_privileged_functions_augenrules_uid" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+-F[\s]+euid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit privileged functions" id="test_64bit_ardm_audit_privileged_functions_augenrules_uid" version="1">
+    <ind:object object_ref="object_64bit_ardm_audit_privileged_functions_augenrules_uid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_audit_privileged_functions_augenrules_uid" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+-F[\s]+euid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit privileged functions" id="test_32bit_ardm_audit_privileged_functions_auditctl_uid" version="1">
+    <ind:object object_ref="object_32bit_ardm_audit_privileged_functions_auditctl_uid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_audit_privileged_functions_auditctl_uid" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+-F[\s]+euid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit privileged functions" id="test_64bit_ardm_audit_privileged_functions_auditctl_uid" version="1">
+    <ind:object object_ref="object_64bit_ardm_audit_privileged_functions_auditctl_uid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_audit_privileged_functions_auditctl_uid" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+-F[\s]+euid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit privileged functions" id="test_32bit_ardm_audit_privileged_functions_augenrules_gid" version="1">
+    <ind:object object_ref="object_32bit_ardm_audit_privileged_functions_augenrules_gid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_audit_privileged_functions_augenrules_gid" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+-F[\s]+egid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit privileged functions" id="test_64bit_ardm_audit_privileged_functions_augenrules_gid" version="1">
+    <ind:object object_ref="object_64bit_ardm_audit_privileged_functions_augenrules_gid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_audit_privileged_functions_augenrules_gid" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+-F[\s]+egid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit privileged functions" id="test_32bit_ardm_audit_privileged_functions_auditctl_gid" version="1">
+    <ind:object object_ref="object_32bit_ardm_audit_privileged_functions_auditctl_gid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_audit_privileged_functions_auditctl_gid" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+-F[\s]+egid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit privileged functions" id="test_64bit_ardm_audit_privileged_functions_auditctl_gid" version="1">
+    <ind:object object_ref="object_64bit_ardm_audit_privileged_functions_auditctl_gid" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_ardm_audit_privileged_functions_auditctl_gid" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+-F[\s]+egid=0[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_privileged_functions/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_privileged_functions/rule.yml
@@ -1,0 +1,42 @@
+documentation_complete: true
+
+title: 'Ensure auditd Collects All Executions Of Privileged Functions'
+
+description: |-
+    At a minimum the audit system should collect privileged function events
+    for all users and root. If the <tt>auditd</tt> daemon is configured to use the
+    <tt>augenrules</tt> program to read audit rules during daemon startup (the
+    default), add the following line to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
+    appropriate for your system:
+    <pre>-a always,exit -F arch=ARCH -S execve -C uid!=euid -F euid=0 -k setuid
+    -a always,exit -F arch=ARCH -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following line to
+    <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
+    appropriate for your system:
+    <pre>-a always,exit -F arch=ARCH -S execve -C uid!=euid -F euid=0 -k setuid
+    -a always,exit -F arch=ARCH -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+
+rationale: |-
+    Misuse of privileged functions, either intentionally or unintentionally 
+    by authorized users, or by unauthorized external entities that have compromised 
+    information system accounts, is a serious and ongoing concern and can have 
+    significant adverse impacts on organizations. Auditing the use of privileged 
+    functions is one way to detect such misuse and identify the risk from insider 
+    threats and the advanced persistent threat.
+
+severity: medium
+
+identifiers:
+    cce@rhel7: 27206-2
+
+references:
+    disa@rhel7: "2234"
+    nist@rhel7: AC-6(9)
+    stigid@rhel7: "030360"
+
+ocil: |-
+    {{{ ocil_audit_syscall(syscall="execve") }}}
+
+{{{ ocil_clause_entry_audit_syscall() }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_value.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+adjtimex[\s]+|([\s]+|[,])adjtimex([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
+	echo "-a always,exit -F arch=b32 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules
+	echo "-a always,exit -F arch=b64 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules
+fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+adjtimex[\s]+|([\s]+|[,])adjtimex([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
@@ -26,13 +26,13 @@
 - name: Inserts/replaces the /var/log/audit/ rule in rules.d
   lineinfile:
     path: '{{ all_files[0] }}'
-    line: -a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset
+    line: -a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=4294967295
       -F key=access-audit-trail
     create: true
 
 - name: Inserts/replaces the /var/log/audit/ rule in audit.rules
   lineinfile:
     path: /etc/audit/audit.rules
-    line: -a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset
+    line: -a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=4294967295
       -F key=access-audit-trail
     create: true

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
@@ -5,7 +5,7 @@
 
 PATTERN="-a always,exit -F path=/var/log/audit/\\s\\+.*"
 GROUP="access-audit-trail"
-FULL_RULE="-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail"
+FULL_RULE="-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access-audit-trail"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
@@ -6,7 +6,7 @@ description: |-
     The audit system should collect access events to read audit log directory.
     The following audit rule will assure that access to audit log directory are
     collected.
-    <pre>-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail</pre>
+    <pre>-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access-audit-trail</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
     program to read audit rules during daemon startup (the default), add the
     rule to a file with suffix <tt>.rules</tt> in the directory

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
@@ -5,4 +5,4 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=4294967295 -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
@@ -5,4 +5,4 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
+echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=4294967295 -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
@@ -2,4 +2,4 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=4294967295 -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
@@ -2,4 +2,4 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=4294967295 -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
@@ -2,4 +2,4 @@
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>=1000 -F auid!=4294967295 -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/bash/rhel7.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/bash/rhel7.sh
@@ -1,0 +1,8 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+populate var_audispd_disk_full_action
+
+replace_or_append /etc/audisp/audisp-remote.conf '^disk_full_action' "$var_audispd_disk_full_action" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/oval/rhel7.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/oval/rhel7.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="auditd_audispd_disk_full_action" version="1">
+    <metadata>
+      <title>Audispd Action to Take When Disk Is Full</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>disk_full_action setting in /etc/audisp/audisp-remote.conf is set to a certain action</description>
+    </metadata>
+
+    <criteria>
+        <criterion comment="disk_full_action setting in audisp-remote.conf" test_ref="test_audisp_data_disk_full_action" />
+    </criteria>
+
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="disk error action" id="test_audisp_data_disk_full_action" version="1">
+    <ind:object object_ref="object_audisp_data_disk_full_action" />
+    <ind:state state_ref="state_audisp_data_disk_full_action" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_audisp_data_disk_full_action" version="2">
+    <ind:filepath>/etc/audisp/audisp-remote.conf</ind:filepath>
+    <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
+    <!-- Require at least one space before and after the equal sign -->
+    <ind:pattern operation="pattern match">^[ ]*disk_full_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_audisp_data_disk_full_action" version="1">
+    <ind:subexpression operation="case insensitive equals" var_ref="var_audispd_disk_full_action" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="audit disk_full_action setting" datatype="string" id="var_audispd_disk_full_action" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/rhel7.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/rhel7.sh
@@ -1,0 +1,8 @@
+# platform = Red Hat Enterprise Linux 7
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+populate var_audispd_network_failure_action
+
+replace_or_append /etc/audisp/audisp-remote.conf '^network_failure_action' "$var_audispd_network_failure_action" "@CCENUM@"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/oval/rhel7.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/oval/rhel7.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="auditd_audispd_network_failure_action" version="1">
+    <metadata>
+      <title>Audispd Action to Take When network failure is encountered</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 7</platform>
+      </affected>
+      <description>network_failure_action setting in /etc/audisp/audisp-remote.conf is set to a certain action</description>
+    </metadata>
+
+    <criteria>
+        <criterion comment="network_failure_action setting in audisp-remote.conf" test_ref="test_audisp_net_failure_action" />
+    </criteria>
+
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="net failure action" id="test_audisp_net_failure_action" version="1">
+    <ind:object object_ref="object_audisp_net_failure_action" />
+    <ind:state state_ref="state_audisp_net_failure_action" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_audisp_net_failure_action" version="2">
+    <ind:filepath>/etc/audisp/audisp-remote.conf</ind:filepath>
+    <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
+    <!-- Require at least one space before and after the equal sign -->
+    <ind:pattern operation="pattern match">^[ ]*network_failure_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_audisp_net_failure_action" version="1">
+    <ind:subexpression operation="case insensitive equals" var_ref="var_audispd_network_failure_action" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="audit network_failure_action setting" datatype="string" id="var_audispd_network_failure_action" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_data.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_data.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = bash
+
+. $SHARED/auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/auditd.conf "flush" "data"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_incremental_async.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_incremental_async.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+# remediation = bash
+
+. $SHARED/auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/auditd.conf "flush" "incremental_async"

--- a/shared/bash_remediation_functions/create_audit_remediation_unsuccessful_file_modification_detailed.sh
+++ b/shared/bash_remediation_functions/create_audit_remediation_unsuccessful_file_modification_detailed.sh
@@ -10,37 +10,37 @@ function create_audit_remediation_unsuccessful_file_modification_detailed {
 		## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
 		## Unsuccessful file creation (open with O_CREAT)
-		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-		-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+		-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
 
 		## Unsuccessful file modifications (open for write or truncate)
-		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-		-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+		-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
 
 		## Unsuccessful file access (any other opens) This has to go last.
-		-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-		-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-		-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-		-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+		-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+		-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+		-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+		-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
 	EOF
 }

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -79,7 +79,7 @@ do
 	local count_of_inspected_files=0
 
 	# Define expected rule form for this binary
-	expected_rule="-a always,exit -F path=${sbinary} -F perm=x -F auid>=${min_auid} -F auid!=unset -k privileged"
+	expected_rule="-a always,exit -F path=${sbinary} -F perm=x -F auid>=${min_auid} -F auid!=4294967295 -k privileged"
 
 	# If list of audit rules files to be inspected is empty, just add new rule and move on to next binary
 	if [[ ${#files_to_inspect[@]} -eq 0 ]]; then

--- a/shared/templates/template_ANSIBLE_audit_rules_dac_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_dac_modification
@@ -37,13 +37,13 @@
 - name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
+    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     create: yes
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
+    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     create: yes
   when: audit_arch is defined and audit_arch == 'b64'
 #   
@@ -51,14 +51,14 @@
 #
 - name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/audit.rules when on x86
   lineinfile:
-    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
+    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
 
 - name: Inserts/replaces the {{{ ATTR }}} rule in audit.rules when on x86_64
   lineinfile:
-    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
+    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     state: present
     dest: /etc/audit/audit.rules
     create: yes

--- a/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
+++ b/shared/templates/template_ANSIBLE_audit_rules_file_deletion_events
@@ -37,13 +37,13 @@
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
+    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=delete"
     create: yes
 
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
+    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=delete"
     create: yes
   when: audit_arch is defined and audit_arch == 'b64'
 #   
@@ -51,14 +51,14 @@
 #
 - name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules when on x86
   lineinfile:
-    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
+    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=delete"
     state: present
     dest: /etc/audit/audit.rules
     create: yes
 
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:
-    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
+    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=delete"
     state: present
     dest: /etc/audit/audit.rules
     create: yes

--- a/shared/templates/template_ANSIBLE_audit_rules_path_syscall
+++ b/shared/templates/template_ANSIBLE_audit_rules_path_syscall
@@ -39,18 +39,18 @@
     path: "{{ all_files[0] }}"
     line: "{{ item }}"
     create: yes
-    regexp: "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
+    regexp: "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=[\\S]+"
   with_items:
-    - "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
+    - "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify"
 
 - name: Inserts/replaces the {{{ SYSCALL }}} rule in rules.d when on x86_64
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "{{ item }}"
     create: yes
-    regexp: "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
+    regexp: "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=[\\S]+"
   with_items:
-    - "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
+    - "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify"
   when: audit_arch is defined and audit_arch == 'b64'
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
@@ -61,9 +61,9 @@
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-    regexp: "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
+    regexp: "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=[\\S]+"
   with_items:
-    - "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
+    - "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify"
 
 - name: Inserts/replaces the {{{ SYSCALL }}} rule in audit.rules when on x86_64
   lineinfile:
@@ -71,7 +71,7 @@
     state: present
     dest: /etc/audit/audit.rules
     create: yes
-    regexp: "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
+    regexp: "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=[\\S]+"
   with_items:
-    - "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
+    - "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify"
   when: audit_arch is defined and audit_arch == 'b64'

--- a/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
+++ b/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
@@ -29,7 +29,7 @@
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+    line: '-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=privileged'
     create: yes
 
 # Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
@@ -37,5 +37,5 @@
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules
   lineinfile:
     path: /etc/audit/audit.rules
-    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+    line: '-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=privileged'
     create: yes

--- a/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_ANSIBLE_audit_rules_unsuccessful_file_modification
@@ -40,8 +40,8 @@
     line: "{{ item }}"
     create: yes
   with_items:
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
 
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
   lineinfile:
@@ -49,8 +49,8 @@
     line: "{{ item }}"
     create: yes
   with_items:
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
   when: audit_arch is defined and audit_arch == 'b64'
 #   
 # Inserts/replaces the rule in /etc/audit/audit.rules
@@ -62,8 +62,8 @@
     dest: /etc/audit/audit.rules
     create: yes
   with_items:
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
 
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
   lineinfile:
@@ -72,6 +72,6 @@
     dest: /etc/audit/audit.rules
     create: yes
   with_items:
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
+    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
   when: audit_arch is defined and audit_arch == 'b64'

--- a/shared/templates/template_BASH_audit_rules_dac_modification
+++ b/shared/templates/template_BASH_audit_rules_dac_modification
@@ -11,7 +11,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	PATTERN="-a always,exit -F arch=$ARCH -S {{{ ATTR }}}.*"
 	GROUP="perm_mod"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
 
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_file_deletion_events
+++ b/shared/templates/template_BASH_audit_rules_file_deletion_events
@@ -11,7 +11,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}}.*"
 	GROUP="delete"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=delete"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_path_syscall
+++ b/shared/templates/template_BASH_audit_rules_path_syscall
@@ -11,7 +11,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	PATTERN="-a always,exit -F arch=$ARCH -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}}.*"
 	GROUP="modify"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=modify"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_privileged_commands
+++ b/shared/templates/template_BASH_audit_rules_privileged_commands
@@ -7,7 +7,7 @@ PATTERN="-a always,exit -F path={{{ PATH }}}\\s\\+.*"
 GROUP="privileged"
 # Although the fix doesn't use ARCH, we reset it because it could have been set by some other remediation
 ARCH=""
-FULL_RULE="-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged"
+FULL_RULE="-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=privileged"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_BASH_audit_rules_unsuccessful_file_modification
@@ -11,7 +11,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EACCES.*"
 	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
+	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
@@ -21,7 +21,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EPERM.*"
         GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
+        FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=4294967295 -F key=access"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
         fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
         fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_BASH_kernel_module_disabled
+++ b/shared/templates/template_BASH_kernel_module_disabled
@@ -9,3 +9,14 @@ else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi
+
+{{% if product in ["rhel7"] %}}
+
+if LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
+	sed -i 's/^blacklist {{{ KERNMODULE }}}.*/blacklist {{{ KERNMODULE }}}/g' /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+else
+	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+	echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+fi
+
+{{% endif %}}

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -3,9 +3,7 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-{{%- if init_system == "systemd" %}}
-
-
+{{% if init_system == "systemd" %}}
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'

--- a/shared/templates/template_BASH_service_enabled
+++ b/shared/templates/template_BASH_service_enabled
@@ -3,13 +3,11 @@
 # strategy = enable
 # complexity = low
 # disruption = low
-{{%- if init_system == "systemd" %}}
-
+{{% if init_system == "systemd" %}}
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
 {{% elif init_system == "upstart" %}}
-
 /sbin/service '{{{ DAEMONNAME }}}' start
 /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' on
 {{% else %}}

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_kernel_module_disabled
+++ b/shared/templates/template_OVAL_kernel_module_disabled
@@ -6,20 +6,37 @@
       {{{- oval_affected(products) }}}
       <description>The kernel module {{{ KERNMODULE }}} should be disabled.</description>
     </metadata>
-    <criteria operator="OR">
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.d" />
+    <criteria operator="AND">
+      <criteria operator="OR">
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.d" />
 
 {{% if product != "ubuntu1804" %}}
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
 {{% endif %}}
 
 {{% if (product != "rhel6") and (product != "ubuntu1804") %}}
 
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d" />
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d" />
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d" />
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d" />
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d" />
+
+{{% endif %}}
+
+      </criteria>
+
+{{% if product in ["rhel7"] %}}
+
+      <criteria operator="OR">
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted" comment="kernel module {{{ KERNMODULE }}} blacklisted in /etc/modprobe.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf_blacklisted" comment="kernel module {{{ KERNMODULE }}} blacklisted in /etc/modprobe.conf" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load_blacklisted" comment="kernel module {{{ KERNMODULE }}} blacklisted in /etc/modules-load.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodules-load_blacklisted" comment="kernel module {{{ KERNMODULE }}} blacklisted in /run/modules-load.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodules-load_blacklisted" comment="kernel module {{{ KERNMODULE }}} blacklisted in /usr/lib/modules-load.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodprobed_blacklisted" comment="kernel module {{{ KERNMODULE }}} blacklisted in /run/modprobe.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodprobed_blacklisted" comment="kernel module {{{ KERNMODULE }}} blacklisted in /usr/lib/modprobe.d" />
+      </criteria>
 
 {{% endif %}}
 
@@ -119,6 +136,100 @@
     <ind:path>/usr/lib/modprobe.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+{{% endif %}}
+
+{{% if product in ["rhel7"] %}}
+
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_modprobeconf_blacklisted" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf_blacklisted" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load_blacklisted" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_etcmodules-load_blacklisted" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_runmodules-load_blacklisted" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_runmodules-load_blacklisted" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_libmodules-load_blacklisted" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_libmodules-load_blacklisted" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_runmodprobed_blacklisted" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_runmodprobed_blacklisted" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_libmodprobed_blacklisted" version="1" check="all"
+  comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_libmodprobed_blacklisted" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_blacklisted"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled">
+    <ind:path>/etc/modprobe.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*blacklist\s+{{{ KERNMODULE }}}\s+$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf_blacklisted"
+  version="1" comment="Check deprecated /etc/modprobe.conf for disablement of {{{ KERNMODULE }}}">
+    <ind:filepath>/etc/modprobe.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*blacklist\s+{{{ KERNMODULE }}}\s+$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_etcmodules-load_blacklisted"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d">
+    <ind:path>/etc/modules-load.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*blacklist\s+{{{ KERNMODULE }}}\s+$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_runmodules-load_blacklisted"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d">
+    <ind:path>/run/modules-load.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*blacklist\s+{{{ KERNMODULE }}}\s+$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_libmodules-load_blacklisted"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d">
+    <ind:path>/usr/lib/modules-load.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*blacklist\s+{{{ KERNMODULE }}}\s+$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_runmodprobed_blacklisted"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d">
+    <ind:path>/run/modprobe.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*blacklist\s+{{{ KERNMODULE }}}\s+$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_libmodprobed_blacklisted"
+  version="1" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d">
+    <ind:path>/usr/lib/modprobe.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*blacklist\s+{{{ KERNMODULE }}}\s+$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/template_OVAL_service_enabled
+++ b/shared/templates/template_OVAL_service_enabled
@@ -1,6 +1,6 @@
 <def-group>
 
-{{%- set package_installed_test_id = "test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_installed" -%}}
+{{% set package_installed_test_id = "test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_installed" %}}
 
 {{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
 

--- a/tests/shared/audit/30-ospp-v42-1-create-failed.rules
+++ b/tests/shared/audit/30-ospp-v42-1-create-failed.rules
@@ -1,13 +1,13 @@
 ## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-create

--- a/tests/shared/audit/30-ospp-v42-1-create-success.rules
+++ b/tests/shared/audit/30-ospp-v42-1-create-success.rules
@@ -1,7 +1,7 @@
 ## Successful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b32 -S creat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S creat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-create
+-a always,exit -F arch=b32 -S creat -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-create
+-a always,exit -F arch=b64 -S creat -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-create

--- a/tests/shared/audit/30-ospp-v42-2-modify-failed.rules
+++ b/tests/shared/audit/30-ospp-v42-2-modify-failed.rules
@@ -1,13 +1,13 @@
 ## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-modification

--- a/tests/shared/audit/30-ospp-v42-2-modify-success.rules
+++ b/tests/shared/audit/30-ospp-v42-2-modify-success.rules
@@ -1,7 +1,7 @@
 ## Successful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-modification

--- a/tests/shared/audit/30-ospp-v42-3-access-failed.rules
+++ b/tests/shared/audit/30-ospp-v42-3-access-failed.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-access
+-a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-access
+-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-access
+-a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-access

--- a/tests/shared/audit/30-ospp-v42-3-access-success.rules
+++ b/tests/shared/audit/30-ospp-v42-3-access-success.rules
@@ -1,4 +1,4 @@
 ## Successful file access (any other opens) This has to go last.
 ## These next two are likely to result in a whole lot of events
--a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access
--a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access
+-a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-access
+-a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-access

--- a/tests/shared/audit/30-ospp-v42-4-delete-failed.rules
+++ b/tests/shared/audit/30-ospp-v42-4-delete-failed.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-delete
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-delete

--- a/tests/shared/audit/30-ospp-v42-4-delete-success.rules
+++ b/tests/shared/audit/30-ospp-v42-4-delete-success.rules
@@ -1,3 +1,3 @@
 ## Successful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-delete

--- a/tests/shared/audit/30-ospp-v42-5-perm-change-failed.rules
+++ b/tests/shared/audit/30-ospp-v42-5-perm-change-failed.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful permission change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-perm-change
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-perm-change
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-perm-change
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-perm-change

--- a/tests/shared/audit/30-ospp-v42-5-perm-change-success.rules
+++ b/tests/shared/audit/30-ospp-v42-5-perm-change-success.rules
@@ -1,3 +1,3 @@
 ## Successful permission change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-perm-change
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-perm-change

--- a/tests/shared/audit/30-ospp-v42-6-owner-change-failed.rules
+++ b/tests/shared/audit/30-ospp-v42-6-owner-change-failed.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful ownership change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-owner-change
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-owner-change
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-owner-change
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccessful-owner-change

--- a/tests/shared/audit/30-ospp-v42-6-owner-change-success.rules
+++ b/tests/shared/audit/30-ospp-v42-6-owner-change-success.rules
@@ -1,3 +1,3 @@
 ## Successful ownership change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-owner-change
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=1000 -F auid!=4294967295 -F key=successful-owner-change

--- a/tests/shared/audit/30-ospp-v42.rules
+++ b/tests/shared/audit/30-ospp-v42.rules
@@ -18,54 +18,54 @@
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and
 ## shadow for writes
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/shadow -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/shadow -F auid>=1000 -F auid!=4294967295 -F key=user-modify
 
 ## User enable and disable. This is entirely handled by pam.
 
 ## Group add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch group and
 ## gshadow for writes
--a always,exit -F path=/etc/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
--a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/passwd -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F path=/etc/shadow -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=user-modify
+-a always,exit -F path=/etc/group -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=group-modify
+-a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=group-modify
 
 
 ## Use of special rights for config changes. This would be use of setuid
 ## programs that relate to user accts. This is not all setuid apps because
 ## requirements are only for ones that affect system configuration.
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=special-config-changes
 
 ## Privilege escalation via su or sudo. This is entirely handled by pam.
 
 ## Audit log access
--a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail
+-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=4294967295 -F key=access-audit-trail
 ## Attempts to Alter Process and Session Initiation Information
--a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
+-a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=session
+-a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=session
+-a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=session
 
 ## Attempts to modify MAC controls
--a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=1000 -F auid!=unset -F key=MAC-policy
+-a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=1000 -F auid!=4294967295 -F key=MAC-policy
 
 ## Software updates. This is entirely handled by rpm.
 

--- a/tests/shared/audit_open.rules
+++ b/tests/shared/audit_open.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-access

--- a/tests/shared/audit_open_o_creat.rules
+++ b/tests/shared/audit_open_o_creat.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create

--- a/tests/shared/audit_open_o_trunc_write.rules
+++ b/tests/shared/audit_open_o_trunc_write.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification

--- a/tests/shared/audit_openat_o_creat.rules
+++ b/tests/shared/audit_openat_o_creat.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-create

--- a/tests/shared/audit_openat_o_trunc_write.rules
+++ b/tests/shared/audit_openat_o_trunc_write.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=unsuccesful-modification


### PR DESCRIPTION

#### Description:

- _Edit audit rules auid values. Changed from "unset" to STIG required values in rules content, shared tests, shared templates and bash remediation functions._

#### Rationale:

- _Values were being set as "unset" flagging as failures in STIG scans._

