### PR TITLE
Fix minor description issue in dconf_gnome_login_banner_text.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
@@ -7,7 +7,7 @@ title: 'Set the GNOME3 Login Warning Banner Text'
 description: |-
     In the default graphical environment, configuring the login warning banner text
     in the GNOME Display Manager's login screen can be configured on the login
-    screen by setting <tt>banner-message-text</tt> to <tt>string '<i>APPROVED_BANNER</i>'</tt>
+    screen by setting <tt>banner-message-text</tt> to <tt>'<i>APPROVED_BANNER</i>'</tt>
     where <i>APPROVED_BANNER</i> is the approved banner for your environment.
     <br /><br />
     To enable, add or edit <tt>banner-message-text</tt> to


### PR DESCRIPTION
#### Description:

- Fix minor description issue in dconf_gnome_login_banner_text. To be consistent across rule's content.
