### PR TITLE
Added SRG to configure_ssh_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 references:
     nist: AC-17(a),AC-17(2),CM-6(a),MA-4(6),SC-13
     cis@rhel8: 5.2.20
+    srg: SRG-OS-000250-GPOS-00093
 
 ocil_clause: 'the CRYPTO_POLICY variable is not set or is commented in the /etc/sysconfig/sshd'
 


### PR DESCRIPTION
It's a generic OS one, used also in other crypto policies rules.

https://www.stigviewer.com/stig/general_purpose_operating_system_srg/2016-04-25/finding/V-56935