### PR TITLE
Remove wrong CCI number from file_permissions_ungroupowned.

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -31,7 +31,7 @@ references:
     disa@rhel6: CCI-000224
     cis@rhel7: 6.1.12
     cis@rhel8: 6.1.12
-    disa: CCI-000366,CCI-002165
+    disa: CCI-002165
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.DS-5,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227


### PR DESCRIPTION
#### Description:

- Remove wrong CCI number from `file_permissions_ungroupowned`.

#### Rationale:

- `CCI-000366` is associated with many items but `file_permissions_ungroupowned` is not one of those.

References: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72009?version=v2r7
