### PR TITLE
Clean OVAL boilerplate

### DIFF
--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/oval/shared.xml
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/oval/shared.xml
@@ -1,14 +1,7 @@
 <def-group>
   <definition class="compliance" id="apt_conf_disallow_unauthenticated" version="1">
-    <metadata>
-      <title>Check that no unauthenticated repository is authorized by configuration</title>
-      <affected family="unix">
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_ubuntu</platform>
-      </affected>
-      <description>Accessing a repository should be
-      allowed only when the repository is authenticated.</description>
-    </metadata>
+    {{{ oval_metadata("Accessing a repository should be
+      allowed only when the repository is authenticated.") }}}
     <criteria comment="Detect any usage of allow-unauthenticated option"
       operator="OR">      
       <criterion comment="Check /etc/apt/apt.conf file"

--- a/linux_os/guide/services/apt/apt_sources_list_official/oval/shared.xml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="apt_sources_list_official" version="1">
-    <metadata>
-      <title>Only official, up-to-date distribution repositories should be used</title>
-      <affected family="unix">
-        <platform>multi_platform_debian</platform>
-      </affected>
-      <description>Official distribution repositories contain up-to-date distribution security and functional patches.</description>
-    </metadata>
+    {{{ oval_metadata("Official distribution repositories contain up-to-date distribution security and functional patches.") }}}
     <criteria comment="Match sources.list distribution repositories usage" operator="AND">      
       <criterion comment="Check /etc/apt/sources(.d/.+).list file for base" test_ref="test_apt_sources_list_base_official" />
       <criterion comment="Check /etc/apt/sources(.d/.+).list file for security" test_ref="test_apt_sources_list_security_official" />

--- a/linux_os/guide/services/dhcp/disabling_dhcp_client/sysconfig_networking_bootproto_ifcfg/oval/shared.xml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_client/sysconfig_networking_bootproto_ifcfg/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="sysconfig_networking_bootproto_ifcfg"
   version="2">
-    <metadata>
-      <title>Disable DHCP Client</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>DHCP configuration should be static for all
-      interfaces.</description>
-    </metadata>
+    {{{ oval_metadata("DHCP configuration should be static for all
+      interfaces.") }}}
     <criteria comment="Test for BOOTPROTO=(static|none) across all interfaces">
       <criterion test_ref="test_sysconfig_networking_bootproto_ifcfg" />
     </criteria>

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_log_transactions/oval/shared.xml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_log_transactions/oval/shared.xml
@@ -1,16 +1,9 @@
 <def-group>
   <definition class="compliance" id="ftp_log_transactions" version="1">
-    <metadata>
-      <title>Banner for FTP Users</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>To trace malicious activity facilitated by the FTP 
+    {{{ oval_metadata("To trace malicious activity facilitated by the FTP 
       service, it must be configured to ensure that all commands sent to 
       the FTP server are logged using the verbose vsftpd log format.
-      </description>
-    </metadata>
+      ") }}}
     <criteria comment="FTP is not being used or the conditions are met" operator="OR">
       <extend_definition comment="vsftp package is not installed" definition_ref="package_vsftpd_installed" negate="true" />
       <criteria comment="FTP configuration conditions are not set or are met" operator="AND">

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/oval/shared.xml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/oval/shared.xml
@@ -1,15 +1,7 @@
 <def-group>
   <definition class="compliance" id="ftp_present_banner" version="1">
-    <metadata>
-      <title>Banner for FTP Users</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_sle</platform>
-      </affected>
-      <description>This setting will cause the system greeting banner to be 
-      used for FTP connections as well.</description>
-    </metadata>
+    {{{ oval_metadata("This setting will cause the system greeting banner to be 
+      used for FTP connections as well.") }}}
     <criteria operator="OR">
       <extend_definition comment="vsftpd package is not installed" definition_ref="package_vsftpd_removed" />
       <criterion comment="Banner for FTP Users" test_ref="test_ftp_present_banner" />

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf/oval/shared.xml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="dir_perms_etc_httpd_conf" version="2">
-    <metadata>
-      <title>Directory /etc/httpd/conf/ Permissions</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Directory permissions for /etc/httpd/conf/ should be set to 0750 (or stronger).</description>
-    </metadata>
+    {{{ oval_metadata("Directory permissions for /etc/httpd/conf/ should be set to 0750 (or stronger).") }}}
     <criteria operator="OR">
       <extend_definition comment="httpd not present or in use"
       definition_ref="package_httpd_removed" />

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_var_log_httpd/oval/shared.xml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_var_log_httpd/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="dir_perms_var_log_httpd" version="2">
-    <metadata>
-      <title>Directory /var/log/httpd/ Permissions</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Directory permissions for /var/log/httpd should be set to 0700 (or stronger).</description>
-    </metadata>
+    {{{ oval_metadata("Directory permissions for /var/log/httpd should be set to 0700 (or stronger).") }}}
     <criteria operator="OR">
       <extend_definition comment="httpd not present or in use"
       definition_ref="package_httpd_removed" />

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/oval/shared.xml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="file_permissions_httpd_server_conf_d_files" version="2">
-    <metadata>
-      <title>Verify Permissions On Apache Web Server Configuration Files</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>The /etc/httpd/conf.d/* files should have the appropriate permissions (0640 or stronger).</description>
-    </metadata>
+    {{{ oval_metadata("The /etc/httpd/conf.d/* files should have the appropriate permissions (0640 or stronger).") }}}
     <criteria operator="OR">
       <extend_definition comment="httpd not present or in use"
       definition_ref="package_httpd_removed" />

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/oval/shared.xml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="file_permissions_httpd_server_conf_files" version="2">
-    <metadata>
-      <title>Verify Permissions On Apache Web Server Configuration Files</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>The /etc/httpd/conf/* files should have the appropriate permissions (0640 or stronger).</description>
-    </metadata>
+    {{{ oval_metadata("The /etc/httpd/conf/* files should have the appropriate permissions (0640 or stronger).") }}}
     <criteria operator="OR">
       <extend_definition comment="httpd not present or in use"
       definition_ref="package_httpd_removed" />

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/oval/shared.xml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="file_permissions_httpd_server_modules_files" version="2">
-    <metadata>
-      <title>Verify Permissions On Apache Web Server Configuration Files</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>The /etc/httpd/conf.modules.d/* files should have the appropriate permissions (0640 or stronger).</description>
-    </metadata>
+    {{{ oval_metadata("The /etc/httpd/conf.modules.d/* files should have the appropriate permissions (0640 or stronger).") }}}
     <criteria operator="OR">
       <extend_definition comment="httpd not present or in use"
       definition_ref="package_httpd_removed" />

--- a/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_disable_plaintext_auth/oval/shared.xml
+++ b/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_disable_plaintext_auth/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="dovecot_disable_plaintext_auth"
   version="1">
-    <metadata>
-      <title>Disable Plaintext Authentication in Dovecot</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Plaintext authentication of mail clients should be disabled.</description>
-    </metadata>
+    {{{ oval_metadata("Plaintext authentication of mail clients should be disabled.") }}}
     <criteria comment="Disable Plaintext Authentication in Dovecot" operator="OR">
       <extend_definition comment="dovecot service is disabled" definition_ref="service_dovecot_disabled" />
       <criterion test_ref="test_dovecot_disable_plaintext_auth" />

--- a/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_enable_ssl/oval/shared.xml
+++ b/linux_os/guide/services/imap/configure_dovecot/dovecot_enabling_ssl/dovecot_enable_ssl/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="dovecot_enable_ssl" version="1">
-    <metadata>
-      <title>Enable SSL in Dovecot</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>SSL capabilities should be enabled for the mail server.</description>
-    </metadata>
+    {{{ oval_metadata("SSL capabilities should be enabled for the mail server.") }}}
     <criteria comment="Enable SSL in Dovecot" operator="OR">
       <extend_definition comment="dovecot service is disabled" definition_ref="service_dovecot_disabled" />
       <criterion test_ref="test_dovecot_enable_ssl" />

--- a/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/oval/shared.xml
+++ b/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="kerberos_disable_no_keytab" version="1">
-    <metadata>
-      <title>Restrict Kerberos operation by removing keytab files</title>
-      <affected family="unix">
-        <platform>Oracle Linux 8</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>Check that there is no Kerberos keytab file present in /etc</description>
-    </metadata>
+    {{{ oval_metadata("Check that there is no Kerberos keytab file present in /etc") }}}
     <criteria>
       <criterion test_ref="test_kerberos_disable_no_keytab"
         comment="Restrict Kerberos operation by removing keytab files" />

--- a/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="enable_ldap_client" version="1">
-    <metadata>
-      <title>Enable the LDAP Client For Use in Authconfig</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_rhv</platform>
-      </affected>
-      <description>Enable LDAP in authconfig.</description>
-    </metadata>
+    {{{ oval_metadata("Enable LDAP in authconfig.") }}}
     <criteria>
       <criterion comment="LDAP client is enabled"
       test_ref="test_enable_ldap_client" />

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="ldap_client_start_tls" version="1">
-    {{{ oval_metadata("Require the use of TLS for ldap clients.") }}}
+    {{{ oval_metadata("Require the use of TLS for LDAP clients.") }}}
     {{%- if product == "rhel6" -%}}
     <criteria comment="package pam_ldap is not present" operator="OR">
       <extend_definition comment="pam_ldap not present or not in use"

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/oval/shared.xml
@@ -1,13 +1,6 @@
 <def-group>
   <definition class="compliance" id="ldap_client_start_tls" version="1">
-    <metadata>
-      <title>Configure LDAP to Use TLS for All Transactions</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Require the use of TLS for ldap clients.</description>
-    </metadata>
+    {{{ oval_metadata("Require the use of TLS for ldap clients.") }}}
     {{%- if product == "rhel6" -%}}
     <criteria comment="package pam_ldap is not present" operator="OR">
       <extend_definition comment="pam_ldap not present or not in use"

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_tls_cacertpath/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_tls_cacertpath/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="ldap_client_tls_cacertpath" version="1">
-    {{{ oval_metadata("Require the use of TLS for ldap clients.") }}}
+    {{{ oval_metadata("Require the use of TLS for LDAP clients.") }}}
     {{%- if product == "rhel6" -%}}
     <criteria comment="package pam_ldap is not present" operator="OR">
       <extend_definition comment="pam_ldap not present or in use"

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_tls_cacertpath/oval/shared.xml
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_tls_cacertpath/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="ldap_client_tls_cacertpath" version="1">
-    <metadata>
-      <title>Configure LDAP CA Certificate Path</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Require the use of TLS for ldap clients.</description>
-    </metadata>
+    {{{ oval_metadata("Require the use of TLS for ldap clients.") }}}
     {{%- if product == "rhel6" -%}}
     <criteria comment="package pam_ldap is not present" operator="OR">
       <extend_definition comment="pam_ldap not present or in use"

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/oval/shared.xml
@@ -1,13 +1,6 @@
 <def-group>
   <definition class="compliance" id="postfix_client_configure_mail_alias" version="1">
-    <metadata>
-      <title>Ensure root has a mail alias</title>
-      <affected family="unix">
-          <platform>Red Hat Virtualization 4</platform>
-          <platform>multi_platform_sle</platform>
-      </affected>
-      <description>Check if root has the correct mail alias.</description>
-    </metadata>
+    {{{ oval_metadata("Check if root has the correct mail alias.") }}}
     <criteria comment="Check if root has the correct mail alias.">
       <criterion comment="Check if root has the correct mail alias." test_ref="test_postfix_client_configure_mail_alias"/>
     </criteria>

--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/oval/shared.xml
@@ -1,13 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="postfix_network_listening_disabled" version="2">
-    <metadata>
-      <title>Postfix network listening should be disabled</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>Postfix network listening should be disabled</description>
-    </metadata>
+    {{{ oval_metadata("Postfix network listening should be disabled") }}}
     <criteria operator="OR">
       <!-- postfix package not installed or postfix service not configured to start -->
       <extend_definition comment="Postfix installed and configured to start" negate="true" definition_ref="service_postfix_enabled" />

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_banner/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_banner/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="postfix_server_banner" version="1">
-    <metadata>
-      <title>Configure Postfix Against Unnecessary Release of Information</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Protect against unnecessary release of information.</description>
-    </metadata>
+    {{{ oval_metadata("Protect against unnecessary release of information.") }}}
     <criteria operator="AND">
       <criterion comment="Limit release of information" test_ref="test_postfix_server_banner" />
     </criteria>

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/no_insecure_locks_exports/oval/shared.xml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/no_insecure_locks_exports/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="no_insecure_locks_exports" version="1">
-    <metadata>
-      <title>Ensure insecure_locks is disabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Allowing insecure file locking could allow for sensitive 
-      data to be viewed or edited by an unauthorized user.</description>
-    </metadata>
+    {{{ oval_metadata("Allowing insecure file locking could allow for sensitive 
+      data to be viewed or edited by an unauthorized user.") }}}
     <criteria>
       <criterion comment="Check for insecure NFS locks in /etc/exports"
       test_ref="test_no_insecure_locks_exports" />

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/oval/shared.xml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group>
   <definition class="compliance" id="use_kerberos_security_all_exports" version="3">
-    <metadata>
-      <title>Use Kerberos Security on All Exports</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Using Kerberos Security allows to cryptography authenticate a
-      valid user to an NFS share.</description>
-    </metadata>
+    {{{ oval_metadata("Using Kerberos Security allows to cryptography authenticate a
+      valid user to an NFS share.") }}}
     <criteria operator="OR">
       <criterion comment="Check for Kerberos settings in /etc/exports"
       test_ref="test_use_kerberos_security_all_exports" />

--- a/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="chronyd_client_only" version="1">
-    <metadata>
-      <title>Disable chrony daemon from acting as server</title>
-      {{{- oval_affected(products) }}}
-      <description>Configure the port setting in /etc/chrony.conf to disable
-      server operation.</description>
-    </metadata>
+    {{{ oval_metadata("Configure the port setting in /etc/chrony.conf to disable
+      server operation.") }}}
     <criteria operator="AND">
       <extend_definition definition_ref="service_chronyd_enabled" comment="service chronyd enabled" />
       <criterion test_ref="test_chronyd_client_only" comment="check if port is 0 in /etc/chrony.conf" />

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="chronyd_no_chronyc_network" version="1">
-    <metadata>
-      <title>Disable network management of chrony daemon</title>
-      {{{- oval_affected(products) }}}
-      <description>Configure the cmdport setting in /etc/chrony.conf to disable
-      chronyc management connections over network.</description>
-    </metadata>
+    {{{ oval_metadata("Configure the cmdport setting in /etc/chrony.conf to disable
+      chronyc management connections over network.") }}}
     <criteria operator="AND">
       <extend_definition definition_ref="service_chronyd_enabled" comment="service chronyd enabled" />
       <criterion test_ref="test_chronyd_no_chronyc_network" comment="check if cmdport is 0 in /etc/chrony.conf" />

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="chronyd_or_ntpd_set_maxpoll" version="1">
-    <metadata>
-      <title>Configure Time Service Maxpoll Interval</title>
-      {{{- oval_affected(products) }}}
-      <description>Configure the maxpoll setting in /etc/ntp.conf or chrony.conf
-      to continuously poll the time source servers.</description>
-    </metadata>
+    {{{ oval_metadata("Configure the maxpoll setting in /etc/ntp.conf or chrony.conf
+      to continuously poll the time source servers.") }}}
     <criteria operator="OR">
       <criteria operator="AND">
         <extend_definition comment="service ntpd enabled" definition_ref="service_ntpd_enabled" />

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="chronyd_or_ntpd_specify_multiple_servers" version="1">
-    <metadata>
-      <title>Specify Multiple Remote chronyd Or ntpd NTP Servers for Time Data</title>
-      {{{- oval_affected(products) }}}
-      <description>Multiple remote chronyd or ntpd NTP Servers for time synchronization should be specified (and dependencies are met)</description>
-    </metadata>
+    {{{ oval_metadata("Multiple remote chronyd or ntpd NTP Servers for time synchronization should be specified (and dependencies are met)") }}}
 
     <criteria operator="OR">
       <criteria comment="chronyd enabled and multiple remote servers specified" operator="AND">

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="chronyd_or_ntpd_specify_remote_server" version="1">
-    <metadata>
-      <title>Specify Remote NTP chronyd Or ntpd Server for Time Data</title>
-      {{{- oval_affected(products) }}}
-      <description>A remote chronyd or ntpd NTP Server for time synchronization should be specified (and dependencies are met)</description>
-    </metadata>
+    {{{ oval_metadata("A remote chronyd or ntpd NTP Server for time synchronization should be specified (and dependencies are met)") }}}
 
     <criteria operator="OR">
       <criteria comment="chronyd enabled and remote server specified" operator="AND">

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="chronyd_specify_remote_server" version="1">
-    <metadata>
-      <title>Specify a Remote NTP Server for Time Data</title>
-      {{{- oval_affected(products) }}}
-      <description>A remote NTP Server for time synchronization should be
-      specified (and dependencies are met)</description>
-    </metadata>
+    {{{ oval_metadata("A remote NTP Server for time synchronization should be
+      specified (and dependencies are met)") }}}
     <criteria comment="chrony.conf conditions are met">
       <criterion test_ref="test_chronyd_remote_server" />
     </criteria>

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="ntpd_configure_restrictions" version="2">
-    <metadata>
-      <title>Specify server restrictions for ntpd</title>
-      {{{- oval_affected(products) }}}
-      <description>Certain restrictions are imposed on ntp servers configured to be used by ntpd</description>
-    </metadata>
+    {{{ oval_metadata("Certain restrictions are imposed on ntp servers configured to be used by ntpd") }}}
     <criteria operator="AND">
       <criterion comment="test ipv6 configuration" test_ref="test_ntpd_configure_restrictions_ipv6" />
       <criterion comment="test ipv4 configuration" test_ref="test_ntpd_configure_restrictions_ipv4" />

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="ntpd_run_as_ntp_user" version="1">
-    <metadata>
-      <title>Configure ntpd To Run As ntp User</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure ntpd is configured to run correctly under the ntp user.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure ntpd is configured to run correctly under the ntp user.") }}}
     <criteria operator="OR">
       <criterion comment="check /etc/sysconfig/ntpd is configured correctly" test_ref="test_ntpd_run_as_ntp_user_etc_sysconfig_ntpd" />
       <criterion comment="check /usr/lib/systemd/system/ntpd.service is configured correctly" test_ref="test_ntpd_run_as_ntp_user_systemd" />

--- a/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="ntpd_specify_multiple_servers" version="2">
-    <metadata>
-      <title>Specify Multiple Remote ntpd NTP Server for Time Data</title>
-      {{{- oval_affected(products) }}}
-      <description>Multiple ntpd NTP Servers for time synchronization should be specified.</description>
-    </metadata>
+    {{{ oval_metadata("Multiple ntpd NTP Servers for time synchronization should be specified.") }}}
     <criteria comment="ntp.conf conditions are met">
       <criterion test_ref="test_ntpd_multiple_servers" />
     </criteria>

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="ntpd_specify_remote_server" version="2">
-    <metadata>
-      <title>Specify a Remote ntpd NTP Server for Time Data</title>
-      {{{- oval_affected(products) }}}
-      <description>A remote ntpd NTP Server for time synchronization should be
-      specified (and dependencies are met)</description>
-    </metadata>
+    {{{ oval_metadata("A remote ntpd NTP Server for time synchronization should be
+      specified (and dependencies are met)") }}}
     <criteria comment="ntp.conf conditions are met">
       <criterion test_ref="test_ntp_remote_server" />
     </criteria>

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="service_chronyd_or_ntpd_enabled" version="1">
-    <metadata>
-      <title>Service chronyd Or Service ntpd Enabled</title>
-      {{{- oval_affected(products) }}}
-      <description>At least one of the chronyd or ntpd services should be enabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("At least one of the chronyd or ntpd services should be enabled if possible.") }}}
 
     <criteria comment="chronyd or ntpd service enabled" operator="OR">
       <extend_definition comment="service chronyd enabled" definition_ref="service_chronyd_enabled" />

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group oval_version="5.10">
   <definition class="compliance" id="no_host_based_files" version="1">
-    <metadata>
-      <title>No shosts.equiv file deployed on the system</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_sle</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>There should not be any shosts.equiv files on the system.</description>
-    </metadata>
+    {{{ oval_metadata("There should not be any shosts.equiv files on the system.") }}}
     <criteria>
       <criterion test_ref="test_no_shosts_equiv"/>
     </criteria>

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_rsh_trust_files" version="1">
-    <metadata>
-      <title>No Legacy .rhosts Or hosts.equiv Files</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>There should not be any .rhosts or hosts.equiv files on the system.</description>
-    </metadata>
+    {{{ oval_metadata("There should not be any .rhosts or hosts.equiv files on the system.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_no_rsh_trust_files_root" negate="true" />
       <criterion test_ref="test_no_rsh_trust_files_home" negate="true" />

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group oval_version="5.10">
   <definition class="compliance" id="no_user_host_based_files" version="1">
-    <metadata>
-      <title>No .shosts file deployed on the system</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_sle</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>There should not be any .shosts files on the system.</description>
-    </metadata>
+    {{{ oval_metadata("There should not be any .shosts files on the system.") }}}
     <criteria>
       <criterion test_ref="test_no_shosts" />
     </criteria>

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="tftpd_uses_secure_mode" version="1">
-    <metadata>
-      <title>TFTP Daemon Uses Secure Mode</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The TFTP daemon should use secure mode.</description>
-    </metadata>
+    {{{ oval_metadata("The TFTP daemon should use secure mode.") }}}
     <criteria comment="package tftp-server removed or /etc/xinetd.d/tftp configured correctly" operator="OR">
       <extend_definition comment="rpm package tftp-server removed" definition_ref="package_tftp-server_removed" />
       <criterion comment="tftpd secure mode" test_ref="test_tftpd_uses_secure_mode" />

--- a/linux_os/guide/services/printing/configure_printing/cups_disable_browsing/oval/shared.xml
+++ b/linux_os/guide/services/printing/configure_printing/cups_disable_browsing/oval/shared.xml
@@ -1,17 +1,11 @@
 <def-group>
   <definition class="compliance" id="cups_disable_browsing" version="1">
-    <metadata>
-      <title>Disable Printer Browsing Entirely if Possible</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>The CUPS print service can be configured to broadcast a list
+    {{{ oval_metadata("The CUPS print service can be configured to broadcast a list
       of available printers to the network. Other machines on the network, also
       running the CUPS print service, can be configured to listen to these
       broadcasts and add and configure these printers for immediate use. By
       disabling this browsing capability, the machine will no longer generate
-      or receive such broadcasts.</description>
-    </metadata>
+      or receive such broadcasts.") }}}
     <criteria operator="AND">
       <criterion comment="Ensure remote printer browsing is off"
       test_ref="test_cups_disable_browsing_browsing_off" />

--- a/linux_os/guide/services/printing/configure_printing/cups_disable_printserver/oval/shared.xml
+++ b/linux_os/guide/services/printing/configure_printing/cups_disable_printserver/oval/shared.xml
@@ -1,18 +1,12 @@
 <def-group>
   <definition class="compliance" id="cups_disable_printserver" version="1">
-    <metadata>
-      <title>Disable Printer Server if Possible</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>By default, locally configured printers will not be shared
+    {{{ oval_metadata("By default, locally configured printers will not be shared
       over the network, but if this functionality has somehow been enabled,
       these recommendations will disable it again. Be sure to disable outgoing
       printer list broadcasts, or remote users will still be able to see the
       locally configured printers, even if they cannot actually print to them.
       To limit print serving to a particular set of users, use the Policy
-      directive.</description>
-    </metadata>
+      directive.") }}}
     <criteria operator="AND">
       <criterion comment="Don't use port directive" test_ref="test_cups_disable_printserver_disable_port" />
       <criterion comment="Do use the listen directive" test_ref="test_cups_disable_printserver_use_listen" />

--- a/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing/oval/shared.xml
+++ b/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing/oval/shared.xml
@@ -1,18 +1,11 @@
 <def-group>
   <definition class="compliance"
   id="mount_option_smb_client_signing" version="1">
-    <metadata>
-      <title>Require Client SMB Packet Signing, if using
-      mount.cifs</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Require packet signing of clients who mount
+    {{{ oval_metadata("Require packet signing of clients who mount
       Samba shares using the mount.cifs program (e.g., those who
       specify shares in /etc/fstab). To do so, ensure that signing
       options (either sec=krb5i or sec=ntlmv2i) are
-      used.</description>
-    </metadata>
+      used.") }}}
     <criteria operator="OR">
       <criteria operator="AND">
         <extend_definition comment="samba-common installed" definition_ref="package_samba-common_installed" />

--- a/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing/oval/shared.xml
+++ b/linux_os/guide/services/smb/configuring_samba/require_smb_client_signing/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="require_smb_client_signing" version="1">
-    <metadata>
-      <title>Require Client SMB Packet Signing in smb.conf</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Require samba clients which use smb.conf, such as smbclient,
+    {{{ oval_metadata("Require samba clients which use smb.conf, such as smbclient,
       to use packet signing. A Samba client should only communicate with
-      servers who can support SMB packet signing.</description>
-    </metadata>
+      servers who can support SMB packet signing.") }}}
     <criteria operator="OR">
       <extend_definition comment="package samba-common is not installed"
       definition_ref="package_samba-common_removed" />

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/oval/shared.xml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="snmpd_not_default_password" version="2">
-    <metadata>
-      <title>SNMP default communities disabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>SNMP default communities must be removed.</description>
-    </metadata>
+    {{{ oval_metadata("SNMP default communities must be removed.") }}}
     <criteria operator="OR">
       <extend_definition comment="SMNP installed" definition_ref="package_net-snmp_removed" />
       <criterion comment="SNMP communities" test_ref="test_snmp_default_communities" />

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/oval/shared.xml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="snmpd_use_newer_protocol" version="2">
-    <metadata>
-      <title>SNMP use newer protocols</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>SNMP version 1 and 2c must not be enabled.</description>
-    </metadata>
+    {{{ oval_metadata("SNMP version 1 and 2c must not be enabled.") }}}
     <criteria operator="OR">
       <extend_definition comment="SMNP installed" definition_ref="package_net-snmp_removed"/>
       <criterion comment="SNMP protocols" test_ref="test_snmp_versions" />

--- a/linux_os/guide/services/ssh/firewalld_sshd_disabled/oval/shared.xml
+++ b/linux_os/guide/services/ssh/firewalld_sshd_disabled/oval/shared.xml
@@ -1,14 +1,7 @@
 <def-group>
   <definition class="compliance" id="firewalld_sshd_disabled" version="1">
-    <metadata>
-      <title>Disallow inbound firewall access to the SSH Server port</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-      </affected>
-      <description>If inbound SSH access is not needed, the firewall should disallow or reject access to
-      the SSH port (22).</description>
-    </metadata>
+    {{{ oval_metadata("If inbound SSH access is not needed, the firewall should disallow or reject access to
+      the SSH port (22).") }}}
     <criteria operator="AND">
       <criterion comment="ssh service is not enabled in services" test_ref="test_firewalld_service_sshd" />
       <criterion comment="ssh port is not enabled in services" test_ref="test_firewalld_service_sshd_port" />

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="firewalld_sshd_port_enabled" version="1">
-    <metadata>
-      <title>Allow inbound firewall access to the SSH Server port</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>If inbound SSH access is needed, the firewall should allow access to
-      the SSH port (22).</description>
-    </metadata>
+    {{{ oval_metadata("If inbound SSH access is needed, the firewall should allow access to
+      the SSH port (22).") }}}
     <criteria operator="OR">
       <criterion comment="ssh service is enabled in services" test_ref="test_firewalld_service_sshd_enabled" />
       <criterion comment="ssh port is enabled in services" test_ref="test_firewalld_service_sshd_port_enabled" />

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="sshd_allow_only_protocol2" version="1">
-    <metadata>
-      <title>Ensure Only Protocol 2 Connections Allowed</title>
-      {{{- oval_affected(products) }}}
-      <description>The OpenSSH daemon should be running protocol 2.</description>
-    </metadata>
+    {{{ oval_metadata("The OpenSSH daemon should be running protocol 2.") }}}
     <criteria comment="SSH is configured correctly or is not installed"
     operator="OR">
       <criteria comment="sshd is not installed" operator="AND">

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="sshd_disable_compression" version="1">
-    <metadata>
-      <title>Disable Compression Or Set Compression to delayed</title>
-      {{{- oval_affected(products) }}}
-      <description>SSH should either have compression disabled or set to delayed.</description>
-    </metadata>
+    {{{ oval_metadata("SSH should either have compression disabled or set to delayed.") }}}
     <criteria comment="SSH is configured correctly or is not installed"
     operator="OR">
       <criteria comment="sshd is not installed" operator="AND">

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="sshd_disable_rhosts_rsa" version="1">
-    <metadata>
-      <title>Disable SSH Support for Rhosts RSA Authentication</title>
-      {{{- oval_affected(products) }}}
-      <description>SSH can allow authentication through the obsolete rsh command
-      through the use of the authenticating user's SSH keys. This should be disabled.</description>
-    </metadata>
+    {{{ oval_metadata("SSH can allow authentication through the obsolete rsh command
+      through the use of the authenticating user's SSH keys. This should be disabled.") }}}
     <criteria comment="SSH is configured correctly or is not installed"
     operator="OR">
       <criteria comment="sshd is not installed" operator="AND">

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
@@ -3,11 +3,7 @@
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    <metadata>
-      <title>{{{ rule_title }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure 'RekeyLimit' is configured with the correct value in '{{{ filepath }}}'</description>
-    </metadata>
+    {{{ oval_metadata("Ensure 'RekeyLimit' is configured with the correct value in '" + filepath + "'") }}}
     <criteria comment="sshd is configured correctly or is not installed" operator="OR">
         {{{- application_not_required_or_requirement_unset() }}}
         {{{- application_required_or_requirement_unset() }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="sshd_set_idle_timeout" version="1">
-    <metadata>
-      <title>Set OpenSSH Idle Timeout Interval</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The SSH idle timeout interval should be set to an
-      appropriate value.</description>
-    </metadata>
+    {{{ oval_metadata("The SSH idle timeout interval should be set to an
+      appropriate value.") }}}
     <criteria comment="SSH is configured correctly or is not installed"
     operator="OR">
       <criteria comment="sshd is not installed" operator="AND">

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="sshd_set_keepalive" version="1">
-    <metadata>
-      <title>Set ClientAliveCountMax for User Logins</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The SSH ClientAliveCountMax should be set to an appropriate
-      value (and dependencies are met)</description>
-    </metadata>
+    {{{ oval_metadata("The SSH ClientAliveCountMax should be set to an appropriate
+      value (and dependencies are met)") }}}
     <criteria comment="SSH is configured correctly or is not installed"
     operator="OR">
       <criteria comment="sshd is not installed" operator="AND">

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="sshd_set_max_auth_tries" version="1">
-    <metadata>
-      <title>Set OpenSSH authentication attempt limit (MaxAuthTries)</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The SSH MaxAuthTries should be set to an
-      appropriate value.</description>
-    </metadata>
+    {{{ oval_metadata("The SSH MaxAuthTries should be set to an
+      appropriate value.") }}}
     <criteria comment="SSH is not being used or conditions are met" operator="OR">
       <extend_definition comment="sshd service is disabled"
       definition_ref="service_sshd_disabled" />

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_sessions/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_sessions/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="sshd_set_max_sessions" version="1">
-    <metadata>
-      <title>Set OpenSSH MaxSessions</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The SSH number of max sessions should be set to an
-      appropriate value.</description>
-    </metadata>
+    {{{ oval_metadata("The SSH number of max sessions should be set to an
+      appropriate value.") }}}
     <criteria comment="SSH is configured correctly or is not installed"
     operator="OR">
       <criteria comment="sshd is not installed" operator="AND">

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="sshd_use_approved_ciphers" version="1">
-    <metadata>
-      <title>Use Only Approved Ciphers</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Oracle Linux 7</platform>
-      </affected>
-      <description>Limit the ciphers to those which are FIPS-approved.</description>
-    </metadata>
+    {{{ oval_metadata("Limit the ciphers to those which are FIPS-approved.") }}}
     <criteria operator="AND">
       <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criteria comment="SSH is configured correctly or is not installed"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="sshd_use_approved_macs" version="1">
-    <metadata>
-      <title>Use Only FIPS MACs</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>multi_platform_sle12</platform>
-        <platform>Oracle Linux 7</platform>
-      </affected>
-      <description>Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.</description>
-    </metadata>
+    {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.") }}}
     <criteria operator="AND">
       <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criteria comment="SSH is configured correctly or is not installed"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="sshd_use_priv_separation" version="1">
-    <metadata>
-      <title>Rule title of sshd_use_priv_separation</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Ensure 'UsePrivilegeSeparation' is configured with value 'sandbox' in '/etc/ssh/sshd_config'</description>
-    </metadata>
+    {{{ oval_metadata("Ensure 'UsePrivilegeSeparation' is configured with value 'sandbox' in '/etc/ssh/sshd_config'") }}}
     <criteria comment="sshd is configured correctly or is not installed"
     operator="OR">
       <criteria comment="sshd is not installed" operator="AND">

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="sssd_ldap_configure_tls_ca_dir" version="1">
-    <metadata>
-      <title>Configure SSSD LDAP Backend Client CA Certificate Location</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Configure SSSD to implement cryptography to protect the integrity of LDAP remote access sessions.</description>
-    </metadata>
+    {{{ oval_metadata("Configure SSSD to implement cryptography to protect the integrity of LDAP remote access sessions.") }}}
     <criteria>
       <criterion test_ref="test_sssd_ldap_tls_ca_dir" />
     </criteria>

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="sssd_ldap_start_tls" version="1">
-    <metadata>
-      <title>Configure SSSD LDAP Backend to Use TLS For All Transactions</title>
-      {{{- oval_affected(products) }}}
-      <description>LDAP should be used for authentication and use STARTTLS</description>
-    </metadata>
+    {{{ oval_metadata("LDAP should be used for authentication and use STARTTLS") }}}
     <criteria>
       <criterion comment="LDAP uses STARTTLS set within /etc/sssd/sssd.conf" test_ref="test_use_starttls" />
     </criteria>

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="sssd_enable_pam_services" version="1">
-    <metadata>
-      <title>Configure PAM in SSSD Services</title>
-      {{{- oval_affected(products) }}}
-      <description>SSSD should be configured to run SSSD PAM services.
-      </description>
-    </metadata>
+    {{{ oval_metadata("SSSD should be configured to run SSSD PAM services.
+      ") }}}
     <criteria>
         <criterion comment="check if pam is configured in the services setting of the sssd section"
         test_ref="test_sssd_enable_pam_services" />

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="sssd_enable_smartcards" version="1">
-    <metadata>
-      <title>Enable Smartcards in SSSD</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>SSSD should be configured to authenticate access to the system
-    using smart cards.</description>
-    </metadata>
+    {{{ oval_metadata("SSSD should be configured to authenticate access to the system
+    using smart cards.") }}}
     <criteria operator="OR">
       <criteria operator="OR">
         <extend_definition comment="Check if sssd service is disabled" definition_ref="service_sssd_disabled" />

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="sssd_memcache_timeout" version="1">
-    <metadata>
-      <title>Configure SSSD's Memory Cache to Expire</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>SSSD's memory cache should be configured to set to expire records after 1 day.</description>
-    </metadata>
+    {{{ oval_metadata("SSSD's memory cache should be configured to set to expire records after 1 day.") }}}
     <criteria operator="OR">
       <criteria operator="OR">
         <extend_definition comment="Check if sssd service is disabled" definition_ref="service_sssd_disabled" />

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="sssd_offline_cred_expiration" version="1">
-    <metadata>
-      <title>Configure SSSD to Expire Offline Credentials</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>SSSD should be configured to expire offline credentials after 1 day.</description>
-    </metadata>
+    {{{ oval_metadata("SSSD should be configured to expire offline credentials after 1 day.") }}}
     <criteria operator="OR">
       <criteria operator="OR">
         <extend_definition comment="Check if sssd service is disabled" definition_ref="service_sssd_disabled" />

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="sssd_run_as_sssd_user" version="1">
-    <metadata>
-      <title>Configure SSSD to run as user sssd</title>
-      {{{- oval_affected(products) }}}
-      <description>SSSD processes should be configured to run as user sssd, not root.</description>
-    </metadata>
+    {{{ oval_metadata("SSSD processes should be configured to run as user sssd, not root.") }}}
     <criteria>
       <criterion comment="Check user setting in SSSD configuration" test_ref="test_sssd_run_as_sssd_user" />
     </criteria>

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="sssd_ssh_known_hosts_timeout" version="1">
-    <metadata>
-      <title>Configure SSSD to Expire SSH Known Hosts</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>SSSD should be configured to expire keys from known SSH hosts after 1 day.</description>
-    </metadata>
+    {{{ oval_metadata("SSSD should be configured to expire keys from known SSH hosts after 1 day.") }}}
     <criteria operator="OR">
       <criteria operator="OR">
         <extend_definition comment="Check if sssd service is disabled" definition_ref="service_sssd_disabled" />

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid/oval/shared.xml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="usbguard_allow_hid" version="1">
-    <metadata>
-      <title>Check that USB Human Interface Devices are allowed by USBGuard rules</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check that /etc/usbguard/rules.conf contains at least one non white space character empty and exists.</description>
-    </metadata>
+    {{{ oval_metadata("Check that /etc/usbguard/rules.conf contains at least one non white space character empty and exists.") }}}
     <criteria comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." operator="AND">
       <extend_definition comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." definition_ref="usbguard_rules_not_empty_not_missing" />
     </criteria>

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid/oval/shared.xml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="usbguard_allow_hid" version="1">
-    {{{ oval_metadata("Check that /etc/usbguard/rules.conf contains at least one non white space character empty and exists.") }}}
+    {{{ oval_metadata("Check that /etc/usbguard/rules.conf exists and that it contains at least one non white space character.") }}}
     <criteria comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." operator="AND">
       <extend_definition comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." definition_ref="usbguard_rules_not_empty_not_missing" />
     </criteria>

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/oval/shared.xml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="usbguard_allow_hid_and_hub" version="1">
-    <metadata>
-      <title>Check that USB human interface devices and hubs are allowed by USBGuard rules</title>
-      {{{- oval_affected(products) }}}
-      <description>Check that /etc/usbguard/rules.conf contains at least one non whitespace character and exists.</description>
-    </metadata>
+    {{{ oval_metadata("Check that /etc/usbguard/rules.conf contains at least one non whitespace character and exists.") }}}
     <criteria comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." operator="AND">
       <extend_definition comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." definition_ref="usbguard_rules_not_empty_not_missing" />
     </criteria>

--- a/linux_os/guide/services/usbguard/usbguard_allow_hub/oval/shared.xml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hub/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="usbguard_allow_hub" version="1">
-    <metadata>
-      <title>Check that USB hubs are allowed by USBGuard rules</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check that /etc/usbguard/rules.conf contains at least one non whitespace character and exists.</description>
-    </metadata>
+    {{{ oval_metadata("Check that /etc/usbguard/rules.conf contains at least one non whitespace character and exists.") }}}
     <criteria comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." operator="AND">
       <extend_definition comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character." definition_ref="usbguard_rules_not_empty_not_missing" />
     </criteria>

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_setting/oval/shared.xml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_setting/oval/shared.xml
@@ -3,18 +3,7 @@
 {{%- else -%}}
 <def-group>
   <definition class="compliance" id="xwindows_runlevel_setting" version="1">
-    <metadata>
-      <title>Disable X Windows Startup By Setting Default SystemD Target</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      {{%- if init_system == "systemd" %}}
-      <description>Checks /etc/systemd/system/default.target to ensure that the default runlevel target is set to multi-user.target.</description>
-      {{%- else %}}
-      <description>Checks /etc/inittab to ensure that default runlevel is set to 3.</description>
-      {{%- endif %}}
-    </metadata>
+    {{{ oval_metadata("Checks /etc/inittab to ensure that default runlevel is set to 3.") }}}
     {{%- if init_system == "systemd" %}}
     <criteria>
       <criterion comment="default.target systemd softlink exists" test_ref="test_disable_xwindows_runlevel" />

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/oval/shared.xml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/oval/shared.xml
@@ -3,11 +3,7 @@
 {{%- else -%}}
 <def-group>
   <definition class="compliance" id="xwindows_runlevel_target" version="1">
-    <metadata>
-      <title>Disable X Windows Startup By Setting Default SystemD Target</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure that the default runlevel target is set to multi-user.target.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure that the default runlevel target is set to multi-user.target.") }}}
     <criteria>
       <criterion comment="default.target systemd softlink exists" test_ref="test_disable_xwindows_runlevel_target" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="banner_etc_issue" version="2">
-    <metadata>
-      <title>System Login Banner Compliance</title>
-      {{{- oval_affected(products) }}}
-      <description>The system login banner text should be set correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The system login banner text should be set correctly.") }}}
     <criteria>
       <criterion comment="/etc/issue is set appropriately" test_ref="test_banner_etc_issue" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="banner_etc_motd" version="2">
-    <metadata>
-      <title>System Login Banner Compliance</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The system login banner text should be set correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The system login banner text should be set correctly.") }}}
     <criteria>
       <criterion comment="/etc/motd is set appropriately" test_ref="test_banner_etc_motd" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_banner_enabled" version="1">
-    <metadata>
-      <title>Enable GNOME3 Login Warning Banner</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Enable the GNOME3 Login warning banner.</description>
-    </metadata>
+    {{{ oval_metadata("Enable the GNOME3 Login warning banner.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Enable GUI banner and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group oval_version="5.11"> 
   <definition class="compliance" id="dconf_gnome_login_banner_text" version="1">
-    <metadata>
-      <title>Enable GUI Warning Banner</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Enable the GUI warning banner.</description>
-    </metadata>
+    {{{ oval_metadata("Enable the GUI warning banner.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Enable GUI banner and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="display_login_attempts" version="1">
-    <metadata>
-      <title>Set Last Login/Access Notification</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>Configure the system to notify users of last login/access using pam_lastlog.</description>
-    </metadata>
+    {{{ oval_metadata("Configure the system to notify users of last login/access using pam_lastlog.") }}}
     <criteria>
       <criterion comment="Conditions for pam_lastlog are satisfied" test_ref="test_display_login_attempts" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_password_pam_unix_remember" version="2">
-    <metadata>
-      <title>Limit Password Reuse</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The passwords to remember should be set correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The passwords to remember should be set correctly.") }}}
     <criteria comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly" operator="OR">
       <criterion comment="remember parameter of pam_unix.so is set correctly" test_ref="test_accounts_password_pam_unix_remember" />
       <criterion comment="remember parameter of pam_pwhistory.so is set correctly" test_ref="test_accounts_password_pam_pwhistory_remember" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_passwords_pam_faillock_deny" version="4">
-    <metadata>
-      <title>Lock out account after failed login attempts</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The number of allowed failed logins should be set correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The number of allowed failed logins should be set correctly.") }}}
     <criteria operator="AND" comment="Checks common to both scenarios">
       <criterion test_ref="test_accounts_passwords_pam_faillock_preauth_silent_system-auth"
       comment="pam_faillock.so preauth silent set in system-auth" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
@@ -1,18 +1,7 @@
 <def-group>
   <definition class="compliance" id="accounts_passwords_pam_faillock_deny_root" version="4">
-    <metadata>
-      <title>Lock out the root account after failed login attempts</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The root account should be configured to deny access after the number of defined
-      failed attempts has been reached.</description>
-    </metadata>
+    {{{ oval_metadata("The root account should be configured to deny access after the number of defined
+      failed attempts has been reached.") }}}
     <criteria>
       <criterion test_ref="test_pam_faillock_preauth_silent_system-auth"
       comment="pam_faillock.so preauth silent set in system-auth" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_passwords_pam_faillock_interval" version="2">
-    <metadata>
-      <title>Lock out account after failed login attempts</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The number of allowed failed logins should be set correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The number of allowed failed logins should be set correctly.") }}}
     <criteria>
       <criterion comment="preauth default is set to 900" test_ref="test_accounts_passwords_pam_faillock_fail_interval_system-auth" />
       <criterion comment="authfail default is set to 900" test_ref="test_accounts_passwords_pam_faillock_authfail_fail_interval_system-auth" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_passwords_pam_faillock_unlock_time" version="2">
-    <metadata>
-      <title>Lock out account after failed login attempts</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The unlock time after number of failed logins should be set correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The unlock time after number of failed logins should be set correctly.") }}}
     <criteria operator="OR">
         <!-- We divide the checking domain space in two,
         1. when the ext var unlock_time is zero, we are only looking for zero or never in the config files,

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_password_pam_retry" version="1">
-    <metadata>
-      <title>Set Password retry Requirements</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>The password retry should meet minimum requirements</description>
-    </metadata>
+    {{{ oval_metadata("The password retry should meet minimum requirements") }}}
     <criteria operator="AND" comment="Conditions for retry are satisfied">
       <criterion comment="pam_pwquality" test_ref="test_password_pam_pwquality_retry" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="set_password_hashing_algorithm_libuserconf" version="1">
-    <metadata>
-      <title>Set SHA512 Password Hashing Algorithm in /etc/libuser.conf</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The password hashing algorithm should be set correctly in /etc/libuser.conf.</description>
-    </metadata>
+    {{{ oval_metadata("The password hashing algorithm should be set correctly in /etc/libuser.conf.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_etc_libuser_conf_cryptstyle" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="set_password_hashing_algorithm_logindefs" version="2">
-    <metadata>
-      <title>Set SHA512 Password Hashing Algorithm in /etc/login.defs</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The password hashing algorithm should be set correctly in /etc/login.defs.</description>
-    </metadata>
+    {{{ oval_metadata("The password hashing algorithm should be set correctly in /etc/login.defs.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_etc_login_defs_encrypt_method" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="set_password_hashing_algorithm_systemauth" version="1">
-    <metadata>
-      <title>Set Password Hashing Algorithm in /etc/pam.d/system-auth</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The password hashing algorithm should be set correctly in /etc/pam.d/system-auth.</description>
-    </metadata>
+    {{{ oval_metadata("The password hashing algorithm should be set correctly in /etc/pam.d/system-auth.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_pam_unix_sha512" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="disable_ctrlaltdel_burstaction" version="1">
-    <metadata>
-      <title>Disable Ctrl-Alt-Del Burst Action</title>
-      {{{- oval_affected(products) }}}
-      <description>Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf
-      to none to prevent a reboot if Ctrl-Alt-Delete is pressed more than 7 times in 2 seconds.</description>
-    </metadata>
+    {{{ oval_metadata("Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf
+      to none to prevent a reboot if Ctrl-Alt-Delete is pressed more than 7 times in 2 seconds.") }}}
     <criteria>
       <criterion comment="check CtrlAltDelBurstAction is set to none"
       test_ref="test_disable_ctrlaltdel_burstaction" />

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
@@ -3,12 +3,8 @@
 {{%- else -%}}
 <def-group>
   <definition class="compliance" id="disable_ctrlaltdel_reboot" version="1">
-    <metadata>
-      <title>Disable Ctrl-Alt-Del Reboot Activation</title>
-      {{{- oval_affected(products) }}}
-      <description>By default, the system will reboot when the
-      Ctrl-Alt-Del key sequence is pressed.</description>
-    </metadata>
+    {{{ oval_metadata("By default, the system will reboot when the
+      Ctrl-Alt-Del key sequence is pressed.") }}}
     {{%- if init_system == "systemd" -%}}
     <criteria>
       <criterion comment="Disable Ctrl-Alt-Del systemd softlink exists" test_ref="test_disable_ctrlaltdel_exists" />

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="grub2_disable_interactive_boot" version="4">
-    <metadata>
-      <title>Verify that Interactive Boot is Disabled</title>
-      {{{- oval_affected(products) }}}
-      <description>The ability for users to perform interactive startups should
-      be disabled.</description>
-    </metadata>
+    {{{ oval_metadata("The ability for users to perform interactive startups should
+      be disabled.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_grub2_disable_interactive_boot_grub_cmdline_linux"
       comment="Check systemd.confirm_spawn=(1|yes|true|on) not in GRUB_CMDLINE_LINUX" />

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="require_emergency_target_auth" version="1">
-    <metadata>
-      <title>Require Authentication for Emergency Mode</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The requirement for a password to boot into emergency mode
-      should be configured correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The requirement for a password to boot into emergency mode
+      should be configured correctly.") }}}
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_emergency_service" />

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="require_singleuser_auth" version="1">
-    <metadata>
-      <title>Require Authentication for Single-User Mode</title>
-      {{{- oval_affected(products) }}}
-      <description>The requirement for a password to boot into single-user mode
-      should be configured correctly.</description>
-    </metadata>
+    {{{ oval_metadata("The requirement for a password to boot into single-user mode
+      should be configured correctly.") }}}
     {{%- if init_system == "systemd" -%}}
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_bashrc_exec_tmux" version="1">
-    <metadata>
-      <title>Check exec tmux configured at the end of bashrc</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check if tmux is configured to exec at the end of bashrc.</description>
-    </metadata>
+    {{{ oval_metadata("Check if tmux is configured to exec at the end of bashrc.") }}}
     <criteria comment="Check exec tmux configured at the end of bashrc" operator="AND">
       <criterion comment="check tmux is configured to exec on the last line of /etc/bashrc"
         test_ref="test_configure_bashrc_exec_tmux" />

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_tmux_lock_after_time" version="1">
-    <metadata>
-      <title>Configure tmux to lock session after inactivity</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check if tmux is configured to lock sessions after period of inactivity.</description>
-    </metadata>
+    {{{ oval_metadata("Check if tmux is configured to lock sessions after period of inactivity.") }}}
     <criteria comment="Configure tmux to lock session after inactivity" operator="AND">
       <criterion comment="check lock-after-time is set to 900 in /etc/tmux.conf"
         test_ref="test_configure_tmux_lock_after_time" />

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_tmux_lock_command" version="1">
-    <metadata>
-      <title>Configure the tmux Lock Command</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check if the vlock command is configured to be used as a locking mechanism in tmux.</description>
-    </metadata>
+    {{{ oval_metadata("Check if the vlock command is configured to be used as a locking mechanism in tmux.") }}}
     <criteria comment="Configure the tmux Lock Command" operator="AND">
       <criterion comment="check lock-command is set to vlock in /etc/tmux.conf"
         test_ref="test_configure_tmux_lock_command" />

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_tmux_in_shells" version="1">
-    <metadata>
-      <title>Check that tmux is not listed in /etc/shells</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check that tmux is not listed in /etc/shells</description>
-    </metadata>
+    {{{ oval_metadata("Check that tmux is not listed in /etc/shells") }}}
     <criteria comment="Check that tmux is not listed in /etc/shells" operator="AND">
       <criterion comment="check that tmux is not listed in /etc/shells" test_ref="test_no_tmux_in_shells" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="configure_opensc_card_drivers" version="1">
-    <metadata>
-      <title>Configure opensc Smart Card Drivers</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Configure the organization's smart card driver so that only
-      the smart card in use by the organization will be recognized by the system.</description>
-    </metadata>
+    {{{ oval_metadata("Configure the organization's smart card driver so that only
+      the smart card in use by the organization will be recognized by the system.") }}}
     <criteria>
       <criterion test_ref="test_configure_opensc_card_drivers"
       comment="Check that card_drivers is configured for opensc" />

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_opensc_nss_db" version="1">
-    <metadata>
-      <title>Check that NSS DB is set to use opensc</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>Oracle Linux 7</platform>
-      </affected>
-      <description>The NSS DB should be set to use opensc library.</description>
-    </metadata>
+    {{{ oval_metadata("The NSS DB should be set to use opensc library.") }}}
     <criteria>
       <criterion test_ref="test_configure_opensc_nss_db"
       comment="Check opensc library is configured in /etc/pki/nssdb/pkcs11.txt" />

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="force_opensc_card_drivers" version="1">
-    <metadata>
-      <title>Force opensc To Use Defined Smart Card Driver</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Force opensc to use the organization's smart card driver so that only
-      the smart card in use by the organization will be recognized by the system.</description>
-    </metadata>
+    {{{ oval_metadata("Force opensc to use the organization's smart card driver so that only
+      the smart card in use by the organization will be recognized by the system.") }}}
     <criteria>
       <criterion test_ref="test_force_opensc_card_drivers"
       comment="Check that force_card_driver is configured for opensc" />

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
@@ -1,13 +1,6 @@
 <def-group>
   <definition class="compliance" id="install_smartcard_packages" version="1">
-    <metadata>
-      <title>Install needed packages for smartcard use.</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Oracle Linux 7</platform>
-      </affected>
-      <description>The RPM packages esc and pam_pkcs11 must be installed.</description>
-    </metadata>
+    {{{ oval_metadata("The RPM packages esc and pam_pkcs11 must be installed.") }}}
       <criteria comment="packages for smartcard use are installed">
       <extend_definition comment="pam_pkcs11 package is installed" definition_ref="package_pam_pkcs11_installed" />
       <extend_definition comment="esc package is installed" definition_ref="package_esc_installed" />

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="smartcard_auth" version="3">
-    <metadata>
-      <title>Enable Smart Card Login</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Oracle Linux 7</platform>
-      </affected>
-      <description>Enable Smart Card logins</description>
-    </metadata>
+    {{{ oval_metadata("Enable Smart Card logins") }}}
     <criteria comment="smart card authentication is configured" operator="AND">
       <extend_definition comment="pam_pkcs11 package is installed" definition_ref="package_pam_pkcs11_installed" />
       <extend_definition comment="pcscd service is enabled" definition_ref="service_pcscd_enabled" />

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="account_disable_post_pw_expiration" version="2">
-    <metadata>
-      <title>Set Accounts to Expire Following Password Expiration</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The accounts should be configured to expire automatically following password expiration.</description>
-    </metadata>
+    {{{ oval_metadata("The accounts should be configured to expire automatically following password expiration.") }}}
     <criteria comment="the value INACTIVE parameter should be set appropriately in /etc/default/useradd">
       <criterion test_ref="test_etc_default_useradd_inactive" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_name/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_name/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="account_unique_name" version="1">
-    <metadata>
-      <title>Set All Accounts To Have Unique Names</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>All accounts on the system should have unique names for proper accountability.</description>
-    </metadata>
+    {{{ oval_metadata("All accounts on the system should have unique names for proper accountability.") }}}
 
       <criteria comment="There should not exist duplicate user name entries in /etc/passwd">
         <criterion test_ref="test_etc_passwd_no_duplicate_user_names" />

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_maximum_age_login_defs" version="3">
-    <metadata>
-      <title>Set Password Expiration Parameters</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The maximum password age policy should meet minimum requirements.</description>
-    </metadata>
+    {{{ oval_metadata("The maximum password age policy should meet minimum requirements.") }}}
     <criteria comment="The value PASS_MAX_DAYS should be set appropriately in /etc/login.defs">
       <criterion test_ref="test_pass_max_days" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_minimum_age_login_defs" version="3">
-    <metadata>
-      <title>Set Password Expiration Parameters</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The minimum password age policy should be set appropriately.</description>
-    </metadata>
+    {{{ oval_metadata("The minimum password age policy should be set appropriately.") }}}
     <criteria comment="The value of PASS_MIN_DAYS should be set appropriately in /etc/login.defs">
       <criterion test_ref="test_pass_min_days" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
 
   <definition class="compliance" id="accounts_password_minlen_login_defs" version="3">
-    <metadata>
-      <title>Set Password Expiration Parameters</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The password minimum length should be set appropriately.</description>
-    </metadata>
+    {{{ oval_metadata("The password minimum length should be set appropriately.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_pass_min_len" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_password_warn_age_login_defs" version="3">
-    <metadata>
-      <title>Set Password Expiration Parameters</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The password expiration warning age should be set appropriately.</description>
-    </metadata>
+    {{{ oval_metadata("The password expiration warning age should be set appropriately.") }}}
     <criteria>
       <criterion test_ref="test_pass_warn_age" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_password_all_shadowed" version="1">
-    <metadata>
-      <title>All Password Hashes Shadowed</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>All password hashes should be shadowed.</description>
-    </metadata>
+    {{{ oval_metadata("All password hashes should be shadowed.") }}}
     <criteria>
       <criterion comment="password hashes are shadowed" test_ref="test_accounts_password_all_shadowed" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="gid_passwd_group_same" version="2">
-    <metadata>
-      <title>All GIDs Are Present In /etc/group</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>All GIDs referenced in /etc/passwd must be defined in /etc/group.</description>
-    </metadata>
+    {{{ oval_metadata("All GIDs referenced in /etc/passwd must be defined in /etc/group.") }}}
     <criteria>
       <criterion test_ref="test_gid_passwd_group_same" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_empty_passwords" version="1">
-    <metadata>
-      <title>No nullok Option in /etc/pam.d/system-auth</title>
-      {{{- oval_affected(products) }}}
-      <description>The file /etc/pam.d/system-auth should not contain the nullok option</description>
-    </metadata>
+    {{{ oval_metadata("The file /etc/pam.d/system-auth should not contain the nullok option") }}}
     <criteria>
       <criterion comment="make sure the nullok option is not used in /etc/pam.d/system-auth" test_ref="test_no_empty_passwords" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_legacy_plus_entries_etc_group" version="1">
-    <metadata>
-      <title>Ensure there are no legacy + NIS entries in /etc/group</title>
-      {{{- oval_affected(products) }}}
-      <description>No lines starting with + are in /etc/group</description>
-    </metadata>
+    {{{ oval_metadata("No lines starting with + are in /etc/group") }}}
     <criteria comment="no lines starting with + are in /etc/group">
       <criterion test_ref="test_no_legacy_plus_entries_etc_group" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_legacy_plus_entries_etc_passwd" version="1">
-    <metadata>
-      <title>Ensure there are no legacy + NIS entries in /etc/passwd</title>
-      {{{- oval_affected(products) }}}
-      <description>No lines starting with + are in /etc/passwd</description>
-    </metadata>
+    {{{ oval_metadata("No lines starting with + are in /etc/passwd") }}}
     <criteria comment="no lines starting with + are in /etc/passwd">
       <criterion test_ref="test_no_legacy_plus_entries_etc_passwd" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_legacy_plus_entries_etc_shadow" version="1">
-    <metadata>
-      <title>Ensure there are no legacy + NIS entries in /etc/shadow</title>
-      {{{- oval_affected(products) }}}
-      <description>No lines starting with + are in /etc/shadow</description>
-    </metadata>
+    {{{ oval_metadata("No lines starting with + are in /etc/shadow") }}}
     <criteria comment="no lines starting with + are in /etc/shadow">
       <criterion test_ref="test_no_legacy_plus_entries_etc_shadow" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_netrc_files" version="1">
-    <metadata>
-      <title>Verify No netrc Files Exist</title>
-      {{{- oval_affected(products) }}}
-      <description>The .netrc files contain login information used to auto-login into FTP servers and reside in the user's home directory. Any .netrc files should be removed.</description>
-    </metadata>
+    {{{ oval_metadata("The .netrc files contain login information used to auto-login into FTP servers and reside in the user's home directory. Any .netrc files should be removed.") }}}
     <criteria>
       <criterion test_ref="test_no_netrc_files_home" negate="true" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_no_uid_except_zero" version="1">
-    <metadata>
-      <title>UID 0 Belongs Only To Root</title>
-      {{{- oval_affected(products) }}}
-      <description>Only the root account should be assigned a user id of 0.</description>
-    </metadata>
+    {{{ oval_metadata("Only the root account should be assigned a user id of 0.") }}}
     <criteria>
       <criterion comment="tests that there are no accounts with UID 0 except root in the /etc/passwd file" test_ref="test_accounts_no_uid_except_root" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="no_direct_root_logins" version="1">
-    <metadata>
-      <title>Direct root Logins Not Allowed</title>
-      {{{- oval_affected(products) }}}
-      <description>Preventing direct root logins help ensure accountability for actions
-      taken on the system using the root account.</description>
-    </metadata>
+    {{{ oval_metadata("Preventing direct root logins help ensure accountability for actions
+      taken on the system using the root account.") }}}
     <criteria operator="AND">
       <criterion comment="serial ports /etc/securetty" test_ref="test_no_direct_root_logins" />
       <criterion comment="serial ports /etc/securetty" test_ref="test_etc_securetty_exists" />

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="no_shelllogin_for_systemaccounts" version="2">
-    <metadata>
-      <title>System Accounts Do Not Run a Shell</title>
-      {{{- oval_affected(products) }}}
-      <description>The root account is the only system account that should have
-      a login shell.</description>
-    </metadata>
+    {{{ oval_metadata("The root account is the only system account that should have
+      a login shell.") }}}
     <criteria operator="OR">
       <!-- If SYS_UID_MIN and SYS_UID_MAX is not defined in /etc/login.defs
            perform the check that all /etc/passwd entries having shell defined

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="restrict_serial_port_logins" version="1">
-    <metadata>
-      <title>Restrict Serial Port Root Logins</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Preventing direct root login to serial port interfaces helps
+    {{{ oval_metadata("Preventing direct root login to serial port interfaces helps
       ensure accountability for actions taken on the system using the root
-      account.</description>
-    </metadata>
+      account.") }}}
     <criteria>
       <criterion comment="serial ports /etc/securetty" test_ref="test_serial_ports_etc_securetty" negate="true" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="securetty_root_login_console_only" version="1">
-    <metadata>
-      <title>Restrict Virtual Console Root Logins</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Preventing direct root login to virtual console devices
+    {{{ oval_metadata("Preventing direct root login to virtual console devices
       helps ensure accountability for actions taken on the system using the
-      root account.</description>
-    </metadata>
+      root account.") }}}
     <criteria>
       <criterion comment="virtual consoles /etc/securetty" test_ref="test_virtual_consoles_etc_securetty" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_have_homedir_login_defs" version="1">
-    <metadata>
-      <title>Ensure new users receive home directories</title>
-      {{{- oval_affected(products) }}}
-      <description>CREATE_HOME should be enabled</description>
-    </metadata>
+    {{{ oval_metadata("CREATE_HOME should be enabled") }}}
     <criteria operator="AND">
       <criterion comment="Check CREATE_HOME in /etc/login.defs" test_ref="test_accounts_have_homedir_login_defs" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="accounts_logon_fail_delay" version="1">
-    <metadata>
-      <title>Ensure that FAIL_DELAY is Configured in /etc/login.defs</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The delay between failed authentication attempts should be
-      set for all users specified in /etc/login.defs</description>
-    </metadata>
+    {{{ oval_metadata("The delay between failed authentication attempts should be
+      set for all users specified in /etc/login.defs") }}}
     <criteria>
       <criterion test_ref="test_accounts_logon_fail_delay" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group>
   <definition class="compliance" id="accounts_max_concurrent_login_sessions" version="1">
-    <metadata>
-      <title>Set Maximum Number of Concurrent Login Sessions Per User</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>The maximum number of concurrent login sessions per user should meet
-      minimum requirements.</description>
-    </metadata>
+    {{{ oval_metadata("The maximum number of concurrent login sessions per user should meet
+      minimum requirements.") }}}
     <criteria operator="OR">
       <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" test_ref="test_limitsd_maxlogins" />
       <criteria operator="AND">

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_permissions_home_dirs" version="1">
-    <metadata>
-      <title>Proper Permissions User Home Directories</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>File permissions should be set correctly for the home directories for all user accounts.</description>
-    </metadata>
+    {{{ oval_metadata("File permissions should be set correctly for the home directories for all user accounts.") }}}
     <criteria >
       <criterion comment="home directories" test_ref="test_file_permissions_home_dirs" negate="true" />
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/oval/shared.xml
@@ -1,14 +1,7 @@
 <def-group>
   <definition class="compliance" id="accounts_root_path_dirs_no_write" version="2">
-    <metadata>
-      <title>Write permissions are disabled for group and other in all
-      directories in Root's Path</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Check each directory in root's path and make use it does
-      not grant write permission to group and other</description>
-    </metadata>
+    {{{ oval_metadata("Check each directory in root's path and make use it does
+      not grant write permission to group and other") }}}
     <criteria comment="Check that write permission to group and other in root's path is denied">
       <criterion comment="Check for write permission to group and other in root's path"
       test_ref="test_accounts_root_path_dirs_no_group_other_write" />

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group>
   <definition class="compliance" id="root_path_no_dot" version="2">
-    <metadata>
-      <title>Ensure that No Dangerous Directories Exist in Root's Path</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>The environment variable PATH should be set correctly for
-      the root user.</description>
-    </metadata>
+    {{{ oval_metadata("The environment variable PATH should be set correctly for
+      the root user.") }}}
     <criteria comment="environment variable PATH contains dangerous path" operator="AND">
       <criterion comment="environment variable PATH starts with : or ." test_ref="test_env_var_begins" />
       <criterion comment="environment variable PATH contains : twice in a row" test_ref="test_env_var_contains_doublecolon" />

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_umask_etc_bashrc" version="2">
-    <metadata>
-      <title>Ensure that Users Have Sensible Umask Values set for bash</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The default umask for users of the bash shell</description>
-    </metadata>
+    {{{ oval_metadata("The default umask for users of the bash shell") }}}
     <criteria operator="AND">
       <extend_definition comment="Get value of var_accounts_user_umask variable as octal number"
       definition_ref="var_accounts_user_umask_as_number" />

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_umask_etc_csh_cshrc" version="2">
-    <metadata>
-      <title>Ensure that Users Have Sensible Umask Values set for csh</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The default umask for users of the csh shell</description>
-    </metadata>
+    {{{ oval_metadata("The default umask for users of the csh shell") }}}
     <criteria operator="AND">
       <extend_definition comment="Get value of var_accounts_user_umask variable as octal number"
       definition_ref="var_accounts_user_umask_as_number" />

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_umask_etc_login_defs" version="2">
-    <metadata>
-      <title>Ensure that Users Have Sensible Umask Values in /etc/login.defs</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The default umask for all users specified in /etc/login.defs</description>
-    </metadata>
+    {{{ oval_metadata("The default umask for all users specified in /etc/login.defs") }}}
     <criteria operator="AND">
       <extend_definition comment="Get value of var_accounts_user_umask variable as octal number"
       definition_ref="var_accounts_user_umask_as_number" />

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_umask_etc_profile" version="2">
-    <metadata>
-      <title>Ensure that Users Have Sensible Umask Values in /etc/profile</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The default umask for all users should be set correctly</description>
-    </metadata>
+    {{{ oval_metadata("The default umask for all users should be set correctly") }}}
     <criteria operator="AND">
       <extend_definition comment="Get value of var_accounts_user_umask variable as octal number"
       definition_ref="var_accounts_user_umask_as_number" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_file_deletion_events" version="1">
-    <metadata>
-      <title>Audit File Deletion Events</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Audit files deletion events.</description>
-    </metadata>
+    {{{ oval_metadata("Audit files deletion events.") }}}
     <criteria operator="AND">
       <extend_definition comment="audit rmdir" definition_ref="audit_rules_file_deletion_events_rmdir" />
       <extend_definition comment="audit unlink" definition_ref="audit_rules_file_deletion_events_unlink" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification" version="1">
-    <metadata>
-      <title>Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful)</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.") }}}
 
     <criteria operator="AND">
       <extend_definition comment="audit creat" definition_ref="audit_rules_unsuccessful_file_modification_creat" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_kernel_module_loading" version="1">
-    <metadata>
-      <title>Audit Kernel Module Loading and Unloading</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_sle</platform>
-        <platform>multi_platform_rhcos</platform>
-      </affected>
-      <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
-    </metadata>
+    {{{ oval_metadata("The audit rules should be configured to log information about kernel module loading and unloading.") }}}
     <criteria operator="AND">
       <extend_definition comment="audit init_module" definition_ref="audit_rules_kernel_module_loading_init" />
       <extend_definition comment="audit delete_module" definition_ref="audit_rules_kernel_module_loading_delete" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_kernel_module_loading_delete" version="1">
-    <metadata>
-      <title>Audit Kernel Module Loading and Unloading - delete_module</title>
-      {{{- oval_affected(products) }}}
-      <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
-    </metadata>
+    {{{ oval_metadata("The audit rules should be configured to log information about kernel module loading and unloading.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_kernel_module_loading_finit" version="1">
-    <metadata>
-      <title>Audit Kernel Module Loading and Unloading - finit_module</title>
-      {{{- oval_affected(products) }}}
-      <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
-    </metadata>
+    {{{ oval_metadata("The audit rules should be configured to log information about kernel module loading and unloading.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_kernel_module_loading_init" version="1">
-    <metadata>
-      <title>Audit Kernel Module Loading and Unloading - init_module</title>
-      {{{- oval_affected(products) }}}
-      <description>The audit rules should be configured to log information about kernel module loading and unloading.</description>
-    </metadata>
+    {{{ oval_metadata("The audit rules should be configured to log information about kernel module loading and unloading.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_login_events" version="2">
-    <metadata>
-      <title>Record Attempts to Alter Login and Logout Events</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ocp</platform>
-        <platform>multi_platform_rhcos</platform>
-      </affected>
-      <description>Audit rules should be configured to log successful and unsuccessful login and logout events.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules should be configured to log successful and unsuccessful login and logout events.") }}}
     <criteria operator="AND">
       <extend_definition comment="audit tallylog" definition_ref="audit_rules_login_events_tallylog" />
       <extend_definition comment="audit faillock" definition_ref="audit_rules_login_events_faillock" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_privileged_commands" version="1">
-    <metadata>
-      <title>Ensure auditd Collects Information on the Use of Privileged Commands</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the information on the use of privileged commands are enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the information on the use of privileged commands are enabled.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_immutable" version="1">
-    <metadata>
-      <title>Make Audit Configuration Immutable</title>
-      {{{- oval_affected(products) }}}
-      <description>Force a reboot to change audit rules is enabled</description>
-    </metadata>
+    {{{ oval_metadata("Force a reboot to change audit rules is enabled") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_mac_modification" version="1">
-    <metadata>
-      <title>Record Events that Modify the System's Mandatory Access Controls</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules that detect changes to the system's mandatory access controls (SELinux) are enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules that detect changes to the system's mandatory access controls (SELinux) are enabled.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/shared.xml
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance" id="audit_rules_networkconfig_modification" version="1">
-    <metadata>
-      <title>Record Events that Modify the System's Network Environment</title>
-      {{{- oval_affected(products) }}}
-      <description>The network environment should not be modified by anything other than
-      administrator action. Any change to network parameters should be audited.</description>
-    </metadata>
+    {{{ oval_metadata("The network environment should not be modified by anything other than
+      administrator action. Any change to network parameters should be audited.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_session_events" version="1">
-    <metadata>
-      <title>Record Attempts to Alter Process and Session Initiation Information</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules should capture information about session initiation.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules should capture information about session initiation.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_sysadmin_actions" version="1">
-    <metadata>
-      <title>Audit System Administrator Actions</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit actions taken by system administrators on the system.</description>
-    </metadata>
+    {{{ oval_metadata("Audit actions taken by system administrators on the system.") }}}
     <criteria operator="OR">
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_system_shutdown" version="1">
-    <metadata>
-      <title>Shutdown System When Auditing Failures Occur</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The system will shutdown when auditing fails.</description>
-    </metadata>
+    {{{ oval_metadata("The system will shutdown when auditing fails.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/oval/shared.xml
@@ -1,18 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_usergroup_modification" version="1">
-    <metadata>
-      <title>Audit User/Group Modification</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ocp</platform>
-        <platform>multi_platform_rhcos</platform>
-      </affected>
-      <description>Audit rules should detect modification to system files that hold information about users and groups.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules should detect modification to system files that hold information about users and groups.") }}}
     <criteria operator="OR">
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_time_adjtimex" version="1">
-    <metadata>
-      <title>Record Attempts to Alter Time Through Adjtimex</title>
-      {{{- oval_affected(products) }}}
-      <description>Record attempts to alter time through adjtimex.</description>
-    </metadata>
+    {{{ oval_metadata("Record attempts to alter time through adjtimex.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_time_clock_settime" version="2">
-    <metadata>
-      <title>Record Attempts to Alter Time Through Clock_settime</title>
-      {{{- oval_affected(products) }}}
-      <description>Record attempts to alter time through clock_settime.</description>
-    </metadata>
+    {{{ oval_metadata("Record attempts to alter time through clock_settime.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_time_settimeofday" version="1">
-    <metadata>
-      <title>Record Attempts to Alter Time Through Settimeofday</title>
-      {{{- oval_affected(products) }}}
-      <description>Record attempts to alter time through settimeofday.</description>
-    </metadata>
+    {{{ oval_metadata("Record attempts to alter time through settimeofday.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/oval/shared.xml
@@ -1,12 +1,8 @@
 <def-group>
   <definition class="compliance" id="audit_rules_time_stime" version="1">
-    <metadata>
-      <title>Record Attempts to Alter Time Through Stime</title>
-      {{{- oval_affected(products) }}}
-      <description>Record attempts to alter time through stime. Note that on
+    {{{ oval_metadata("Record attempts to alter time through stime. Note that on
       64-bit architectures the stime system call is not defined in the audit
-      system calls lookup table.</description>
-    </metadata>
+      system calls lookup table.") }}}
 
     <criteria operator="AND">
       <!-- System is 32-bit or 64-bit -->

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_time_watch_localtime" version="1">
-    <metadata>
-      <title>Record Attempts to Alter Time Through the Localtime File</title>
-      {{{- oval_affected(products) }}}
-      <description>Record attempts to alter time through /etc/localtime.</description>
-    </metadata>
+    {{{ oval_metadata("Record attempts to alter time through /etc/localtime.") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="directory_access_var_log_audit" version="1">
-    <metadata>
-      <title>Ensure auditd Collects Information Read Access to /var/log/audit</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the read events to /var/log/audit</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the read events to /var/log/audit") }}}
 
     <criteria operator="OR">
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="directory_permissions_var_log_audit" version="1">
-    <metadata>
-      <title>Verify /var/log/audit Directory Permissions</title>
-      {{{- oval_affected(products) }}}
-      <description>Checks for correct permissions for /var/log/audit.</description>
-    </metadata>
+    {{{ oval_metadata("Checks for correct permissions for /var/log/audit.") }}}
     <criteria operator="OR">
       <criterion test_ref="test_dir_permissions_var_log_audit" negate="true" />
       <criteria operator="AND" comment="log_group in auditd.conf is not root">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_ownership_var_log_audit" version="3">
-    <metadata>
-      <title>Verify /var/log/audit Ownership</title>
-      {{{- oval_affected(products) }}}
-      <description>Checks that all /var/log/audit files and directories are owned by the root user and group.</description>
-    </metadata>
+    {{{ oval_metadata("Checks that all /var/log/audit files and directories are owned by the root user and group.") }}}
     <criteria operator="OR">
       <criteria operator="AND" comment="directories are root owned">
         <criterion test_ref="test_ownership_var_log_audit_files" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_permissions_var_log_audit" version="2">
-    <metadata>
-      <title>Verify /var/log/audit Permissions</title>
-      {{{- oval_affected(products) }}}
-      <description>Checks for correct permissions for all log files in /var/log/audit.</description>
-    </metadata>
+    {{{ oval_metadata("Checks for correct permissions for all log files in /var/log/audit.") }}}
     <criteria operator="OR">
       <criterion test_ref="test_file_permissions_var_log_audit" negate="true" />
       <criteria operator="AND" comment="log_group in auditd.conf is not root">

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
@@ -5,11 +5,7 @@
 {{% endif %}}
 <def-group>
   <definition class="compliance" id="auditd_audispd_configure_remote_server" version="1">
-    <metadata>
-      <title>Configure audispd Plugin Remote Server IP address or Hostname</title>
-      {{{- oval_affected(products) }}}
-      <description>remote_server setting in {{{ audisp_config_file_path }}} is set to a certain IP address or hostname</description>
-    </metadata>
+    {{{ oval_metadata("remote_server setting in " + audisp_config_file_path + " is set to a certain IP address or hostname") }}}
     <criteria>
         <criterion comment="remote_server setting in audisp-remote.conf" test_ref="test_auditd_audispd_configure_remote_server" />
     </criteria>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
@@ -1,6 +1,10 @@
 <def-group>
   <definition class="compliance" id="auditd_audispd_encrypt_sent_records" version="1">
+    {{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
+    {{{ oval_metadata("transport setting in /etc/audit/audisp-remote.conf is set to 'KRB5'") }}}
+    {{% else %}}
     {{{ oval_metadata("enable_krb5 setting in /etc/audisp/audisp-remote.conf is set to 'yes'") }}}
+    {{% endif %}}
 
     <criteria>
       <criterion comment="setting in audisp-remote.conf" test_ref="test_auditd_audispd_encrypt_sent_records" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_audispd_encrypt_sent_records" version="1">
-    <metadata>
-      <title>Kerberos 5 Authentication and Encryption in Audit Event Multiplexor (audispd) Is Activated</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-{{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
-      <description>transport setting in /etc/audit/audisp-remote.conf is set to 'KRB5'</description>
-{{% else %}}
-      <description>enable_krb5 setting in /etc/audisp/audisp-remote.conf is set to 'yes'</description>
-{{% endif %}}
-    </metadata>
+    {{{ oval_metadata("enable_krb5 setting in /etc/audisp/audisp-remote.conf is set to 'yes'") }}}
 
     <criteria>
       <criterion comment="setting in audisp-remote.conf" test_ref="test_auditd_audispd_encrypt_sent_records" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_audispd_syslog_plugin_activated" version="1">
-    <metadata>
-      <title>The syslog Plugin Of the Audit Event Multiplexor (audispd) Is Activated</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-{{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
-      <description>active setting in /etc/audit/plugins.d/syslog.conf is set to 'yes'</description>
-{{% else %}}
-      <description>active setting in /etc/audisp/plugins.d/syslog.conf is set to 'yes'</description>
-{{% endif %}}
-    </metadata>
+    {{{ oval_metadata("active setting in /etc/audisp/plugins.d/syslog.conf is set to 'yes'") }}}
 
     <criteria>
         <criterion comment="active setting in syslog.conf" test_ref="test_auditd_audispd_syslog_plugin_activated" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_audispd_syslog_plugin_activated" version="1">
-    {{{ oval_metadata("active setting in /etc/audisp/plugins.d/syslog.conf is set to 'yes'") }}}
+    {{{ oval_metadata("active setting in " + ("/etc/audit/plugins.d/syslog.conf" if product in ["rhel8", "fedora", "ol8", "rhv4"] else "/etc/audisp/plugins.d/syslog.conf") + " is set to 'yes'") }}}
 
     <criteria>
         <criterion comment="active setting in syslog.conf" test_ref="test_auditd_audispd_syslog_plugin_activated" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_disk_error_action" version="1">
-    <metadata>
-      <title>Auditd Action to Take When Disk Errors</title>
-      {{{- oval_affected(products) }}}
-      <description>disk_error_action setting in /etc/audit/auditd.conf is set to a certain action</description>
-    </metadata>
+    {{{ oval_metadata("disk_error_action setting in /etc/audit/auditd.conf is set to a certain action") }}}
 
     <criteria>
         <criterion comment="disk_error_action setting in auditd.conf" test_ref="test_auditd_data_disk_error_action" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_disk_full_action" version="1">
-    <metadata>
-      <title>Auditd Action to Take When Disk Is Full</title>
-      {{{- oval_affected(products) }}}
-      <description>disk_full_action setting in /etc/audit/auditd.conf is set to a certain action</description>
-    </metadata>
+    {{{ oval_metadata("disk_full_action setting in /etc/audit/auditd.conf is set to a certain action") }}}
 
     <criteria>
         <criterion comment="disk_full_action setting in auditd.conf" test_ref="test_auditd_data_disk_full_action" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_action_mail_acct" version="2">
-    <metadata>
-      <title>Auditd Email Account to Notify Upon Action</title>
-      {{{- oval_affected(products) }}}
-      <description>action_mail_acct setting in /etc/audit/auditd.conf is set to a certain account</description>
-    </metadata>
+    {{{ oval_metadata("action_mail_acct setting in /etc/audit/auditd.conf is set to a certain account") }}}
     <criteria>
         <criterion comment="action_mail_acct setting in auditd.conf" test_ref="test_auditd_data_retention_action_mail_acct" />
     </criteria>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_admin_space_left_action" version="2">
-    <metadata>
-      <title>Auditd Action to Take When Disk is Low on Space</title>
-      {{{- oval_affected(products) }}}
-      <description>admin_space_left_action setting in /etc/audit/auditd.conf is set to a certain action</description>
-    </metadata>
+    {{{ oval_metadata("admin_space_left_action setting in /etc/audit/auditd.conf is set to a certain action") }}}
 
     <criteria>
        <criterion comment="admin_space_left_action setting in auditd.conf" test_ref="test_auditd_data_retention_admin_space_left_action" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_flush" version="1">
-    <metadata>
-      <title>Auditd priority for flushing data to disk</title>
-      {{{- oval_affected(products) }}}
-      <description>The setting for flush in /etc/audit/auditd.conf</description>
-    </metadata>
+    {{{ oval_metadata("The setting for flush in /etc/audit/auditd.conf") }}}
 
     <criteria>
         <criterion comment="flush setting in auditd.conf" test_ref="test_auditd_data_retention_flush" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_max_log_file" version="2">
-    <metadata>
-      <title>Auditd Maximum Log File Size</title>
-      {{{- oval_affected(products) }}}
-      <description>max_log_file setting in /etc/audit/auditd.conf is set to at least a certain value</description>
-    </metadata>
+    {{{ oval_metadata("max_log_file setting in /etc/audit/auditd.conf is set to at least a certain value") }}}
 
     <criteria>
         <criterion comment="max_log_file setting in auditd.conf" test_ref="test_auditd_data_retention_max_log_file" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_max_log_file_action" version="2">
-    <metadata>
-      <title>Auditd Action to Take When Maximum Log Size Reached</title>
-      {{{- oval_affected(products) }}}
-      <description>max_log_file_action setting in /etc/audit/auditd.conf is set to a certain action</description>
-    </metadata>
+    {{{ oval_metadata("max_log_file_action setting in /etc/audit/auditd.conf is set to a certain action") }}}
 
     <criteria>
         <criterion comment="max_log_file_action setting in auditd.conf" test_ref="test_auditd_data_retention_max_log_file_action" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_num_logs" version="2">
-    <metadata>
-      <title>Auditd Maximum Number of Logs to Retain</title>
-      {{{- oval_affected(products) }}}
-      <description>num_logs setting in /etc/audit/auditd.conf is set to at least a certain value</description>
-    </metadata>
+    {{{ oval_metadata("num_logs setting in /etc/audit/auditd.conf is set to at least a certain value") }}}
 
     <criteria>
         <criterion comment="num_logs setting in auditd.conf" test_ref="test_auditd_data_retention_num_logs" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_space_left" version="2">
-    <metadata>
-      <title>Configure auditd space_left on Low Disk Space</title>
-      {{{- oval_affected(products) }}}
-      <description>space_left setting in /etc/audit/auditd.conf is set to at least a certain value</description>
-    </metadata>
+    {{{ oval_metadata("space_left setting in /etc/audit/auditd.conf is set to at least a certain value") }}}
 
     <criteria>
         <criterion comment="space_left setting in auditd.conf" test_ref="test_auditd_data_retention_space_left" />

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="auditd_data_retention_space_left_action" version="3">
-    <metadata>
-      <title>Auditd Action to Take When Disk Starting to Run Low on Space</title>
-      {{{- oval_affected(products) }}}
-      <description>space_left_action setting in /etc/audit/auditd.conf is set to a certain action</description>
-    </metadata>
+    {{{ oval_metadata("space_left_action setting in /etc/audit/auditd.conf is set to a certain action") }}}
 
     <criteria>
         <criterion comment="space_left_action setting in auditd.conf" test_ref="test_auditd_data_retention_space_left_action" />

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/oval/shared.xml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/oval/shared.xml
@@ -32,15 +32,7 @@
 
 <def-group>
   <definition class="compliance" id="audit_rules_for_ospp" version="1">
-    <metadata>
-      <title>Check audit rules for OSPP</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Compare configure audit rules againd the recommended pre-configured files</description>
-    </metadata>
+    {{{ oval_metadata("Compare configure audit rules againd the recommended pre-configured files") }}}
 
     <criteria operator="AND">
       {{{- audit_file_compare_criterion("10-base-config") -}}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/oval/shared.xml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/oval/shared.xml
@@ -32,7 +32,7 @@
 
 <def-group>
   <definition class="compliance" id="audit_rules_for_ospp" version="1">
-    {{{ oval_metadata("Compare configure audit rules againd the recommended pre-configured files") }}}
+    {{{ oval_metadata("Compare configure audit rules against the recommended pre-configured files.") }}}
 
     <criteria operator="AND">
       {{{- audit_file_compare_criterion("10-base-config") -}}}

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_groupowner_efi_grub2_cfg" version="1">
-    <metadata>
-      <title>Verify the UEFI Boot Loader grub.cfg Group Owner</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Verify that UEFI Boot Loader grub.cfg is group owned by 0.</description>
-    </metadata>
+    {{{ oval_metadata("Verify that UEFI Boot Loader grub.cfg is group owned by 0.") }}}
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
       <criterion comment="Check file group ownership of /boot/efi/EFI/redhat/grub.cfg" test_ref="test_file_groupowner_efi_grub2_cfg" />

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_grub2_cfg/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_groupowner_grub2_cfg" version="1">
-    <metadata>
-      <title>Verify /boot/grub2/grub.cfg Group Owner</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Verify that /boot/grub2/grub.cfg is group owned by gid 0.</description>
-    </metadata>
+    {{{ oval_metadata("Verify that /boot/grub2/grub.cfg is group owned by gid 0.") }}}
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />
       <criterion comment="Check file group ownership of /boot/grub2/grub.cfg" test_ref="test_file_groupowner_grub2_cfg" />

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_owner_efi_grub2_cfg" version="1">
-    <metadata>
-      <title>Verify the UEFI Boot Loader grub.cfg Owner</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Verify that UEFI Boot Loader grub.cfg is owned by uid 0.</description>
-    </metadata>
+    {{{ oval_metadata("Verify that UEFI Boot Loader grub.cfg is owned by uid 0.") }}}
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
       <criterion comment="Check file ownership of /boot/efi/EFI/redhat/grub.cfg" test_ref="test_file_owner_efi_grub2_cfg" />

--- a/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_grub2_cfg/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_owner_grub2_cfg" version="1">
-    <metadata>
-      <title>Verify /boot/grub2/grub.cfg Owner</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Verify that /boot/grub2/grub.cfg is owned by uid 0.</description>
-    </metadata>
+    {{{ oval_metadata("Verify that /boot/grub2/grub.cfg is owned by uid 0.") }}}
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />
       <criterion comment="Check file ownership of /boot/grub2/grub.cfg" test_ref="test_file_owner_grub2_cfg" />

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_permissions_efi_grub2_cfg" version="1">
-    <metadata>
-      <title>Verify the UEFI Boot Loader grub.cfg Permissions</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Verify that UEFI Boot Loader grub.cfg file permissions set to 0700 (or stronger).</description>
-    </metadata>
+    {{{ oval_metadata("Verify that UEFI Boot Loader grub.cfg file permissions set to 0700 (or stronger).") }}}
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
       <criterion test_ref="test_file_permissions_efi_grub2_cfg" />

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_permissions_grub2_cfg" version="1">
-    <metadata>
-      <title>Verify /boot/grub2/grub.cfg Mode Permissions</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>File permissions for /boot/grub2/grub.cfg should be set to 0600 (or stronger).</description>
-    </metadata>
+    {{{ oval_metadata("File permissions for /boot/grub2/grub.cfg should be set to 0600 (or stronger).") }}}
     <criteria operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if system boot mode is UEFI" />      
       <criterion comment="Check file mode of /boot/grub2/grub.cfg" test_ref="test_file_permissions_grub2_cfg" />

--- a/linux_os/guide/system/bootloader-grub2/grub2_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_admin_username/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="grub2_admin_username" version="1">
-    <metadata>
-      <title>Set Boot Loader Superuser Username to Unique Value</title>
-      {{{- oval_affected(products) }}}
-      <description>The grub2 boot loader superuser should have a username that is hard to guess.</description>
-    </metadata>
+    {{{ oval_metadata("The grub2 boot loader superuser should have a username that is hard to guess.") }}}
 
     <criteria operator="OR">
       {{{ oval_file_absent_criterion("/boot/grub2/grub.cfg", rule_id + "_grub_cfg") }}}

--- a/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="grub2_enable_iommu_force" version="1">
-    <metadata>
-      <title>Force IOMMU usage in GRUB2</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Ensure iommu=force is configured in the kernel line in /etc/default/grub.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure iommu=force is configured in the kernel line in /etc/default/grub.") }}}
     <criteria operator="AND">
       <extend_definition definition_ref="grub2_default_exists" comment="check for GRUB_CMDLINE_LINUX_DEFAULT exists in /etc/default/grub" />
       <criteria operator="OR">

--- a/linux_os/guide/system/bootloader-grub2/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_password/oval/shared.xml
@@ -1,11 +1,7 @@
 {{% set grub_cfg_prefix = "/boot/grub2" %}}
 <def-group>
   <definition class="compliance" id="grub2_password" version="1">
-    <metadata>
-      <title>Set Boot Loader Password</title>
-      {{{- oval_affected(products) }}}
-      <description>The grub2 boot loader should have password protection enabled.</description>
-    </metadata>
+    {{{ oval_metadata("The grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
       {{{ oval_file_absent_criterion(grub_cfg_prefix + "/grub.cfg", rule_id + "_grub_cfg") }}}

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_admin_username/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="grub2_uefi_admin_username" version="1">
-    <metadata>
-      <title>Set the UEFI Boot Loader Superuser Username to Unique Value</title>
-      {{{- oval_affected(products) }}}
-      <description>The grub2 boot loader superuser should have a username that is hard to guess.</description>
-    </metadata>
+    {{{ oval_metadata("The grub2 boot loader superuser should have a username that is hard to guess.") }}}
 
     <criteria operator="OR">
       {{{ oval_file_absent_criterion("/boot/efi/EFI/redhat/grub.cfg", rule_id + "_grub_cfg") }}}

--- a/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_uefi_password/oval/shared.xml
@@ -6,11 +6,7 @@
 
 <def-group>
   <definition class="compliance" id="grub2_uefi_password" version="1">
-    <metadata>
-      <title>Set the UEFI Boot Loader Password</title>
-      {{{- oval_affected(products) }}}
-      <description>The UEFI grub2 boot loader should have password protection enabled.</description>
-    </metadata>
+    {{{ oval_metadata("The UEFI grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
       {{{ oval_file_absent_criterion(grub_cfg_prefix + "/grub.cfg", rule_id + "_grub_cfg") }}}

--- a/linux_os/guide/system/bootloader-zipl/zipl_bls_entries_only/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bls_entries_only/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="zipl_bls_entries_only" version="1">
-    <metadata>
-      <title>Ensure zIPL entries are BLS compliant</title>
-      {{{- oval_affected(products) }}}
-      <description>Check if /etc/zipl.conf configures any boot entry</description>
-    </metadata>
+    {{{ oval_metadata("Check if /etc/zipl.conf configures any boot entry") }}}
     <criteria operator="AND">
       <criterion test_ref="test_zipl_bls_entries_only"
       comment="Test presence of image configuration in /etc/zipl.conf" />

--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="zipl_bootmap_is_up_to_date" version="1">
-    <metadata>
-      <title>Ensure zIPL bootmap is up to date</title>
-      {{{- oval_affected(products) }}}
-      <description>Check if /boot/bootmap is up to date</description>
-    </metadata>
+    {{{ oval_metadata("Check if /boot/bootmap is up to date") }}}
     <criteria operator="AND">
       <criterion test_ref="test_zipl_bootmap_is_up_to_date"
       comment="Compare mtime of /boot/bootmap against /etc/zipl.conf and /boot/loader/entries/*.conf" />

--- a/linux_os/guide/system/logging/configure_logwatch_on_logserver/logwatch_configured_hostlimit/oval/shared.xml
+++ b/linux_os/guide/system/logging/configure_logwatch_on_logserver/logwatch_configured_hostlimit/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="logwatch_configured_hostlimit" version="1">
-    <metadata>
-      <title>Ensure Logwatch HostLimit Configured</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Test if HostLimit line in logwatch.conf is set appropriately.</description>
-    </metadata>
+    {{{ oval_metadata("Test if HostLimit line in logwatch.conf is set appropriately.") }}}
     <criteria operator="AND">
       <criterion comment="Test value of HostLimit" test_ref="test_logwatch_configured_hostlimit" />
     </criteria>

--- a/linux_os/guide/system/logging/configure_logwatch_on_logserver/logwatch_configured_splithosts/oval/shared.xml
+++ b/linux_os/guide/system/logging/configure_logwatch_on_logserver/logwatch_configured_splithosts/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="logwatch_configured_splithosts" version="1">
-    <metadata>
-      <title>Ensure Logwatch SplitHosts Configured</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Check if SplitHosts line in logwatch.conf is set appropriately.</description>
-    </metadata>
+    {{{ oval_metadata("Check if SplitHosts line in logwatch.conf is set appropriately.") }}}
     <criteria>
       <criterion comment="Test value of SplitHosts" test_ref="test_logwatch_configured_splithosts" />
     </criteria>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="rsyslog_cron_logging" version="1">
-    <metadata>
-      <title>Verify Cron is Logging to Rsyslog</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>Rsyslog should be configured to capture cron messages.</description>
-    </metadata>
+    {{{ oval_metadata("Rsyslog should be configured to capture cron messages.") }}}
     <criteria operator="OR">
       <criterion comment="cron is configured in /etc/rsyslog.conf"
       test_ref="test_cron_logging_rsyslog" />

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="rsyslog_files_groupownership" version="1">
-    <metadata>
-      <title>Confirm Existence and Permissions of System Log Files</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ubuntu</platform>
-      </affected>
-      <description>All syslog log files should be owned by the appropriate group.</description>
-    </metadata>
+    {{{ oval_metadata("All syslog log files should be owned by the appropriate group.") }}}
 
     <criteria operator="AND">
       {{% if product in ["debian8", "debian9", "debian10", "ubuntu1404", "ubuntu1604"] %}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="rsyslog_files_ownership" version="1">
-    <metadata>
-      <title>Confirm Existence and Permissions of System Log Files</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ubuntu</platform>
-      </affected>
-      <description>All syslog log files should be owned by the appropriate user.</description>
-    </metadata>
+    {{{ oval_metadata("All syslog log files should be owned by the appropriate user.") }}}
 
     <criteria>
       <criterion comment="Check if all system log files are owned by root user" test_ref="test_rsyslog_files_ownership" />

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="rsyslog_files_permissions" version="1">
-    <metadata>
-      <title>Confirm Existence and Permissions of System Log Files</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ubuntu</platform>
-      </affected>
-      <description>File permissions for all syslog log files should be set correctly.</description>
-    </metadata>
+    {{{ oval_metadata("File permissions for all syslog log files should be set correctly.") }}}
 
     <criteria operator="AND">
       {{% if product in ["debian8", "debian9", "debian10", "ubuntu1404", "ubuntu1604", "ubuntu1804"] %}}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="ensure_logrotate_activated" version="1">
-    <metadata>
-      <title>Ensure the logrotate utility performs the automatic rotation of log files on daily basis</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>
+    {{{ oval_metadata("
       The frequency of automatic log files rotation performed by the logrotate utility should be configured to run daily
-      </description>
-    </metadata>
+      ") }}}
     <criteria comment="/etc/logrotate.conf contains daily setting and /etc/cron.daily/logrotate file exists" operator="AND">
       <criterion comment="Check if daily is set in /etc/logrotate.conf"
       test_ref="test_logrotate_conf_daily_setting" />

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="rsyslog_nolisten" version="2">
-    <metadata>
-      <title>Disable Rsyslogd from Accepting Remote Messages on Loghosts
-      Only</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>rsyslogd should reject remote messages</description>
-    </metadata>
+    {{{ oval_metadata("rsyslogd should reject remote messages") }}}
     <criteria>
       <criterion comment="Conditions are satisfied"
       test_ref="test_rsyslog_nolisten" />

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
@@ -1,18 +1,6 @@
 <def-group>
   <definition class="compliance" id="rsyslog_remote_loghost" version="1">
-    <metadata>
-      <title>Send Logs to a Remote Loghost</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ubuntu</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>Syslog logs should be sent to a remote loghost</description>
-    </metadata>
+    {{{ oval_metadata("Syslog logs should be sent to a remote loghost") }}}
     <criteria operator="OR">
       <criterion comment="Remote logging set within /etc/rsyslog.conf" test_ref="test_remote_rsyslog_conf" />
       <criterion comment="Remote logging set within /etc/rsyslog.d" test_ref="test_remote_rsyslog_d" />

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="rsyslog_remote_tls" version="1">
-    <metadata>
-      <title>Check that rsyslog is configured to use TLS for remote logging</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check that all needed TLS-related options are present</description>
-    </metadata>
+    {{{ oval_metadata("Check that all needed TLS-related options are present") }}}
     <criteria comment="Check that rsyslog is configured to use TLS for remote logging" operator="AND">
       <criterion comment="Check that all needed TLS-related options are present" test_ref="test_rsyslog_remote_tls" />
     </criteria>

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="rsyslog_remote_tls_cacert" version="1">
-    <metadata>
-      <title>Check that CA certificate is configured for rsyslog remote logging</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Oracle Linux 8</platform>
-      </affected>
-      <description>Check that the CA certificate path is set</description>
-    </metadata>
+    {{{ oval_metadata("Check that the CA certificate path is set") }}}
     <criteria comment="Check that CA certificate is configured for rsyslog remote logging" operator="AND">
       <criterion comment="Check that the CA certificate path is set" test_ref="test_rsyslog_remote_tls_cacert" />
     </criteria>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="configure_firewalld_ports" version="1">
-    <metadata>
-      <title>Configure the Firewalld Ports</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Configure the firewalld ports to allow approved
-      services to have access to the system.</description>
-    </metadata>
+    {{{ oval_metadata("Configure the firewalld ports to allow approved
+      services to have access to the system.") }}}
     <criteria operator="AND">
       <extend_definition comment="ssh port is enabled" definition_ref="firewalld_sshd_port_enabled" />
     </criteria>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_firewalld_rate_limiting" version="1">
-    <metadata>
-      <title>Configure firewalld To Rate Limit Connections</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <!--  there is problem with remediation on rhel8 -->
-        <platform>Red Hat Enterprise Linux 8</platform>
-        -->
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Create a direct firewall rule to protect against DoS attacks by rate limiting incoming connections.</description>
-    </metadata>
+    {{{ oval_metadata("Create a direct firewall rule to protect against DoS attacks by rate limiting incoming connections.") }}}
     <criteria operator="AND">
       <criterion comment="check if the file /etc/firewalld/direct.xml contains correct rule" test_ref="test_firewalld_rate_limiting"/>
     </criteria>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="set_firewalld_default_zone" version="2">
-    <metadata>
-      <title>Change the default firewalld zone to drop</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Change the default firewalld zone to drop.</description>
-    </metadata>
+    {{{ oval_metadata("Change the default firewalld zone to drop.") }}}
     <criteria>
       <criterion comment="Set default zone to drop" test_ref="test_firewalld_input_drop" />
     </criteria>

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_default_gateway/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_default_gateway/oval/shared.xml
@@ -1,14 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="network_ipv6_default_gateway" version="1">
-    <metadata>
-      <title>Manually Assign IPv6 Router Address</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Define default gateways for IPv6 traffic</description>
-    </metadata>
+    {{{ oval_metadata("Define default gateways for IPv6 traffic") }}}
     <criteria operator="OR">
       {{%- if product == "rhel6" -%}}
       <extend_definition comment="IPv6 disabled or..."

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="network_ipv6_privacy_extensions" version="1">
-    <metadata>
-      <title>Enable Privacy Extensions for IPv6</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Enable privacy extensions for IPv6</description>
-    </metadata>
+    {{{ oval_metadata("Enable privacy extensions for IPv6") }}}
     <criteria operator="OR">
       {{%- if product == "rhel6" -%}}
       <extend_definition comment="IPv6 disabled or..."

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/oval/shared.xml
@@ -1,14 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="network_ipv6_static_address" version="1">
-    <metadata>
-      <title>Manually Assign Global IPv6 Address</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Manually configure addresses for IPv6</description>
-    </metadata>
+    {{{ oval_metadata("Manually configure addresses for IPv6") }}}
     <criteria operator="OR">
       {{%- if product == "rhel6" -%}}
       <extend_definition comment="IPv6 disabled or..."

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="kernel_module_ipv6_option_disabled" version="1">
-    <metadata>
-      <title>Disable IPv6 Kernel Module Functionality via Disable Option</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The disable option will allow the IPv6 module to be inserted, but prevent address assignment and activation of the network stack.</description>
-    </metadata>
+    {{{ oval_metadata("The disable option will allow the IPv6 module to be inserted, but prevent address assignment and activation of the network stack.") }}}
     <criteria>
       <criterion test_ref="test_kernel_module_ipv6_option_disabled" comment="ipv6 disabled any modprobe conf file"/>
     </criteria>

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/oval/shared.xml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/oval/shared.xml
@@ -1,14 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="network_ipv6_disable_rpc" version="1">
-    <metadata>
-      <title>Disable Support for RPC IPv6</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Disable ipv6 based rpc services</description>
-    </metadata>
+    {{{ oval_metadata("Disable ipv6 based rpc services") }}}
     <criteria operator="AND">
       <criterion comment="Disable udp6" test_ref="test_network_ipv6_disable_rpc_udp6" />
       <criterion comment="Disable tcp6" test_ref="test_network_ipv6_disable_rpc_tcp6" />

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="wireless_disable_interfaces" version="1">
-    <metadata>
-      <title>Deactivate Wireless Interfaces</title>
-      {{{- oval_affected(products) }}}
-      <description>All wireless interfaces should be disabled.</description>
-    </metadata>
+    {{{ oval_metadata("All wireless interfaces should be disabled.") }}}
     <criteria>
       <criterion comment="query /proc/net/wireless" test_ref="test_wireless_disable_interfaces" />
     </criteria>

--- a/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
+++ b/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="network_configure_name_resolution" version="1">
-    <metadata>
-      <title>Configure Multiple DNS Servers in /etc/resolv.conf</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Multiple Domain Name System (DNS) Servers should be configured
-      in /etc/resolv.conf.</description>
-    </metadata>
+    {{{ oval_metadata("Multiple Domain Name System (DNS) Servers should be configured
+      in /etc/resolv.conf.") }}}
     <criteria>
       <criterion comment="check if more than one nameserver in /etc/resolv.conf"
       test_ref="test_network_configure_name_resolution" />

--- a/linux_os/guide/system/network/network_disable_ddns_interfaces/oval/shared.xml
+++ b/linux_os/guide/system/network/network_disable_ddns_interfaces/oval/shared.xml
@@ -1,15 +1,8 @@
 <def-group>
   <definition class="compliance" id="network_disable_ddns_interfaces"
   version="1">
-    <metadata>
-      <title>Disable Client Dynamic DNS Updates</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-      </affected>
-      <description>Clients should not automatically update their own
-      DNS record.</description>
-    </metadata>
+    {{{ oval_metadata("Clients should not automatically update their own
+      DNS record.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_network_disable_ddns_interfaces_ifcfg" />
       <criterion test_ref="test_network_disable_ddns_interfaces_dhclient" />

--- a/linux_os/guide/system/network/network_disable_zeroconf/oval/shared.xml
+++ b/linux_os/guide/system/network/network_disable_zeroconf/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="network_disable_zeroconf" version="1">
-    <metadata>
-      <title>Disable Zeroconf Networking</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Disable Zeroconf automatic route assignment in the
-      169.254.0.0 subnet.</description>
-    </metadata>
+    {{{ oval_metadata("Disable Zeroconf automatic route assignment in the
+      169.254.0.0 subnet.") }}}
     <criteria>
       <criterion comment="Look for NOZEROCONF=yes in /etc/sysconfig/network"
       test_ref="test_sysconfig_nozeroconf_yes" />

--- a/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="network_nmcli_permissions" version="1">
-    <metadata>
-      <title>Ensure non-Privileged Users Cannot Change Network Settings</title>
-      {{{- oval_affected(products) }}}
-      <description>polkit is properly configured to prevent non-privilged users from changing networking settings</description>
-    </metadata>
+    {{{ oval_metadata("polkit is properly configured to prevent non-privilged users from changing networking settings") }}}
     <criteria>
       <criterion test_ref="test_network_nmcli_permissions" comment="check for properly configured .pkla file" />
     </criteria>

--- a/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="network_nmcli_permissions" version="1">
-    {{{ oval_metadata("polkit is properly configured to prevent non-privilged users from changing networking settings") }}}
+    {{{ oval_metadata("polkit is properly configured to prevent non-privileged users from changing networking settings") }}}
     <criteria>
       <criterion test_ref="test_network_nmcli_permissions" comment="check for properly configured .pkla file" />
     </criteria>

--- a/linux_os/guide/system/network/network_sniffer_disabled/oval/shared.xml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="network_sniffer_disabled" version="1">
-    <metadata>
-      <title>Disable the network sniffer</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Disable the network sniffer</description>
-    </metadata>
+    {{{ oval_metadata("Disable the network sniffer") }}}
     <criteria>
       <criterion comment="promisc interfaces" test_ref="test_promisc_interfaces" negate="true" />
     </criteria>

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="dir_perms_world_writable_sticky_bits" version="1">
-    <metadata>
-      <title>Verify that All World-Writable Directories Have Sticky Bits Set</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>The sticky bit should be set for all world-writable directories.</description>
-    </metadata>
+    {{{ oval_metadata("The sticky bit should be set for all world-writable directories.") }}}
     <criteria>
       <criterion comment="all local world writable directories have sticky bit set" test_ref="test_dir_perms_world_writable_sticky_bits" negate="true" />
     </criteria>

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="dir_perms_world_writable_system_owned" version="1">
-    <metadata>
-      <title>Find world writable directories not owned by a system account</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>All world writable directories should be owned by a system user.</description>
-    </metadata>
+    {{{ oval_metadata("All world writable directories should be owned by a system user.") }}}
     <criteria comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" negate="true">
       <criterion comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" test_ref="test_dir_world_writable_uid_gt_value" />
     </criteria>

--- a/linux_os/guide/system/permissions/files/file_permissions_systemmap/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_systemmap/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="file_permissions_systemmap" version="1">
-    <metadata>
-      <title>Verify that System.map files are readable only by root</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>
+    {{{ oval_metadata("
         Checks that /boot/System.map-* are only readable by root.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <criterion test_ref="test_permissions_systemmap_files" />
     </criteria>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
     <definition id="file_permissions_unauthorized_sgid" version="1" class="compliance">
-        <metadata>
-            <title>Find SGID files that are not owned by RPM packages</title>
-            <affected family="unix">
-                <platform>multi_platform_fedora</platform>
-                <platform>multi_platform_rhel</platform>
-                <platform>multi_platform_ol</platform>
-                <platform>multi_platform_wrlinux</platform>
-            </affected>
-            <description>Evaluates to true if all files with SGID set are owned by RPM packages.</description>
-        </metadata>
+        {{{ oval_metadata("Evaluates to true if all files with SGID set are owned by RPM packages.") }}}
         <criteria>
             <criterion comment="Check all sgid files" test_ref="test_file_permissions_unauthorized_sgid"/>
         </criteria>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
     <definition id="file_permissions_unauthorized_suid" version="1" class="compliance">
-        <metadata>
-            <title>Find SUID files that are not owned by RPM packages</title>
-            <affected family="unix">
-                <platform>multi_platform_fedora</platform>
-                <platform>multi_platform_rhel</platform>
-                <platform>multi_platform_ol</platform>
-                <platform>multi_platform_wrlinux</platform>
-            </affected>
-            <description>Evaluates to true if all files with SUID set are owned by RPM packages.</description>
-        </metadata>
+        {{{ oval_metadata("Evaluates to true if all files with SUID set are owned by RPM packages.") }}}
         <criteria>
             <criterion comment="Check all suid files" test_ref="test_file_permissions_unauthorized_suid"/>
         </criteria>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_permissions_unauthorized_world_writable" version="1">
-    <metadata>
-      <title>Find Unauthorized World-Writable Files</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_opensuse</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>The world-write permission should be disabled for all files.</description>
-    </metadata>
+    {{{ oval_metadata("The world-write permission should be disabled for all files.") }}}
     <criteria>
       <criterion test_ref="test_file_permissions_unauthorized_world_write" />
     </criteria>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_permissions_ungroupowned" version="2">
-    <metadata>
-      <title>Find files unowned by a group</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>All files should be owned by a group</description>
-    </metadata>
+    {{{ oval_metadata("All files should be owned by a group") }}}
     <criteria>
       <criterion comment="Check all files and make sure they are owned by a group"
       test_ref="test_file_permissions_ungroupowned" />

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="no_files_unowned_by_user" version="1">
-    <metadata>
-      <title>Find files unowned by a user</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>All files should be owned by a user</description>
-    </metadata>
+    {{{ oval_metadata("All files should be owned by a user") }}}
     <criteria>
       <criterion comment="Check all files and make sure they are owned by a user" test_ref="no_files_unowned_by_user_test" />
     </criteria>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -1,18 +1,9 @@
 <def-group>
   <definition class="compliance" id="file_ownership_binary_dirs" version="2">
-    <metadata>
-      <title>Verify that System Executables Have Root Ownership</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>
+    {{{ oval_metadata("
         Checks that /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
         /usr/local/sbin, /usr/libexec, and objects therein, are owned by root.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <criterion test_ref="test_ownership_binary_directories" />
       <criterion test_ref="test_ownership_binary_files" />

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/oval/shared.xml
@@ -1,18 +1,9 @@
 <def-group>
   <definition class="compliance" id="file_ownership_library_dirs" version="1">
-    <metadata>
-      <title>Verify that Shared Library Files Have Root Ownership</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>
+    {{{ oval_metadata("
         Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and
         objects therein, are owned by root.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <criterion test_ref="test_ownership_lib_dir" />
       <criterion test_ref="test_ownership_lib_files" />

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/oval/shared.xml
@@ -1,18 +1,9 @@
 <def-group>
   <definition class="compliance" id="file_permissions_binary_dirs" version="2">
-    <metadata>
-      <title>Verify that System Executables Have Restrictive Permissions</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>
+    {{{ oval_metadata("
         Checks that binary files under /bin, /sbin, /usr/bin, /usr/sbin,
         /usr/local/bin, /usr/local/sbin, and /usr/libexec are not group-writable or world-writable.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <criterion test_ref="test_perms_binary_files" />
     </criteria>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/oval/shared.xml
@@ -1,18 +1,9 @@
 <def-group>
   <definition class="compliance" id="file_permissions_library_dirs" version="1">
-    <metadata>
-      <title>Verify that Shared Library Files Have Restrictive Permissions</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>
+    {{{ oval_metadata("
         Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and
         objects therein, are not group-writable or world-writable.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <criterion test_ref="test_perms_lib_dir" />
       <criterion test_ref="test_perms_lib_files" />

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
@@ -1,17 +1,11 @@
 <def-group>
   <definition class="compliance"
   id="mount_option_nodev_nonroot_local_partitions" version="1">
-    <metadata>
-      <title>Add nodev Option to Non-Root Local Partitions</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The nodev mount option prevents files from being interpreted
+    {{{ oval_metadata("The nodev mount option prevents files from being interpreted
       as character or block devices. Legitimate character and block devices
       should exist in the /dev directory on the root partition or within chroot
       jails built for system services. All other locations should not allow
-      character and block devices.</description>
-    </metadata>
+      character and block devices.") }}}
     <criteria>
       <criterion comment="nodev on local filesystems"
       test_ref="test_nodev_nonroot_local_partitions" negate="true" />

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/oval/shared.xml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="mount_option_var_tmp_bind" version="1">
-    <metadata>
-      <title>Bind Mount /var/tmp To /tmp</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The /var/tmp directory should be bind mounted to /tmp in
+    {{{ oval_metadata("The /var/tmp directory should be bind mounted to /tmp in
       order to consolidate temporary storage into one location protected by the
-      same techniques as /tmp.</description>
-    </metadata>
+      same techniques as /tmp.") }}}
     <criteria operator="AND">
       <criterion comment="Ensure /var/tmp is configured to bind mount to /tmp"
       test_ref="test_configure_mount_option_var_tmp_bind_tmp" />

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="disable_users_coredumps" version="1">
-    <metadata>
-      <title>Disable Core Dumps</title>
-      {{{- oval_affected(products) }}}
-      <description>Core dumps for all users should be disabled</description>
-    </metadata>
+    {{{ oval_metadata("Core dumps for all users should be disabled") }}}
     <criteria operator="OR">
       <criterion comment="Are core dumps disabled in /etc/security/limits.d/*" test_ref="test_core_dumps_limits_d" />
       <criteria operator="AND">

--- a/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="umask_for_daemons" version="2">
-    <metadata>
-      <title>Set Daemon umask</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>The daemon umask should be set as appropriate</description>
-    </metadata>
+    {{{ oval_metadata("The daemon umask should be set as appropriate") }}}
     <criteria operator="AND">
       <extend_definition comment="Get value of var_accounts_user_umask variable as octal number"
       definition_ref="var_umask_for_daemons_as_number" />

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="sysctl_kernel_exec_shield" version="2">
-    <metadata>
-      <title>Kernel Runtime Parameter "kernel.exec-shield" Check</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-      </affected>
-      <description>The kernel runtime parameter "kernel.exec-shield" should not be disabled and set to 1 on 32-bit systems.</description>
-    </metadata>
+    {{{ oval_metadata("The kernel runtime parameter 'kernel.exec-shield' should not be disabled and set to 1 on 32-bit systems.") }}}
     <criteria operator="OR">
       <criteria operator="AND" comment="system is RHEL6">
         <extend_definition comment="RHEL6 installed" definition_ref="installed_OS_is_rhel6" />

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/oval/shared.xml
@@ -1,15 +1,7 @@
 <def-group>
   <definition class="compliance" id="install_PAE_kernel_on_x86-32" version="2">
-    <metadata>
-      <title>Package kernel-PAE Installed</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>The RPM package kernel-PAE should be installed on 32-bit
-      systems.</description>
-    </metadata>
+    {{{ oval_metadata("The RPM package kernel-PAE should be installed on 32-bit
+      systems.") }}}
     <criteria operator="OR">
       <!-- System is not 32-bit. In that case, there's
            nothing more to check -->

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
@@ -1,12 +1,8 @@
 <def-group>
   <definition class="compliance" id="grub2_enable_selinux" version="1">
-    <metadata>
-      <title>Enable SELinux in the GRUB2 Bootloader"</title>
-      {{{- oval_affected(products) }}}
-      <description>
+    {{{ oval_metadata("
         Check if selinux=0 OR enforcing=0 within the GRUB2 configuration files, fail if found.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <criterion comment="check value selinux|enforcing=0 in /etc/default/grub, fail if found" test_ref="test_selinux_default_grub" />
       <criterion comment="check value selinux|enforcing=0 in /etc/grub2.cfg, fail if found" test_ref="test_selinux_grub2_cfg" />

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="selinux_all_devicefiles_labeled" version="1">
-    <metadata>
-      <title>Device Files Have Proper SELinux Context</title>
-      {{{- oval_affected(products) }}}
-      <description>All device files in /dev should be assigned an SELinux security context other than 'device_t' and 'unlabeled_t'.</description>
-    </metadata>
+    {{{ oval_metadata("All device files in /dev should be assigned an SELinux security context other than 'device_t' and 'unlabeled_t'.") }}}
     <criteria operator="AND">
       <criterion comment="device_t in /dev" test_ref="test_selinux_dev_device_t" />
       <criterion comment="unlabeled_t in /dev" test_ref="test_selinux_dev_unlabeled_t" />

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="selinux_confinement_of_daemons" version="1">
-    <metadata>
-      <title>Ensure No Daemons are Unconfined by SELinux</title>
-      {{{- oval_affected(products) }}}
-      <description>All pids in /proc should be assigned an SELinux security context other than 'initrc_t'.</description>
-    </metadata>
+    {{{ oval_metadata("All pids in /proc should be assigned an SELinux security context other than 'initrc_t'.") }}}
     <criteria>
       <criterion comment="device_t in /dev" test_ref="test_selinux_confinement_of_daemons" />
     </criteria>

--- a/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="selinux_policytype" version="1">
-    <metadata>
-      <title>Enable SELinux</title>
-      {{{- oval_affected(products) }}}
-      <description>The SELinux policy should be set appropriately.</description>
-    </metadata>
+    {{{ oval_metadata("The SELinux policy should be set appropriately.") }}}
     <criteria>
       <criterion test_ref="test_selinux_policy" />
     </criteria>

--- a/linux_os/guide/system/selinux/selinux_state/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_state/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="selinux_state" version="1">
-    <metadata>
-      <title>SELinux Enforcing</title>
-      {{{- oval_affected(products) }}}
-      <description>The SELinux state should be enforcing the local policy.</description>
-    </metadata>
+    {{{ oval_metadata("The SELinux state should be enforcing the local policy.") }}}
     <criteria operator="AND">
       <criterion comment="enforce is disabled" test_ref="test_etc_selinux_config" />
     </criteria>

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/oval/shared.xml
@@ -48,16 +48,7 @@
   {{% endmacro %}}
 
   <definition class="compliance" id="dconf_db_up_to_date" version="2">
-    <metadata>
-      <title>The dconf databases are up-to-date.</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Make sure that the dconf databases are up-to-date with regards to respective keyfiles.</description>
-    </metadata>
+    {{{ oval_metadata("Make sure that the dconf databases are up-to-date with regards to respective keyfiles.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check that all DBs in question are up-to-date" operator="AND">

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="enable_dconf_user_profile" version="1">
-    <metadata>
-      <title>Implement Local DB for DConf User Profile</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The DConf User profile should have the local DB configured.</description>
-    </metadata>
+    {{{ oval_metadata("The DConf User profile should have the local DB configured.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criterion comment="dconf user profile exists" test_ref="test_dconf_user_profile" />

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_restart_shutdown" version="1">
-    <metadata>
-      <title>Disable the GNOME3 Login Restart and Shutdown Buttons</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Disable the GNOME3 Login GUI Restart and Shutdown buttons to all users on the login screen.</description>
-    </metadata>
+    {{{ oval_metadata("Disable the GNOME3 Login GUI Restart and Shutdown buttons to all users on the login screen.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Disable GUI shutdown and restart buttons and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_user_list" version="1">
-    <metadata>
-      <title>Disable the GNOME3 Login User List</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Disable the GNOME3 GUI listing of all known users on the login screen.</description>
-    </metadata>
+    {{{ oval_metadata("Disable the GNOME3 GUI listing of all known users on the login screen.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Disable GUI listing of known users and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_enable_smartcard_auth" version="1">
-    <metadata>
-      <title>Enable the GNOME3 Login Smartcard Authentication</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Enable smartcard authentication in the GNOME3 Login GUI.</description>
-    </metadata>
+    {{{ oval_metadata("Enable smartcard authentication in the GNOME3 Login GUI.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Enable smartcard authentication and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_login_retries" version="1">
-    <metadata>
-      <title>Set the GNOME3 Login Number of Failures</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Set the GNOME3 number of login failure attempts.</description>
-    </metadata>
+    {{{ oval_metadata("Set the GNOME3 number of login failure attempts.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Set number of login attempts and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="gnome_gdm_disable_automatic_login" version="2">
-    <metadata>
-      <title>Disable GDM Automatic Login</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Disable the GNOME Display Manager (GDM) ability to allow users to
-      automatically login.</description>
-    </metadata>
+    {{{ oval_metadata("Disable the GNOME Display Manager (GDM) ability to allow users to
+      automatically login.") }}}
     <criteria operator="OR">
       <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criterion comment="Disable GDM Automatic Login" test_ref="test_disable_automatic_login" />

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/oval/shared.xml
@@ -1,17 +1,7 @@
 <def-group>
   <definition class="compliance" id="gnome_gdm_disable_guest_login" version="2">
-    <metadata>
-      <title>Disable GDM Guest Login</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 6</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Disable the GNOME Display Manager (GDM) ability to allow guest users
-      to login.</description>
-    </metadata>
+    {{{ oval_metadata("Disable the GNOME Display Manager (GDM) ability to allow guest users
+      to login.") }}}
     <criteria operator="OR">
       <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
       <criterion comment="Disable GDM Guest Login" test_ref="test_disable_guest_login" />

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/oval/shared.xml
@@ -1,17 +1,9 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_automount" version="1">
-    <metadata>
-      <title>Disable GNOME3 Automounting</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>The system's default desktop environment, GNOME3, will mount
+    {{{ oval_metadata("The system's default desktop environment, GNOME3, will mount
       devices and removable media (such as DVDs, CDs and USB flash drives)
       whenever they are inserted into the system. Disable automount and autorun
-      within GNOME3.</description>
-    </metadata>
+      within GNOME3.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Disable GNOME3 automount/autorun and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/oval/shared.xml
@@ -1,17 +1,9 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_thumbnailers" version="1">
-    <metadata>
-      <title>Disable All GNOME3 Thumbnailers</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>The system's default desktop environment, GNOME3, uses a
+    {{{ oval_metadata("The system's default desktop environment, GNOME3, uses a
       number of different thumbnailer programs to generate thumbnails for any
       new or modified content in an opened folder. Disable the execution of
-      these thumbnail applications within GNOME3.</description>
-    </metadata>
+      these thumbnail applications within GNOME3.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Disable Gnome3 Thumbnailers and prevent user from enabling" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_wifi_create" version="1">
-    <metadata>
-      <title>Disable WIFI Network Connection Creation in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>Disable the GNOME3 wireless network creation settings.</description>
-    </metadata>
+    {{{ oval_metadata("Disable the GNOME3 wireless network creation settings.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_wifi_notification" version="1">
-    <metadata>
-      <title>Disable WIFI Network Notification in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>Disable the GNOME3 wireless network notification.</description>
-    </metadata>
+    {{{ oval_metadata("Disable the GNOME3 wireless network notification.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_remote_access_credential_prompt" version="1">
-    <metadata>
-      <title>Require Credential Prompting for Remote Access in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Configure GNOME3 to require credential prompting for remote access.</description>
-    </metadata>
+    {{{ oval_metadata("Configure GNOME3 to require credential prompting for remote access.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_remote_access_encryption" version="1">
-    <metadata>
-      <title>Require Encryption for Remote Access in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Configure GNOME3 to require encryption for remote access connections.</description>
-    </metadata>
+    {{{ oval_metadata("Configure GNOME3 to require encryption for remote access connections.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_idle_activation_enabled" version="1">
-    <metadata>
-      <title>Enable GNOME3 Screensaver Idle Activation</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Idle activation of the screen saver should be enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Idle activation of the screen saver should be enabled.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check screensaver idle activation and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_idle_activation_locked" version="1">
-    <metadata>
-      <title>Ensure Users Cannot Change GNOME3 Screensaver Idle Activation</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Idle activation of the screen saver should not be changed by users.</description>
-    </metadata>
+    {{{ oval_metadata("Idle activation of the screen saver should not be changed by users.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check screensaver idle activation and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_idle_delay" version="2">
-    <metadata>
-      <title>Configure the GNOME3 GUI Screen locking</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The allowed period of inactivity before the screensaver is activated.</description>
-    </metadata>
+    {{{ oval_metadata("The allowed period of inactivity before the screensaver is activated.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check screensaver idle delay and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_lock_delay" version="2">
-    <metadata>
-      <title>Enable GNOME3 Screensaver Lock Delay After Idle Period</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Idle activation of the screen lock should be enabled immediately or
-      after a delay.</description>
-    </metadata>
+    {{{ oval_metadata("Idle activation of the screen lock should be enabled immediately or
+      after a delay.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Enable screensaver lock and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_lock_enabled" version="2">
-    <metadata>
-      <title>Enable GNOME3 Screensaver Lock After Idle Period</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Idle activation of the screen lock should be enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Idle activation of the screen lock should be enabled.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Enable screensaver lock and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_lock_locked" version="1">
-    <metadata>
-      <title>Ensure Users Cannot Change GNOME3 Screensaver Lock After Idle Period</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Idle activation of the screen lock should not be changed by users.</description>
-    </metadata>
+    {{{ oval_metadata("Idle activation of the screen lock should not be changed by users.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Enable screensaver lock and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_mode_blank" version="2">
-    <metadata>
-      <title>Implement Blank Screensaver</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The GNOME3 screensaver should be blank.</description>
-    </metadata>
+    {{{ oval_metadata("The GNOME3 screensaver should be blank.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Enable blank screensaver and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_user_info" version="1">
-    <metadata>
-      <title>Disable Full User Name on Splash Shield</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>GNOME3 screen splash shield should not display full name of logged in user.</description>
-    </metadata>
+    {{{ oval_metadata("GNOME3 screen splash shield should not display full name of logged in user.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="Disable screensaver user info and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_screensaver_user_locks" version="1">
-    <metadata>
-      <title>Ensure Users Cannot Change GNOME3 Screensaver Lock Delay Settings</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Ensure that users cannot change GNOME3 screensaver idle and lock settings.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure that users cannot change GNOME3 screensaver idle and lock settings.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check screensaver idle delay and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_session_idle_user_locks" version="1">
-    <metadata>
-      <title>Ensure Users Cannot Change GNOME3 Session Idle Settings</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Ensure that users cannot change GNOME3 session idle settings.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure that users cannot change GNOME3 session idle settings.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check screensaver idle delay and prevent user from changing it" operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_ctrlaltdel_reboot" version="1">
-    <metadata>
-      <title>Disable Ctrl-Alt-Del Reboot Key Sequence in GNOME3</title>
-      {{{- oval_affected(products) }}}
-      <description>Disable the GNOME3 ctrl-alt-del reboot key sequence in GNOME3.</description>
-    </metadata>
+    {{{ oval_metadata("Disable the GNOME3 ctrl-alt-del reboot key sequence in GNOME3.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_geolocation" version="1">
-    <metadata>
-      <title>Disable Geolocation in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>Disable GNOME3 Geolocation for the clock and system.</description>
-    </metadata>
+    {{{ oval_metadata("Disable GNOME3 Geolocation for the clock and system.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_power_settings" version="1">
-    <metadata>
-      <title>Disable Power Settings in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>Disable GNOME3 power settings.</description>
-    </metadata>
+    {{{ oval_metadata("Disable GNOME3 power settings.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="dconf_gnome_disable_user_admin" version="1">
-    <metadata>
-      <title>Disable User Administration in GNOME3</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Disable GNOME3's ability to give users some administrative rights.</description>
-    </metadata>
+    {{{ oval_metadata("Disable GNOME3's ability to give users some administrative rights.") }}}
     <criteria operator="OR">
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
@@ -1,12 +1,8 @@
 <def-group>
   <definition class="compliance" id="installed_OS_is_FIPS_certified" version="1">
-    <metadata>
-      <title>FIPS 140-2 Certified Operating System</title>
-      {{{- oval_affected(products) }}}
-      <description>
+    {{{ oval_metadata("
           The operating system installed on the system is a certified operating system that meets FIPS 140-2 requirements.
-      </description>
-    </metadata>
+      ") }}}
     <criteria comment="Installed operating system is a certified operating system" operator="OR">
       <extend_definition comment="Installed OS is RHEL6" definition_ref="installed_OS_is_rhel6" />
       <extend_definition comment="Installed OS is RHEL7" definition_ref="installed_OS_is_rhel7" />

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
@@ -1,12 +1,8 @@
 <def-group>
   <definition class="compliance" id="installed_OS_is_vendor_supported" version="1">
-    <metadata>
-      <title>Vendor Supported Operating System</title>
-      {{{- oval_affected(products) }}}
-     <description>
+    {{{ oval_metadata("
         The operating system installed on the system is supported by a vendor that provides security patches.
-      </description>
-    </metadata>
+      ") }}}
     <criteria comment="Installed operating system is supported by a vendor" operator="OR">
       <extend_definition comment="Installed OS is RHEL6" definition_ref="installed_OS_is_rhel6" />
       <extend_definition comment="Installed OS is RHEL7" definition_ref="installed_OS_is_rhel7" />

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_bind_crypto_policy" version="1">
-    <metadata>
-      <title>Configure BIND to use System Crypto Policy.</title>
-      {{{- oval_affected(products) }}}
-      <description>BIND should be configured to use the system-wide crypto policy setting.</description>
-    </metadata>
+    {{{ oval_metadata("BIND should be configured to use the system-wide crypto policy setting.") }}}
     <criteria operator="OR">
       <extend_definition comment="Check if package bind is not installed" definition_ref="package_bind_removed" />
       <criterion test_ref="test_configure_bind_crypto_policy"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_crypto_policy" version="1">
-    <metadata>
-      <title>Configure System Cryptographic Policies</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure crypto policy is correctly configured in /etc/crypto-policies/config, and the policy is current.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure crypto policy is correctly configured in /etc/crypto-policies/config, and the policy is current.") }}}
     <criteria operator="AND">
       <criterion comment="check for crypto policy correctly configured in /etc/crypto-policy/config"
       test_ref="test_configure_crypto_policy" />

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/oval/shared.xml
@@ -3,11 +3,7 @@
 {{% set backend_krb5_config = "/etc/crypto-policies/back-ends/krb5.config" %}}
 <def-group>
   <definition class="compliance" id="configure_kerberos_crypto_policy" version="2">
-    <metadata>
-      <title>Configure kerberos to use System Crypto Policy</title>
-      {{{- oval_affected(products) }}}
-      <description>Kerberos should be configured to use the system-wide crypto policy setting.</description>
-    </metadata>
+    {{{ oval_metadata("Kerberos should be configured to use the system-wide crypto policy setting.") }}}
     <criteria operator="OR" comment="The config file is always a symlink to the backend, but the backend itself may be either a file, or a symlink. For this reason, we need two tests, if one passes, the other one is expected to either fail, or error.">
       <criterion comment="kerberos crypto-policy configuration links to same file as kerberos crypto-policy backend" test_ref="test_configure_kerberos_crypto_policy_symlink" />
       <criterion comment="kerberos crypto-policy configuration links to the crypto-policy backend file" test_ref="test_configure_kerberos_crypto_policy_nosymlink" />

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_libreswan_crypto_policy" version="1">
-    <metadata>
-      <title>Configure Libreswan to use System Crypto Policy.</title>
-      {{{- oval_affected(products) }}}
-      <description>Libreswan should be configured to use the system-wide crypto policy setting.</description>
-    </metadata>
+    {{{ oval_metadata("Libreswan should be configured to use the system-wide crypto policy setting.") }}}
     <criteria operator="OR">
       <extend_definition comment="Check if package libreswan is not installed" definition_ref="package_libreswan_installed" negate="true" />
       <criterion test_ref="test_configure_libreswan_crypto_policy"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_openssl_crypto_policy" version="1">
-    <metadata>
-      <title>Configure OpenSSL to use System Crypto Policy</title>
-      {{{- oval_affected(products) }}}
-      <description>OpenSSL should be configured to use the system-wide crypto policy setting.</description>
-    </metadata>
+    {{{ oval_metadata("OpenSSL should be configured to use the system-wide crypto policy setting.") }}}
     <criteria>
       <criterion test_ref="test_configure_openssl_crypto_policy"
       comment="Check that the configuration mandates usage of system-wide crypto policies." />

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="configure_ssh_crypto_policy" version="1">
-    <metadata>
-      <title>Configure SSH to use System Crypto Policy.</title>
-      {{{- oval_affected(products) }}}
-      <description>SSH should be configured to use the system-wide crypto policy setting.</description>
-    </metadata>
+    {{{ oval_metadata("SSH should be configured to use the system-wide crypto policy setting.") }}}
     <criteria>
       <criterion test_ref="test_configure_ssh_crypto_policy"
       comment="Check that the SSH configuration mandates usage of system-wide crypto policies." />

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/oval/shared.xml
@@ -131,11 +131,7 @@
 
 <def-group>
   <definition class="compliance" id="harden_ssh_client_crypto_policy" version="3">
-    <metadata>
-      <title>Harden SSH client Crypto Policy</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure the ssh client ciphers are configured correctly in /etc/ssh/ssh_config.d/02-ospp.conf</description>
-    </metadata>
+    {{{ oval_metadata("Ensure the ssh client ciphers are configured correctly in /etc/ssh/ssh_config.d/02-ospp.conf") }}}
     <criteria comment="SSH client is configured correctly"
     operator="AND">
         {{{ oval_line_in_file_criterion(path='/etc/ssh/ssh_config.d/02-ospp.conf', parameter='Match') }}}

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="openssl_use_strong_entropy" version="1">
-    <metadata>
-      <title>Configure OpenSSL to use strong entropy</title>
-      {{{- oval_affected(products) }}}
-      <description>OpenSSL should be configured to generate random data with strong entropy.</description>
-    </metadata>
+    {{{ oval_metadata("OpenSSL should be configured to generate random data with strong entropy.") }}}
     <criteria>
       <criterion test_ref="test_openssl_strong_entropy"
       comment="Check that the OpenSSL is configured to generate random data with strong entropy." />

--- a/linux_os/guide/system/software/integrity/crypto/ssh_client_rekey_limit/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/ssh_client_rekey_limit/oval/shared.xml
@@ -1,11 +1,7 @@
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    <metadata>
-      <title>{{{ rule_title }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure 'RekeyLimit' is configured with the correct value in /etc/ssh/ssh_config and /etc/ssh/ssh_config.d/*.conf</description>
-    </metadata>
+    {{{ oval_metadata("Ensure 'RekeyLimit' is configured with the correct value in /etc/ssh/ssh_config and /etc/ssh/ssh_config.d/*.conf") }}}
     <criteria comment="RekeyLimit is correctly configured for ssh client" operator="AND">
       <criterion comment="check that RekeyLimit is not configured in /etc/ssh/ssh_config" test_ref="test_ssh_client_rekey_limit_main_config" negate="true" />
       <criterion comment="check correct RekeyLimit configuration in /etc/ssh/ssh_config.d/*.conf" test_ref="test_ssh_client_rekey_limit_include_configs" />

--- a/linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/oval/shared.xml
@@ -1,14 +1,10 @@
 
 <def-group>
   <definition class="compliance" id="disable_prelink" version="3">
-    <metadata>
-      <title>Disable Prelinking</title>
-      {{{- oval_affected(products) }}}
-      <description>The prelinking feature can interfere with the operation of
+    {{{ oval_metadata("The prelinking feature can interfere with the operation of
       checksum integrity tools (e.g. AIDE), mitigates the protection provided
       by ASLR, and requires additional CPU cycles by software upgrades.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="OR" comment="Conditions for prelinking disabled are satisfied">
       <extend_definition comment="prelink RPM package not installed" definition_ref="package_prelink_removed" />
       <criterion comment="Prelinking is disabled" test_ref="test_prelinking_disabled" />

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="install_antivirus"
   version="1">
-    <metadata>
-      <title>Package Antivirus Installed</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Antivirus software should be installed.</description>
-    </metadata>
+    {{{ oval_metadata("Antivirus software should be installed.") }}}
     <criteria comment="Antivirus is not being used or conditions are met">
       <extend_definition comment="McAfee A/V Installed" definition_ref="install_mcafee_antivirus" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/oval/shared.xml
@@ -1,15 +1,7 @@
 <def-group>
   <definition class="compliance" id="install_hids"
   version="1">
-    <metadata>
-      <title>Install Intrusion Detection Software</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Intrusion detection software or SELinux should be installed and enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Intrusion detection software or SELinux should be installed and enabled.") }}}
     <criteria operator="OR">
       <extend_definition comment="McAfee HBSS" definition_ref="install_mcafee_hbss" />
       <criterion comment="SELinux enabled" test_ref="test_selinux_enforcing" />

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="install_mcafee_antivirus"
   version="1">
-    <metadata>
-      <title>Package McAfeeVSEForLinux Installed</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>McAfee Antivirus software should be installed.</description>
-    </metadata>
+    {{{ oval_metadata("McAfee Antivirus software should be installed.", affected_platforms=["multi_platform_all"]) }}}
     <criteria comment="Antivirus is not being used or conditions are met" operator="AND">
       <extend_definition comment="McAfee Runtime Libraries and Agent" definition_ref="install_mcafee_cma_rt" />
       <criterion comment="Linuxshield AntiVirus package is installed"

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_cma_rt/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_cma_rt/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="install_mcafee_cma_rt"
   version="1">
-    <metadata>
-      <title>Install the McAfee Runtime Libraries and Linux Agent</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Install the McAfee Runtime Libraries (MFErt) and Linux Agent (MFEcma).</description>
-    </metadata>
+    {{{ oval_metadata("Install the McAfee Runtime Libraries (MFErt) and Linux Agent (MFEcma).", affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="AND">
       <criterion comment="McAfee runtime library package installed"
       test_ref="test_mcafee_runtime_installed" />

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group oval_version="5.10">
   <definition class="compliance" id="mcafee_antivirus_definitions_updated" version="1">
-    <metadata>
-      <title>McAfee AntiVirus Definitions Updated</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Verify that McAfee AntiVirus definitions have been updated.</description>
-    </metadata>
+    {{{ oval_metadata("Verify that McAfee AntiVirus definitions have been updated.") }}}
 
     <criteria>
       <criterion comment="Check if McAfee AntiVirus definitions have been updated" test_ref="test_mcafee_antivirus_definitions_updated" />

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/install_mcafee_hbss_accm/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/install_mcafee_hbss_accm/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="install_mcafee_hbss_accm"
   version="1">
-    <metadata>
-      <title>Install the Asset Configuration Compliance Module (ACCM)</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Install the Asset Configuration Compliance Module (ACCM).</description>
-    </metadata>
+    {{{ oval_metadata("Install the Asset Configuration Compliance Module (ACCM).", affected_platforms=["multi_platform_all"]) }}}
     <criteria>
       <criterion comment="McAfee ACCM is installed"
       test_ref="test_mcafee_accm_exists" />

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/install_mcafee_hbss_hips/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/install_mcafee_hbss_hips/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="install_mcafee_hbss_hips"
   version="1">
-    <metadata>
-      <title>Install the Host Intrusion Prevention System (HIPS) Module</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Install the McAfee Host Intrusion Prevention System (HIPS) Module if it is
-      absolutely necessary. If SELinux is enabled, do not install or enable this module.</description>
-    </metadata>
+	  {{{ oval_metadata("Install the McAfee Host Intrusion Prevention System (HIPS) Module if it is absolutely necessary. If SELinux is enabled, do not install or enable this module.",
+	  affected_platforms=["multi_platform_all"]) }}}
     <criteria>
       <criterion comment="McAfee IPS  is installed"
       test_ref="test_mcafee_hbss_hips_installed" />

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/install_mcafee_hbss_pa/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/install_mcafee_hbss_pa/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="install_mcafee_hbss_pa"
   version="1">
-    <metadata>
-      <title>Install the Policy Auditor (PA) Module</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Install the Policy Auditor (PA) Module.</description>
-    </metadata>
+    {{{ oval_metadata("Install the Policy Auditor (PA) Module.", affected_platforms=["multi_platform_all"]) }}}
     <criteria>
       <criterion comment="McAfee Policy Auditor is installed"
       test_ref="test_mcafee_auditengine_exists" />

--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="enable_dracut_fips_module" version="1">
-    <metadata>
-      <title>Enable Dracut FIPS Module</title>
-      {{{- oval_affected(products) }}}
-      <description>fips module should be enabled in Dracut configuration</description>
-    </metadata>
+    {{{ oval_metadata("fips module should be enabled in Dracut configuration") }}}
     <criteria operator="AND">
       <criterion comment="dracut fips module is enabled" test_ref="test_enable_dracut_fips_module" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group oval_version="5.10">
   <definition class="compliance" id="enable_fips_mode" version="1">
-    <metadata>
-      <title>Enable FIPS Mode</title>
-      {{{- oval_affected(products) }}}
-      <description>Check if FIPS mode is enabled on the system</description>
-    </metadata>
+    {{{ oval_metadata("Check if FIPS mode is enabled on the system") }}}
     <criteria operator="AND">
       <extend_definition comment="check /etc/system-fips exists" definition_ref="etc_system_fips_exists" />
       <extend_definition comment="check sysctl crypto.fips_enabled = 1" definition_ref="sysctl_crypto_fips_enabled" />

--- a/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group oval_version="5.10">
   <definition class="compliance" id="etc_system_fips_exists" version="1">
-    <metadata>
-      <title>Check /etc/system-fips exists</title>
-      {{{- oval_affected(products) }}}
-      <description>Check /etc/system-fips exists</description>
-    </metadata>
+    {{{ oval_metadata("Check /etc/system-fips exists") }}}
     <criteria operator="AND">
       <criterion test_ref="test_etc_system_fips" comment="/etc/system-fips exists" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group oval_version="5.10">
   <definition class="compliance" id="grub2_enable_fips_mode" version="1">
-    <metadata>
-      <title>Enable FIPS Mode in GRUB2</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure fips=1 is configured in the kernel line in /etc/default/grub.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure fips=1 is configured in the kernel line in /etc/default/grub.") }}}
     <criteria operator="AND">
       <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <extend_definition comment="prelink disabled" definition_ref="disable_prelink" />

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
@@ -5,11 +5,7 @@
 <def-group>
   <definition class="compliance" id="package_dracut-fips-aesni_installed"
   version="1">
-    <metadata>
-      <title>Package dracut-fips-aesni Installed</title>
-      {{{- oval_affected(products) }}}
-      <description>The RPM package dracut-fips-aesni should be installed.</description>
-    </metadata>
+    {{{ oval_metadata("The RPM package dracut-fips-aesni should be installed.") }}}
     <criteria operator="OR">
       <criterion comment="System does not support AES instruction set" test_ref="test_processor_aes_instruction" />
       <criteria operator="AND">

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
@@ -5,11 +5,7 @@
 <def-group>
   <definition class="compliance" id="package_dracut-fips_installed"
   version="1">
-    <metadata>
-      <title>Package dracut-fips Installed</title>
-      {{{- oval_affected(products) }}}
-      <description>The RPM package dracut-fips should be installed.</description>
-    </metadata>
+    {{{ oval_metadata("The RPM package dracut-fips should be installed.") }}}
     <criteria>
       <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criterion comment="package dracut-fips is installed"

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/oval/shared.xml
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="sysctl_crypto_fips_enabled" version="1">
-    <metadata>
-      <title>Kernel "crypto.fips_enabled" Parameter Runtime Check</title>
-      {{{- oval_affected(products) }}}
-      <description>The kernel "crypto.fips_enabled" parameter should be set to "1" in system runtime.</description>
-    </metadata>
+    {{{ oval_metadata("The kernel 'crypto.fips_enabled' parameter should be set to '1' in system runtime.") }}}
     <criteria operator="AND">
       <criterion comment="kernel runtime parameter crypto.fips_enabled set to 1" test_ref="test_sysctl_crypto_fips_enabled" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
@@ -1,15 +1,6 @@
 <def-group>
   <definition class="compliance" id="aide_build_database" version="2">
-    <metadata>
-      <title>Aide Database Must Exist</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>The aide database must be initialized.</description>
-    </metadata>
+    {{{ oval_metadata("The aide database must be initialized.") }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <!-- Only the configuration when location of the Aide database file is specified in the

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/shared.xml
@@ -1,19 +1,9 @@
 <def-group>
   <definition class="compliance" id="aide_periodic_cron_checking" version="3">
-    <metadata>
-      <title>Configure Periodic Execution of AIDE</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_ol</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-      </affected>
-      <description>By default, AIDE does not install itself for periodic
+    {{{ oval_metadata("By default, AIDE does not install itself for periodic
       execution. Periodically running AIDE is necessary to reveal
       unexpected changes in installed files.
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criteria operator="OR">

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group>
   <definition class="compliance" id="aide_scan_notification" version="1">
-    <metadata>
-      <title>Configure Notification of Post-AIDE Scan Details</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>AIDE should notify appropriate personnel of the details
-      of a scan after the scan has been run.</description>
-    </metadata>
+    {{{ oval_metadata("AIDE should notify appropriate personnel of the details
+      of a scan after the scan has been run.") }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criteria operator="OR">

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
@@ -1,15 +1,7 @@
 <def-group>
   <definition class="compliance" id="aide_use_fips_hashes" version="1">
-    <metadata>
-      <title>Configure AIDE to Use FIPS 140-2 for Validating Hashes</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>AIDE should be configured to use the FIPS 140-2 
-      cryptographic hashes.</description>
-    </metadata>
+    {{{ oval_metadata("AIDE should be configured to use the FIPS 140-2 
+      cryptographic hashes.") }}}
     <criteria operator="AND">
       <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="aide_verify_acls" version="1">
-    <metadata>
-      <title>Configure AIDE to Verify Access Control Lists (ACLs)</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>AIDE should be configured to verify Access Control Lists (ACLs).</description>
-    </metadata>
+    {{{ oval_metadata("AIDE should be configured to verify Access Control Lists (ACLs).") }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criterion comment="acl is set in /etc/aide.conf" test_ref="test_aide_verify_acls" />

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="aide_verify_ext_attributes" version="1">
-    <metadata>
-      <title>Configure AIDE to Verify Extended Attributes</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>AIDE should be configured to verify extended file attributes.</description>
-    </metadata>
+    {{{ oval_metadata("AIDE should be configured to verify extended file attributes.") }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criterion comment="xattrs is set in /etc/aide.conf" test_ref="test_aide_verify_ext_attributes" />

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/oval/shared.xml
@@ -1,16 +1,6 @@
 <def-group>
   <definition class="compliance" id="rpm_verify_hashes" version="3">
-    <metadata>
-      <title>Verify File Hashes with RPM</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Verify the RPM digests of system binaries using the RPM database.</description>
-    </metadata>
+    {{{ oval_metadata("Verify the RPM digests of system binaries using the RPM database.") }}}
     <criteria>
       <criterion test_ref="test_files_fail_md5_hash" comment="verify file md5 hashes" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/oval/shared.xml
@@ -1,18 +1,9 @@
 <def-group>
   <definition class="compliance" id="rpm_verify_ownership" version="3">
-    <metadata>
-      <title>Verify File Ownership Using RPM</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Verify ownership of installed packages
+    {{{ oval_metadata("Verify ownership of installed packages
       by comparing the installed files with information about the
       files taken from the package metadata stored in the RPM
-      database.</description>
-    </metadata>
+      database.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_verify_all_rpms_user_ownership" comment="user ownership of all files matches local rpm database" />
       <criterion test_ref="test_verify_all_rpms_group_ownership" comment="group ownership of all files matches local rpm database" />

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/oval/shared.xml
@@ -1,19 +1,9 @@
 <def-group>
   <definition class="compliance" id="rpm_verify_permissions" version="3">
-    <metadata>
-      <title>Verify File Permissions Using RPM</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Verify the permissions of installed packages
+    {{{ oval_metadata("Verify the permissions of installed packages
       by comparing the installed files with information about the
       files taken from the package metadata stored in the RPM
-      database.</description>
-    </metadata>
+      database.") }}}
     <criteria>
       <criterion test_ref="test_verify_all_rpms_mode" comment="mode of all files matches local rpm database" />
     </criteria>

--- a/linux_os/guide/system/software/sap_host/accounts_authorized_local_users/oval/shared.xml
+++ b/linux_os/guide/system/software/sap_host/accounts_authorized_local_users/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="accounts_authorized_local_users" version="1">
-    <metadata>
-      <title>Only Authorized Local User Accounts Exist on Operating System</title>
-      <affected family="unix">
-        <platform>Oracle Linux 7</platform>
-      </affected>
-      <description>Besides the default operating system user, there should be no other users
-      except the users that are authorized to exist locally on the operating system.</description>
-    </metadata>
+    {{{ oval_metadata("Besides the default operating system user, there should be no other users
+      except the users that are authorized to exist locally on the operating system.") }}}
     <criteria>
       <criterion test_ref="test_accounts_authorized_local_users"
       comment="only root user and explicitly authorized users are allowed in /etc/passwd" />

--- a/linux_os/guide/system/software/sap_host/accounts_authorized_local_users_sidadm_orasid/oval/shared.xml
+++ b/linux_os/guide/system/software/sap_host/accounts_authorized_local_users_sidadm_orasid/oval/shared.xml
@@ -1,16 +1,10 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="accounts_authorized_local_users_sidadm_orasid" version="1">
-    <metadata>
-      <title>Only sidadm and orasid/oracle Exist as Local Users on Operating System</title>
-      <affected family="unix">
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description> SAP system users sidadm/sapadm and orasid/oracle should be the only
+    {{{ oval_metadata(" SAP system users sidadm/sapadm and orasid/oracle should be the only
       users besides the authorized usrs listed in var_accounts_authorized_local_users_regex
       that exist locally on the operating system.
       Limitation: only works with zero to one SAP system on each OS/VM. 
-      </description>
-    </metadata>
+      ") }}}
     <criteria operator="AND">
       <!-- users in the external list -->
       <criterion test_ref="test_accounts_authorized_local_users_sidadm_orasid"

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/oval/shared.xml
@@ -1,18 +1,6 @@
 <def-group>
   <definition class="compliance" id="sudo_remove_no_authenticate" version="1">
-    <metadata>
-      <title>Ensure !authenticate Is Not Used in Sudo</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ubuntu</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Checks sudo usage without authentication</description>
-    </metadata>
+    {{{ oval_metadata("Checks sudo usage without authentication") }}}
     <criteria operator="AND">
       <criterion comment="!authenticate does not exist in /etc/sudoers" test_ref="test_no_authenticate_etc_sudoers" />
       <criterion comment="!authenticate does not exist in /etc/sudoers.d" test_ref="test_no_authenticate_etc_sudoers_d" />

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/oval/shared.xml
@@ -1,18 +1,6 @@
 <def-group>
   <definition class="compliance" id="sudo_remove_nopasswd" version="1">
-    <metadata>
-      <title>Ensure NOPASSWD Is Not Used in Sudo</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ubuntu</platform>
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Checks sudo usage without password</description>
-    </metadata>
+    {{{ oval_metadata("Checks sudo usage without password") }}}
     <criteria operator="AND">
       <criterion comment="NOPASSWD is not configured in /etc/sudoers" test_ref="test_nopasswd_etc_sudoers" />
       <criterion comment="NOPASSWD is not configured in /etc/sudoers.d" test_ref="test_nopasswd_etc_sudoers_d" />

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/oval/shared.xml
@@ -1,17 +1,6 @@
 <def-group>
   <definition class="compliance" id="sudo_require_authentication" version="1">
-    <metadata>
-      <title>Ensure Users Re-Authenticate for Privilege Escalation - sudo</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_debian</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ubuntu</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Checks sudo usage without password</description>
-    </metadata>
+    {{{ oval_metadata("Checks sudo usage without password") }}}
     <criteria operator="AND">
       <extend_definition definition_ref="sudo_remove_no_authenticate" />
       <extend_definition definition_ref="sudo_remove_nopasswd" />

--- a/linux_os/guide/system/software/sudo/sudo_vdsm_nopasswd/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_vdsm_nopasswd/oval/shared.xml
@@ -1,14 +1,6 @@
 <def-group>
   <definition class="compliance" id="sudo_vdsm_nopasswd" version="1">
-    <metadata>
-      <title>Ensure NOPASSWD Is Used Only for the VDSM User in Sudo</title>
-      <affected family="unix">
-        <platform>Red Hat Virtualization 4</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhel</platform>
-      </affected>
-      <description>Checks sudo usage for the vdsm user without a password</description>
-    </metadata>
+    {{{ oval_metadata("Checks sudo usage for the vdsm user without a password") }}}
     <criteria operator="AND">
       <criterion comment="NOPASSWD only exists for vdsm user in /etc/sudoers" test_ref="test_vdsm_nopasswd_etc_sudoers" />
       <criterion comment="NOPASSWD only exists for vdsm user in /etc/sudoers.d" test_ref="test_vdsm_nopasswd_etc_sudoers_d" />

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group oval_version="5.10">
   <definition class="compliance" id="clean_components_post_updating" version="1">
-    <metadata>
-      <title>Ensure YUM Removes Previous Package Versions</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The clean_requirements_on_remove option should be used to ensure that old 
-      versions of software components are removed after updating.</description>
-    </metadata>
+    {{{ oval_metadata("The clean_requirements_on_remove option should be used to ensure that old 
+      versions of software components are removed after updating.") }}}
     <criteria>
       <criterion comment="check value of clean_requirements_on_remove in /etc/yum.conf" test_ref="test_yum_clean_components_post_updating" />
     </criteria>

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
@@ -20,13 +20,7 @@
 
 <def-group>
   <definition class="compliance" id="ensure_fedora_gpgkey_installed" version="2">
-    <metadata>
-      <title>Fedora Release gpg-pubkey Package Installed</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-      </affected>
-      <description>The Fedora release key package is required to be installed.</description>
-    </metadata>
+    {{{ oval_metadata("The Fedora release key package is required to be installed.") }}}
     <criteria comment="Fedora Vendor keys" operator="AND">
       <extend_definition comment="Fedora installed" definition_ref="installed_OS_is_fedora" />
       <criteria comment="Supported Fedora key is installed" operator="OR">

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
@@ -1,14 +1,8 @@
 <def-group>
   <definition class="compliance" id="ensure_gpgcheck_globally_activated" version="1">
-    <metadata>
-      <title>Ensure {{{ pkg_manager }}} gpgcheck Globally Activated</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The gpgcheck option should be used to ensure that checking
+    {{{ oval_metadata("The gpgcheck option should be used to ensure that checking
       of an RPM package's signature always occurs prior to its
-      installation.</description>
-    </metadata>
+      installation.") }}}
     <criteria operator="AND">
      <criterion comment="check value of gpgcheck in {{{ pkg_manager_config_file }}}" test_ref="test_ensure_gpgcheck_globally_activated" />
     </criteria>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/oval/shared.xml
@@ -1,19 +1,8 @@
 <def-group>
   <definition class="compliance" id="ensure_gpgcheck_local_packages" version="1">
-    <metadata>
-      <title>Ensure gpgcheck Enabled for Local Packages</title>
-      <affected family="unix">
-        <platform>multi_platform_wrlinux</platform>
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The localpkg_gpgcheck option should be used to ensure that checking 
+    {{{ oval_metadata("The localpkg_gpgcheck option should be used to ensure that checking 
       of an RPM package's signature always occurs prior to its
-      installation.</description>
-    </metadata>
+      installation.") }}}
     <criteria>
       <criterion comment="check value of localpkg_gpgcheck in {{{ pkg_manager_config_file }}}" test_ref="test_yum_ensure_gpgcheck_local_packages" />
     </criteria>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/oval/shared.xml
@@ -1,16 +1,7 @@
 <def-group>
   <definition class="compliance" id="ensure_gpgcheck_never_disabled"
   version="1">
-    <metadata>
-      <title>Ensure gpgcheck Enabled For All Yum or Dnf Package Repositories</title>
-      <affected family="unix">
-        <platform>multi_platform_fedora</platform>
-        <platform>multi_platform_rhv</platform>
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>Ensure all yum or dnf repositories utilize signature checking.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure all yum or dnf repositories utilize signature checking.") }}}
     <criteria comment="ensure all yum or dnf repositories utilize signiature checking" operator="AND">
       <criterion comment="verify no gpgpcheck=0 present in /etc/yum.repos.d files"
       test_ref="test_ensure_gpgcheck_never_disabled" />

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
@@ -1,15 +1,7 @@
 <def-group>
   <definition class="compliance" id="ensure_gpgcheck_repo_metadata" version="1">
-    <metadata>
-      <title>Ensure gpgcheck Enabled for Repository Metadata</title>
-      <affected family="unix">
-        <platform>Red Hat Enterprise Linux 7</platform>
-        <platform>Red Hat Enterprise Linux 8</platform>
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The repo_gpgcheck option should be used to ensure that checking
-      of repository metadata always occurs.</description>
-    </metadata>
+    {{{ oval_metadata("The repo_gpgcheck option should be used to ensure that checking
+      of repository metadata always occurs.") }}}
     <criteria>
       <criterion comment="check value of repo_gpgcheck in /etc/yum.conf" test_ref="test_yum_ensure_gpgcheck_repo_metadata" />
     </criteria>

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
@@ -1,12 +1,6 @@
 <def-group>
   <definition class="compliance" id="ensure_oracle_gpgkey_installed" version="1">
-    <metadata>
-      <title>Oracle Linux gpg-pubkey Package Installed</title>
-      <affected family="unix">
-        <platform>multi_platform_ol</platform>
-      </affected>
-      <description>The Oracle Linux key packages are required to be installed.</description>
-    </metadata>
+    {{{ oval_metadata("The Oracle Linux key packages are required to be installed.") }}}
     <criteria comment="Vendor GPG keys" operator="OR">
       <criteria comment="Oracle Vendor GPG Keys" operator="AND">
         <criteria comment="Oracle Linux Release Installed" operator="OR">

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -1,13 +1,6 @@
 <def-group>
   <definition class="compliance" id="ensure_redhat_gpgkey_installed" version="2">
-    <metadata>
-      <title>Red Hat Release and Auxiliary gpg-pubkey Packages Installed</title>
-      <affected family="unix">
-        <platform>multi_platform_rhel</platform>
-        <platform>multi_platform_rhv</platform>
-      </affected>
-      <description>The Red Hat release and auxiliary key packages are required to be installed.</description>
-    </metadata>
+    {{{ oval_metadata("The Red Hat release and auxiliary key packages are required to be installed.") }}}
     <criteria comment="Vendor GPG keys" operator="OR">
       <criteria comment="Red Hat Vendor Keys" operator="AND">
         <criteria comment="Red Hat Installed" operator="OR">

--- a/rhcos4/product.yml
+++ b/rhcos4/product.yml
@@ -13,3 +13,9 @@ init_system: "systemd"
 # Mapping of CPE platform to package
 platform_package_overrides:
   login_defs: "shadow-utils"
+
+# The fingerprints below are retrieved from https://access.redhat.com/security/team/key
+pkg_release: "4ae0493b"
+pkg_version: "fd431d51"
+
+release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -522,7 +522,7 @@
 {{%- else %}}
         <title>{{{ rule_title }}}</title>
 {{%- endif -%}}
-{{%- if affected_platforms -%}}
+{{%- if affected_platforms %}}
             <affected family="unix">
 {{%- for platform in affected_platforms %}}
                 <platform>{{{ platform }}}</platform>

--- a/shared/templates/template_OVAL_accounts_password
+++ b/shared/templates/template_OVAL_accounts_password
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="accounts_password_pam_{{{ VARIABLE }}}" version="3">
-    <metadata>
-      <title>Set Password {{{ VARIABLE }}} Requirements</title>
-      {{{- oval_affected(products) }}}
-      <description>The password {{{ VARIABLE }}} should meet minimum requirements</description>
-    </metadata>
+    {{{ oval_metadata("The password " + VARIABLE + " should meet minimum requirements") }}}
 {{% if product == "rhel6" %}}
     <criteria>
         <criterion comment="rhel6 pam_cracklib {{{ VARIABLE }}}" test_ref="test_password_pam_cracklib_{{{ VARIABLE }}}" />

--- a/shared/templates/template_OVAL_audit_rules_dac_modification
+++ b/shared/templates/template_OVAL_audit_rules_dac_modification
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    <metadata>
-      <title>Audit Discretionary Access Control Modification Events - {{{ ATTR }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>The changing of file permissions and attributes should be audited.</description>
-    </metadata>
+    {{{ oval_metadata("The changing of file permissions and attributes should be audited.") }}}
     <criteria operator="OR">
 
       <!-- Test the augenrules case -->

--- a/shared/templates/template_OVAL_audit_rules_file_deletion_events
+++ b/shared/templates/template_OVAL_audit_rules_file_deletion_events
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_file_deletion_events_{{{ NAME }}}" version="1">
-    <metadata>
-      <title>Audit File Deletion Events - {{{ NAME }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>The deletion of files should be audited.</description>
-    </metadata>
+    {{{ oval_metadata("The deletion of files should be audited.") }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_login_events
+++ b/shared/templates/template_OVAL_audit_rules_login_events
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_login_events_{{{ NAME }}}" version="2">
-    <metadata>
-      <title>Record Attempts to Alter Login and Logout Events - {{{ NAME }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules should be configured to log successful and unsuccessful login and logout events.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules should be configured to log successful and unsuccessful login and logout events.") }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_path_syscall
+++ b/shared/templates/template_OVAL_audit_rules_path_syscall
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_{{{ PATHID }}}_{{{ SYSCALL }}}" version="1">
-    <metadata>
-      <title>Ensure auditd Collects Write Events to {{{ PATH }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the write events to {{{ PATH }}}</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the write events to " + PATH) }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ ID }}}" version="1">
-    <metadata>
-      <title>{{{ TITLE }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the information on the use of {{{ NAME }}} is enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the information on the use of " + NAME + " is enabled.") }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ NAME }}}" version="1">
-    <metadata>
-      <title>Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful) - {{{ NAME }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.") }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_o_creat" version="1">
-    <metadata>
-      <title>Ensure auditd Collects Information on Unsuccesful Creation Attempts to Files - {{{ SYSCALL }}} o_creat</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the information on the unsuccessful use of {{{ SYSCALL }}} O_CREAT is enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the information on the unsuccessful use of " + SYSCALL + " O_CREAT is enabled.") }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_o_trunc_write" version="1">
-    <metadata>
-      <title>Ensure auditd Collects Information on Unsuccesful Creation Attempts to Files - {{{ SYSCALL }}} o_trunc</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the information on the unsuccessful use of {{{ SYSCALL }}} O_TRUNC is enabled.</description>
-    </metadata>
+    {{{ oval_metadata("Audit rules about the information on the unsuccessful use of " + SYSCALL + " O_TRUNC is enabled.") }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_rule_order
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_rule_order
@@ -1,11 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_rule_order" version="1">
-    <metadata>
-      <title>Ensure auditd Rules For Unauthorized Attempts To {{{ SYSCALL }}} Are Ordered Correctly</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit rules about the information on the unsuccessful use of {{{ SYSCALL }}} is configured in the proper rule order.</description>
-
-    </metadata>
+    {{{ oval_metadata("Audit rules about the information on the unsuccessful use of " + SYSCALL + " is configured in the proper rule order.") }}}
 
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_usergroup_modification
+++ b/shared/templates/template_OVAL_audit_rules_usergroup_modification
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="audit_rules_usergroup_modification_{{{ NAME }}}" version="1">
-    <metadata>
-      <title>Audit User/Group Modification - {{{ NAME }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Audit user/group modification.</description>
-    </metadata>
+    {{{ oval_metadata("Audit user/group modification.") }}}
     <criteria operator="OR">
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />

--- a/shared/templates/template_OVAL_bls_entries_option
+++ b/shared/templates/template_OVAL_bls_entries_option
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
-    <metadata>
-      <title>Ensure that BLS-compatible boot loader is configured to run Linux operating system with argument {{{ ARG_NAME_VALUE }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure {{{ ARG_NAME_VALUE }}} option is configured in the 'options' line in /boot/loader/entries/*.conf.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " option is configured in the 'options' line in /boot/loader/entries/*.conf.") }}}
     <criteria operator="AND">
         <criterion test_ref="test_bls_{{{ SANITIZED_ARG_NAME }}}_options"
         comment="Check if {{{ ARG_NAME_VALUE }}} is present in the 'options' line in /boot/loader/entries/*" />

--- a/shared/templates/template_OVAL_file_groupowner
+++ b/shared/templates/template_OVAL_file_groupowner
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_groupowner{{{ FILEID }}}" version="1">
-    <metadata>
-      <title>Verify {{{ FILEPATH }}} Group Owner</title>
-      {{{- oval_affected(products) }}}
-      <description>This test makes sure that {{{ FILEPATH }}} is group owned by {{{ FILEGID }}}.</description>
-    </metadata>
+    {{{ oval_metadata("This test makes sure that " + FILEPATH + " is group owned by " + FILEGID + ".") }}}
     <criteria>
       <criterion comment="Check file group ownership of {{{ FILEPATH }}}" test_ref="test_file_groupowner{{{ FILEID }}}" />
     </criteria>

--- a/shared/templates/template_OVAL_file_owner
+++ b/shared/templates/template_OVAL_file_owner
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="file_owner{{{ FILEID }}}" version="1">
-    <metadata>
-      <title>Verify {{{ FILEPATH }}} Owner</title>
-      {{{- oval_affected(products) }}}
-      <description>This test makes sure that {{{ FILEPATH }}} is owned by {{{ FILEUID }}}.</description>
-    </metadata>
+    {{{ oval_metadata("This test makes sure that " + FILEPATH + " is owned by " + FILEUID + ".") }}}
     <criteria>
       <criterion comment="Check file ownership of {{{ FILEPATH }}}" test_ref="test_file_owner{{{ FILEID }}}" />
     </criteria>

--- a/shared/templates/template_OVAL_file_permissions
+++ b/shared/templates/template_OVAL_file_permissions
@@ -1,12 +1,8 @@
 <def-group>
   <definition class="compliance" id="file_permissions{{{ FILEID }}}" version="1">
-    <metadata>
-      <title>Verify {{{ FILEPATH }}} Mode Permissions</title>
-      {{{- oval_affected(products) }}}
-      <description>This test makes sure that {{{ FILEPATH }}} has mode {{{ FILEMODE }}}.
+    {{{ oval_metadata("This test makes sure that " + FILEPATH + " has mode " + FILEMODE + ".
       If the target file or directory has an extended ACL, then it will fail the mode check.
-      </description>
-    </metadata>
+      ") }}}
     <criteria>
       <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_file_permissions{{{ FILEID }}}" />
     </criteria>

--- a/shared/templates/template_OVAL_grub2_bootloader_argument
+++ b/shared/templates/template_OVAL_grub2_bootloader_argument
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
-    <metadata>
-      <title>Ensure GRUB 2 is configured to run Linux operating system with argument {{{ ARG_NAME_VALUE }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure {{{ ARG_NAME_VALUE }}} is configured in the kernel line in /etc/default/grub.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is configured in the kernel line in /etc/default/grub.") }}}
     <criteria operator="AND">
       {{% if product in ["rhel7", "ol7"] %}}
         <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"

--- a/shared/templates/template_OVAL_kernel_module_disabled
+++ b/shared/templates/template_OVAL_kernel_module_disabled
@@ -1,11 +1,7 @@
 <def-group>
   <definition class="compliance"
   id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
-    <metadata>
-      <title>Disable {{{ KERNMODULE }}} Kernel Module</title>
-      {{{- oval_affected(products) }}}
-      <description>The kernel module {{{ KERNMODULE }}} should be disabled.</description>
-    </metadata>
+    {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.d" />
 

--- a/shared/templates/template_OVAL_mount
+++ b/shared/templates/template_OVAL_mount
@@ -1,14 +1,10 @@
 <def-group>
   <definition class="compliance" id="partition_for{{{ POINTID }}}" version="1">
-    <metadata>
-      <title>Ensure {{{ MOUNTPOINT }}} Located On Separate Partition</title>
-      {{{- oval_affected(products) }}}
-      <description>If stored locally, create a separate partition for
+    {{{ oval_metadata("If stored locally, create a separate partition for
       {{{ MOUNTPOINT }}}. If {{{ MOUNTPOINT }}} will be mounted from another
       system such as an NFS server, then creating a separate partition is not
       necessary at this time, and the mountpoint can instead be configured
-      later.</description>
-    </metadata>
+      later.") }}}
     <criteria>
       <criterion test_ref="test{{{ POINTID }}}_partition" comment="{{{ MOUNTPOINT }}} on own partition" />
     </criteria>

--- a/shared/templates/template_OVAL_mount_option
+++ b/shared/templates/template_OVAL_mount_option
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="mount_option_{{{ POINTID }}}_{{{ MOUNTOPTION }}}" version="1">
-    <metadata>
-      <title>Add {{{ MOUNTOPTION }}} Option to {{{ MOUNTPOINT }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>{{{ MOUNTPOINT }}} should be mounted with mount option {{{ MOUNTOPTION }}}.</description>
-    </metadata>
+    {{{ oval_metadata(MOUNTPOINT + " should be mounted with mount option " + MOUNTOPTION + ".") }}}
     <criteria>
       <criterion comment="{{{ MOUNTOPTION }}} on {{{ MOUNTPOINT }}}" test_ref="test_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" />
     </criteria>

--- a/shared/templates/template_OVAL_mount_option_remote_filesystems
+++ b/shared/templates/template_OVAL_mount_option_remote_filesystems
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
-    <metadata>
-      <title>Mount Remote Filesystems with {{{ MOUNTOPTIONID }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>The {{{ MOUNTOPTIONID }}} option should be enabled for all NFS mounts in /etc/fstab.</description>
-    </metadata>
+    {{{ oval_metadata("The " + MOUNTOPTIONID + " option should be enabled for all NFS mounts in /etc/fstab.") }}}
     <criteria operator="XOR">
       <!-- these tests are designed to be mutually exclusive; either no nfs mounts exist in /etc/fstab -->
       <!-- or all of the nfs mounts defined in /etc/fstab have the {{{ MOUNTOPTIONID }}} mount option specified -->

--- a/shared/templates/template_OVAL_mount_option_removable_partitions
+++ b/shared/templates/template_OVAL_mount_option_removable_partitions
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="mount_option_{{{ MOUNTOPTION }}}_removable_partitions" version="5">
-    <metadata>
-      <title>Add {{{ MOUNTOPTION }}} Option to Removable Media Partitions</title>
-      {{{- oval_affected(products) }}}
-      <description>The {{{ MOUNTOPTION }}} option should be enabled for all removable devices mounts in /etc/fstab.</description>
-    </metadata>
+    {{{ oval_metadata("The " + MOUNTOPTION + " option should be enabled for all removable devices mounts in /etc/fstab.") }}}
     <criteria operator="OR">
       <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab
            since there's no device to check against -->

--- a/shared/templates/template_OVAL_package_installed
+++ b/shared/templates/template_OVAL_package_installed
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="package_{{{ PKGNAME }}}_installed"
   version="1">
-    <metadata>
-      <title>Package {{{ PKGNAME }}} Installed</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ pkg_system|upper }}} package {{{ PKGNAME }}} should be installed.</description>
-    </metadata>
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be installed.", affected_platforms=["multi_platform_all"]) }}}
     <criteria>
       <criterion comment="package {{{ PKGNAME }}} is installed"
       test_ref="test_package_{{{ PKGNAME }}}_installed" />

--- a/shared/templates/template_OVAL_package_removed
+++ b/shared/templates/template_OVAL_package_removed
@@ -1,13 +1,7 @@
 <def-group>
   <definition class="compliance" id="package_{{{ PKGNAME }}}_removed"
   version="1">
-    <metadata>
-      <title>Package {{{ PKGNAME }}} Removed</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ pkg_system|upper }}} package {{{ PKGNAME }}} should be removed.</description>
-    </metadata>
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be removed.", affected_platforms=["multi_platform_all"]) }}}
     <criteria>
       <criterion comment="package {{{ PKGNAME }}} is removed"
       test_ref="test_package_{{{ PKGNAME }}}_removed" />

--- a/shared/templates/template_OVAL_permissions
+++ b/shared/templates/template_OVAL_permissions
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="permissions{{{ FILEID }}}" version="1">
-    <metadata>
-      <title>Ensure Correct Mode, Owner, Group Owner for {{{ FILEPATH }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Checks for correct UNIX permissions on {{{ FILEPATH }}}.</description>
-    </metadata>
+    {{{ oval_metadata("Checks for correct UNIX permissions on " + FILEPATH + ".") }}}
     <criteria operator="AND">
       {{% if FILEGID != "" %}}
       <extend_definition comment="Check file group ownership of {{{ FILEPATH }}}" definition_ref="file_groupowner{{{ FILEID }}}" />

--- a/shared/templates/template_OVAL_sebool
+++ b/shared/templates/template_OVAL_sebool
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="sebool_{{{ SEBOOLID }}}" version="1">
-    <metadata>
-      <title>SELinux "{{{ SEBOOLID }}}" Boolean Check</title>
-      {{{- oval_affected(products) }}}
-      <description>The SELinux "{{{ SEBOOLID }}}" boolean should be set in the system configuration.</description>
-    </metadata>
+    {{{ oval_metadata("The SELinux '" + SEBOOLID + "' boolean should be set in the system configuration.") }}}
     <criteria>
       <criterion comment="{{{ SEBOOLID }}} is configured correctly" test_ref="test_sebool_{{{ SEBOOLID }}}" />
     </criteria>

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -7,13 +7,7 @@
   {{# we are using systemd and our target OVAL version does support the systemd related tests #}}
 
   <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled" version="1">
-    <metadata>
-      <title>Service {{{ SERVICENAME }}} Disabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
     <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
       <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
       <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
@@ -95,13 +89,7 @@
 
   <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled"
   version="1">
-    <metadata>
-      <title>Service {{{ SERVICENAME }}} Disabled</title>
-      <affected family="unix">
-        <platform>Ubuntu 14.04</platform>
-      </affected>
-      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
    <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
     <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
 
@@ -132,13 +120,7 @@
 
   <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled"
   version="1">
-    <metadata>
-      <title>Service {{{ SERVICENAME }}} Disabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
    <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
     <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
     <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
@@ -232,13 +214,7 @@
   {{# fallback if we are using systemd but can't use the new systemd features of OVAL 5.11 #}}
 
   <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled" version="2">
-    <metadata>
-      <title>Service {{{ SERVICENAME }}} Disabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ SERVICENAME }}} service should be disabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
     <criteria comment="package {{{ PACKAGENAME }}} removed or service and socket {{{ SERVICENAME }}} are not configured to start" operator="OR">
       <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
       <criteria operator="AND" comment="service and socket {{{ SERVICENAME }}} are disabled">

--- a/shared/templates/template_OVAL_service_enabled
+++ b/shared/templates/template_OVAL_service_enabled
@@ -5,13 +5,7 @@
 {{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
 
   <definition class="compliance" id="service_{{{ SERVICENAME }}}_enabled" version="1">
-    <metadata>
-      <title>Service {{{ SERVICENAME }}} Enabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ SERVICENAME }}} service should be enabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
     <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
       <criteria comment="service {{{ SERVICENAME }}} is configured to start and is running" operator="AND">
@@ -62,13 +56,7 @@
 
   <definition class="compliance" id="service_{{{ SERVICENAME }}}_enabled"
   version="1">
-    <metadata>
-      <title>Service {{{ SERVICENAME }}} Enabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ SERVICENAME }}} service should be enabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
     <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
     <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">

--- a/shared/templates/template_OVAL_sysctl
+++ b/shared/templates/template_OVAL_sysctl
@@ -17,11 +17,7 @@
 
 <def-group>
   <definition class="compliance" id="sysctl_{{{ SYSCTLID }}}" version="3">
-    <metadata>
-      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Configuration and Runtime Check</title>
-      {{{- oval_affected(products) }}}
-      <description>The "{{{ SYSCTLVAR }}}" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
-    </metadata>
+    {{{ oval_metadata("The '" + SYSCTLVAR + "' kernel parameter should be set to the appropriate value in both system configuration and system runtime.") }}}
     <criteria operator="AND">
       <extend_definition comment="{{{ SYSCTLVAR }}} configuration setting check" definition_ref="sysctl_static_{{{ SYSCTLID }}}" />
       <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check" definition_ref="sysctl_runtime_{{{ SYSCTLID }}}" />
@@ -33,13 +29,7 @@
 
 <def-group>
   <definition class="compliance" id="sysctl_{{{ SYSCTLID }}}" version="4">
-    <metadata>
-      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Configuration and Runtime Check</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The "{{{ SYSCTLVAR }}}" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
-    </metadata>
+    {{{ oval_metadata("The kernel '" + SYSCTLVAR + "' parameter should be set to the appropriate value in both system configuration and system runtime.") }}}
     <criteria comment="IPv6 disabled or {{{ SYSCTLVAR }}} set correctly" operator="OR">
 {{% if product in ["rhel6", "debian8", "ubuntu1404", "ubuntu1604", "ubuntu1804"] %}}
       <extend_definition comment="is IPv6 enabled?" definition_ref="kernel_module_ipv6_option_disabled" />
@@ -59,17 +49,7 @@
 
 <def-group>
   <definition class="compliance" id="sysctl_runtime_{{{ SYSCTLID }}}" version="3">
-    <metadata>
-      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Runtime Check</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-{{%- if SYSCTLVAL == "" %}}
-      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to the appropriate value in system runtime.</description>
-{{%- else %}}
-      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to "{{{ SYSCTLVAL }}}" in system runtime.</description>
-{{%- endif %}}
-    </metadata>
+    {{{ oval_metadata("The kernel '" + SYSCTLVAR + "' parameter should be set to " + ("'" + SYSCTLVAL + "'") if SYSCTLVAL else " the appropriate value" + " in the system runtime.") }}}
     <criteria operator="AND">
 {{%- if SYSCTLVAL == "" %}}
       <criterion comment="kernel runtime parameter {{{ SYSCTLVAR }}} set to the appropriate value" test_ref="test_sysctl_runtime_{{{ SYSCTLID }}}" />
@@ -108,17 +88,7 @@
 
 <def-group>
   <definition class="compliance" id="sysctl_static_{{{ SYSCTLID }}}" version="3">
-    <metadata>
-      <title>Kernel "{{{ SYSCTLVAR }}}" Parameter Configuration Check</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-{{%- if SYSCTLVAL == "" %}}
-      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to the appropriate value in the system configuration.</description>
-{{%- else %}}
-      <description>The kernel "{{{ SYSCTLVAR }}}" parameter should be set to "{{{ SYSCTLVAL }}}" in the system configuration.</description>
-{{%- endif %}}
-    </metadata>
+    {{{ oval_metadata("The kernel '" + SYSCTLVAR + "' parameter should be set to " + ("'" + SYSCTLVAL + "'") if SYSCTLVAL else " the appropriate value" + " in the system configuration.") }}}
 {{% if product == "rhel6" %}}
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_timer_enabled
+++ b/shared/templates/template_OVAL_timer_enabled
@@ -3,11 +3,7 @@
 {{% if target_oval_version >= [5, 11] %}}
 
   <definition class="compliance" id="timer_{{{ TIMERNAME }}}_enabled" version="1">
-    <metadata>
-      <title>Timer {{{ TIMERNAME }}} Enabled</title>
-      {{{- oval_affected(products) }}}
-      <description>The {{{ TIMERNAME }}} timer should be enabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + TIMERNAME + " service should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and timer {{{ TIMERNAME }}} is configured to start" operator="AND">
       <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
       <criteria comment="timer {{{ TIMERNAME }}} is configured to start and is running" operator="AND">
@@ -45,13 +41,7 @@
 {{# fallback if we are using systemd but can't use the new systemd features of OVAL 5.11 #}}
 
   <definition class="compliance" id="timer_{{{ TIMERNAME }}}_enabled" version="1">
-    <metadata>
-      <title>Timer {{{ TIMERNAME }}} Enabled</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>The {{{ TIMERNAME }}} timer should be enabled if possible.</description>
-    </metadata>
+    {{{ oval_metadata("The " + TIMERNAME + " service should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and timer {{{ TIMERNAME }}} is configured to start" operator="AND">
       <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
       <criterion comment="{{{ TIMERNAME }}} enabled in multi-user.target" test_ref="test_{{{ TIMERNAME }}}_enabled_multi_user_target" />

--- a/shared/templates/template_OVAL_timer_enabled
+++ b/shared/templates/template_OVAL_timer_enabled
@@ -3,7 +3,7 @@
 {{% if target_oval_version >= [5, 11] %}}
 
   <definition class="compliance" id="timer_{{{ TIMERNAME }}}_enabled" version="1">
-    {{{ oval_metadata("The " + TIMERNAME + " service should be enabled if possible.") }}}
+    {{{ oval_metadata("The " + TIMERNAME + " timer should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and timer {{{ TIMERNAME }}} is configured to start" operator="AND">
       <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
       <criteria comment="timer {{{ TIMERNAME }}} is configured to start and is running" operator="AND">

--- a/shared/templates/template_OVAL_yamlfile_value
+++ b/shared/templates/template_OVAL_yamlfile_value
@@ -1,13 +1,8 @@
 {{% if target_oval_version >= [5, 11] %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    <metadata>
-      <title>Check the value(s) of '{{{ YAMLPATH }}}' in the file "{{{ FILEPATH }}}"</title>
-      {{{- oval_affected(products) }}}
-      <description>
-        The file "{{{ FILEPATH }}}" should {{% if NEGATE %}}not {{% endif %}}contain value "{{{ VALUE }}}"{{% if TYPE %}} of type {{{ TYPE }}}{{% endif %}} at '{{{ YAMLPATH }}}'.
-      </description>
-    </metadata>
+    {{{ oval_metadata("
+        The file '" + FILEPATH + "' should " + "not " if NEGATE else "" + "contain value '" + VALUE + "' " + ("of type " + TYPE + " ") if TYPE else "" + "at '" + YAMLPATH + "'.") }}}
     <criteria>
         <criterion comment="Make sure that {{% if NEGATE %}}no {{% endif %}}{{% if ENTITY_CHECK %}}({{{ ENTITY_CHECK }}}) {{% endif %}} element(s) of '{{{ YAMLPATH }}}' contain value '{{{ VALUE }}}'{{% if TYPE %}} of type {{{ TYPE }}}{{% endif %}}."{{% if NEGATE %}} negate="true"{{% endif %}} test_ref="test_{{{ rule_id }}}"/>
         {{% if NEGATE %}}

--- a/shared/templates/template_OVAL_zipl_bls_entries_option
+++ b/shared/templates/template_OVAL_zipl_bls_entries_option
@@ -1,10 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
-    <metadata>
-      <title>Ensure that BLS-compatible boot loader is configured to run Linux operating system with argument {{{ ARG_NAME_VALUE }}}</title>
-      {{{- oval_affected(products) }}}
-      <description>Ensure {{{ ARG_NAME_VALUE }}} option is configured in the 'options' line in /boot/loader/entries/*.conf.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " option is configured in the 'options' line in /boot/loader/entries/*.conf.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_bls_{{{ SANITIZED_ARG_NAME }}}_options"
       comment="Check if {{{ ARG_NAME_VALUE }}} is present in the 'options' line in /boot/loader/entries/*.conf" />


### PR DESCRIPTION
I have removed the OVAL metadata boilerplate in favor of the respective macro. That means that we can say goodbye to thousands of lines of cobweb code.

As a result, the code is lighter, and "affected platforms" are minimized or follow the rule applicability, which helped to uncover some problems with OVAL interdependence, and it even turned out that the RHCOS4 product used the gpgkey rule without providing fingerprints.