### PR TITLE
Select uefi_no_removeable_media in DISA RHEL7 STIG profile

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 references:
     disa: CCI-001814
     srg: SRG-OS-000364-GPOS-00151
+    stigid@rhel7: RHEL-07-021700
 
 ocil_clause: 'it is not'
 

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -160,6 +160,7 @@ selections:
     - aide_verify_ext_attributes
     - aide_use_fips_hashes
     - grub2_no_removeable_media
+    - uefi_no_removeable_media
     - package_telnet-server_removed
     - service_auditd_enabled
     - audit_rules_system_shutdown


### PR DESCRIPTION
#### Description:

- Select uefi_no_removeable_media in DISA RHEL7 STIG profile

#### Rationale:

- The UEFI counterpart of this rule was not being selected by the profile and didn't contain some of the references.
- DISA STIG reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72075?version=v2r7
