### PR TITLE
Select sshd_disable_rhosts in RHEL7 STIG profile.

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -241,6 +241,7 @@ selections:
     - sshd_required=yes
     - service_sshd_enabled
     - sshd_set_idle_timeout
+    - sshd_disable_rhosts
     - sshd_disable_rhosts_rsa
     - sshd_set_keepalive
     - sshd_print_last_log


### PR DESCRIPTION
Rule was missing in the RHEL 7 STIG profile.

Reference:
https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72243?version=v2r7

