### PR TITLE
Remove wrong CCI number from no_files_unowned_by_user.

### DIFF
--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -31,7 +31,7 @@ references:
     disa@rhel6: CCI-000224
     cis@rhel7: 6.1.11
     cis@rhel8: 6.1.11
-    disa: CCI-000366,CCI-002165
+    disa: CCI-002165
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.AC-6,PR.DS-5,PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227


### PR DESCRIPTION
#### Description:

- Remove wrong CCI number from `no_files_unowned_by_user`.

#### Rationale:

- `CCI-000366` is associated with many items but `no_files_unowned_by_user` is not one of those.

References: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72007?version=v2r7
