### PR TITLE
Converted kube remediation to use the macro

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/kubernetes/shared.yml
@@ -1,14 +1,7 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-spec:
-  config:
-    ignition:
-      version: 2.2.0
-    storage:
-      files:
-      - contents:
-          source: data:,%23%23%20Successful%20file%20delete%0A-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20unlink%2Cunlinkat%2Crename%2Crenameat%20-F%20success%3D1%20-F%20auid%26gt%3B%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dsuccessful-delete%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20unlink%2Cunlinkat%2Crename%2Crenameat%20-F%20success%3D1%20-F%20auid%26gt%3B%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dsuccessful-delete
-        filesystem: root
-        mode: 0600
-        path: /etc/audit/rules.d/30-ospp-v42-4-delete-success.rules
+
+{{% set file_contents = """## Successful file delete
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete""" -%}}
+
+{{{- kubernetes_machine_config_file(path='/etc/audit/rules.d/30-ospp-v42-4-delete-success.rules', file_permissions_mode='0600', source=file_contents) }}}

--- a/tests/unit/kubernetes/unit_test.go
+++ b/tests/unit/kubernetes/unit_test.go
@@ -8,6 +8,7 @@ var ruleExceptions = []string{
 	"sshd_disable_compression",
 	"sshd_set_idle_timeout",
 	"sshd_set_keepalive",
+	"audit_delete_success",  // The remediation uses a macro, so it looks like as an invalid YAML
 }
 
 func TestUnit(t *testing.T) {


### PR DESCRIPTION
The `{{% set file_contents ...` bit is not needed - it is possible to supply file contents string directly as the source kwarg, but I find this two-step way less confusing.

I have used the decoder https://www.urldecoder.org/ to reverse-engineer the remediation and verified that the `source` in the result is the same.