### PR TITLE
Update accounts_passwords_pam_faillock_unlock_time to work with "never" as value

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -38,7 +38,7 @@
     <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_unlock_time_system-auth" version="2">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*unlock_time=(\w*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
@@ -50,7 +50,7 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_password-auth" version="2">
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authfail_unlock_time_password-auth" version="2">
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:sufficient)|(?:\[default=die\]))\s+pam_faillock\.so\s+authfail.*unlock_time=(\w*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -40,25 +40,25 @@
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*unlock_time=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*unlock_time=(\w*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" version="2">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:sufficient)|(?:\[default=die\]))\s+pam_faillock\.so\s+authfail.*unlock_time=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:sufficient)|(?:\[default=die\]))\s+pam_faillock\.so\s+authfail.*unlock_time=(\w*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_password-auth" version="2">
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:sufficient)|(?:\[default=die\]))\s+pam_faillock\.so\s+authfail.*unlock_time=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:sufficient)|(?:\[default=die\]))\s+pam_faillock\.so\s+authfail.*unlock_time=(\w*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" version="2">
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*unlock_time=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+(?:(?:required))\s+pam_faillock\.so\s+preauth.*unlock_time=(\w*).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -10,33 +10,53 @@
       </affected>
       <description>The number of allowed failed logins should be set correctly.</description>
     </metadata>
-    <criteria>
-      <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_system-auth" />
-      <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" />
-      <criterion comment="authfail default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_unlock_time_password-auth" />
-      <criterion comment="preauth default is set to 604800" test_ref="test_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" />
+    <criteria operator="OR">
+        <!-- We divide the checking domain space in two,
+        1. when the target unlock_time is zero, we are only looking for zero or never in the config files,
+        2. When the target unlock_time is not zero, the unlock_time in the config files can be zero or never (as it is the most secure value), or greater than or equal the target_unlock time -->
+      <criteria comment="When target unlock_time is zero, all configs must be zero or never">
+        <criterion comment="Is target unlock time zero?" test_ref="test_var_faillock_unlock_time_is_never" />
+        <criterion comment="Test if config is zero or never" test_ref="test_accounts_passwords_pam_faillock_unlock_time_is_never" />
+      </criteria>
+      <criteria comment="When target unlock_time is not zero, configs should be zero or never, or greater than or equal the policy target">
+        <criterion comment="Is target unlock time zero?" test_ref="test_var_faillock_unlock_time_is_never" negate="true"/>
+        <criterion comment="Test if config is greater than or equals the target unlock time" test_ref="test_accounts_passwords_pam_faillock_unlock_time_greater_or_equal_policy_target" />
+      </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_system-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_greater_or_equal_policy_target" state_operator="OR" version="3">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_greater_or_equal_than_target" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_never" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check authfail maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" version="2">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_is_never" version="3">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_never" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check authfail maximum failed login attempts allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_unlock_time_password-auth" version="2">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_password-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
-  </ind:textfilecontent54_test>
+  <!-- OVAL allows only two reference objects in a set, so we create the set in two stages -->
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time" version="2">
+    <set>
+      <object_reference>object_accounts_passwords_pam_faillock_unlock_time_system-auth</object_reference>
+      <object_reference>object_accounts_passwords_pam_faillock_unlock_time_password-auth</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" version="2">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
-  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
+    <set>
+      <object_reference>object_accounts_passwords_pam_faillock_preauth_unlock_time_system-auth</object_reference>
+      <object_reference>object_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_password-auth" version="2">
+    <set>
+      <object_reference>object_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth</object_reference>
+      <object_reference>object_accounts_passwords_pam_faillock_authfail_unlock_time_password-auth</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_unlock_time_system-auth" version="2">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
@@ -62,9 +82,27 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_var" version="2">
+  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_greater_or_equal_than_target" version="2">
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
   </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_never" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^0$|^never$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:variable_test id="test_var_faillock_unlock_time_is_never" version="1" check="all"
+  comment="Check if policy target unlock time to be never">
+    <ind:object object_ref="object_var_faillock_unlock_time" />
+    <ind:state state_ref="state_var_faillock_unlock_time_is_never" />
+  </ind:variable_test>
+
+  <ind:variable_object id="object_var_faillock_unlock_time" version="1">
+    <ind:var_ref>var_accounts_passwords_pam_faillock_unlock_time</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_var_faillock_unlock_time_is_never" version="1">
+    <ind:value datatype="int" operation="equals">0</ind:value>
+  </ind:variable_state>
 
   <external_variable comment="number of failed login attempts allowed" datatype="int" id="var_accounts_passwords_pam_faillock_unlock_time" version="2" />
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -8,7 +8,7 @@
         <platform>multi_platform_rhv</platform>
         <platform>multi_platform_ol</platform>
       </affected>
-      <description>The number of allowed failed logins should be set correctly.</description>
+      <description>The unlock time after number of failed logins should be set correctly.</description>
     </metadata>
     <criteria operator="OR">
         <!-- We divide the checking domain space in two,

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -12,31 +12,38 @@
     </metadata>
     <criteria operator="OR">
         <!-- We divide the checking domain space in two,
-        1. when the target unlock_time is zero, we are only looking for zero or never in the config files,
-        2. When the target unlock_time is not zero, the unlock_time in the config files can be zero or never (as it is the most secure value), or greater than or equal the target_unlock time -->
-      <criteria comment="When target unlock_time is zero, all configs must be zero or never">
-        <criterion comment="Is target unlock time zero?" test_ref="test_var_faillock_unlock_time_is_never" />
+        1. when the ext var unlock_time is zero, we are only looking for zero or never in the config files,
+        2. When the ext var unlock_time is not zero, the unlock_time in the config files can be zero or never
+           (as it is the most secure value), or greater than or equal the ext var unlock time -->
+      <criteria comment="When ext var unlock_time is zero, all configs must be zero or never">
+        <criterion comment="Is ext var unlock time zero?" test_ref="test_var_faillock_unlock_time_is_never" />
         <criterion comment="Test if config is zero or never" test_ref="test_accounts_passwords_pam_faillock_unlock_time_is_never" />
       </criteria>
-      <criteria comment="When target unlock_time is not zero, configs should be zero or never, or greater than or equal the policy target">
-        <criterion comment="Is target unlock time zero?" test_ref="test_var_faillock_unlock_time_is_never" negate="true"/>
-        <criterion comment="Test if config is greater than or equals the target unlock time" test_ref="test_accounts_passwords_pam_faillock_unlock_time_greater_or_equal_policy_target" />
+      <criteria comment="When ext var unlock_time is not zero, configs should be zero or never, or greater than or equal the external variable">
+        <criterion comment="Is ext var unlock time different than zero?" test_ref="test_var_faillock_unlock_time_is_never" negate="true"/>
+        <criterion comment="Test if config is greater than or equals the ext var unlock time" test_ref="test_accounts_passwords_pam_faillock_unlock_time_greater_or_equal_ext_var" />
       </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_greater_or_equal_policy_target" state_operator="OR" version="3">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="Check if unlock time is never, or greater than or equal external variable"
+      id="test_accounts_passwords_pam_faillock_unlock_time_greater_or_equal_ext_var"
+      state_operator="OR" version="3">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time" />
-    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_greater_or_equal_than_target" />
-    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_never" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_greater_or_equal_than_ext_var" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_is_never" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_is_never" version="3">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="Check if unlock time is never"
+      id="test_accounts_passwords_pam_faillock_unlock_time_is_never" version="3">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time" />
-    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_never" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_is_never" />
   </ind:textfilecontent54_test>
 
   <!-- OVAL allows only two reference objects in a set, so we create the set in two stages -->
+  <!-- The collected object is always the same, the value of unlock_time -->
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time" version="2">
     <set>
       <object_reference>object_accounts_passwords_pam_faillock_unlock_time_system-auth</object_reference>
@@ -82,16 +89,16 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_greater_or_equal_than_target" version="2">
+  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_greater_or_equal_than_ext_var" version="2">
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
   </ind:textfilecontent54_state>
 
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_never" version="1">
+  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_is_never" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^0$|^never$</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <ind:variable_test id="test_var_faillock_unlock_time_is_never" version="1" check="all"
-  comment="Check if policy target unlock time to be never">
+  comment="Check if external variable unlock time is never">
     <ind:object object_ref="object_var_faillock_unlock_time" />
     <ind:state state_ref="state_var_faillock_unlock_time_is_never" />
   </ind:variable_test>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -20,22 +20,22 @@
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_system-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_system-auth" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check authfail maximum failed login attempts allowed in /etc/pam.d/system-auth" id="test_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_authfail_unlock_time_system-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_system-auth" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check authfail maximum failed login attempts allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_unlock_time_password-auth" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_password-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_password-auth" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check preauth maximum failed login attempts allowed in /etc/pam.d/password-auth" id="test_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_preauth_unlock_time_password-auth" />
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_password-auth" />
+    <ind:state state_ref="state_accounts_passwords_pam_unlock_time_var" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
@@ -62,11 +62,7 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
-    <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
-  </ind:textfilecontent54_state>
-
-  <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_unlock_time_password-auth" version="2">
+  <ind:textfilecontent54_state id="state_accounts_passwords_pam_unlock_time_var" version="2">
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
   </ind:textfilecontent54_state>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -63,11 +63,11 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_unlock_time_system-auth" version="2">
-    <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
+    <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
   </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_state id="state_accounts_passwords_pam_faillock_unlock_time_password-auth" version="2">
-    <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
+    <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_accounts_passwords_pam_faillock_unlock_time" />
   </ind:textfilecontent54_state>
 
   <external_variable comment="number of failed login attempts allowed" datatype="int" id="var_accounts_passwords_pam_faillock_unlock_time" version="2" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_0.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_0.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# value of var_accounts_passwords_pam_faillock_unlock_time for PCI-DSS profile is 1800
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"0" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"0" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_1800.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_1800.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# value of var_accounts_passwords_pam_faillock_unlock_time for PCI-DSS profile is 1800
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"1800" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"1800" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_3600.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_3600.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# value of var_accounts_passwords_pam_faillock_unlock_time for PCI-DSS profile is 1800
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"3600" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"3600" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_3600_except_one.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_3600_except_one.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# value of var_accounts_passwords_pam_faillock_unlock_time for PCI-DSS profile is 1800
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"3600" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"3600" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done
+
+sed -i --follow-symlinks 's/\(.*pam_faillock.so preauth silent '"unlock_time"'='"\)3600/\\1600/" "/etc/pam.d/system-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_600.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_600.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# value of var_accounts_passwords_pam_faillock_unlock_time for PCI-DSS profile is 1800
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"600" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"600" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_never.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_1800_and_config_never.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# profiles = xccdf_org.ssgproject.content_profile_pci-dss
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# value of var_accounts_passwords_pam_faillock_unlock_time for PCI-DSS profile is 1800
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"never" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"never" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_default_and_config_0.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_default_and_config_0.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# default value of var_accounts_passwords_pam_faillock_unlock_time is 0
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"0" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"0" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_default_and_config_600.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_default_and_config_600.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# default value of var_accounts_passwords_pam_faillock_unlock_time is 0
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"600" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"600" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_default_and_config_never.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/var_default_and_config_never.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+auth_files[0]="/etc/pam.d/system-auth"
+auth_files[1]="/etc/pam.d/password-auth"
+
+# Make sure pam_faillock is configured,
+# default value of var_accounts_passwords_pam_faillock_unlock_time is 0
+for file in "${auth_files[@]}" ; do
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent '"unlock_time"'='"never" "$file"
+    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        [default=die] pam_faillock.so authfail '"unlock_time"'='"never" "$file"
+    sed -E -i --follow-symlinks '/^\s*account\s*required\s*pam_unix.so/i account     required      pam_faillock.so' "$file"
+done


### PR DESCRIPTION
#### Description:
- Fixes a bug in the logic for unlock_time, the higher the unlock time, the more secure it it.
- Fixes the OVAL check to accept "never" in the config files.
- Adds test scenarios for the rule

#### Rationale:
- Fixes #5544