### PR TITLE
Update file permissions/ownership/group bash template to better support "file_regex" parameter

### DIFF
--- a/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
+++ b/applications/openshift/ocp-permissions/ocp-files/file_permissions_master_openvswitch/rule.yml
@@ -32,5 +32,3 @@ template:
         filepath: /etc/origin/openvswitch/
         file_regex: ^[^.].*$
         filemode: '0644'
-    backends:
-        bash: 'off'

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1584,7 +1584,7 @@ file_groupowner::
 * Parameters:
 ** *filepath* - File path to be checked. If the file path ends with `/` it describes a directory.
 ** *missing_file_pass* - If set to `"true"` the OVAL check will pass when file is absent. Default value is `"false"`.
-** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory.
+** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory. Note: Applies to base name of files, so if a file `/foo/bar/file.txt` is processed, only `file.txt` is tested against *file_regex*.
 ** *filegid* - group ID (GID)
 * Languages: Ansible, Bash, OVAL
 
@@ -1593,7 +1593,7 @@ file_owner::
 * Parameters:
 ** *filepath* - File path to be checked. If the file path ends with `/` it describes a directory.
 ** *missing_file_pass* - If set to `"true"` the OVAL check will pass when file is absent. Default value is `"false"`.
-** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory.
+** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory. Note: Applies to base name of files, so if a file `/foo/bar/file.txt` is processed, only `file.txt` is tested against *file_regex*.
 ** *fileuid* - user ID (UID)
 * Languages: Ansible, Bash, OVAL
 
@@ -1602,7 +1602,7 @@ file_permissions::
 * Parameters:
 ** *filepath* - File path to be checked. If the file path ends with `/` it describes a directory.
 ** *missing_file_pass* - If set to `"true"` the OVAL check will pass when file is absent. Default value is `"false"`.
-** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory.
+** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory. Note: Applies to base name of files, so if a file `/foo/bar/file.txt` is processed, only `file.txt` is tested against *file_regex*.
 ** *filemode* - File permissions in a hexadecimal format, eg. `'0640'`.
 * Languages: Ansible, Bash, OVAL
 

--- a/shared/templates/template_BASH_file_groupowner
+++ b/shared/templates/template_BASH_file_groupowner
@@ -5,7 +5,12 @@
 # disruption = low
 
 {{% if IS_DIRECTORY and FILE_REGEX %}}
-find {{{ FILEPATH }}} -regex '{{{ FILE_REGEX }}}' -exec chgrp {{{ FILEGID }}} {} \;
+readarray -t files < <(find {{{ FILEPATH }}})
+for file in ${files[@]}; do
+    if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
+        chgrp {{{ FILEGID }}} $file
+    fi
+done
 {{% else %}}
 chgrp {{{ FILEGID }}} {{{ FILEPATH }}}
 {{% endif %}}

--- a/shared/templates/template_BASH_file_groupowner
+++ b/shared/templates/template_BASH_file_groupowner
@@ -6,7 +6,7 @@
 
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ FILEPATH }}})
-for file in ${files[@]}; do
+for file in "${files[@]}"; do
     if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
         chgrp {{{ FILEGID }}} $file
     fi

--- a/shared/templates/template_BASH_file_owner
+++ b/shared/templates/template_BASH_file_owner
@@ -5,7 +5,12 @@
 # disruption = low
 
 {{% if IS_DIRECTORY and FILE_REGEX %}}
-find {{{ FILEPATH }}} -regex '{{{ FILE_REGEX }}}' -exec chown {{{ FILEUID }}} {} \;
+readarray -t files < <(find {{{ FILEPATH }}})
+for file in ${files[@]}; do
+    if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
+        chown {{{ FILEUID }}} $file
+    fi
+done
 {{% else %}}
 chown {{{ FILEUID }}} {{{ FILEPATH }}}
 {{% endif %}}

--- a/shared/templates/template_BASH_file_owner
+++ b/shared/templates/template_BASH_file_owner
@@ -6,7 +6,7 @@
 
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ FILEPATH }}})
-for file in ${files[@]}; do
+for file in "${files[@]}"; do
     if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
         chown {{{ FILEUID }}} $file
     fi

--- a/shared/templates/template_BASH_file_permissions
+++ b/shared/templates/template_BASH_file_permissions
@@ -3,9 +3,10 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ FILEPATH }}})
-for file in ${files[@]}; do
+for file in "${files[@]}"; do
     if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
         chmod {{{ FILEMODE }}} $file
     fi    

--- a/shared/templates/template_BASH_file_permissions
+++ b/shared/templates/template_BASH_file_permissions
@@ -4,7 +4,12 @@
 # complexity = low
 # disruption = low
 {{% if IS_DIRECTORY and FILE_REGEX %}}
-find {{{ FILEPATH }}} -regex '{{{ FILE_REGEX }}}' -exec chmod {{{ FILEMODE }}} {} \;
+readarray -t files < <(find {{{ FILEPATH }}})
+for file in ${files[@]}; do
+    if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
+        chmod {{{ FILEMODE }}} $file
+    fi    
+done
 {{% else %}}
 chmod {{{ FILEMODE }}} {{{ FILEPATH }}}
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Update file permissions/ownership/group bash template to better support `file_regex` parameter.
- It also enables back again bash remediation for `file_permissions_master_openvswitch`.

#### Rationale:

- Now the `file_regex` applies to basename of the file instead of what's is outputed from `find`.

TODO:

- [x] New template documentation.
