### PR TITLE
Add an evaluation for OpenShift allowedRegistries

### DIFF
--- a/applications/openshift/registry/ocp_allowed_registries/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries/rule.yml
@@ -1,0 +1,28 @@
+prodtype: ocp4
+
+title: "Allowed registries are configured"
+
+description: |-
+    The configuration <tt>registrySources.allowedRegistries</tt> determines the
+    permitted registries that the OpenShift container runtime can access for builds
+    and pods.
+
+rationale: |-
+    Allowed registries should be configured to restrict the registries that the
+    OpenShift container runtime can access.
+
+severity: medium
+
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/apis/config.openshift.io/v1/images/cluster") | indent(8) }}}
+
+template:
+    name: yamlfile_value
+    vars:
+        filepath: /apis/config.openshift.io/v1/images/cluster
+        yamlpath: ".spec.registrySources.allowedRegistries[:]"
+        value: ".*"
+        entity_check: "at least one"
+        operation: "pattern match"
+        ocp_data: 'true'

--- a/applications/openshift/registry/ocp_allowed_registries/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries/rule.yml
@@ -5,11 +5,13 @@ title: "Allowed registries are configured"
 description: |-
     The configuration <tt>registrySources.allowedRegistries</tt> determines the
     permitted registries that the OpenShift container runtime can access for builds
-    and pods.
+    and pods. This configuration setting ensures that all registries other than
+    those specified are blocked.
 
 rationale: |-
     Allowed registries should be configured to restrict the registries that the
-    OpenShift container runtime can access.
+    OpenShift container runtime can access, and all other registries should be
+    blocked.
 
 severity: medium
 

--- a/applications/openshift/registry/ocp_allowed_registries/tests/correct.pass.sh
+++ b/applications/openshift/registry/ocp_allowed_registries/tests/correct.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir -p /tmp/apis/config.openshift.io/v1/images
+
+cat << EOF > /tmp/apis/config.openshift.io/v1/images/cluster
+spec:
+  registrySources:
+    allowedRegistries:
+    - my-trusted-registry.internal.example.com
+EOF

--- a/applications/openshift/registry/ocp_allowed_registries/tests/no_file.fail.sh
+++ b/applications/openshift/registry/ocp_allowed_registries/tests/no_file.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# remediation = none
+
+rm -rf /tmp/apis/config.openshift.io/v1/images

--- a/applications/openshift/registry/ocp_allowed_registries/tests/registries.fail.sh
+++ b/applications/openshift/registry/ocp_allowed_registries/tests/registries.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# remediation = none
+
+mkdir -p /tmp/apis/config.openshift.io/v1/images
+
+cat << EOF > /tmp/apis/config.openshift.io/v1/images/cluster
+spec:
+EOF

--- a/ocp4/profiles/e8.profile
+++ b/ocp4/profiles/e8.profile
@@ -14,3 +14,4 @@ description: |-
 selections:
     - ocp_idp_no_htpasswd
     - ocp_allowed_registries_for_import
+    - ocp_allowed_registries

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -30,3 +30,4 @@ description: |-
 selections:
     - ocp_idp_no_htpasswd
     - ocp_allowed_registries_for_import
+    - ocp_allowed_registries


### PR DESCRIPTION
#### Description:

Checks whether `registrySources.allowedRegistries` are configured for the OpenShift container runtime

#### Rationale:

This evaluation aligns with the ACSC Essential Eight, and checks whether trusted registries are configured for the container runtime. This is distinct from https://github.com/ComplianceAsCode/content/pull/5839, as it checks registry sources for the container runtime, and not the image APIs (https://access.redhat.com/solutions/4931451)
