### PR TITLE
Encode special characters in ansible role's description

### DIFF
--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -204,7 +204,8 @@ class PlaybookToRoleConverter():
     @memoize
     def title(self):
         try:
-            return re.search(r'Profile Title:\s+(.+)$', self._description, re.MULTILINE).group(1)
+            title = re.search(r'Profile Title:\s+(.+)$', self._description, re.MULTILINE).group(1)
+            return '"' + title + '"'
         except AttributeError:
             return re.search(r'Ansible Playbook for\s+(.+)$', self._description, re.MULTILINE) \
                      .group(1)


### PR DESCRIPTION
Addressing:
```
  # ansible-lint -v '/build/ansible_roles/rhel8_stig/meta/main.yml'
  Syntax Error while loading YAML.
    did not find expected key

  The error appears to be in '/build/ansible_roles/rhel8_stig/meta/main.yml': line 4, column 24, but may
  be elsewhere in the file depending on the exact syntax problem.

  The offending line appears to be:

    author: ComplianceAsCode development team
    description: [DRAFT] DISA STIG for Red Hat Enterprise Linux 8
                         ^ here
```