### PR TITLE
Introduce package conditionals to Ansible remediations

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -345,7 +345,7 @@ class AnsibleRemediation(Remediation):
     def inject_package_facts_task(self, parsed_snippet):
         """ Injects a package_facts task only if
             the snippet has a task with a when clause with ansible_facts.packages,
-            and the snippet doesn't already have an package_facts task
+            and the snippet doesn't already have a package_facts task
         """
         has_package_facts_task = False
         has_ansible_facts_packages_clause = False
@@ -361,7 +361,7 @@ class AnsibleRemediation(Remediation):
             # When clause of the task can be string or a list, lets normalize to list
             task_when = p_task.get("when", "")
             if type(task_when) is str:
-                task_when = [ task_when ]
+                task_when = [task_when]
             for when in task_when:
                 if "ansible_facts.packages" in when:
                     has_ansible_facts_packages_clause = True

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -374,8 +374,9 @@ class AnsibleRemediation(Remediation):
     def update_when_from_rule(self, to_update):
         additional_when = []
 
-        rule_platforms = set([self.associated_rule.platform] +
-                              self.associated_rule.inherited_platforms)
+        # There can be repeated inherited platforms and rule platforms
+        rule_platforms = set(self.associated_rule.inherited_platforms)
+        rule_platforms.add(self.associated_rule.platform)
 
         for platform in rule_platforms:
             if platform == "machine":

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -832,6 +832,7 @@ class Rule(object):
         "conflicts": lambda: list(),
         "requires": lambda: list(),
         "platform": lambda: None,
+        "inherited_platforms": lambda: list(),
         "template": lambda: None,
     }
 
@@ -851,6 +852,7 @@ class Rule(object):
         self.requires = []
         self.conflicts = []
         self.platform = None
+        self.inherited_platforms = [] # platforms inherited from the group
         self.template = None
 
     @classmethod
@@ -1293,6 +1295,9 @@ class BuildLoader(DirectoryLoader):
                 continue
             self.all_rules.add(rule)
             self.loaded_group.add_rule(rule)
+
+            rule.inherited_platforms.append(self.loaded_group.platform)
+
             if self.resolved_rules_dir:
                 output_for_rule = os.path.join(
                     self.resolved_rules_dir, "{id_}.yml".format(id_=rule.id_))


### PR DESCRIPTION
#### Description:

- Trickle down the CPE Platform to the Ansible remediations as `when` conditionals.
  - When a rule has a `platform` that is not `machine`, a `when` condition is added.
  - `fact_package` tasks are added to remediations that have a when condition with `ansible_facts.packages`

#### Rationale:
When a rule has a Package CPE platform, like `platform: grub2` for example.
It is meant to be evaluated and remediated when the  systems has grub2 package installed.
Evaluation and remediation done with OpenSCAP respects these CPEs, as the scanner understands the `CPE` and the `XCCDF:Platform` field.
But when the Playbooks are generated, the Package applicability of the remediation is lost.