### PR TITLE
Update rpm_verify_hashes according to STIG RHEL7 v2r7

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -14,7 +14,7 @@
   when: (ansible_distribution == "RedHat" or ansible_distribution == "OracleLinux")
 
 - name: "Read files with incorrect hash"
-  command: rpm -Va --nodeps --nosize --nomtime --nordev --nocaps --nolinkto --nouser --nogroup --nomode --noconfig --noghost
+  command: rpm -Va --nodeps --nosize --nomtime --nordev --nocaps --nolinkto --nouser --nogroup --nomode --noghost {{{ "--noconfig" if product != "rhel6" }}}
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect hash using rpm module
   register: files_with_incorrect_hash

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -1,3 +1,5 @@
+# Note: RHEL6 is not included in the platform list because it doesn't support rpm option --noconfig
+# and the regex_findall does not filter out configuration files the same as bash remediation does
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 # reboot = false
 # strategy = restrict

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 # reboot = false
 # strategy = restrict
 # complexity = high
@@ -14,7 +14,7 @@
   when: (ansible_distribution == "RedHat" or ansible_distribution == "OracleLinux")
 
 - name: "Read files with incorrect hash"
-  command: rpm -Va --nodeps --nosize --nomtime --nordev --nocaps --nolinkto --nouser --nogroup --nomode --noghost {{{ "--noconfig" if product != "rhel6" }}}
+  command: rpm -Va --nodeps --nosize --nomtime --nordev --nocaps --nolinkto --nouser --nogroup --nomode --noghost --noconfig
   args:
     warn: False # Ignore ANSIBLE0006, we can't fetch files with incorrect hash using rpm module
   register: files_with_incorrect_hash

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/bash/shared.sh
@@ -1,8 +1,12 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
-# Find which files have incorrect hash and then get files names
-# --noconfig ensures that no configuration file is listed
+# Find which files have incorrect hash {{{ "(not in /etc, because there are all system related config. files) " if product == "rhel6" }}}and then get files names
+{{%- if product == "rhel6" %}}
+files_with_incorrect_hash="$(rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/' | awk '{print $NF}' )"
+{{%- else %}}
 files_with_incorrect_hash="$(rpm -Va --noconfig | grep -E '^..5' | awk '{print $NF}' )"
+{{%- endif %}}
+
 # From files names get package names and change newline to space, because rpm writes each package to new line
 packages_to_reinstall="$(rpm -qf $files_with_incorrect_hash | tr '\n' ' ')"
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/bash/shared.sh
@@ -1,7 +1,8 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
-# Find which files have incorrect hash (not in /etc, because there are all system related config. files) and then get files names
-files_with_incorrect_hash="$(rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/' | awk '{print $NF}' )"
+# Find which files have incorrect hash and then get files names
+# --noconfig ensures that no configuration file is listed
+files_with_incorrect_hash="$(rpm -Va --noconfig | grep -E '^..5' | awk '{print $NF}' )"
 # From files names get package names and change newline to space, because rpm writes each package to new line
 packages_to_reinstall="$(rpm -qf $files_with_incorrect_hash | tr '\n' ' ')"
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
@@ -11,12 +11,12 @@ description: |-
     The RPM package management system can check the hashes of
     installed software packages, including many that are important to system
     security.
-    To verify that the cryptographic hash of system files and commands match vendor
+    To verify that the cryptographic hash of system files and commands matches vendor
     values, run the following command to list which files on the system
     have hashes that differ from what is expected by the RPM database:
-    <pre>$ rpm -Va | grep '^..5'</pre>
+    <pre>$ rpm -Va --noconfig | grep '^..5'</pre>
     A "c" in the second column indicates that a file is a configuration file, which
-    may appropriately be expected to change.  If the file was not expected to
+    may appropriately be expected to change. If the file was not expected to
     change, investigate the cause of the change using audit logs or other means.
     The package can then be reinstalled to restore the file.
     Run the following command to determine which package owns the file:
@@ -64,4 +64,4 @@ ocil_clause: 'there is output'
 ocil: |-
     The following command will list which files on the system
     have file hashes different from what is expected by the RPM database.
-    <pre>$ rpm -Va | awk '$1 ~ /..5/ &amp;&amp; $2 != "c"'</pre>
+    <pre>$ rpm -Va --noconfig | awk '$1 ~ /..5/ &amp;&amp; $2 != "c"'</pre>

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
@@ -14,7 +14,7 @@ description: |-
     To verify that the cryptographic hash of system files and commands matches vendor
     values, run the following command to list which files on the system
     have hashes that differ from what is expected by the RPM database:
-    <pre>$ rpm -Va --noconfig | grep '^..5'</pre>
+    <pre>$ rpm -Va{{{ " --noconfig" if product != "rhel6" }}} | grep '^..5'</pre>
     A "c" in the second column indicates that a file is a configuration file, which
     may appropriately be expected to change. If the file was not expected to
     change, investigate the cause of the change using audit logs or other means.
@@ -64,4 +64,4 @@ ocil_clause: 'there is output'
 ocil: |-
     The following command will list which files on the system
     have file hashes different from what is expected by the RPM database.
-    <pre>$ rpm -Va --noconfig | awk '$1 ~ /..5/ &amp;&amp; $2 != "c"'</pre>
+    <pre>$ rpm -Va{{{ " --noconfig" if product != "rhel6" }}} | awk '$1 ~ /..5/ &amp;&amp; $2 != "c"'</pre>

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/fresh_system.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/fresh_system.pass.sh
@@ -4,6 +4,6 @@
 
 # verify (-V) all installed (-a) packages digests,
 # if digest differs from package metadata, then attribute '5' is printed
-result=$(rpm -Va | grep -E '^..5.* /(bin|sbin|lib|lib64|usr)/')
+result=$(rpm -Va --noconfig | grep -E '^..5')
 
 [ -z "$result" ]


### PR DESCRIPTION
#### Description:

Update rpm_verify_hashes according to STIG RHEL7 v2r7:

- Changes based on: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71855?version=V1R4&compareto=v2r7

Note: Test scenarios pass just fine using latest RHEL7
