### PR TITLE
The problem with Kerberos and OSPP is in the trusted channel requirement not allowing it, not in handling authentication failures.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/rule.yml
@@ -26,7 +26,7 @@ references:
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
     nist: CM-7(a),CM-7(b),CM-6(a),AC-17(a)
     nist-csf: PR.IP-1
-    ospp: FIA_AFL.1
+    ospp: FTP_ITC_EXT.1
     srg: SRG-OS-000364-GPOS-00151
     vmmsrg: SRG-OS-000480-VMM-002000
     stigid@rhel7: "040430"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
@@ -27,7 +27,7 @@ references:
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
     nist: AC-17(a),CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1
-    ospp: FIA_AFL.1
+    ospp: FTP_ITC_EXT.1
     srg: SRG-OS-000364-GPOS-00151
     vmmsrg: SRG-OS-000480-VMM-002000
     stigid@rhel7: "040440"


### PR DESCRIPTION

#### Description:

- The problem with Kerberos and OSPP is in the trusted channel requirement not allowing it, not in handling authentication failures.

#### Rationale:

- Linking OSPP requirements that the rules implement helps navigate the content.
