### PR TITLE
Add ansible remediation for dconf_gnome_screensaver_idle_activation_locked

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
@@ -1,0 +1,11 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+- name: "Prevent user modification of GNOME Screensaver idle-activation-enabled"
+  lineinfile:
+    path: /etc/dconf/db/local.d/locks/00-security-settings-lock
+    regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled'
+    line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
+    create: yes

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 
 
 {{{ bash_dconf_lock("org/gnome/desktop/screensaver", "idle-activation-enabled", "local.d", "00-security-settings-lock") }}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value.pass.sh
@@ -3,6 +3,6 @@
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
+install_dconf_and_gdm_if_needed
 clean_dconf_settings
 add_dconf_lock "org/gnome/desktop/screensaver" "idle-activation-enabled" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+yum -y install dconf
+clean_dconf_settings
+add_dconf_lock "org/gnome/desktop/screensaver" "idle-activation-enabled" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/wrong_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+yum -y install dconf
+clean_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/wrong_value.fail.sh
@@ -3,5 +3,5 @@
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
+install_dconf_and_gdm_if_needed
 clean_dconf_settings


### PR DESCRIPTION
#### Description:

- Add ansible remediation for dconf_gnome_screensaver_idle_activation_locked.
- Add RHEL8 CCE
- Add Fedora platform in bash remediation
