### PR TITLE
fix rules about sshd idle timeout

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -55,6 +55,9 @@ references:
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
     anssi: BP28(R29)
 
+requires:
+    - sshd_set_keepalive
+
 ocil_clause: 'it is commented out or not configured properly'
 
 ocil: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -64,9 +64,6 @@ ocil: |-
     <pre>ClientAliveInterval {{{ xccdf_value("sshd_idle_timeout_value") }}}</pre>
 
 warnings:
-    - general: |-
-        The configuration will not have desired effect without configuring an
-        additional SSH option. To ensure that SSH disconnects idle clients
-        precisely after the timeout configured in this rule, the following line
-        has to exist in the SSHD configuration:
-        <pre>ClientAliveCountMax 0</pre>
+    - dependency: |-
+        SSH disconnecting idle clients will not have desired effect without also
+        configuring ClientAliveCountMax in the SSH service configuration.

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -62,3 +62,11 @@ ocil: |-
     <pre>$ sudo grep ClientAliveInterval /etc/ssh/sshd_config</pre>
     If properly configured, the output should be:
     <pre>ClientAliveInterval {{{ xccdf_value("sshd_idle_timeout_value") }}}</pre>
+
+warnings:
+    - general: |-
+        The configuration wil not have desired effect without configuring
+        additional SSH option. To ensure that SSH disconnects idle clients
+        precisely after the timeout configured in this rule, the following line
+        has to exist in the SSHD configuration:
+        <pre>ClientAliveCountMax 0</pre>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -65,7 +65,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        The configuration wil not have desired effect without configuring
+        The configuration will not have desired effect without configuring an
         additional SSH option. To ensure that SSH disconnects idle clients
         precisely after the timeout configured in this rule, the following line
         has to exist in the SSHD configuration:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -3,15 +3,17 @@ documentation_complete: true
 title: 'Set SSH Client Alive Count Max'
 
 description: |-
-    The SSH option <tt>ClientAliveCountMax</tt> is connected with the option
-    <tt>ClientAliveInterval</tt>. The SSH server sends at most
-    <tt>ClientAliveCountMax</tt> messages and waits for a response from a
-    client. The option <tt>ClientAliveInterval</tt> configures timeout after
-    each message. If it does not receive a response from the client, then the
-    connection is considered idle and terminated. To ensure the SSH idle timeout
-    occurs precisely when the <tt>ClientAliveInterval</tt> is set, set the
-    <tt>ClientAliveCountMax</tt> to value of <tt>0</tt>. This profile sets
-    <tt>ClientAliveCountMax</tt> to <tt>{{{ xccdf_value("var_sshd_set_keepalive") }}}</tt>. To modify the
+    The SSH server sends at most <tt>ClientAliveCountMax</tt> messages
+    during a SSH session and waits for a response from the SSH client.
+    The option <tt>ClientAliveInterval</tt> configures timeout after
+    each <tt>ClientAliveCountMax</tt> message. If the SSH server does not
+    receive a response from the client, then the connection is considered idle
+    and terminated.
+    
+    To ensure the SSH idle timeout occurs precisely when the
+    <tt>ClientAliveInterval</tt> is set, set the <tt>ClientAliveCountMax</tt> to
+    value of <tt>0</tt>. This profile sets <tt>ClientAliveCountMax</tt> to
+    <tt>{{{ xccdf_value("var_sshd_set_keepalive") }}}</tt>. To modify the
     <tt>ClientAliveCountMax</tt> option, edit <tt>/etc/ssh/sshd_config</tt> as
     follows:
     <pre>ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}</pre>
@@ -54,17 +56,11 @@ references:
 ocil_clause: 'it is commented out or not configured properly'
 
 ocil: |-
-<<<<<<< HEAD
-    To ensure the SSH idle timeout will occur when the <tt>ClientAliveInterval</tt> is set, run the following command:
+    To ensure <tt>ClientAliveInterval</tt> is set correctly, run the following command:
     <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
-    If properly configured, output should be:
+    If properly configured, the output should be:
     <pre>ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}</pre>
-=======
-    To ensure the SSH idle timeout will occur when the
-    <tt>ClientAliveInterval</tt> is set, run the following command: <pre>$ sudo
-    grep ClientAliveCountMax /etc/ssh/sshd_config</pre> If properly configured,
-    output should be:
-    <pre>ClientAliveCountMax 0</pre>
-    If the option is set to a different number, then the idle session will be disconnected after
+    If the option is set to <tt>0</tt>, then the SSH idle timeout occurs precisely when
+    the <tt>ClientAliveInterval</tt> is set.
+    If the option is set to a number greater than <tt>0</tt>, then the idle session will be disconnected after
     <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds.
->>>>>>> f1ce329d9... update description stressing that value of 0 should be configured

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -1,10 +1,19 @@
 documentation_complete: true
 
-title: 'Set SSH Client Alive Max Count'
+title: 'Set SSH Client Alive Count Max'
 
 description: |-
-    To ensure the SSH idle timeout occurs precisely when the <tt>ClientAliveInterval</tt> is set,
-    edit <tt>/etc/ssh/sshd_config</tt> as follows:
+    The SSH option <tt>ClientAliveCountMax</tt> is connected with the option
+    <tt>ClientAliveInterval</tt>. The SSH server sends at most
+    <tt>ClientAliveCountMax</tt> messages and waits for a response from a
+    client. The option <tt>ClientAliveInterval</tt> configures timeout after
+    each message. If it does not receive a response from the client, then the
+    connection is considered idle and terminated. To ensure the SSH idle timeout
+    occurs precisely when the <tt>ClientAliveInterval</tt> is set, set the
+    <tt>ClientAliveCountMax</tt> to value of <tt>0</tt>. This profile sets
+    <tt>ClientAliveCountMax</tt> to <tt>{{{ xccdf_value("var_sshd_set_keepalive") }}}</tt>. To modify the
+    <tt>ClientAliveCountMax</tt> option, edit <tt>/etc/ssh/sshd_config</tt> as
+    follows:
     <pre>ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}</pre>
 
 rationale: |-
@@ -45,7 +54,17 @@ references:
 ocil_clause: 'it is commented out or not configured properly'
 
 ocil: |-
+<<<<<<< HEAD
     To ensure the SSH idle timeout will occur when the <tt>ClientAliveInterval</tt> is set, run the following command:
     <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
     If properly configured, output should be:
     <pre>ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}</pre>
+=======
+    To ensure the SSH idle timeout will occur when the
+    <tt>ClientAliveInterval</tt> is set, run the following command: <pre>$ sudo
+    grep ClientAliveCountMax /etc/ssh/sshd_config</pre> If properly configured,
+    output should be:
+    <pre>ClientAliveCountMax 0</pre>
+    If the option is set to a different number, then the idle session will be disconnected after
+    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds.
+>>>>>>> f1ce329d9... update description stressing that value of 0 should be configured


### PR DESCRIPTION
#### Description:

- add warning to sshd_set_idle_timout that it needs addiitonal configuration to work properly

- get rid of variable for sshd_set_keepalive as the rule does not make sense with other variables than 0 if we keep the current description

- remove variable from all profiles

#### Rationale:

https://bugzilla.redhat.com/show_bug.cgi?id=1873547