### PR TITLE
Add grub2 platform to grub2 kernel option rules

### DIFF
--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -102,6 +102,8 @@ warnings:
 {{% endif %}}
         </ul>
 
+platform: grub2
+
 template:
     name: grub2_bootloader_argument
     vars:

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -60,7 +60,7 @@ warnings:
 {{% endif %}}
         </ul>
 
-platform: machine
+platform: grub2
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
@@ -87,6 +87,8 @@ warnings:
 {{% endif %}}
         </ul>
 
+platform: grub2
+
 template:
     name: grub2_bootloader_argument
     vars:

--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/rule.yml
@@ -37,3 +37,5 @@ warnings:
         Disabling all kernel support for USB will cause problems for systems
         with USB-based keyboards, mice, or printers. This configuration is
         infeasible for systems which require USB devices, which is common.
+
+platform: grub2

--- a/linux_os/guide/system/permissions/restrictions/poisoning/group.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/group.yml
@@ -6,3 +6,5 @@ description: |-
     Memory Poisoning consists of writing a special value to uninitialized or freed memory.
     Poisoning can be used as a mechanism to prevent leak of information and detection of
     corrupted memory.
+
+platform: machine

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
@@ -60,7 +60,7 @@ warnings:
 {{% endif %}}
         </ul>
 
-platform: machine
+platform: grub2
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -60,7 +60,7 @@ warnings:
 {{% endif %}}
         </ul>
 
-platform: machine
+platform: grub2
 
 template:
     name: grub2_bootloader_argument


### PR DESCRIPTION

#### Description:

- This will make sure these rules are applicable only when grub2 is installed.

#### Rationale:

- These rules are being evaluated on `s390x` systems.