### PR TITLE
Introduced rule to disable XDMCP in gdm

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/ansible/shared.yml
@@ -1,0 +1,7 @@
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+
+{{{ ansible_ini_file_set("/etc/gdm/custom.conf", "xdmcp", "Enable", "false", description=rule_title) }}}

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/bash/shared.sh
@@ -1,17 +1,3 @@
 # platform = multi_platform_all
 
-CONF="/etc/gdm/custom.conf"
-DISABL_XDMCP_REGEX="[[:space:]]*\[xdmcp]([^\n\[]*\n+)+?[[:space:]]*Enable"
-XDMCP_REGEX="[[:space:]]*\[xdmcp]"
-
-# This is a candidate of bash ini Jinja macro
-# Try find [xdmcp] and Enable in custom.conf, if it exists, set
-# to false, if it isn't here, add it, if [xdmcp] doesn't exist, add it there
-if grep -qzosP "$DISABL_XDMCP_REGEX" $CONF; then
-    sed -i "s/Enable[^(\n)]*/Enable=false/" $CONF
-elif grep -qs "$XDMCP_REGEX" $CONF; then
-    sed -i "/$XDMCP_REGEX/a Enable=false" $CONF
-else
-    mkdir -p /etc/gdm
-    printf '%s\n' "[xdmcp]" "Enable=false" >> $CONF
-fi
+{{{ bash_ini_file_set("/etc/gdm/custom.conf", "xdmcp", "Enable", "false") }}}

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/bash/shared.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_all
+
+CONF="/etc/gdm/custom.conf"
+DISABL_XDMCP_REGEX="[[:space:]]*\[xdmcp]([^\n\[]*\n+)+?[[:space:]]*Enable"
+XDMCP_REGEX="[[:space:]]*\[xdmcp]"
+
+# This is a candidate of bash ini Jinja macro
+# Try find [xdmcp] and Enable in custom.conf, if it exists, set
+# to false, if it isn't here, add it, if [xdmcp] doesn't exist, add it there
+if grep -qzosP "$DISABL_XDMCP_REGEX" $CONF; then
+    sed -i "s/Enable[^(\n)]*/Enable=false/" $CONF
+elif grep -qs "$XDMCP_REGEX" $CONF; then
+    sed -i "/$XDMCP_REGEX/a Enable=false" $CONF
+else
+    mkdir -p /etc/gdm
+    printf '%s\n' "[xdmcp]" "Enable=false" >> $CONF
+fi

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/oval/shared.xml
@@ -1,0 +1,1 @@
+{{{- oval_check_ini_file(path='/etc/gdm/custom.conf', section='xdmcp', parameter='Enable', value='false', missing_parameter_pass=false, application='gdm', multi_value=false, missing_config_file_fail=true) }}}

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
@@ -6,31 +6,31 @@ description: |-
     XDMCP is an unencrypted protocol, and therefore, presents a security risk, see e.g.
     {{{ weblink("https://help.gnome.org/admin/gdm/stable/security.html.en_GB#xdmcpsecurity", "XDMCP Gnome docs") }}}.
 
-    To disable XDMCP support in GDM, follow {{{ weblink("https://help.gnome.org/admin/gdm/stable/configuration.html.en#xdmcpsection", "GDM docs") }}},
-    and therefore make sure that there is the <code>Enable=false</code> line under the <code>[xdmcp]</code> configuration section in <code>/etc/gdm/custom.conf</code>
+    To disable XDMCP support in Gnome, set <code>Enable</code> to <code>false</code> under the <code>[xdmcp]</code> configuration section in <code>/etc/gdm/custom.conf</code>. For example:
+    <pre>
+    [xdmcp]
+    Enable=false
+    </pre>
 
 rationale: |-
-    Even though your display is protected by cookies, XEvents and keystrokes typed when entering passwords
-    will still go over the network in clear text. It is trivial to capture these.
+    XDMCP provides unencrypted remote access through the Gnome Display Manager (GDM) which does
+    not provide for the confidentiality and integrity of user passwords or the
+    remote session. If a privileged user were to login using XDMCP, the
+    privileged user password could be compromised due to typed XEvents
+    and keystrokes will traversing over the network in clear text.
 
-    XDMCP is primarily useful for running thin clients such as in terminal labs.
-    Those thin clients will only ever need the network to access the server, and so it seems like the best security policy
-    to have those thin clients on a separate network that cannot be accessed by the outside world, and can only connect to the server.
-    The only point from which you need to access outside is the server. This type of set up should never use an unmanaged hub or other sniffable network.
+severity: high
 
-severity: medium
-
-ocil_clause: 'the Enable=false setting is missing in the xdmcp section of the /etc/gdm/custom.conf gdm configuration file'
+ocil_clause: 'the Enable is not set to false or is missing in the xdmcp section of the /etc/gdm/custom.conf gdm configuration file'
 
 ocil: |-
-    Check whether there is the xdmcp section in the gdm configuration - run <code>grep '^\s*\[xdmcp\]' /etc/gdm/custom.conf</code>
-    If no results are returned, the whole section is missing, in which case you can add it to the file
-    using printf - <code>printf '%\n' "" "[xdmcp]" "Enable=false" >> /etc/gdm/custom.conf</code>
-
-    If grep returned results, you have to open the custom.conf file in a text editor,
-    and make sure that there is only one assignment to Enable,
-    namely Enable=false between the beginning of the [xdmcp] section
-    and another section or the end of the file.
+    To ensure that XDMCP is disabled in <code>/etc/gdm/custom.conf</code>, run the following command:
+    <pre>grep -Pzo "\[xdmcp\]\nEnable=false" /etc/gdm/custom.conf</pre>
+    The output should return the following:
+    <pre>
+    [xdmcp]
+    Enable=false
+    </pre>
 
 # There is a gdm platform implied by the parent group.
 # platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Disable XDMCP in GDM'
 
 description: |-
-    XDMCP is an unencrypted protocol, and therefore presents a security risK, see e.g.
+    XDMCP is an unencrypted protocol, and therefore, presents a security risk, see e.g.
     {{{ weblink("https://help.gnome.org/admin/gdm/stable/security.html.en_GB#xdmcpsecurity", "XDMCP Gnome docs") }}}.
 
     To disable XDMCP support in GDM, follow {{{ weblink("https://help.gnome.org/admin/gdm/stable/configuration.html.en#xdmcpsection", "GDM docs") }}},

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Disable XDMCP in GDM'
+
+description: |-
+    XDMCP is an unencrypted protocol, and therefore presents a security risK, see e.g.
+    {{{ weblink("https://help.gnome.org/admin/gdm/stable/security.html.en_GB#xdmcpsecurity", "XDMCP Gnome docs") }}}.
+
+    To disable XDMCP support in GDM, follow {{{ weblink("https://help.gnome.org/admin/gdm/stable/configuration.html.en#xdmcpsection", "GDM docs") }}},
+    and therefore make sure that there is the <code>Enable=false</code> line under the <code>[xdmcp]</code> configuration section in <code>/etc/gdm/custom.conf</code>
+
+rationale: |-
+    Even though your display is protected by cookies, XEvents and keystrokes typed when entering passwords
+    will still go over the network in clear text. It is trivial to capture these.
+
+    XDMCP is primarily useful for running thin clients such as in terminal labs.
+    Those thin clients will only ever need the network to access the server, and so it seems like the best security policy
+    to have those thin clients on a separate network that cannot be accessed by the outside world, and can only connect to the server.
+    The only point from which you need to access outside is the server. This type of set up should never use an unmanaged hub or other sniffable network.
+
+severity: medium
+
+ocil_clause: 'the Enable=false setting is missing in the xdmcp section of the /etc/gdm/custom.conf gdm configuration file'
+
+ocil: |-
+    Check whether there is the xdmcp section in the gdm configuration - run <code>grep '^\s*\[xdmcp\]' /etc/gdm/custom.conf</code>
+    If no results are returned, the whole section is missing, in which case you can add it to the file
+    using printf - <code>printf '%\n' "" "[xdmcp]" "Enable=false" >> /etc/gdm/custom.conf</code>
+
+    If grep returned results, you have to open the custom.conf file in a text editor,
+    and make sure that there is only one assignment to Enable,
+    namely Enable=false between the beginning of the [xdmcp] section
+    and another section or the end of the file.
+
+# There is a gdm platform implied by the parent group.
+# platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/empty.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/empty.fail.sh
@@ -2,5 +2,4 @@
 
 dnf install -y gdm
 
-mkdir -p /etc/gdm
 printf '%s\n' "# comment" "[xdmcp]" > /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/empty.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/empty.fail.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+
+dnf install -y gdm
+
+mkdir -p /etc/gdm
+printf '%s\n' "# comment" "[xdmcp]" > /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/enabled.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/enabled.fail.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+
+dnf install -y gdm
+
+mkdir -p /etc/gdm
+printf '%s\n' "# comment" "[xdmcp]" "Enable=true" > /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/missing.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/missing.fail.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+
+dnf install -y gdm
+
+mkdir -p /etc/gdm
+rm -f /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/simple.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/simple.pass.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+
+dnf install -y gdm
+
+mkdir -p /etc/gdm
+printf '%s\n' "# comment" "[xdmcp]" "# Enable=true" "Enable=false" > /etc/gdm/custom.conf

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -547,3 +547,15 @@ See official documentation: https://jinja.palletsprojects.com/en/2.11.x/template
     - test_id_provider.stdout is defined
     - test_id_provider.stdout | length < 1
 {{%- endmacro %}}
+
+
+{{% macro ansible_ini_file_set(filename, section, key, value, description="") -%}}
+- name: "{{{ description if description else ("Set '" + key + "' to '" + value + "' in the [" + section + "] section of '" + filename + "'") }}}"
+  ini_file:
+    path: "{{{ filename }}}"
+    section: "{{{ section }}}"
+    option: "{{{ key }}}"
+    value: "{{{ value }}}"
+    create: yes
+    mode: 0644
+{{%- endmacro %}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -583,3 +583,16 @@ EOF
 {{% macro bash_deregexify_banner_backslash(banner_var_name) -%}}
 {{{ banner_var_name }}}=$(echo "${{{ banner_var_name }}}" | sed 's/\\//g')
 {{%- endmacro %}}
+
+{{% macro bash_ini_file_set(filename, section, key, value) -%}}
+# Try find '[{{{ section }}}]' and '{{{ key }}}' in '{{{ filename }}}', if it exists, set
+# to '{{{ value }}}', if it isn't here, add it, if '[{{{ section }}}]' doesn't exist, add it there
+if grep -qzosP '[[:space:]]*\[{{{ section }}}]([^\n\[]*\n+)+?[[:space:]]*{{{ key }}}' '{{{ filename }}}'; then
+    sed -i 's/{{{ key }}}[^(\n)]*/{{{ key }}}={{{ value }}}/' '{{{ filename }}}'
+elif grep -qs '[[:space:]]*\[{{{ section }}}]' '{{{ filename }}}'; then
+    sed -i '/[[:space:]]*\[{{{ section }}}]/a {{{ key }}}={{{ value }}}' '{{{ filename }}}'
+else
+    mkdir -p {{{ "/".join(filename.split("/")[:-1]) }}}
+    printf '%s\n' '[{{{ section }}}]' '{{{ key }}}={{{ value }}}' >> '{{{ filename }}}'
+fi
+{{%- endmacro %}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -585,6 +585,7 @@ EOF
 {{%- endmacro %}}
 
 {{% macro bash_ini_file_set(filename, section, key, value) -%}}
+{{% set config_dir = "/".join(filename.split("/")[:-1]) %}}
 # Try find '[{{{ section }}}]' and '{{{ key }}}' in '{{{ filename }}}', if it exists, set
 # to '{{{ value }}}', if it isn't here, add it, if '[{{{ section }}}]' doesn't exist, add it there
 if grep -qzosP '[[:space:]]*\[{{{ section }}}]([^\n\[]*\n+)+?[[:space:]]*{{{ key }}}' '{{{ filename }}}'; then
@@ -592,7 +593,10 @@ if grep -qzosP '[[:space:]]*\[{{{ section }}}]([^\n\[]*\n+)+?[[:space:]]*{{{ key
 elif grep -qs '[[:space:]]*\[{{{ section }}}]' '{{{ filename }}}'; then
     sed -i '/[[:space:]]*\[{{{ section }}}]/a {{{ key }}}={{{ value }}}' '{{{ filename }}}'
 else
-    mkdir -p {{{ "/".join(filename.split("/")[:-1]) }}}
-    printf '%s\n' '[{{{ section }}}]' '{{{ key }}}={{{ value }}}' >> '{{{ filename }}}'
+    if test -d "{{{ config_dir }}}"; then
+        printf '%s\n' '[{{{ section }}}]' '{{{ key }}}={{{ value }}}' >> '{{{ filename }}}'
+    else
+        echo "Config file directory '{{{ config_dir }}}' doesnt exist, not remediating, assuming non-applicability." >&2
+    fi
 fi
 {{%- endmacro %}}


### PR DESCRIPTION
Introduce a new rule to disable the insecure xdmcp.

TBD:

- [x] Ansible remediation
- [x] Make the Bash ini snippet a jinja macro.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1807173