### PR TITLE
Introduced a minimal reference-rule mapping generator.

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -700,6 +700,18 @@ macro(ssg_make_html_stats_for_product PRODUCT)
     )
 endmacro()
 
+macro(ssg_make_all_tables PRODUCT)
+    add_custom_command(
+        OUTPUT "${CMAKE_BINARY_DIR}/tables-${PRODUCT}-all.html"
+	COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/gen_tables.py" --build-dir "${CMAKE_BINARY_DIR}" --output-type html --output "${CMAKE_BINARY_DIR}/tables-${PRODUCT}-all.html" "${PRODUCT}"
+        # Actually we mean that it depends on resolved rules - see also ssg_build_templated_content
+        DEPENDS generate-internal-${PRODUCT}-shorthand.xml
+    )
+    add_custom_target(generate-ssg-tables-${PRODUCT}-all
+        DEPENDS "${CMAKE_BINARY_DIR}/tables-${PRODUCT}-all.html"
+    )
+endmacro()
+
 macro(ssg_build_product PRODUCT)
     # Enforce folder naming rules, we require SSG contributors to use
     # scap-security-guide/${PRODUCT}/ for all products. This makes it easier
@@ -723,6 +735,7 @@ macro(ssg_build_product PRODUCT)
     endforeach()
 
     ssg_build_shorthand_xml(${PRODUCT})
+    ssg_make_all_tables(${PRODUCT})
     ssg_build_templated_content(${PRODUCT})
     ssg_build_xccdf_unlinked(${PRODUCT})
     ssg_build_ocil_unlinked(${PRODUCT})
@@ -753,6 +766,7 @@ macro(ssg_build_product PRODUCT)
         generate-ssg-${PRODUCT}-ocil.xml
         generate-ssg-${PRODUCT}-cpe-dictionary.xml
         generate-ssg-${PRODUCT}-ds.xml
+        generate-ssg-tables-${PRODUCT}-all
     )
 
     add_dependencies(zipfile "generate-ssg-${PRODUCT}-ds.xml")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -702,13 +702,14 @@ endmacro()
 
 macro(ssg_make_all_tables PRODUCT)
     add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/tables-${PRODUCT}-all.html"
-	COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/gen_tables.py" --build-dir "${CMAKE_BINARY_DIR}" --output-type html --output "${CMAKE_BINARY_DIR}/tables-${PRODUCT}-all.html" "${PRODUCT}"
+        OUTPUT "${CMAKE_BINARY_DIR}/tables/tables-${PRODUCT}-all.html"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/gen_tables.py" --build-dir "${CMAKE_BINARY_DIR}" --output-type html --output "${CMAKE_BINARY_DIR}/tables/tables-${PRODUCT}-all.html" "${PRODUCT}"
         # Actually we mean that it depends on resolved rules - see also ssg_build_templated_content
         DEPENDS generate-internal-${PRODUCT}-shorthand.xml
     )
     add_custom_target(generate-ssg-tables-${PRODUCT}-all
-        DEPENDS "${CMAKE_BINARY_DIR}/tables-${PRODUCT}-all.html"
+        DEPENDS "${CMAKE_BINARY_DIR}/tables/tables-${PRODUCT}-all.html"
     )
 endmacro()
 

--- a/utils/gen_tables.py
+++ b/utils/gen_tables.py
@@ -1,0 +1,96 @@
+from glob import glob
+import collections
+import os
+
+import argparse
+
+import ssg.build_yaml
+
+
+class References:
+    def __init__(self):
+        self.ref_by_family = collections.defaultdict(lambda: collections.defaultdict(set))
+
+    def handle_rule_ref_family(self, rule_name, family, rule_content):
+        ids = rule_content.split(",")
+        for id in ids:
+            self.ref_by_family[family][id].add(rule_name)
+
+    def handle_rule(self, rule_entry):
+        for family, content in rule_entry.references.items():
+            self.handle_rule_ref_family(rule_entry.id_, family, content)
+
+    def sorted(self):
+        refs_by_family = collections.OrderedDict()
+        families = sorted(self.ref_by_family.keys())
+        for f in families:
+            refs_by_family[f] = collections.OrderedDict()
+            sorted_refs = sorted(self.ref_by_family[f].keys())
+            for ref in sorted_refs:
+                refs_by_family[f][ref] = sorted(self.ref_by_family[f][ref])
+        return refs_by_family
+
+
+class Output(object):
+    def __init__(self, product, build_dir):
+        path = "{build_dir}/{product}/rules".format(build_dir=build_dir, product=product)
+        rule_files = glob("{path}/*".format(path=path))
+        if not rule_files:
+            msg = (
+                "No files found in '{path}', please make sure that you select the build dir "
+                "correctly and that the appropriate product is built.".format(path=path)
+            )
+            raise ValueError(msg)
+        rules_dict = dict()
+        for r_file in rule_files:
+            rule = ssg.build_yaml.Rule.from_yaml(r_file)
+            rules_dict[rule.id_] = rule
+
+        references = References()
+        for rule in rules_dict.values():
+            references.handle_rule(rule)
+
+        self.product = product
+        self.sorted_refs = references.sorted()
+        self.rules_dict = rules_dict
+
+    def get_result(self):
+        raise NotImplementedError()
+
+
+class HtmlOutput(Output):
+    def get_result(self):
+        import ssg.jinja
+        subst_dict = dict(all_refs=self.sorted_refs, rules=self.rules_dict, product=self.product)
+        html_jinja_template = os.path.join(os.path.dirname(__file__), "references-template.html")
+        return ssg.jinja.process_file(html_jinja_template, subst_dict)
+
+
+class JsonOutput(Output):
+    def get_result(self):
+        import json
+        return json.dumps(self.sorted_refs, indent=2, sort_keys=True)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate reference-rule mapping.")
+    parser.add_argument("product", help="What product to consider")
+    parser.add_argument("--build-dir", default="build", help="Path to the build directory")
+    parser.add_argument("--output-type", choices=("html", "json"), default="html")
+    parser.add_argument("--output", help="The filename to generate")
+    parser.add_argument("--family", help="Which family of references to output (output all by default)")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    output_class_map = dict(
+            html=HtmlOutput,
+            json=JsonOutput,
+    )
+    args = parse_args()
+    result = output_class_map[args.output_type](args.product, args.build_dir).get_result()
+    if not args.output:
+        print(result)
+    else:
+        with open(args.output, "w") as outfile:
+            outfile.write(result)

--- a/utils/references-template.html
+++ b/utils/references-template.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style type="text/css">
+
+/* Style the button that is used to open and close the collapsible content */
+.collapsible {
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 7px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 15px;
+}
+
+/* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
+.active, .collapsible:hover {
+  background-color: #ccc;
+}
+
+/* Style the collapsible content. Note: hidden by default */
+.content {
+  padding: 0 18px;
+  display: none;
+  overflow: hidden;
+  background-color: #f1f1f1;
+} 
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 2;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -60px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip .tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}
+</style>
+</head>
+<body>
+
+<h2>References for product {{{ product }}}</h2>
+
+<ul>
+{{% for family in all_refs -%}}
+  <li class="collapsible">{{{ family }}}</li>
+  <ul class="content">
+  {{% for refid in all_refs[family] -%}}
+    <li class="collapsible">{{{ refid }}}</li>
+    <ul class="content">
+    {{% for rulid in all_refs[family][refid] -%}}
+      <li><div class="tooltip">{{{ rulid }}}<span class="tooltiptext">{{{ rules[rulid].title }}}</span></div></li>
+    {{% endfor -%}}
+    </ul>
+  {{% endfor -%}}
+  </ul>
+{{% endfor -%}}
+</ul>  
+
+<script>
+var coll = document.getElementsByClassName("collapsible");
+var i;
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", function() {
+    this.classList.toggle("active");
+    var content = this.nextElementSibling;
+    if (content.style.display === "block") {
+      content.style.display = "none";
+    } else {
+      content.style.display = "block";
+    }
+  });
+} 
+</script>
+</body>
+</html>


### PR DESCRIPTION
Generate a simple reference-rules HTML page for each product to `build/tables-<product>-all.html`. References and rules are sorted lexicographically.
This PR can serve as a PoC of a lightweight table generation.

Advantages:

- The code is jinaj2 and Pyhon-based, so it is very small and customizable, and it can be tuned easily (e.g. do version-based sorting for version-like reference IDs)
- As the functionality supports HTML and JSON ordered output, it can serve as a support for modifications to the references processing.

Problems with the current table generation:

- Tables are user-unfriendly - it is not uncommon for one control to be referenced in multiple table rows, which may not be consecutive.
- Introduction of a new reference type requires a lot of XML copy-pasting.