### PR TITLE
Fix typo in OCIL checking command for file_groupownership_home_directories.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
@@ -34,4 +34,4 @@ ocil_clause: 'the group ownership is incorrect'
 ocil: |-
     To verify the assigned home directory of all interactive users is group-
     owned by that users primary GID, run the following command:
-    <pre>$ sudo ls -ld $ (egrep ':[0-9]{4}' /etc/passwd | cut -d: -f6)</pre>
+    <pre>$ sudo ls -ld $(egrep ':[0-9]{4}' /etc/passwd | cut -d: -f6)</pre>


### PR DESCRIPTION
#### Description:

- Fix typo in OCIL checking command for file_groupownership_home_directories.
