### PR TITLE
Add RHEL7 STIG ID to sysctl_net_ipv4_conf_all_rp_filter.

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -38,6 +38,7 @@ references:
     cis-csc: 1,12,13,14,15,16,18,2,4,6,7,8,9
     srg: SRG-OS-000480-GPOS-00227
     cis@sle15: 3.3.7
+    stigid@rhel7: RHEL-07-040611
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.rp_filter", value="1") }}}
 


### PR DESCRIPTION
#### Description:

- Add RHEL7 STIG ID to sysctl_net_ipv4_conf_all_rp_filter.

#### Rationale:

- Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72285?version=v2r7