### PR TITLE
Look for private keys in the whole file system.

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -43,7 +43,7 @@ ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
 template:
     name: file_permissions
     vars:
-        filepath: /etc/ssh/
+        filepath: /
         missing_file_pass: 'true'
         file_regex: ^.*_key$
         filemode: '0640'


### PR DESCRIPTION
#### Description:

- Start discussion around the fact that we only check for private keys that are in `/etc/ssh/` and STIG says we should check the whole system for files that match a given regex.

Note: The check is not recursive and it doesn't look for all files in the filesystem. So they way it is doesn't work. It's more to open the discussion.

@redhatrises What do you think about this?

Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72257?version=v2r7
