### PR TITLE
The rules enable expected seeding, not handling of authentication failures.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@rhel8: 82462-3
 
 references:
-    ospp: FIA_AFL.1
+    ospp: FCS_RBG_EXT.1.2
     srg: SRG-OS-000480-GPOS-00227
 
 ocil: |-

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@rhel8: 82721-2
 
 references:
-    ospp: FIA_AFL.1
+    ospp: FCS_RBG_EXT.1.2
     srg: SRG-OS-000480-GPOS-00227
 
 ocil: |-


### PR DESCRIPTION

#### Description:

- The rules enable expected seeding, not handling of authentication failures.

#### Rationale:

- Linking OSPP requirements that the rules implement helps navigate the content.
