### PR TITLE
Update DISA CCI for rpm_verify_hashes.

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
@@ -46,7 +46,7 @@ references:
     cis: 1.2.6
     cjis: 5.10.4.1
     cui: 3.3.8,3.4.1
-    disa: CCI-000366,CCI-000663
+    disa: CCI-000366,CCI-001749
     hipaa: 164.308(a)(1)(ii)(D),164.312(b),164.312(c)(1),164.312(c)(2),164.312(e)(2)(i)
     nist: CM-6(d),CM-6(c),SI-7,SI-7(1),SI-7(6),AU-9(3)
     nist-csf: PR.DS-6,PR.DS-8,PR.IP-1


### PR DESCRIPTION
#### Description:

- Update DISA CCI for rpm_verify_hashes.

Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71855?version=V1R4&compareto=v2r7