### PR TITLE
Update dconf_db_up_to_date to check for gdm.d in RHEL8.

### DIFF
--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/oval/shared.xml
@@ -61,7 +61,7 @@
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check that all DBs in question are up-to-date" operator="AND">
-        {{% if product == 'rhel7' %}}
+        {{% if product == 'rhel7' or product == 'rhel8' %}}
           {{{ check_db_criterion("gdm") }}}
         {{% endif %}}
         {{{ check_db_criterion("local") }}}
@@ -69,7 +69,7 @@
     </criteria>
   </definition>
 
-  {{% if product == 'rhel7' %}}
+  {{% if product == 'rhel7' or product == 'rhel8' %}}
     {{{ check_db_is_up_to_date("gdm") }}}
   {{% endif %}}
   {{{ check_db_is_up_to_date("local") }}}


### PR DESCRIPTION
#### Description:

- A follow up from #5951 
- RHEL8 will start considering `gdm.d` from RHEL8.3. It was a bug not considering that directory.