### PR TITLE
Fix syntax in OCIL checking command for accounts_user_dot_no_world_writable_programs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/rule.yml
@@ -32,5 +32,5 @@ ocil_clause: 'files are executing world-writable programs'
 ocil: |-
     To verify that local initialization files do not execute world-writable programs,
     execute the following command:
-    <pre>$ sudo find /home -perm -002 -type f -exec ls -ld {} -name ".[^.]*"\;</pre>
+    <pre>$ sudo find /home -perm -002 -type f -exec ls -ld {} -name ".[^.]*" \;</pre>
     There should be no output.


### PR DESCRIPTION
#### Description:
- Fix syntax in OCIL checking command for accounts_user_dot_no_world_writable_programs

#### Rationale:

- Without space it throws: `find: missing argument to `-exec'`
