### PR TITLE
Update dconf_gnome_banner_enabled to use local.d dconf database.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 - name: "Enable GNOME3 Login Warning Banner"
   ini_file:
-    dest: "/etc/dconf/db/gdm.d/00-security-settings"
+    dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/login-screen"
     option: banner-message-enable
     value: "true"
@@ -14,7 +14,7 @@
 
 - name: "Prevent user modification of GNOME banner-message-enabled"
   lineinfile:
-    path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
+    path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/login-screen/banner-message-enable'
     line: '/org/gnome/login-screen/banner-message-enable'
     create: yes

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
 
 
-{{{ bash_dconf_settings("org/gnome/login-screen", "banner-message-enable", "true", "gdm.d", "00-security-settings") }}}
-{{{ bash_dconf_lock("org/gnome/login-screen", "banner-message-enable", "gdm.d", "00-security-settings-lock") }}}
+{{{ bash_dconf_settings("org/gnome/login-screen", "banner-message-enable", "true", "local.d", "00-security-settings") }}}
+{{{ bash_dconf_lock("org/gnome/login-screen", "banner-message-enable", "local.d", "00-security-settings-lock") }}}

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_banner_gui_enabled"
   version="1">
-    <ind:path>/etc/dconf/db/gdm.d/</ind:path>
+    <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^\[org/gnome/login-screen]([^\n]*\n+)+?banner-message-enable=true$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
@@ -40,7 +40,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_prevent_user_banner_gui_enabled_change"
   version="1">
-    <ind:path>/etc/dconf/db/gdm.d/locks/</ind:path>
+    <ind:path>/etc/dconf/db/local.d/locks/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^/org/gnome/login-screen/banner-message-enable$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
@@ -10,11 +10,11 @@ description: |-
     screen by setting <tt>banner-message-enable</tt> to <tt>true</tt>.
     <br /><br />
     To enable, add or edit <tt>banner-message-enable</tt> to
-    <tt>/etc/dconf/db/gdm.d/00-security-settings</tt>. For example:
+    <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/login-screen]
     banner-message-enable=true</pre>
     Once the setting has been added, add a lock to
-    <tt>/etc/dconf/db/gdm.d/locks/00-security-settings-lock</tt> to prevent user modification.
+    <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.
     For example:
     <pre>/org/gnome/login-screen/banner-message-enable</pre>
     After the settings have been set, run <tt>dconf update</tt>.
@@ -54,8 +54,8 @@ ocil_clause: 'it is not'
 
 ocil: |-
     To ensure a login warning banner is enabled, run the following:
-    <pre>$ grep banner-message-enable /etc/dconf/db/gdm.d/*</pre>
+    <pre>$ grep banner-message-enable /etc/dconf/db/local.d/*</pre>
     If properly configured, the output should be <tt>true</tt>.
     To ensure a login warning banner is locked and cannot be changed by a user, run the following:
-    <pre>$ grep banner-message-enable /etc/dconf/db/gdm.d/locks/*</pre>
+    <pre>$ grep banner-message-enable /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/banner-message-enable</tt>.

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
@@ -6,7 +6,7 @@ source $SHARED/dconf_test_functions.sh
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "gdm.d" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings"
+add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "local.d" "00-security-settings"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
@@ -6,7 +6,7 @@ source $SHARED/dconf_test_functions.sh
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "false" "gdm.d" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "gdm.d" "00-security-settings"
+add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "false" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "local.d" "00-security-settings"
 
 dconf update


### PR DESCRIPTION
#### Description:

- Update dconf_gnome_banner_enabled to use `local.d` dconf database.

#### Rationale:

- Open the questioning around these type of rules that still use `gdm.d` dconf databases. The thing is that RHEL8 does not `look` for databases in `gdm.d` as RHEL7 does, that means in RHEL8 by default the contents of `/usr/share/dconf/profile/gdm` are
```
$ cat /usr/share/dconf/profile/gdm
user-db:user
system-db:local
system-db:site
system-db:distro
file-db:/usr/share/gdm/greeter-dconf-defaults
```
This means it doesn't consider keys and values under `/etc/dconf/gdm.d/`. Even RHEL7 STIG says we should use `local.d`, but so far we didn't have any problems because RHEL7 still considers the `gdm.d` folder. But RHEL8 doesn't.

I would risk to say that this rule selected by [RHEL8 CIS profile](https://github.com/ComplianceAsCode/content/blob/master/rhel8/profiles/cis.profile#L237) doesn't work at all. I mean, the checks and remediation work but the actual configuration doesn't happen in the system. To make it work the user needs to include `system-db:gdm` into  `/usr/share/dconf/profile/gdm` manually.

References:
RHEL7 STIG - https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71859?version=v2r7
RHEL8 Draft STIG - https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_8_V1R0-1_IDraftSTIG.zip
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1631378 (especially [comment13](https://bugzilla.redhat.com/show_bug.cgi?id=1631378#c13))