### PR TITLE
Fix file regex in OCP3 content.

### DIFF
--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
@@ -32,3 +32,5 @@ template:
         filepath: /etc/origin/openvswitch/
         file_regex: ^[^.].*$
         filemode: '0644'
+    backends:
+        bash: 'off'

--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
@@ -30,5 +30,5 @@ template:
     name: file_permissions
     vars:
         filepath: /etc/origin/openvswitch/
-        file_regex: ^[^\.].*$
+        file_regex: ^[^.].*$
         filemode: '0644'


### PR DESCRIPTION
#### Description:

- Fix file regex in OCP3 content. Yaml parser thinks that the backslash is escaping the symbol dot and
that raises an excetpion.

#### Rationale:

- Fix build of OCP3 content.

Tested on https://regex101.com/ and works as expected. Texts that begin with `.` are not matched
