### PR TITLE
fix descriptions of rules audit_rules_privileged_command_*

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -27,7 +27,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -14,20 +14,20 @@ description: |-
     <tt>/etc/audit/rules.d</tt> for each setuid / setgid program on the system,
     replacing the <i>SETUID_PROG_PATH</i> part with the full path of that setuid /
     setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt> for each setuid / setgid program on the
     system, replacing the <i>SETUID_PROG_PATH</i> part with the full path of that
     setuid / setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/at -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/at -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chsh -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/chsh -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/crontab -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/crontab -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/gpasswd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/gpasswd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgrp -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newgrp -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newuidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/newuidmap -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/pam_timestamp_check -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/passwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/passwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postdrop -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postdrop -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postqueue -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/postqueue -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/pt_chown -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -14,7 +14,7 @@ description: |-
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/openssh/key-sign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/openssh/key-sign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/libexec/openssh/key-sign -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/su -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/su -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudo -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudo -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudoedit -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/sudoedit -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path=/usr/sbin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path=/usr/sbin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/unix_chkpwd -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -10,11 +10,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path=/usr/sbin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path=/usr/sbin/userhelper -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -10,18 +10,18 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F auid&gt;={{{ auid }}} -F auid!=unset -F key=special-config-changes</pre>
+    <pre>-a always,exit -F path=/usr/sbin/usernetctl -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threat.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threat.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but


### PR DESCRIPTION
#### Description:

- fix typo which got copied into all descriptions

- fix the key name in audit rules mentioned in descriptions so that it alligns with our own remediations