### PR TITLE
Fix build of Playbooks for extended profiles

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import os
 import os.path
 from collections import defaultdict
+from copy import deepcopy
 import datetime
 import re
 import sys
@@ -317,6 +318,62 @@ class Profile(object):
         profile.variables = dict ((k, v) for (k, v) in self.variables.items()
                              if k not in other.variables or v != other.variables[k])
         return profile
+
+
+class ResolvableProfile(Profile):
+    def __init__(self, * args, ** kwargs):
+        super(ResolvableProfile, self).__init__(* args, ** kwargs)
+        self.resolved = False
+
+    def resolve(self, all_profiles):
+        if self.resolved:
+            return
+
+        resolved_selections = set(self.selected)
+        if self.extends:
+            if self.extends not in all_profiles:
+                msg = (
+                    "Profile {name} extends profile {extended}, but"
+                    "only profiles {known_profiles} are available for resolution."
+                    .format(name=self.id_, extended=self.extends,
+                            profiles=list(all_profiles.keys())))
+                raise RuntimeError(msg)
+            extended_profile = all_profiles[self.extends]
+            extended_profile.resolve(all_profiles)
+
+            extended_selects = set(extended_profile.selected)
+            resolved_selections.update(extended_selects)
+
+            updated_variables = dict(extended_profile.variables)
+            updated_variables.update(self.variables)
+            self.variables = updated_variables
+
+            extended_refinements = deepcopy(extended_profile.refine_rules)
+            updated_refinements = self._subtract_refinements(extended_refinements)
+            updated_refinements.update(self.refine_rules)
+            self.refine_rules = updated_refinements
+
+        for uns in self.unselected:
+            resolved_selections.discard(uns)
+
+        self.unselected = []
+        self.extends = None
+
+        self.selected = sorted(resolved_selections)
+
+        self.resolved = True
+
+    def _subtract_refinements(self, extended_refinements):
+        """
+        Given a dict of rule refinements from the extended profile,
+        "undo" every refinement prefixed with '!' in this profile.
+        """
+        for rule, refinements in list(self.refine_rules.items()):
+            if rule.startswith("!"):
+                for prop, val in refinements:
+                    extended_refinements[rule[1:]].remove((prop, val))
+                del self.refine_rules[rule]
+        return extended_refinements
 
 
 class Value(object):


### PR DESCRIPTION
#### Description:

ResolvableProfile class can properly resolve the extension relation in
profiles.  We don't need to have a second implementation of profile
resolution, we can reuse the ResolvableProfile class. Moreover, the
implementation in playbook_builder.py doesn't support rules removal
using exclamation mark, as described in #5874.

#### Rationale:


Fixes: #5874
