### PR TITLE
Introduce platform to package mapping

### DIFF
--- a/rhcos4/product.yml
+++ b/rhcos4/product.yml
@@ -9,3 +9,7 @@ profiles_root: "./profiles"
 pkg_system: "rpm"
 
 init_system: "systemd"
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/rhel6/product.yml
+++ b/rhel6/product.yml
@@ -20,3 +20,7 @@ aux_pkg_version: "2fa658e0"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/rhel7/product.yml
+++ b/rhel7/product.yml
@@ -18,3 +18,7 @@ aux_pkg_version: "2fa658e0"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/rhel8/product.yml
+++ b/rhel8/product.yml
@@ -19,3 +19,6 @@ aux_pkg_version: "d4082792"
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
 
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/rhel8/product.yml
+++ b/rhel8/product.yml
@@ -18,3 +18,10 @@ aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  grub2: "grub2-pc"
+  login_defs: "shadow-utils"
+  sssd: "sssd-common"
+  zipl: "s390x-utils"

--- a/rhel8/product.yml
+++ b/rhel8/product.yml
@@ -19,9 +19,3 @@ aux_pkg_version: "d4082792"
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
 
-# Mapping of CPE platform to package
-platform_package_overrides:
-  grub2: "grub2-pc"
-  login_defs: "shadow-utils"
-  sssd: "sssd-common"
-  zipl: "s390x-utils"

--- a/rhosp10/product.yml
+++ b/rhosp10/product.yml
@@ -10,3 +10,6 @@ pkg_manager: "yum"
 
 init_system: "systemd"
 
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/rhosp13/product.yml
+++ b/rhosp13/product.yml
@@ -9,3 +9,7 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/rhv4/product.yml
+++ b/rhv4/product.yml
@@ -18,3 +18,7 @@ aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -389,6 +389,9 @@ class AnsibleRemediation(Remediation):
                 if "package_facts" in to_update:
                     continue
 
+                if platform in self.local_env_yaml["platform_package_overrides"]:
+                    platform = self.local_env_yaml["platform_package_overrides"].get(platform)
+
                 additional_when.append('"' + platform + '" in ansible_facts.packages')
                 # After adding the conditional, we need to make sure package_facts are collected.
                 # This is done via inject_package_facts_task()

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -501,6 +501,14 @@ XCCDF_PLATFORM_TO_CPE = {
     "zipl": "cpe:/a:zipl",
 }
 
+# Default platform to package mapping
+XCCDF_PLATFORM_TO_PACKAGE = {
+  "grub2": "grub2-pc",
+  "login_defs": "login",
+  "sssd": "sssd-common",
+  "zipl": "s390x-utils",
+}
+
 # _version_name_map = {
 MAKEFILE_ID_TO_PRODUCT_MAP = {
     'chromium': 'Google Chromium Browser',

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -10,7 +10,8 @@ from collections import OrderedDict
 
 from .jinja import load_macros, process_file
 from .constants import (PKG_MANAGER_TO_SYSTEM,
-                        PKG_MANAGER_TO_CONFIG_FILE)
+                        PKG_MANAGER_TO_CONFIG_FILE,
+                        XCCDF_PLATFORM_TO_PACKAGE)
 from .constants import DEFAULT_UID_MIN
 
 try:
@@ -138,6 +139,9 @@ def open_raw(yaml_file):
 
 def open_environment(build_config_yaml, product_yaml):
     contents = open_raw(build_config_yaml)
+    # Load common platform package mappings,
+    # any specific mapping in product_yaml will override the default
+    contents["platform_package_overrides"] = XCCDF_PLATFORM_TO_PACKAGE
     contents.update(open_raw(product_yaml))
     contents.update(_get_implied_properties(contents))
     return contents


### PR DESCRIPTION
#### Description:

Introduce a mapping of CPE package platform name to a package name.

Each linux distro or version may have its specific name for a package,
this mapping allows a product to override the package name of a
platform.

In `ssg/constants.py` a default `package` name is mapped when it is different from the `platform` name.
And if the default `package` name still needs to be tweaked, it can be done in the `product.yml`.

The package name override mapping can also be extended to the actual OVALs that check for the package installed.
But I'd leave this for another PR.

#### Rationale:

- Allows larger flexibility of package names. Debian and RHEL often have different package names for example..

- Fixes #6041
