### PR TITLE
Revert "Remove wrong CCI number from no_files_unowned_by_user."

### DIFF
--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -31,7 +31,7 @@ references:
     disa@rhel6: CCI-000224
     cis@rhel7: 6.1.11
     cis@rhel8: 6.1.11
-    disa: CCI-002165
+    disa: CCI-000366,CCI-002165
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.AC-6,PR.DS-5,PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227


### PR DESCRIPTION
Reverts ComplianceAsCode/content#5966

That CCI number comes from Oracle Linux STIG: https://vaulted.io/library/disa-stigs-srgs/oracle_linux_7_security_technical_implementation_guide/V-99187