### PR TITLE
Fixed dconf_gnome_screensaver_idle_activation_enabled wrt RHEL7 STIG

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
@@ -36,7 +36,7 @@ identifiers:
     cce@rhel8: CCE-80774-3
 
 references:
-    stigid@ol7: OL07-00-010100
+    stigid@ol7: OL07-00-010070
     cjis: 5.5.5
     cui: 3.1.10
     disa: CCI-000057
@@ -45,7 +45,7 @@ references:
     ospp: FMT_MOF_EXT.1
     pcidss: Req-8.1.8
     srg: SRG-OS-000029-GPOS-00010
-    stigid@rhel7: RHEL-07-010100
+    stigid@rhel7: RHEL-07-010070
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
     cobit5: DSS05.04,DSS05.10,DSS06.10

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/var_screensaver_lock_delay.var
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/var_screensaver_lock_delay.var
@@ -15,3 +15,4 @@ options:
     5_seconds: 5
     default: "0"
     immediate: "0"
+    15_minutes: 900

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -19,7 +19,6 @@ description: |-
 selections:
     - login_banner_text=dod_banners
     - inactivity_timeout_value=15_minutes
-    - var_screensaver_lock_delay=5_seconds
     - sshd_idle_timeout_value=10_minutes
     - sshd_approved_macs=stig
     - var_accounts_fail_delay=4
@@ -66,6 +65,7 @@ selections:
     - dconf_gnome_screensaver_lock_locked
     - dconf_gnome_enable_smartcard_auth
     - dconf_gnome_screensaver_idle_delay
+    - var_screensaver_lock_delay=15_minutes
     - package_screen_installed
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_activation_locked


### PR DESCRIPTION
- Fixed the STIG ID.
- Adjusted the timeout to the STIG value.

https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71893?version=v2r7