### PR TITLE
remove redundant srg from audit_rules_privileged_commands_umount

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -43,7 +43,7 @@ references:
     hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3)(ii)(A),164.308(a)(5)(ii)(C),164.312(a)(2)(i),164.312(b),164.312(d),164.312(e)
     nist: AU-2(d),AU-12(c),AC-6(9),CM-6(a)
     nist-csf: DE.CM-1,DE.CM-3,DE.CM-7,ID.SC-4,PR.PT-1
-    srg: SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215
+    srg: SRG-OS-000042-GPOS-00020,SRG-OS-000392-GPOS-00172
     vmmsrg: SRG-OS-000471-VMM-001910
     stigid@rhel7: RHEL-07-030750
     isa-62443-2013: 'SR 2.10,SR 2.11,SR 2.12,SR 2.8,SR 2.9,SR 6.1,SR 6.2'


### PR DESCRIPTION
#### Description:

- remove srg mapping

#### Rationale:

https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72173?version=V1R4&compareto=v2r7
