### PR TITLE
change URI of CIS benchmark to general one

### DIFF
--- a/rhel6/transforms/constants.xslt
+++ b/rhel6/transforms/constants.xslt
@@ -9,7 +9,7 @@
 <xsl:variable name="prod_type">rhel6</xsl:variable>
 
 <!-- Define URI of official CIS Red Hat Enterprise Linux 6 Benchmark -->
-<xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Red_Hat_Enterprise_Linux_6_Benchmark_v1.1.0.pdf</xsl:variable>
+<xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/red_hat_linux/</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="disa-srguri" select="$disa-ossrguri"/>
 <xsl:variable name="os-stigid-concat"></xsl:variable>

--- a/rhel7/transforms/constants.xslt
+++ b/rhel7/transforms/constants.xslt
@@ -10,7 +10,7 @@
 
 
 <!-- Define URI of official CIS Red Hat Enterprise Linux 7 Benchmark -->
-<xsl:variable name="cisuri">https://benchmarks.cisecurity.org/tools2/linux/CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v1.1.0.pdf</xsl:variable>
+<xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/red_hat_linux/</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="disa-srguri" select="$disa-ossrguri"/>
 <xsl:variable name="os-stigid-concat">RHEL-07-</xsl:variable>

--- a/rhel8/transforms/constants.xslt
+++ b/rhel8/transforms/constants.xslt
@@ -7,7 +7,7 @@
 <xsl:variable name="product_stig_id_name">RHEL_8_STIG</xsl:variable>
 <xsl:variable name="prod_type">rhel8</xsl:variable>
 
-<xsl:variable name="cisuri"></xsl:variable>
+<xsl:variable name="cisuri">https://www.cisecurity.org/benchmark/red_hat_linux/</xsl:variable>
 <xsl:variable name="product_guide_id_name">RHEL-8</xsl:variable>
 <xsl:variable name="disa-stigs-uri" select="$disa-stigs-os-unix-linux-uri"/>
 <xsl:variable name="disa-srguri" select="$disa-ossrguri"/>


### PR DESCRIPTION
#### Description:

- URI pointing to CIS benchmark is changed so that it points to general CIS benchmark for Red Hat Enterprise Linux

#### Rationale:

- the old URL was not working anymore. Because CIS does not allow direct access to benchmark documents, the general URI is chosen.