### PR TITLE
Fix CPE check that detects if package manager is installed.

### DIFF
--- a/shared/checks/oval/installed_env_has_yum_package.xml
+++ b/shared/checks/oval/installed_env_has_yum_package.xml
@@ -21,7 +21,7 @@
     <linux:object object_ref="obj_env_has_yum_installed" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_env_has_yum_installed" version="1">
-    <linux:name>yum</linux:name>
+    <linux:name>{{{ pkg_manager }}}</linux:name>
   </linux:rpminfo_object>
 {{% elif pkg_system == "dpkg" %}}
   <linux:dpkginfo_test check="all" check_existence="all_exist"
@@ -30,7 +30,7 @@
     <linux:object object_ref="obj_env_has_yum_installed" />
   </linux:dpkginfo_test>
   <linux:dpkginfo_object id="obj_env_has_yum_installed" version="1">
-    <linux:name>yum</linux:name>
+    <linux:name>{{{ pkg_manager }}}</linux:name>
   </linux:dpkginfo_object>
 {{% endif %}}
 


### PR DESCRIPTION
#### Description:

- Fix CPE check that detects if package manager is installed. In fedora, the returned valid for this rpmtest is `dnf`, so we can use the product.yml variable `pkg_manager` to detect correctly.

#### Rationale:

- Checks that have `platform: yum` in fedora are returning `notapplicable`.

`oscap xccdf eval --profile "(all)" --rule xccdf_org.ssgproject.content_rule_ensure_gpgcheck_local_packages build/ssg-fedora-ds.xml`

```
Title   Ensure gpgcheck Enabled for Local Packages
Rule    xccdf_org.ssgproject.content_rule_ensure_gpgcheck_local_packages
Result  notapplicable
```

With the changes it returns different then `notapplicable`:

```
Title   Ensure gpgcheck Enabled for Local Packages
Rule    xccdf_org.ssgproject.content_rule_ensure_gpgcheck_local_packages
Result  fail
```

