### PR TITLE
Use helper functions to install dconf and gdm.

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/correct_value.pass.sh
@@ -3,6 +3,6 @@
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
+install_dconf_and_gdm_if_needed
 clean_dconf_settings
 add_dconf_lock "org/gnome/desktop/screensaver" "lock-enabled" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/wrong_value.fail.sh
@@ -3,5 +3,5 @@
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
+install_dconf_and_gdm_if_needed
 clean_dconf_settings


### PR DESCRIPTION
A follow up from #5959

#### Description:

- Use helper functions to install dconf and gdm.

#### Rationale:

- Make sure that rules are applicable before testing
