### PR TITLE
fix ansible remediation for zipl_bootmap_is_up_to_date

### DIFF
--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
@@ -21,4 +21,4 @@
     - name: "Update zIPL bootmap"
       command: /usr/sbin/zipl
       changed_when: True
-      when: boot_bootmap.stat.mtime is defined and  boot_bootmap.stat.mtime < zipl_conf.stat.mtime
+      when: boot_bootmap.stat.mtime is defined and zipl_conf.stat.mtime is defined and  boot_bootmap.stat.mtime < zipl_conf.stat.mtime

--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
@@ -21,4 +21,4 @@
     - name: "Update zIPL bootmap"
       command: /usr/sbin/zipl
       changed_when: True
-      when: boot_bootmap.stat.mtime < zipl_conf.stat.mtime
+      when: boot_bootmap.stat.mtime is defined and  boot_bootmap.stat.mtime < zipl_conf.stat.mtime


### PR DESCRIPTION
#### Description:

- fix missing is defined in when clause

#### Rationale:

playbook for ospp was failing

- Fixes # 5926
