### PR TITLE
Add zipl to CPE dictionaries in all Linux products

### DIFF
--- a/debian10/cpe/debian10-cpe-dictionary.xml
+++ b/debian10/cpe/debian10-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/debian8/cpe/debian8-cpe-dictionary.xml
+++ b/debian8/cpe/debian8-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/debian9/cpe/debian9-cpe-dictionary.xml
+++ b/debian9/cpe/debian9-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/fedora/cpe/fedora-cpe-dictionary.xml
+++ b/fedora/cpe/fedora-cpe-dictionary.xml
@@ -107,4 +107,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ol7/cpe/ol7-cpe-dictionary.xml
+++ b/ol7/cpe/ol7-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ol8/cpe/ol8-cpe-dictionary.xml
+++ b/ol8/cpe/ol8-cpe-dictionary.xml
@@ -67,4 +67,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/opensuse/cpe/opensuse-cpe-dictionary.xml
+++ b/opensuse/cpe/opensuse-cpe-dictionary.xml
@@ -87,4 +87,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhcos4/cpe/rhcos4-cpe-dictionary.xml
+++ b/rhcos4/cpe/rhcos4-cpe-dictionary.xml
@@ -57,4 +57,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhel6/cpe/rhel6-cpe-dictionary.xml
+++ b/rhel6/cpe/rhel6-cpe-dictionary.xml
@@ -87,4 +87,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhel7/cpe/rhel7-cpe-dictionary.xml
+++ b/rhel7/cpe/rhel7-cpe-dictionary.xml
@@ -102,4 +102,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/rhv4/cpe/rhv4-cpe-dictionary.xml
+++ b/rhv4/cpe/rhv4-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/sle11/cpe/sle11-cpe-dictionary.xml
+++ b/sle11/cpe/sle11-cpe-dictionary.xml
@@ -77,4 +77,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/sle12/cpe/sle12-cpe-dictionary.xml
+++ b/sle12/cpe/sle12-cpe-dictionary.xml
@@ -77,4 +77,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/sle15/cpe/sle15-cpe-dictionary.xml
+++ b/sle15/cpe/sle15-cpe-dictionary.xml
@@ -77,4 +77,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
+++ b/ubuntu1404/cpe/ubuntu1404-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
+++ b/ubuntu1604/cpe/ubuntu1604-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
+++ b/ubuntu1804/cpe/ubuntu1804-cpe-dictionary.xml
@@ -72,4 +72,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
+++ b/wrlinux1019/cpe/wrlinux1019-cpe-dictionary.xml
@@ -71,4 +71,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>

--- a/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
+++ b/wrlinux8/cpe/wrlinux8-cpe-dictionary.xml
@@ -71,4 +71,8 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_yum_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:zipl">
+            <title xml:lang="en-us">System uses zipl</title>
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
+      </cpe-item>
 </cpe-list>


### PR DESCRIPTION
The CPE platform `cpe:/a:zipl` has been set as a platform for XCCDF
group `bootloader-zipl` but the definition of the CPE was missing from
the CPE dictionary in some datastreams, for example fedora datastream.
This triggered error SRC-15 in NIST scapval tool.

