### PR TITLE
Update OVAL check and remediation for aide_use_fips_hashes.

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
@@ -5,7 +5,7 @@
 aide_conf="/etc/aide.conf"
 forbidden_hashes=(sha1 rmd160 sha256 whirlpool tiger haval gost crc32)
 
-groups=$(LC_ALL=C grep "^[A-Z]\+" $aide_conf | cut -f1 -d ' ' | tr -d ' ' | sort -u)
+groups=$(LC_ALL=C grep "^[A-Za-z]\+" $aide_conf | cut -f1 -d ' ' | tr -d ' ' | sort -u)
 
 for group in $groups
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
@@ -26,7 +26,7 @@
   <ind:textfilecontent54_object id="object_aide_non_fips_hashes"
   version="1">
     <ind:filepath>/etc/aide.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[A-Z]*[\s]*=[\s]*.*(sha1|rmd160|sha256|whirlpool|tiger|haval|gost|crc32).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[a-zA-Z]*[\s]*=[\s]*.*(sha1|rmd160|sha256|whirlpool|tiger|haval|gost|crc32).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">0</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -39,8 +39,8 @@
   <ind:textfilecontent54_object id="object_aide_use_fips_hashes"
   version="1">
     <ind:filepath>/etc/aide.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[A-Z]*[\s]*=[\s]*([a-z0-9\+]*)$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than">1</ind:instance>
+    <ind:pattern operation="pattern match">^[a-zA-Z]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_aide_use_fips_hashes" version="1">
     <ind:subexpression operation="pattern match">^.*sha512.*$</ind:subexpression>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+yum install -y aide
+
+cat >/etc/aide.conf <<EOL
+All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+/bin All # apply the custom rule to the files in bin 
+/sbin All # apply the same custom rule to the files in sbin 
+EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+yum install -y aide
+
+cat >/etc/aide.conf <<EOL
+All = p+i+n+u+g+s+m+S+acl+xattrs+selinux
+/bin All # apply the custom rule to the files in bin 
+/sbin All # apply the same custom rule to the files in sbin 
+EOL


### PR DESCRIPTION
#### Description:

- Update OVAL check and remediation for aide_use_fips_hashes.

#### Rationale:

- Similar to: #5941. See comments on that for more details.