### PR TITLE
update xccdf variable options for auditd and audispd

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_disk_full_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_disk_full_action.var
@@ -10,9 +10,10 @@ interactive: false
 
 options:
     default: single
-    email: email
     exec: exec
     halt: halt
     single: single
     suspend: suspend
     syslog: syslog
+    warn_once: warn_once
+    stop: stop

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_network_failure_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_audispd_network_failure_action.var
@@ -10,9 +10,10 @@ interactive: false
 
 options:
     default: single
-    email: email
     exec: exec
     halt: halt
     single: single
     suspend: suspend
     syslog: syslog
+    warn_once: warn_once
+    stop: stop

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
@@ -15,4 +15,3 @@ options:
     single: single
     suspend: suspend
     syslog: syslog
-

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
@@ -10,8 +10,9 @@ interactive: false
 
 options:
     default: single
-    email: email
     exec: exec
     halt: halt
     single: single
+    suspend: suspend
     syslog: syslog
+

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
@@ -10,7 +10,6 @@ interactive: false
 
 options:
     default: single
-
     exec: exec
     halt: halt
     single: single

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
@@ -10,8 +10,9 @@ interactive: false
 
 options:
     default: single
-    email: email
+
     exec: exec
     halt: halt
     single: single
+    suspend: suspend
     syslog: syslog


### PR DESCRIPTION
#### Description:

- add / remove options for xccdf variables

#### Rationale:

Options were no talligned with Audit documentation - some were missing, some variables included invalid options.

