### PR TITLE
Select sshd_disable_user_known_hosts in RHEL7 STIG profile.

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -254,6 +254,7 @@ selections:
     - sshd_enable_strictmodes
     - sshd_use_priv_separation
     - sshd_disable_compression
+    - sshd_disable_user_known_hosts
     - chronyd_or_ntpd_set_maxpoll
     - configure_firewalld_rate_limiting
     - service_firewalld_enabled


### PR DESCRIPTION
The rule was missing in the profile selection:

https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72249?version=v2r7
