### PR TITLE
Remove extra zero on SRG ref mapping from kernel_module_dccp_disabled.

### DIFF
--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -38,7 +38,7 @@ references:
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS05.02,DSS05.05,DSS06.06
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4,A.9.1.2
     cis-csc: 11,14,3,9
-    srg: SRG-OS-000096-GPOS-00050,SRG-OS-000378-GPOS-000163
+    srg: SRG-OS-000096-GPOS-00050,SRG-OS-000378-GPOS-00163
 
 {{{ complete_ocil_entry_module_disable(module="dccp") }}}
 


### PR DESCRIPTION
#### Description:

- Remove extra zero on SRG ref mapping from kernel_module_dccp_disabled.

#### Rationale:

- Reference:https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-77821?version=V1R4&compareto=v2r7
