### PR TITLE
Update RHEL7 STIG profile to use pam unlock_time=900.

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -29,7 +29,7 @@ selections:
     - var_password_pam_ocredit=1
     - var_password_pam_lcredit=1
     - var_password_pam_ucredit=1
-    - var_accounts_passwords_pam_faillock_unlock_time=never
+    - var_accounts_passwords_pam_faillock_unlock_time=900
     - var_accounts_passwords_pam_faillock_fail_interval=900
     - var_accounts_passwords_pam_faillock_deny=3
     - var_password_pam_unix_remember=5


### PR DESCRIPTION
#### Description:

- Per: [V-71943](https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71943?version=v2r7) the `unlock_time` should be maximum of `900`, which means any value less equal than that is accepted by the check. Unless there is something wrong with this STIG item, I'd say it's reasonable to have it like this.