### PR TITLE
The problem with Kerberos and OSPP is in the trusted channel requirement not allowing it, not really in the crypto.

### DIFF
--- a/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/rule.yml
+++ b/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@rhel8: 82175-1
 
 references:
-    ospp: FCS_CKM.1
+    ospp: FTP_ITC_EXT.1
     srg: SRG-OS-000120-GPOS-00061
 
 ocil_clause: 'it is present on the system'


### PR DESCRIPTION

#### Description:

- The problem with Kerberos and OSPP is in the trusted channel requirement not allowing it, not really in the crypto.

#### Rationale:

- Linking OSPP requirements that the rules implement helps navigate the content.
