### PR TITLE
edit rhel6 oval for gconf_gnome_screen_locking_keybindings

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screen_locking_keybindings/oval/rhel6.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screen_locking_keybindings/oval/rhel6.xml
@@ -21,7 +21,7 @@
   </ind:xmlfilecontent_test>
   <ind:xmlfilecontent_object id="object_gnome_screen_locking_keybindings" version="1">
     <ind:filepath>/etc/gconf/gconf.xml.mandatory/apps/gnome_settings_daemon/keybindings/%gconf.xml</ind:filepath>
-    <ind:xpath>/gconf/entry[@name='screen']/stringvalue[1]/text()</ind:xpath>
+    <ind:xpath>/gconf/entry[@name='screensaver']/stringvalue[1]/text()</ind:xpath>
   </ind:xmlfilecontent_object>
 
   <ind:xmlfilecontent_test check="all"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screen_locking_keybindings/oval/rhel6.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/gconf_gnome_screen_locking_keybindings/oval/rhel6.xml
@@ -32,7 +32,7 @@
   </ind:xmlfilecontent_test>
   <ind:xmlfilecontent_object id="object_gconf_tree_gnome_screen_locking_keybindings" version="1">
     <ind:filepath>/etc/gconf/gconf.xml.mandatory/%gconf-tree.xml</ind:filepath>
-    <ind:xpath>/gconf/dir/dir/dir/entry[@name='screen']/stringvalue[1]/text()</ind:xpath>
+    <ind:xpath>/gconf/dir/dir/dir/entry[@name='screensaver']/stringvalue[1]/text()</ind:xpath>
   </ind:xmlfilecontent_object>
 
   <ind:xmlfilecontent_state id="state_gnome_screen_locking_keybindings" version="1">


### PR DESCRIPTION

#### Description:

- _Change entry name from screen to screensaver per STIG req_


