### PR TITLE
edit remediation for dconf_gnome_disable_automount

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/bash/shared.sh
@@ -1,9 +1,9 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 
-{{{ bash_dconf_settings("org/gnome/desktop/media-handling", "automount", "false", "local.d", "00-security-settings") }}}
-{{{ bash_dconf_settings("org/gnome/desktop/media-handling", "automount-open", "false", "local.d", "00-security-settings") }}}
-{{{ bash_dconf_settings("org/gnome/desktop/media-handling", "autorun-never", "true", "local.d", "00-security-settings") }}}
-{{{ bash_dconf_lock("org/gnome/desktop/media-handling", "automount", "local.d", "00-security-settings-lock") }}}
-{{{ bash_dconf_lock("org/gnome/desktop/media-handling", "automount-open", "local.d", "00-security-settings-lock") }}}
-{{{ bash_dconf_lock("org/gnome/desktop/media-handling", "autorun-never", "local.d", "00-security-settings-lock") }}}
+{{{ bash_dconf_settings("org/gnome/desktop/media-handling", "automount", "false", "local.d", "00-No-Automount") }}}
+{{{ bash_dconf_settings("org/gnome/desktop/media-handling", "automount-open", "false", "local.d", "00-No-Automount") }}}
+{{{ bash_dconf_settings("org/gnome/desktop/media-handling", "autorun-never", "true", "local.d", "00-No-Automount") }}}
+{{{ bash_dconf_lock("org/gnome/desktop/media-handling", "automount", "local.d", "00-No-Automount") }}}
+{{{ bash_dconf_lock("org/gnome/desktop/media-handling", "automount-open", "local.d", "00-No-Automount") }}}
+{{{ bash_dconf_lock("org/gnome/desktop/media-handling", "autorun-never", "local.d", "00-No-Automount") }}}


### PR DESCRIPTION

#### Description:

- _edit remediation for dconf_gnome_disable_automount change value to meet STIG requirement._

#### Rationale:

- _meet STIG requirement_

