### PR TITLE
Add policy tracking metadata

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -677,7 +677,11 @@ A profile should define these attributes:
 * `title`: Human-readable title of the profile.
 * `description`: Human-readable HTML description, which provides broader context for non-experts than the rationale.
 * `extends`: The `id` of a profile to be extended. A profile can make incremental changes based on another profile, via `extends` attribute. The extendee can then, via the `selections` attribute, select/unselect rules and change XCCDF Value selectors.
-* `selections`: List of rule `id`s to be included in the profile, or changes to XCCDF Value selectors.
+* `selections`: List composed of items of these types:
+  * `id`s of rules to be included in the profile, e.g. `accounts_tmout`, or
+  * `id`s of rules to be excluded from the profile prefixed by an exclamation mark, e.g. `!accounts_tmout`, or
+  * changes to XCCDF Value selectors, e.g. `var_accounts_tmout=10_min`, or
+  * rule refinements, e.g. `accounts_tmout.severity=high`.
 
 == Updating Reference and Overlay Content
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -670,7 +670,7 @@ A profile YAML file can, optionally, include metadata about its maintainers and 
 * `metadata`: Dictionary for profile metadata.
   * `policy_hub`: URL pointing to page or organization that publishes the policy.
   * `current_version`: Version of the policy implemented by the profile.
-  * `maintainers`: List of people maintaining, responsible or experienced in the profile.
+  * `maintainers`: List of people maintaining, responsible or experienced in the profile. The prefered method is the GitHub handle, but email is also accepted.
 
 A profile should define these attributes:
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -670,7 +670,7 @@ A profile YAML file can, optionally, include metadata about the implemented poli
 * `metadata`: Dictionary for profile metadata.
   * `reference`: URL pointing to page or organization that publishes the policy.
   * `version`: Version of the policy implemented by the profile.
-  * `SMEs`: List of people experienced with the profile, or how they are applied. The prefered method is the GitHub handle, but email is also accepted.
+  * `SMEs`: List of people experienced with the profile, or how they are applied. The preferred method is the GitHub handle, but email is also accepted.
 
 A profile should define these attributes:
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -665,12 +665,12 @@ A profile YAML file has one implied attribute:
 
 * `id`: The primary identifier for the profile, to be referenced during evaluations. This is inferred from the file name.
 
-A profile YAML file can, optionally, include metadata about its maintainers and the implemented policy:
+A profile YAML file can, optionally, include metadata about the implemented policy and experts in the field, called Subject Matter Experts (SMEs). The SMEs usually are people familiar with the policy requirements or how it is applied.
 
 * `metadata`: Dictionary for profile metadata.
   * `reference`: URL pointing to page or organization that publishes the policy.
   * `version`: Version of the policy implemented by the profile.
-  * `maintainers`: List of people maintaining, responsible or experienced in the profile. The prefered method is the GitHub handle, but email is also accepted.
+  * `SMEs`: List of people experienced with the profile, or how they are applied. The prefered method is the GitHub handle, but email is also accepted.
 
 A profile should define these attributes:
 

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -656,6 +656,29 @@ For any of the `[red]#Required#` directories that may not yet add content,
 add a `.gitkeep` file for any empty directories.
 ====
 
+=== Profiles
+
+Profiles define the set of rules and variables aligned to a compliance standard.
+
+Structurally, a profile is a YAML file that represents a dictionary.
+A profile YAML file has one implied attribute:
+
+* `id`: The primary identifier for the profile, to be referenced during evaluations. This is inferred from the file name.
+
+A profile YAML file can, optionally, include metadata about its maintainers and the implemented policy:
+
+* `metadata`: Dictionary for profile metadata.
+  * `policy_hub`: URL pointing to page or organization that publishes the policy.
+  * `current_version`: Version of the policy implemented by the profile.
+  * `maintainers`: List of people maintaining, responsible or experienced in the profile.
+
+A profile should define these attributes:
+
+* `title`: Human-readable title of the profile.
+* `description`: Human-readable HTML description, which provides broader context for non-experts than the rationale.
+* `extends`: The `id` of a profile to be extended. A profile can make incremental changes based on another profile, via `extends` attribute. The extendee can then, via the `selections` attribute, select/unselect rules and change XCCDF Value selectors.
+* `selections`: List of rule `id`s to be included in the profile, or changes to XCCDF Value selectors.
+
 == Updating Reference and Overlay Content
 
 === Reference Content

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -668,8 +668,8 @@ A profile YAML file has one implied attribute:
 A profile YAML file can, optionally, include metadata about its maintainers and the implemented policy:
 
 * `metadata`: Dictionary for profile metadata.
-  * `policy_hub`: URL pointing to page or organization that publishes the policy.
-  * `current_version`: Version of the policy implemented by the profile.
+  * `reference`: URL pointing to page or organization that publishes the policy.
+  * `version`: Version of the policy implemented by the profile.
   * `maintainers`: List of people maintaining, responsible or experienced in the profile. The prefered method is the GitHub handle, but email is also accepted.
 
 A profile should define these attributes:

--- a/ocp4/profiles/e8.profile
+++ b/ocp4/profiles/e8.profile
@@ -1,5 +1,11 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - shaneboulden
+
+reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-linux-environments
+
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - JAORMX
+        - mrogers950
+
+reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
+
 title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift'
 
 description: |-

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -4,6 +4,7 @@ metadata:
     SMEs:
         - JAORMX
         - mrogers950
+        - redhatrises
 
 reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
 

--- a/ocp4/profiles/ncp.profile
+++ b/ocp4/profiles/ncp.profile
@@ -1,5 +1,9 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - redhatrises
+
 title: 'NIST National Checklist for Red Hat OpenShift Container Platform'
 
 description: |-

--- a/rhcos4/profiles/e8.profile
+++ b/rhcos4/profiles/e8.profile
@@ -1,5 +1,11 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - shaneboulden
+
+reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-linux-environments
+
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -1,9 +1,10 @@
 documentation_complete: true
 
 metadata:
-    reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
     SMEs:
         - mrogers950
+
+reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
 
 title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS'
 

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -1,8 +1,7 @@
 documentation_complete: true
 
 metadata:
-    policy_hub: https://www.fedramp.gov/documents/
-    current_version: N/A
+    reference: https://www.fedramp.gov/documents/
     maintainers:
         - mrogers950
 

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -2,7 +2,7 @@ documentation_complete: true
 
 metadata:
     reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
-    maintainers:
+    SMEs:
         - mrogers950
 
 title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS'

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 metadata:
-    reference: https://www.fedramp.gov/documents/
+    reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
     maintainers:
         - mrogers950
 

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - JAORMX
         - mrogers950
 
 reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -1,5 +1,11 @@
 documentation_complete: true
 
+metadata:
+    policy_hub: https://www.fedramp.gov/documents/
+    current_version: N/A
+    maintainers:
+        - mrogers950
+
 title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS'
 
 description: |-

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -4,6 +4,7 @@ metadata:
     SMEs:
         - JAORMX
         - mrogers950
+        - redhatrises
 
 reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
 

--- a/rhcos4/profiles/ncp.profile
+++ b/rhcos4/profiles/ncp.profile
@@ -1,5 +1,9 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - redhatrises
+
 title: 'NIST National Checklist for Red Hat Enterprise Linux CoreOS'
 
 description: |-

--- a/rhel7/profiles/C2S.profile
+++ b/rhel7/profiles/C2S.profile
@@ -1,5 +1,10 @@
 documentation_complete: true
 
+metadata:
+    version: TBD
+    SMEs:
+        - redhatrises
+
 title: 'C2S for Red Hat Enterprise Linux 7'
 
 description: |-

--- a/rhel7/profiles/cis.profile
+++ b/rhel7/profiles/cis.profile
@@ -6,7 +6,8 @@ metadata:
         - vojtapolasek
         - yuumasato
 
-reference: TODO
+reference: https://www.cisecurity.org/cis-benchmarks/#red_hat_linux
+
 
 title: 'CIS Red Hat Enterprise Linux 7 Benchmark'
 

--- a/rhel7/profiles/cis.profile
+++ b/rhel7/profiles/cis.profile
@@ -1,5 +1,13 @@
 documentation_complete: true
 
+metadata:
+    version: 2.2.0
+    SMEs:
+        - vojtapolasek
+        - yuumasato
+
+reference: TODO
+
 title: 'CIS Red Hat Enterprise Linux 7 Benchmark'
 
 description: |-

--- a/rhel7/profiles/cjis.profile
+++ b/rhel7/profiles/cjis.profile
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+metadata:
+    version: 5.4
+    SMEs:
+        - redhatrises
+
+reference: https://www.fbi.gov/services/cjis/cjis-security-policy-resource-center
+
 title: 'Criminal Justice Information Services (CJIS) Security Policy'
 
 description: |-

--- a/rhel7/profiles/cui.profile
+++ b/rhel7/profiles/cui.profile
@@ -1,5 +1,10 @@
 documentation_complete: true
 
+metadata:
+    version: TBD
+    SMEs:
+        - redhatrises
+
 title: 'Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)'
 
 description: |-

--- a/rhel7/profiles/e8.profile
+++ b/rhel7/profiles/e8.profile
@@ -1,5 +1,11 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - shaneboulden
+
+reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-linux-environments
+
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-

--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -1,5 +1,11 @@
 documentation_complete: True
 
+metadata:
+    SMEs:
+        - jjaswanson4
+
+reference: https://www.hhs.gov/hipaa/for-professionals/index.html
+
 title: 'Health Insurance Portability and Accountability Act (HIPAA)'
 
 description: |-

--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -3,6 +3,7 @@ documentation_complete: True
 metadata:
     SMEs:
         - jjaswanson4
+        - redhatrises
 
 reference: https://www.hhs.gov/hipaa/for-professionals/index.html
 

--- a/rhel7/profiles/ncp.profile
+++ b/rhel7/profiles/ncp.profile
@@ -1,5 +1,9 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - redhatrises
+
 title: 'NIST National Checklist Program Security Guide'
 
 description: |-

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -1,5 +1,13 @@
 documentation_complete: true
 
+metadata:
+    version: 4.2.1
+    SMEs:
+        - stevegrubb
+        - redhatrises
+
+reference: https://www.niap-ccevs.org/Profile/PP.cfm
+
 title: 'OSPP - Protection Profile for General Purpose Operating Systems v4.2.1'
 
 description: |-

--- a/rhel7/profiles/ospp.profile
+++ b/rhel7/profiles/ospp.profile
@@ -3,8 +3,9 @@ documentation_complete: true
 metadata:
     version: 4.2.1
     SMEs:
-        - stevegrubb
+        - comps
         - redhatrises
+        - stevegrubb
 
 reference: https://www.niap-ccevs.org/Profile/PP.cfm
 

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+metadata:
+    version: V2R8
+    SMEs:
+        - redhatrises
+
+reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+
 title: 'DISA STIG for Red Hat Enterprise Linux 7'
 
 description: |-

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -1,5 +1,13 @@
 documentation_complete: true
 
+metadata:
+    version: 1.1.0
+    SMEs:
+        - vojtapolasek
+        - yuumasato
+
+reference: https://www.cisecurity.org/cis-benchmarks/#red_hat_linux
+
 title: 'CIS Red Hat Enterprise Linux 8 Benchmark'
 
 description: |-

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -6,7 +6,7 @@ metadata:
         - vojtapolasek
         - yuumasato
 
-reference: https://www.cisecurity.org/cis-benchmarks/#red_hat_linux
+reference: https://www.cisecurity.org/benchmark/red_hat_linux/
 
 title: 'CIS Red Hat Enterprise Linux 8 Benchmark'
 

--- a/rhel8/profiles/cjis.profile
+++ b/rhel8/profiles/cjis.profile
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+metadata:
+    version: 5.4
+    SMEs:
+        - redhatrises
+
+reference: https://www.fbi.gov/services/cjis/cjis-security-policy-resource-center
+
 title: 'Criminal Justice Information Services (CJIS) Security Policy'
 
 description: |-

--- a/rhel8/profiles/cui.profile
+++ b/rhel8/profiles/cui.profile
@@ -1,5 +1,10 @@
 documentation_complete: true
 
+metadata:
+    version: TBD
+    SMEs:
+        - redhatrises
+
 title: 'Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)'
 
 description: |-

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 metadata:
-    reference: https://www.cyber.gov.au/acsc/view-all-content/essential-eight
+    reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-linux-environments
     SMEs:
         - shaneboulden
 

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -1,9 +1,10 @@
 documentation_complete: true
 
 metadata:
-    reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-linux-environments
     SMEs:
         - shaneboulden
+
+reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-linux-environments
 
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -2,7 +2,7 @@ documentation_complete: true
 
 metadata:
     reference: https://www.cyber.gov.au/acsc/view-all-content/essential-eight
-    maintainers:
+    SMEs:
         - shaneboulden
 
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -1,8 +1,7 @@
 documentation_complete: true
 
 metadata:
-    policy_hub: https://www.cyber.gov.au/acsc/view-all-content/essential-eight
-    current_version: N/A
+    reference: https://www.cyber.gov.au/acsc/view-all-content/essential-eight
     maintainers:
         - shaneboulden
 

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -1,5 +1,11 @@
 documentation_complete: true
 
+metadata:
+    policy_hub: https://www.cyber.gov.au/acsc/view-all-content/essential-eight
+    current_version: N/A
+    maintainers:
+        - shaneboulden
+
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -1,5 +1,11 @@
 documentation_complete: True
 
+metadata:
+    SMEs:
+        - jjaswanson4
+
+reference: https://www.hhs.gov/hipaa/for-professionals/index.html
+
 title: 'Health Insurance Portability and Accountability Act (HIPAA)'
 
 description: |-

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -3,6 +3,7 @@ documentation_complete: True
 metadata:
     SMEs:
         - jjaswanson4
+        - redhatrises
 
 reference: https://www.hhs.gov/hipaa/for-professionals/index.html
 

--- a/rhel8/profiles/ism_o.profile
+++ b/rhel8/profiles/ism_o.profile
@@ -1,5 +1,13 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - shaneboulden
+        - wcushen
+        - ahamilto156
+
+reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential-eight-linux-environments
+
 title: 'Australian Cyber Security Centre (ACSC) Information Security Manual (ISM) Official'
 
 description: |-

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -4,6 +4,7 @@ metadata:
     version: 4.2.1
     SMEs:
         - stevegrubb
+        - redhatrises
 
 reference: https://www.niap-ccevs.org/Profile/PP.cfm
 

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 metadata:
     reference: https://www.niap-ccevs.org/Profile/PP.cfm
     version: 4.2.1
-    maintainers:
+    SMEs:
         - stevegrubb
 
 title: 'Protection Profile for General Purpose Operating Systems'

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -1,10 +1,11 @@
 documentation_complete: true
 
 metadata:
-    reference: https://www.niap-ccevs.org/Profile/PP.cfm
     version: 4.2.1
     SMEs:
         - stevegrubb
+
+reference: https://www.niap-ccevs.org/Profile/PP.cfm
 
 title: 'Protection Profile for General Purpose Operating Systems'
 

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -1,5 +1,11 @@
 documentation_complete: true
 
+metadata:
+    policy_hub: https://www.niap-ccevs.org/Profile/PP.cfm
+    current_version: 4.2.1
+    maintainers:
+        - stevegrubb
+
 title: 'Protection Profile for General Purpose Operating Systems'
 
 description: |-

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -1,8 +1,8 @@
 documentation_complete: true
 
 metadata:
-    policy_hub: https://www.niap-ccevs.org/Profile/PP.cfm
-    current_version: 4.2.1
+    reference: https://www.niap-ccevs.org/Profile/PP.cfm
+    version: 4.2.1
     maintainers:
         - stevegrubb
 

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -3,8 +3,9 @@ documentation_complete: true
 metadata:
     version: 4.2.1
     SMEs:
-        - stevegrubb
+        - comps
         - redhatrises
+        - stevegrubb
 
 reference: https://www.niap-ccevs.org/Profile/PP.cfm
 

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -1,5 +1,11 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - redhatrises
+
+reference: https://www.hhs.gov/hipaa/for-professionals/index.html
+
 title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 8'
 
 description: |-

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 metadata:
     reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
     version: V1R0.1-Draft
-    maintainers:
+    SMEs:
         - redhatrises
         - tedbrunell
 

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -1,8 +1,8 @@
 documentation_complete: true
 
 metadata:
-    policy_hub: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
-    current_version: V1R0.1-Draft
+    reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+    version: V1R0.1-Draft
     maintainers:
         - redhatrises
         - tedbrunell

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+metadata:
+    policy_hub: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+    current_version: V1R0.1-Draft
+    maintainers:
+        - redhatrises
+        - tedbrunell
+
 title: '[DRAFT] DISA STIG for Red Hat Enterprise Linux 8'
 
 description: |-

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -4,7 +4,6 @@ metadata:
     version: V1R0.1-Draft
     SMEs:
         - redhatrises
-        - tedbrunell
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -1,11 +1,12 @@
 documentation_complete: true
 
 metadata:
-    reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
     version: V1R0.1-Draft
     SMEs:
         - redhatrises
         - tedbrunell
+
+reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
 title: '[DRAFT] DISA STIG for Red Hat Enterprise Linux 8'
 

--- a/rhv4/profiles/rhvh-stig.profile
+++ b/rhv4/profiles/rhvh-stig.profile
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+metadata:
+    version: TBD
+    SMEs:
+        - redhatrises
+
+reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+
 title: '[DRAFT] DISA STIG for Red Hat Virtualization Host (RHVH)'
 
 description: |-

--- a/rhv4/profiles/rhvh-vpp.profile
+++ b/rhv4/profiles/rhvh-vpp.profile
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+metadata:
+    version: 1.0
+    SMEs:
+        - redhatrises
+
+reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=408&id=408
+
 title: 'VPP - Protection Profile for Virtualization v. 1.0 for Red Hat Virtualization Host (RHVH)'
 
 description: |-

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -337,8 +337,8 @@ class ResolvableProfile(Profile):
         if self.extends:
             if self.extends not in all_profiles:
                 msg = (
-                    "Profile {name} extends profile {extended}, but"
-                    "only profiles {known_profiles} are available for resolution."
+                    "Profile {name} extends profile {extended}, but "
+                    "only profiles {profiles} are available for resolution."
                     .format(name=self.id_, extended=self.extends,
                             profiles=list(all_profiles.keys())))
                 raise RuntimeError(msg)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -111,6 +111,7 @@ class Profile(object):
         self.unselected = []
         self.variables = dict()
         self.refine_rules = defaultdict(list)
+        self.metadata = None
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None):
@@ -131,10 +132,7 @@ class Profile(object):
             profile._parse_selections(selection_entries)
         del yaml_contents["selections"]
 
-        # Delete metadata keyword, at the moment this is not be included in the built profiles
-        # The goal for now is to provides development and tracking information
-        if "metadata" in yaml_contents:
-            del yaml_contents["metadata"]
+        profile.metadata = yaml_contents.pop("metadata", None)
 
         if yaml_contents:
             raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
@@ -147,6 +145,9 @@ class Profile(object):
         to_dump["documentation_complete"] = documentation_complete
         to_dump["title"] = self.title
         to_dump["description"] = self.description
+        if self.metadata is not None:
+            to_dump["metadata"] = self.metadata
+
         if self.extends is not None:
             to_dump["extends"] = self.extends
 
@@ -196,6 +197,12 @@ class Profile(object):
         title.set("override", "true")
         desc = add_sub_element(element, "description", self.description)
         desc.set("override", "true")
+
+        if self.metadata:
+            reference = self.metadata.pop("reference", None)
+            # At the moment, only 'reference' is included in the Profile XML
+            if reference is not None:
+                add_sub_element(element, "reference", reference)
 
         for selection in self.selected:
             select = ET.Element("select")

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -112,6 +112,7 @@ class Profile(object):
         self.variables = dict()
         self.refine_rules = defaultdict(list)
         self.metadata = None
+        self.reference = None
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None):
@@ -132,7 +133,11 @@ class Profile(object):
             profile._parse_selections(selection_entries)
         del yaml_contents["selections"]
 
-        profile.metadata = yaml_contents.pop("metadata", None)
+        profile.reference = yaml_contents.pop("reference", None)
+
+        # At the moment, metadata is not used to build content
+        if "metadata" in yaml_contents:
+            del yaml_contents["metadata"]
 
         if yaml_contents:
             raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
@@ -145,6 +150,7 @@ class Profile(object):
         to_dump["documentation_complete"] = documentation_complete
         to_dump["title"] = self.title
         to_dump["description"] = self.description
+        to_dump["reference"] = self.reference
         if self.metadata is not None:
             to_dump["metadata"] = self.metadata
 
@@ -198,11 +204,8 @@ class Profile(object):
         desc = add_sub_element(element, "description", self.description)
         desc.set("override", "true")
 
-        if self.metadata:
-            reference = self.metadata.pop("reference", None)
-            # At the moment, only 'reference' is included in the Profile XML
-            if reference is not None:
-                add_sub_element(element, "reference", reference)
+        if self.reference:
+            add_sub_element(element, "reference", self.reference)
 
         for selection in self.selected:
             select = ET.Element("select")

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 import datetime
 import re
 import sys
+from xml.sax.saxutils import escape
 
 import yaml
 
@@ -205,7 +206,7 @@ class Profile(object):
         desc.set("override", "true")
 
         if self.reference:
-            add_sub_element(element, "reference", self.reference)
+            add_sub_element(element, "reference", escape(self.reference))
 
         for selection in self.selected:
             select = ET.Element("select")

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -131,6 +131,11 @@ class Profile(object):
             profile._parse_selections(selection_entries)
         del yaml_contents["selections"]
 
+        # Delete metadata keyword, at the moment this is not be included in the built profiles
+        # The goal for now is to provides development and tracking information
+        if "metadata" in yaml_contents:
+            del yaml_contents["metadata"]
+
         if yaml_contents:
             raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
                                % (yaml_file, yaml_contents))


### PR DESCRIPTION
#### Description:
- Adds Policy metadata to the Profile
  - At the moment the metadata does not go into the built Profile
- [x] Metadata documentation

#### Rationale:
-  To make it easier to understand:
  - What policy a Profile follows, and where one can access it;
  - What is the implemented Policy version;
  - Who are the people involved with the profile (stakeholders, SMEs, field representatives);
