### PR TITLE
Remove Fedora platform from test scenarios working with FIPS:OSPP crypto policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_nss_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_nss_config.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_file.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_file.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_symlink.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_symlink.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_fips_ospp_set.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_fips_ospp_set.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"


### PR DESCRIPTION
#### Description:
Remove Fedora platform from tests that are not applicable for Fedora

#### Rationale:
The tests are working with `FIPS:OSPP` crypto policy, but Fedora ospp profile uses `FIPS` value (see [fedora ospp](https://github.com/ComplianceAsCode/content/blob/master/fedora/profiles/ospp.profile#L21)).
