### PR TITLE
Remove listing functions from yaml_to_shorthand.py

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -109,12 +109,6 @@ macro(ssg_build_shorthand_xml PRODUCT)
         list(APPEND BASH_REMEDIATION_FNS_DEPENDS "generate-internal-bash-remediation-functions.xml" "${CMAKE_BINARY_DIR}/bash-remediation-functions.xml")
     endif()
 
-    execute_process(
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${BASH_REMEDIATION_FNS} --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" list-inputs
-        OUTPUT_VARIABLE SHORTHAND_INPUTS_STR
-    )
-    string(REPLACE "\n" ";" SHORTHAND_INPUTS "${SHORTHAND_INPUTS_STR}")
-
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/profiles"
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/profiles"
@@ -127,9 +121,8 @@ macro(ssg_build_shorthand_xml PRODUCT)
         # The command also produces the directory with rules, but this is done before the the shorthand XML.
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/rules"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${BASH_REMEDIATION_FNS} --profiles-root "${CMAKE_CURRENT_BINARY_DIR}/profiles" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" build
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${BASH_REMEDIATION_FNS} --profiles-root "${CMAKE_CURRENT_BINARY_DIR}/profiles" --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
-        DEPENDS ${SHORTHAND_INPUTS}
         DEPENDS ${BASH_REMEDIATION_FNS_DEPENDS}
         DEPENDS "${SSG_BUILD_SCRIPTS}/yaml_to_shorthand.py"
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/profiles"


### PR DESCRIPTION
This patch removes the ability of the `yaml_to_shorthand.py` script to
list inputs and outputs of shorthand generation to its stdout. It's
removing the action argument from the CLI of the script. It leaves the
build action as the only feature of the script. As a result, removing
it simplifies the code in `ssg.build_yaml` module.

Action `list-outputs` only prints the value `--output` command line
argument, therefore it is useless.

Action `list-inputs` lists some of the input files from which the
shorthand.xml will be generated. For example profile files, group files,
and rule files. I find this feature useless, as generating shorthand
involves many other files such as Jinja macro definitions, shared
checks, remediations and others.

The `list-inputs` command is used during configure time in CMake.
However, removing this step from the CMake macro is safe, because all
the files aren't generated, but are part of the source repository
(profile files, group files, and rule files are stored in git).  An
exception is the bash-remediation-functions.xml, but that is already
passed by using `DEPENDS ${BASH_REMEDIATION_FNS_DEPENDS}` in the CMake
command. As the affected CMake command already depends on compiled
profiles, it is sure that the built shorthand.xml file will contain
complete profile data.

The `list-inputs` doesn't work correctly anyway, because during CMake configuration it consumes the original profiles, ignoring the `extends:` relation, but during the build it consumes the compiled profiles.