### PR TITLE
reword ocils of password rules wrt existing accounts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -34,7 +34,6 @@ ocil_clause: 'existing passwords are not configured correctly'
 
 ocil: |-
     Check whether the maximum time period for existing passwords is restricted
-    to 60 days by running the following command for each user:
-    <pre>$ sudo chage -l <i>USER</i> | grep Maximum</pre>
-    The output for each user should return something similary to the following:
-    <pre>Maximum number of days between password change\t\t: 60</pre>
+    to 60 days:
+    <pre>sudo awk -F: '$5 &gt; 60 {print $1 " " $5}' /etc/shadow</pre>
+    The output must not contain names of any system account.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
@@ -33,9 +33,7 @@ references:
 ocil_clause: 'existing passwords are not configured correctly'
 
 ocil: |-
-    Check whether the minimum time period between password changes for each
-    user account is one day or greater by running the following command for
-    each user:
-    <pre>$ sudo chage -l <i>USER</i> | grep Minimum</pre>
-    The output for each user should return something similary to the following:
-    <pre>Minimum number of days between password change\t\t: 1</pre>
+    Check whether the minimum time period between password changes for each user
+    account is one day or greater:
+    <pre>sudo awk -F: '$4 &lt; 1 {print $1 " " $4}' /etc/shadow</pre>
+    The output must not contain names of any system account.


### PR DESCRIPTION
#### Description:

- reword ocils to use awk instead of chage

#### Rationale:

- it is aligned with STIG for rhel7 and also it is prone to problems caused by different than english locale
