### PR TITLE
Update ansible additional when statement to fix issues with rules not being applied to vm's

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -346,8 +346,7 @@ class AnsibleRemediation(Remediation):
     def update_when_from_rule(self, to_update):
         additional_when = ""
         if self.associated_rule.platform == "machine":
-            additional_when = ('ansible_virtualization_role != "guest" '
-                               'or ansible_virtualization_type != "docker"')
+            additional_when = 'ansible_virtualization_type not in ["docker", "lxc", "openvz"]'
         to_update.setdefault("when", "")
         new_when = ssg.yaml.update_yaml_list_or_string(to_update["when"], additional_when)
         if not new_when:

--- a/tests/unit/ssg-module/data/ansible-resolved.yml
+++ b/tests/unit/ssg-module/data/ansible-resolved.yml
@@ -2,7 +2,7 @@
   stat:
     path: /boot/grub2/grub.cfg
   register: file_exists
-  when: ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
+  when: ansible_virtualization_type not in ["docker", "lxc", "openvz"]
   tags:
     - file_owner_grub2_cfg
     - medium_severity
@@ -22,7 +22,7 @@
     owner: 0
   when:
     - file_exists.stat.exists
-    - ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
+    - ansible_virtualization_type not in ["docker", "lxc", "openvz"]
   tags:
     - file_owner_grub2_cfg
     - medium_severity


### PR DESCRIPTION
#### Description:

Update additional when clause and introduce new container checks.

#### Rationale:

- Additional when clause was confusing and not targeting a big issue - ensuring certain tasks don't run on containers. Trying to approach this - it became apparent that we needed another variable to be added to playbooks that contains a list of containers (as seen in upstream https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/facts/virtual/linux.py). This allows us to target the list in a clean manner when doing our `when:` clause check.

- Fixes #5048 
