### PR TITLE
The OSPP requirements for cryptographically verifying the integrity of updates are FPT_TUD_EXT.1.2 and FPT_TUD_EXT.2.2.

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -47,7 +47,7 @@ references:
     hipaa: 164.308(a)(1)(ii)(D),164.312(b),164.312(c)(1),164.312(c)(2),164.312(e)(2)(i)
     nist: CM-5(3),SI-7,SC-12,SC-12(3),CM-6(a),SA-12,SA-12(10),CM-11(a),CM-11(b)
     nist-csf: PR.DS-6,PR.DS-8,PR.IP-1
-    ospp: FAU_GEN.1.1.c
+    ospp: FPT_TUD_EXT.1,FPT_TUD_EXT.2
     pcidss: Req-6.2
     srg: SRG-OS-000366-GPOS-00153
     vmmsrg: SRG-OS-000366-VMM-001430,SRG-OS-000370-VMM-001460,SRG-OS-000404-VMM-001650

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -30,7 +30,7 @@ references:
     hipaa: 164.308(a)(1)(ii)(D),164.312(b),164.312(c)(1),164.312(c)(2),164.312(e)(2)(i)
     nist: CM-11(a),CM-11(b),CM-6(a),CM-5(3),SA-12,SA-12(10)
     nist-csf: PR.IP-1
-    ospp: FAU_GEN.1.1.c
+    ospp: FPT_TUD_EXT.1,FPT_TUD_EXT.2
     srg: SRG-OS-000366-GPOS-00153
     vmmsrg: SRG-OS-000366-VMM-001430,SRG-OS-000370-VMM-001460,SRG-OS-000404-VMM-001650
     stigid@rhel7: "020060"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
@@ -36,7 +36,7 @@ references:
     hipaa: 164.308(a)(1)(ii)(D),164.312(b),164.312(c)(1),164.312(c)(2),164.312(e)(2)(i)
     nist: CM-5(3),SI-7,SC-12,SC-12(3),CM-6(a),SA-12,SA-12(10),CM-11(a),CM-11(b)
     nist-csf: PR.DS-6,PR.DS-8,PR.IP-1
-    ospp: FAU_GEN.1.1.c
+    ospp: FPT_TUD_EXT.1,FPT_TUD_EXT.2
     pcidss: Req-6.2
     isa-62443-2013: 'SR 3.1,SR 3.3,SR 3.4,SR 3.8,SR 7.6'
     isa-62443-2009: 4.3.4.3.2,4.3.4.3.3,4.3.4.4.4

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/rule.yml
@@ -51,7 +51,7 @@ references:
     hipaa: 164.308(a)(1)(ii)(D),164.312(b),164.312(c)(1),164.312(c)(2),164.312(e)(2)(i)
     nist: CM-5(3),SI-7,SC-12,SC-12(3),CM-6(a)
     nist-csf: PR.DS-6,PR.DS-8,PR.IP-1
-    ospp: FAU_GEN.1.1.c
+    ospp: FPT_TUD_EXT.1,FPT_TUD_EXT.2
     pcidss: Req-6.2
     isa-62443-2013: 'SR 3.1,SR 3.3,SR 3.4,SR 3.8,SR 7.6'
     isa-62443-2009: 4.3.4.3.2,4.3.4.3.3,4.3.4.4.4


### PR DESCRIPTION

#### Description:

- The OSPP requirements for cryptographically verifying the integrity of updates are FPT_TUD_EXT.1.2 and FPT_TUD_EXT.2.2.

#### Rationale:

- Rule's ospp reference should reference the requirement which it addresses.
