### PR TITLE
Add Fedora product to package_bind_removed rule prodtype

### DIFF
--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel6,rhel7,rhel8,rhv4
+prodtype: fedora,rhcos4,ol7,ol8,rhel6,rhel7,rhel8,rhv4
 
 title: 'Uninstall bind Package'
 


### PR DESCRIPTION
#### Description:
Adds `fedora` to `prodype` of `package_bind_rule` rule.

#### Rationale:
The `package_bind_rule` rule is used by [configure_bind_crypto_policy](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml#L9) rule used in Fedora OSPP profile. The `package_bind_rule` rule needs to have `fedora` in `prodtype` to be included in Fedora datastream.
