### PR TITLE
The CC/OSPP requirement for handling authentication failures is FIA_AFL.1.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -40,7 +40,7 @@ references:
     disa: 44,2238
     nist: CM-6(a),AC-7(a)
     nist-csf: PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FIA_AFL.1
     pcidss: Req-8.1.6
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     vmmsrg: SRG-OS-000021-VMM-000050

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -47,7 +47,7 @@ references:
     disa: 44,2238
     nist: CM-6(a),AC-7(a)
     nist-csf: PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FIA_AFL.1
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     vmmsrg: SRG-OS-000021-VMM-000050
     stigid@rhel7: "010320"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -44,7 +44,7 @@ references:
     disa: 44,2238
     nist: CM-6(a),AC-7(b)
     nist-csf: PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FIA_AFL.1
     pcidss: Req-8.1.7
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     vmmsrg: SRG-OS-000329-VMM-001180

--- a/ol8/profiles/ospp.profile
+++ b/ol8/profiles/ospp.profile
@@ -291,7 +291,7 @@ selections:
     - no_empty_passwords
 
     ## Set Maximum Number of Authentication Failures to 3 Within 15 Minutes
-    ## AC-7(a) / FMT_MOF_EXT.1
+    ## AC-7 / FIA_AFL.1
     - var_accounts_passwords_pam_faillock_deny=3
     - accounts_passwords_pam_faillock_deny
     - var_accounts_passwords_pam_faillock_fail_interval=900

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -308,7 +308,7 @@ selections:
     - no_empty_passwords
 
     ## Set Maximum Number of Authentication Failures to 3 Within 15 Minutes
-    ## AC-7(a) / FMT_MOF_EXT.1
+    ## AC-7 / FIA_AFL.1
     #- var_accounts_passwords_pam_faillock_deny=3
     #- accounts_passwords_pam_faillock_deny
     #- var_accounts_passwords_pam_faillock_fail_interval=900

--- a/rhcos4/profiles/ncp.profile
+++ b/rhcos4/profiles/ncp.profile
@@ -319,7 +319,7 @@ selections:
     - no_empty_passwords
 
     ## Set Maximum Number of Authentication Failures to 3 Within 15 Minutes
-    ## AC-7(a) / FMT_MOF_EXT.1
+    ## AC-7 / FIA_AFL.1
     #- var_accounts_passwords_pam_faillock_deny=3
     #- accounts_passwords_pam_faillock_deny
     #- var_accounts_passwords_pam_faillock_fail_interval=900

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -212,7 +212,7 @@ selections:
     - no_empty_passwords
 
     ## Set Maximum Number of Authentication Failures to 3 Within 15 Minutes
-    ## AC-7(a) / FMT_MOF_EXT.1
+    ## AC-7 / FIA_AFL.1
     - var_accounts_passwords_pam_faillock_deny=3
     - accounts_passwords_pam_faillock_deny
     - var_accounts_passwords_pam_faillock_fail_interval=900

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -299,7 +299,7 @@ selections:
     - no_empty_passwords
 
     ## Set Maximum Number of Authentication Failures to 3 Within 15 Minutes
-    ## AC-7(a) / FMT_MOF_EXT.1
+    ## AC-7 / FIA_AFL.1
     - var_accounts_passwords_pam_faillock_deny=3
     - accounts_passwords_pam_faillock_deny
     - var_accounts_passwords_pam_faillock_fail_interval=900


### PR DESCRIPTION

#### Description:

- The CC/OSPP requirement for handling authentication failures is FIA_AFL.1.

#### Rationale:

- Rule's ospp reference should reference the requirement which it addresses.
