### PR TITLE
Update OVAL check and remediations for sshd_use_priv_separation.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+- (xccdf-var var_sshd_priv_separation)
+
+{{{ ansible_sshd_set(parameter="UsePrivilegeSeparation", value="{{ var_sshd_priv_separation }}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/rule.yml
@@ -42,11 +42,3 @@ ocil: |-
     following command:
     <pre>$ sudo grep UsePrivilegeSeparation /etc/ssh/sshd_config</pre>
     If configured properly, output should be <tt><sub idref="var_sshd_priv_separation" /></tt>.
-
-template:
-    name: sshd_lineinfile
-    vars:
-        missing_parameter_pass: 'false'
-        parameter: UsePrivilegeSeparation
-        rule_id: sshd_use_priv_separation
-        value: sandbox


### PR DESCRIPTION
#### Description:

- Add ansible remediation for `sshd_use_priv_separation` and remove template entry from its `rule.yml` as it is not needed.

~~- Per [V-72265](https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72265?version=v2r7) `sshd_use_priv_separation` should accept both `sandbox` and `yes` values for `UsePrivilegeSeparation`:~~

~~`Uncomment the "UsePrivilegeSeparation" keyword in "/etc/ssh/sshd_config" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor) and set the value to "sandbox" or "yes":`~~

~~So the OVAL check has to use the regex `(sandbox|yes)` similar to what is done in [sshd_disable_compression](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml)~~

~~The variable `var_sshd_priv_separation` is still being used so remediations (including the new Ansible one) know how to remediate.~~

~~And last but not least, the default value for this parameter is `yes` so we have to switch `missing_parameter_pass` to `true`:~~

~~`UsePrivilegeSeparation
Specifies whether sshd(8) separates privileges by creating an unprivileged child process to deal with incoming network traffic. After successful authentication, another process will be created that has the privilege of the authenticated user. The goal of privilege separation is to prevent privilege escalation by containing any corruption within the unprivileged processes. The default is ''yes''. `~~
~~Reference: https://linux.die.net/man/5/sshd_config~~

#### Rationale:

- STIG Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72265?version=v2r7