### PR TITLE
Update dconf_gnome_disable_ctrlaltdel_reboot and select it in RHEL7 STIG profile.

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -8,8 +8,9 @@
     dest: /etc/dconf/db/local.d/00-security-settings
     section: org/gnome/settings-daemon/plugins/media-keys
     option: logout
-    value: string ''
+    value: "''"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME disablement of Ctrl-Alt-Del"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,5 +1,5 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 
-{{{ bash_dconf_settings("org/gnome/settings-daemon/plugins/media-keys", "logout", "string ''", "local.d", "00-security-settings") }}}
+{{{ bash_dconf_settings("org/gnome/settings-daemon/plugins/media-keys", "logout", "''", "local.d", "00-security-settings") }}}
 {{{ bash_dconf_lock("org/gnome/settings-daemon/plugins/media-keys", "logout", "local.d", "00-security-settings-lock") }}}

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
@@ -24,7 +24,7 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys]([^\n]*\n+)+?logout=[\s]''$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys]([^\n]*\n+)+?logout[\s]*=[\s]*''$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
@@ -10,7 +10,7 @@ description: |-
     <br /><br />
     To configure the system to ignore the <tt>Ctrl-Alt-Del</tt> key sequence
     from the Graphical User Interface (GUI) instead of rebooting the system,
-    add or set <tt>logout</tt> to <tt>string ''</tt> in
+    add or set <tt>logout</tt> to <tt>''</tt> in
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/settings-daemon/plugins/media-keys]
     logout=''</pre>
@@ -42,6 +42,7 @@ references:
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 12,13,14,15,16,18,3,5
+    stigid@rhel7: RHEL-07-020231
 
 ocil_clause: 'GNOME3 is configured to reboot when Ctrl-Alt-Del is pressed'
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/comment.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "#logout" "''" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/settings-daemon/plugins/media-keys" "logout" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "''" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/settings-daemon/plugins/media-keys" "logout" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_unlocked.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_unlocked.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "''" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/setting_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/setting_not_there.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "'Something different'" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/settings-daemon/plugins/media-keys" "logout" "local.d" "00-security-settings"

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -70,6 +70,7 @@ selections:
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_activation_locked
     - dconf_gnome_screensaver_lock_delay
+    - dconf_gnome_disable_ctrlaltdel_reboot
     - accounts_password_pam_ucredit
     - accounts_password_pam_lcredit
     - accounts_password_pam_dcredit


### PR DESCRIPTION
#### Description:

- A follow up from #5992. This pull request updates some of the artefacts for rule `dconf_gnome_disable_ctrlaltdel_reboot`.

#### Rationale:

Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-94843?version=v2r7