### PR TITLE
Remove unrelated SRG from home nosuid option rule

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -36,7 +36,7 @@ references:
     iso27001-2013: A.11.2.9,A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4,A.8.2.1,A.8.2.2,A.8.2.3,A.8.3.1,A.8.3.3,A.9.1.2
     cis-csc: 11,13,14,3,8,9
     anssi: NT28(R12)
-    srg: SRG-OS-000368-GPOS-00154,SRG-OS-000480-GPOS-00227
+    srg: SRG-OS-000480-GPOS-00227
 
 platform: machine
 


### PR DESCRIPTION

#### Description:

- SRG-OS-000368-GPOS-00154 is about /dev/shm options
  - https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-81009?version=v2r7
  - https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-81011?version=v2r7
  - https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-81013?version=v2r7

#### Note:
- SRG for /home nosuid is: [SRG-OS-000480-GPOS-00227 ](https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72041?version=v2r7) 