### PR TITLE
Minor ansible changes that fix failing rules after remediations

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -30,6 +30,6 @@
     dest: /etc/sssd/sssd.conf
     section: pam
     option: pam_cert_auth
-    value: true
+    value: 'true'
     create: yes
     mode: 0600

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
@@ -10,10 +10,17 @@
     path: /etc/opensc-{{ ansible_architecture }}.conf
   register: opensc_conf_cd
 
-- name: "{{{ rule_title }}}"
-  lineinfile:
-    path: /etc/opensc-{{ ansible_architecture }}.conf
-    line: '        card_drivers = {{ var_smartcard_drivers }}'
-    regexp: '(^\s+#|^)\s+card_drivers\s+=\s+.*'
-    state: present
-  when: opensc_conf_cd.stat.exists    
+- name: Configure smartcard driver block
+  block:
+    - name: Check if card_drivers is defined
+      command: /usr/bin/opensc-tool -G app:default:card_drivers
+      changed_when: false
+      register: card_drivers
+
+    - name: "{{{ rule_title }}}"
+      command: |
+        /usr/bin/opensc-tool -S app:default:card_drivers:{{ var_smartcard_drivers }}
+      when:
+        - card_drivers.stdout != var_smartcard_drivers
+  when:
+    - opensc_conf_cd.stat.exists

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
@@ -10,10 +10,17 @@
     path: /etc/opensc-{{ ansible_architecture }}.conf
   register: opensc_conf_fcd
 
-- name: "{{{ rule_title }}}"
-  lineinfile:
-    path: /etc/opensc-{{ ansible_architecture }}.conf
-    line: '        force_card_driver = {{ var_smartcard_drivers }}'
-    regexp: '(^\s+#|^)\s+force_card_driver\s+=\s+.*'
-    state: present
-  when: opensc_conf_fcd.stat.exists    
+- name: Force smartcard driver block
+  block:
+    - name: Check if force_card_driver is defined
+      command: /usr/bin/opensc-tool -G app:default:force_card_driver
+      changed_when: false
+      register: force_card_driver
+
+    - name: "{{{ rule_title }}}"
+      command: |
+        /usr/bin/opensc-tool -S app:default:force_card_driver:{{ var_smartcard_drivers }}
+      when:
+        - force_card_driver.stdout != var_smartcard_drivers
+  when:
+    - opensc_conf_fcd.stat.exists

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/rule.yml
@@ -49,6 +49,6 @@ ocil: |-
     To verify that <tt><sub idref="var_smartcard_drivers" /></tt> is configured
     as the smart card driver, run the following command changing <i>ARCH</i> for
     the architecture of your operating system:
-    <pre>$ grep card_drivers /etc/opensc-<i>ARCH</i></pre>
+    <pre>$ grep force_card_driver /etc/opensc-<i>ARCH</i></pre>
     The output should return something similar to:
-    <pre>card_drivers = <sub idref="var_smartcard_drivers" />;</pre>
+    <pre>force_card_drivers = <sub idref="var_smartcard_drivers" />;</pre>

--- a/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
@@ -10,6 +10,7 @@
     section: Disable General User Access to NetworkManager
     option: "{{ item.option }}"
     value: "{{ item.value }}"
+    no_extra_spaces: yes
     create: yes
   loop:
     - { option: 'Identity', value: 'default' }


### PR DESCRIPTION
#### Description:

Fix issues found in #5937 

#### Rationale:

Smartcard changes needed to be re-evaluated. Even though it's not best practice to use the command module, in this instance it makes better sense, because we want to ensure the 2 configurations end up in the proper section. This is something that the opensc-tool does for us, and probably why we use it as our bash remediation. I couldn't find a good regex'y way of ensuring we put these configs in the app default section. So in this case, I say let the tool do its job.

The SSSD and network changes were minor fixes.

- Fixes #5937 
