### PR TITLE
The CC/OSPP requirement for the TOE access banner is FTA_TAB.1.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
@@ -35,7 +35,7 @@ references:
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
     nist: AC-8(a),AC-8(c),AC-17(a),CM-6(a)
     nist-csf: PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FTA_TAB.1
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088
     vmmsrg: SRG-OS-000023-VMM-000060,SRG-OS-000024-VMM-000070
     stigid@rhel7: "040170"


### PR DESCRIPTION
#### Description:

- The CC/OSPP requirement for the TOE access banner is FTA_TAB.1.

#### Rationale:

- Rule's ospp reference should reference the requirement which it addresses.
