### PR TITLE
Add zipl and grub2 CPEs

### DIFF
--- a/debian10/cpe/debian10-cpe-dictionary.xml
+++ b/debian10/cpe/debian10-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/debian8/cpe/debian8-cpe-dictionary.xml
+++ b/debian8/cpe/debian8-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/debian9/cpe/debian9-cpe-dictionary.xml
+++ b/debian9/cpe/debian9-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/fedora/cpe/fedora-cpe-dictionary.xml
+++ b/fedora/cpe/fedora-cpe-dictionary.xml
@@ -62,6 +62,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
@@ -48,4 +48,4 @@ ocil: |-
     Presence of a <tt>systemd.confirm_spawn=(1|yes|true|on)</tt> indicates
     that interactive boot is enabled at boot time.
 
-platform: machine
+platform: grub2

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
@@ -51,6 +51,8 @@ ocil: |-
     {{{ ocil_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
 {{%- endif %}}
 
+platform: machine
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/rule.yml
@@ -39,6 +39,8 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/boot/grub2/grub.cfg", grou
 
 ocil: '{{{ ocil_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'
 
+platform: machine
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
@@ -49,6 +49,8 @@ ocil: |-
     {{{ ocil_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
 {{%- endif %}}
 
+platform: machine
+
 template:
     name: file_owner
     vars:

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/rule.yml
@@ -37,6 +37,8 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/boot/grub2/grub.cfg", owner="roo
 
 ocil: '{{{ ocil_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'
 
+platform: machine
+
 template:
     name: file_owner
     vars:

--- a/linux_os/guide/system/bootloader-grub2/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/group.yml
@@ -15,4 +15,4 @@ description: |-
     with a password and ensure its configuration file's permissions
     are set properly.
 
-platform: machine
+platform: grub2

--- a/linux_os/guide/system/bootloader-grub2/grub2_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_admin_username/rule.yml
@@ -68,3 +68,5 @@ warnings:
 
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
@@ -17,3 +17,5 @@ identifiers:
 
 references:
     anssi: NT28(R11)
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_no_removeable_media/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable
     media which should not exist in the line:
     <pre>set root='hd0,msdos1'</pre>
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_password/rule.yml
@@ -72,3 +72,5 @@ warnings:
 
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/rule.yml
@@ -75,3 +75,5 @@ warnings:
 
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/rule.yml
@@ -73,3 +73,5 @@ warnings:
 
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/rule.yml
@@ -35,3 +35,5 @@ ocil: |-
     <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable
     media which should not exist in the line:
     <pre>set root='hd0,msdos1'</pre>
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/group.yml
+++ b/linux_os/guide/system/bootloader-zipl/group.yml
@@ -8,4 +8,4 @@ description: |-
     options to it.
     The default {{{ full_name }}} boot loader for s390x systems is called zIPL.
 
-platform: machine
+platform: zipl

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
   and <tt>/etc/zipl.conf</tt>:
   <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
   No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
@@ -39,3 +39,5 @@ ocil: |-
   and <tt>/etc/zipl.conf</tt>:
   <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
   No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
@@ -35,3 +35,5 @@ ocil: |-
     and <tt>/etc/zipl.conf</tt>:
     <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
     No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
@@ -39,3 +39,5 @@ ocil: |-
   and <tt>/etc/zipl.conf</tt>:
   <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
   No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/zipl_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_pti_argument/rule.yml
@@ -38,3 +38,5 @@ ocil: |-
   and <tt>/etc/zipl.conf</tt>:
   <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
   No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
@@ -39,3 +39,5 @@ ocil: |-
   and <tt>/etc/zipl.conf</tt>:
   <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
   No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.
+
+platform: machine

--- a/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
@@ -36,3 +36,5 @@ ocil: |-
   and <tt>/etc/zipl.conf</tt>:
   <pre>find /boot/loader/entries/*.conf /etc/zipl.conf -newer /boot/bootmap</pre>
   No line should be returned, if a line is returned <tt>/boot/bootmap</tt> needs to be regenerated.
+
+platform: machine

--- a/ol7/cpe/ol7-cpe-dictionary.xml
+++ b/ol7/cpe/ol7-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ol8/cpe/ol8-cpe-dictionary.xml
+++ b/ol8/cpe/ol8-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/opensuse/cpe/opensuse-cpe-dictionary.xml
+++ b/opensuse/cpe/opensuse-cpe-dictionary.xml
@@ -42,6 +42,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/rhel7/cpe/rhel7-cpe-dictionary.xml
+++ b/rhel7/cpe/rhel7-cpe-dictionary.xml
@@ -57,6 +57,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/rhel8/cpe/rhel8-cpe-dictionary.xml
+++ b/rhel8/cpe/rhel8-cpe-dictionary.xml
@@ -32,6 +32,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/rhel8/cpe/rhel8-cpe-dictionary.xml
+++ b/rhel8/cpe/rhel8-cpe-dictionary.xml
@@ -67,4 +67,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhv4/cpe/rhv4-cpe-dictionary.xml
+++ b/rhv4/cpe/rhv4-cpe-dictionary.xml
@@ -32,6 +32,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/shared/checks/oval/installed_env_has_grub2_package.xml
+++ b/shared/checks/oval/installed_env_has_grub2_package.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_grub2_package" version="1">
+    <metadata>
+      <title>Package grub2 is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package grub2-pc is installed.</description>
+      <reference ref_id="cpe:/a:grub2" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package grub2-pc is installed" test_ref="test_env_has_grub2_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_grub2_installed" version="1"
+  comment="system has package grub2-pc installed">
+    <linux:object object_ref="obj_env_has_grub2_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_grub2_installed" version="1">
+    <linux:name>grub2-pc</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_grub2_installed" version="1"
+  comment="system has package grub2-pc installed">
+    <linux:object object_ref="obj_env_has_grub2_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_grub2_installed" version="1">
+    <linux:name>grub2-pc</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>

--- a/shared/checks/oval/installed_env_has_zipl_package.xml
+++ b/shared/checks/oval/installed_env_has_zipl_package.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_zipl_package" version="1">
+    <metadata>
+      <title>System uses zIPL</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if system uses zIPL bootloader.</description>
+      <reference ref_id="cpe:/a:zipl" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package s390utils-base is installed" test_ref="test_env_has_zipl_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_zipl_installed" version="1"
+  comment="system has package zipl installed">
+    <linux:object object_ref="obj_env_has_zipl_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_zipl_installed" version="1">
+    <linux:name>s390utils-base</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_zipl_installed" version="1"
+  comment="system has package zipl installed">
+    <linux:object object_ref="obj_env_has_zipl_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_zipl_installed" version="1">
+    <linux:name>s390utils-base</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>

--- a/sle11/cpe/sle11-cpe-dictionary.xml
+++ b/sle11/cpe/sle11-cpe-dictionary.xml
@@ -32,6 +32,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/sle12/cpe/sle12-cpe-dictionary.xml
+++ b/sle12/cpe/sle12-cpe-dictionary.xml
@@ -32,6 +32,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/sle15/cpe/sle15-cpe-dictionary.xml
+++ b/sle15/cpe/sle15-cpe-dictionary.xml
@@ -32,6 +32,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -506,6 +506,7 @@ XCCDF_PLATFORM_TO_CPE = {
     "sssd": "cpe:/a:sssd",
     "systemd": "cpe:/a:systemd",
     "yum": "cpe:/a:yum",
+    "zipl": "cpe:/a:zipl",
 }
 
 # _version_name_map = {

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -498,6 +498,7 @@ XCCDF_PLATFORM_TO_CPE = {
     "container": "cpe:/a:container",
     "chrony": "cpe:/a:chrony",
     "gdm": "cpe:/a:gdm",
+    "grub2": "cpe:/a:grub2",
     "libuser": "cpe:/a:libuser",
     "nss-pam-ldapd": "cpe:/a:nss-pam-ldapd",
     "ntp": "cpe:/a:ntp",

--- a/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
+++ b/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
+++ b/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
+++ b/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
@@ -27,6 +27,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
+++ b/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
@@ -26,6 +26,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->

--- a/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
+++ b/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
@@ -26,6 +26,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->


### PR DESCRIPTION
#### Description:

- Add zipl and grub2 CPEs
- Update relevant CPE-Dictionaries

#### Rationale:
- This will make it possible to distinguish between GRUB2 and zIPL rule.
