### PR TITLE
fix descriptions and ocils of audit_rules_execution_*

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -10,18 +10,18 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/bin/chcon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/bin/chcon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but
@@ -56,7 +56,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/bin/chcon" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/bin/chcon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -10,18 +10,18 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/restorecon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/restorecon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but
@@ -54,7 +54,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/restorecon" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/restorecon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -10,18 +10,18 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/semanage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/semanage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but
@@ -56,7 +56,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/semanage" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/semanage -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -10,18 +10,18 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setfiles -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setfiles -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but
@@ -47,7 +47,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/setfiles" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setfiles -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -10,18 +10,18 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setsebool -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setsebool -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but
@@ -56,7 +56,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/setsebool" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/setsebool -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
@@ -10,18 +10,18 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/seunshare -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/seunshare -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
     authorized users, or by unauthorized external entities that have compromised system accounts,
     is a serious and ongoing concern and can have significant adverse impacts on organizations.
     Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threast.
+    the risk from insider and advanced persistent threats.
     <br /><br />
     Privileged programs are subject to escalation-of-privilege attacks,
     which attempt to subvert their normal role of providing some necessary but
@@ -45,7 +45,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/sbin/seunshare" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged-priv_change</pre>
+    <pre>-a always,exit -F path=/usr/sbin/seunshare -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 template:
     name: audit_rules_privileged_commands


### PR DESCRIPTION
#### Description:

- remove perm=x
- fix typo
- modify audit rule keys to match remediations

