### PR TITLE
remove perm=x from rules about auditing of privileged commands

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/at -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/at -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chsh -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chsh -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/crontab -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/crontab -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/gpasswd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/gpasswd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgrp -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgrp -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newuidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newuidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/passwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/passwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postdrop -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postdrop -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postqueue -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postqueue -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/openssh/key-sign -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/openssh/key-sign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/su -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/su -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudo -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudo -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
@@ -3,5 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
@@ -3,5 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
@@ -4,4 +4,4 @@
 # platform = Red Hat Enterprise Linux 7,Fedora
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
@@ -4,5 +4,5 @@
 # platform = Red Hat Enterprise Linux 7,Fedora
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
@@ -4,4 +4,4 @@
 # platform = Red Hat Enterprise Linux 7,Fedora
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
@@ -4,4 +4,4 @@
 # platform = Red Hat Enterprise Linux 7,Fedora
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudoedit -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
@@ -4,4 +4,4 @@
 # platform = Red Hat Enterprise Linux 7,Fedora
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
@@ -3,4 +3,4 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k own_key" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k own_key" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudoedit -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudoedit -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
+++ b/shared/templates/template_ANSIBLE_audit_rules_privileged_commands
@@ -29,7 +29,7 @@
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d
   lineinfile:
     path: "{{ all_files[0] }}"
-    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+    line: '-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: yes
 
 # Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
@@ -37,5 +37,5 @@
 - name: Inserts/replaces the {{{ NAME }}} rule in audit.rules
   lineinfile:
     path: /etc/audit/audit.rules
-    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+    line: '-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: yes

--- a/shared/templates/template_BASH_audit_rules_privileged_commands
+++ b/shared/templates/template_BASH_audit_rules_privileged_commands
@@ -7,7 +7,7 @@ PATTERN="-a always,exit -F path={{{ PATH }}}\\s\\+.*"
 GROUP="privileged"
 # Although the fix doesn't use ARCH, we reset it because it could have been set by some other remediation
 ARCH=""
-FULL_RULE="-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged"
+FULL_RULE="-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
 fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+perm=x[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

remove the argument perm=x from rules audit_rules_privileged_commands_*

- templates (Ansible, Oval, Bash)

- tests (audit_rules_privileged_commands_sudo)
- rule descriptions



#### Rationale:

This is done to be alligned with latest rhel7 STIG guide. It does not introduce regression from the security point of view.