### PR TITLE
Fix SCAPVAL error SRC-15

### DIFF
--- a/rhel6/cpe/rhel6-cpe-dictionary.xml
+++ b/rhel6/cpe/rhel6-cpe-dictionary.xml
@@ -47,6 +47,11 @@
             <!-- the check references an OVAL file that contains an inventory definition -->
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_gdm_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
       <cpe-item name="cpe:/a:libuser">
             <title xml:lang="en-us">Package libuser is installed</title>
             <!-- the check references an OVAL file that contains an inventory definition -->


### PR DESCRIPTION
The CPE `cpe:/a:grub2` is used in `xccdf-1.2:platform` element
in group `bootloader-grub2`, but this CPE isn't defined in the
RHEL 6 CPE dictionary. All used CPEs should be defined in the
dictionary.
