### PR TITLE
fix rule selinux_all_devicefiles_labeled

### DIFF
--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
@@ -2,32 +2,54 @@
   <definition class="compliance" id="selinux_all_devicefiles_labeled" version="1">
     <metadata>
       <title>Device Files Have Proper SELinux Context</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>All device files in /dev should be assigned an SELinux security context other than 'device_t'.</description>
+      {{{- oval_affected(products) }}}
+      <description>All device files in /dev should be assigned an SELinux security context other than 'device_t' and 'unlabeled_t'.</description>
     </metadata>
-    <criteria>
-      <criterion comment="device_t in /dev" test_ref="test_selinux_all_devicefiles_labeled" />
+    <criteria operator="AND">
+      <criterion comment="device_t in /dev" test_ref="test_selinux_dev_device_t" />
+      <criterion comment="unlabeled_t in /dev" test_ref="test_selinux_dev_unlabeled_t" />
     </criteria>
   </definition>
-  <linux:selinuxsecuritycontext_test check="none satisfy" check_existence="any_exist" comment="device_t in /dev" id="test_selinux_all_devicefiles_labeled" version="2">
-    <linux:object object_ref="object_selinux_all_devicefiles_labeled" />
-    <linux:state state_ref="state_selinux_all_devicefiles_labeled" />
+
+  <!-- collect all special files from /dev directory -->
+  <unix:file_object id="object_dev_device_files" comment="device files within /dev directory" version="1">
+    <unix:behaviors recurse_direction="down" />
+    <unix:path operation="equals">/dev</unix:path>
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <filter action="include">state_block_or_char_device_file</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_block_or_char_device_file" version="1" comment="device files" >
+    <unix:type operation="pattern match">^(block|character) special$</unix:type>
+  </unix:file_state>
+
+  <local_variable id="variable_dev_device_files" comment="all device files within /dev directory" datatype="string" version="1">
+    <object_component object_ref="object_dev_device_files" item_field="filepath" />
+  </local_variable>
+
+
+  <linux:selinuxsecuritycontext_test check="none satisfy" check_existence="any_exist" comment="device_t in /dev" id="test_selinux_dev_device_t" version="2">
+    <linux:object object_ref="object_selinux_dev_device_t" />
+    <linux:state state_ref="state_selinux_dev_device_t" />
   </linux:selinuxsecuritycontext_test>
-  <linux:selinuxsecuritycontext_object comment="device_t in /dev" id="object_selinux_all_devicefiles_labeled" version="1">
-    <linux:behaviors recurse_direction="down" />
-    <linux:path>/dev</linux:path>
-    <linux:filename operation="pattern match">^.*$</linux:filename>
-    <filter action="include">state_selinux_all_devicefiles_labeled</filter>
+  <linux:selinuxsecuritycontext_object comment="device_t in /dev" id="object_selinux_dev_device_t" version="1">
+    <linux:filepath operation="equals" var_ref="variable_dev_device_files"  var_check="at least one"/>
+    <filter action="include">state_selinux_dev_device_t</filter>
   </linux:selinuxsecuritycontext_object>
-  <linux:selinuxsecuritycontext_state comment="do it" id="state_selinux_all_devicefiles_labeled" version="1">
+  <linux:selinuxsecuritycontext_state comment="device_t label" id="state_selinux_dev_device_t" version="1">
     <linux:type datatype="string" operation="equals">device_t</linux:type>
   </linux:selinuxsecuritycontext_state>
+
+  <linux:selinuxsecuritycontext_test check="none satisfy" check_existence="any_exist" comment="unlabeled_t in /dev" id="test_selinux_dev_unlabeled_t" version="2">
+    <linux:object object_ref="object_selinux_dev_unlabeled_t" />
+    <linux:state state_ref="state_selinux_dev_unlabeled_t" />
+  </linux:selinuxsecuritycontext_test>
+  <linux:selinuxsecuritycontext_object comment="unlabeled_t in /dev" id="object_selinux_dev_unlabeled_t" version="1">
+    <linux:filepath operation="equals" var_ref="variable_dev_device_files"  var_check="at least one"/>
+    <filter action="include">state_selinux_dev_unlabeled_t</filter>
+  </linux:selinuxsecuritycontext_object>
+  <linux:selinuxsecuritycontext_state comment="unlabeled_t label" id="state_selinux_dev_unlabeled_t" version="1">
+    <linux:type datatype="string" operation="equals">unlabeled_t</linux:type>
+  </linux:selinuxsecuritycontext_state>
+
 </def-group>

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
@@ -6,18 +6,20 @@ title: 'Ensure No Device Files are Unlabeled by SELinux'
 
 description: |-
     Device files, which are used for communication with important system
-    resources, should be labeled with proper SELinux types. If any device
-    files do not carry the SELinux type <tt>device_t</tt>, report the bug so
-    that policy can be corrected. Supply information about what the device is
-    and what programs use it.
+    resources, should be labeled with proper SELinux types. If any device files
+    carry the SELinux type <tt>device_t</tt> or <tt>unlabeled_t</tt>, report the
+    bug so that policy can be corrected. Supply information about what the
+    device is and what programs use it.
     <br /><br />
-    To check for unlabeled device files, run the following command:
+    To check for incorrectly labeled device files, run following commands:
     <pre>$ sudo find /dev -context *:device_t:* \( -type c -o -type b \) -printf "%p %Z\n"</pre>
+    <pre>$ sudo find /dev -context *:unlabeled_t:* \( -type c -o -type b \) -printf "%p %Z\n"</pre>
     It should produce no output in a well-configured system.
 
 rationale: |-
-    If a device file carries the SELinux type <tt>device_t</tt>, then SELinux
-    cannot properly restrict access to the device file.
+    If a device file carries the SELinux type <tt>device_t</tt> or
+    <tt>unlabeled_t</tt>, then SELinux cannot properly restrict access to the
+    device file.
 
 severity: medium
 
@@ -45,8 +47,9 @@ references:
 ocil_clause: 'there is output'
 
 ocil: |-
-    To check for unlabeled device files, run the following command:
+    To check for incorrectly labeled device files, run following commands:
     <pre>$ sudo find /dev -context *:device_t:* \( -type c -o -type b \) -printf "%p %Z\n"</pre>
+    <pre>$ sudo find /dev -context *:unlabeled_t:* \( -type c -o -type b \) -printf "%p %Z\n"</pre>
     It should produce no output in a well-configured system.
 
 warnings:

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/block_device_device_t.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/block_device_device_t.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mknod /dev/foo b 1 5
+chcon -t device_t /dev/foo

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/char_device_unlabeled_t.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/char_device_unlabeled_t.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# selinux does not allow unlabeled_t in /dev
+# we have to modify the selinux policy to allow that
+
+echo '(allow unlabeled_t device_t (filesystem (associate)))' > /tmp/unlabeled_t.cil
+semodule -i /tmp/unlabeled_t.cil
+
+mknod /dev/foo c 1 5
+chcon -t unlabeled_t /dev/foo
+
+
+mknod /dev/foo c 1 5
+chcon -t device_t /dev/foo

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/regular_file_device_t.pass.sh
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/regular_file_device_t.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/foo
+restorecon -F /dev/foo

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/symlink_with_wrong_label.pass.sh
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/symlink_with_wrong_label.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ln -s /dev/cpu /dev/foo
+restorecon -F /dev/foo


### PR DESCRIPTION
#### Description:

- update rule description and oval to match latest DISA STIG for rhel7

    - check now honors only device files and checks also for unlabeled_t

- add tests

#### Rationale:

The rule was marking symbolic links as findings and in general was not up-to-date.