### PR TITLE
Add bash and ansible remediation for sudo_remove_nopasswd and sudo_remove_no_authenticate

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/ansible/shared.yml
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-{{{ ansible_sudo_remove_config("NOPASSWD", "NOPASSWD[\s]*\:") }}}
+{{{ ansible_sudo_remove_config("!authenticate", "!authenticate") }}}

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-{{{ ansible_sudo_remove_config("NOPASSWD", "NOPASSWD[\s]*\:") }}}
+{{{ bash_sudo_remove_config("!authenticate", "!authenticate") }}}

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/correct_value.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+rm -f /etc/sudoers
+echo "Defaults authenticate" > /etc/sudoers
+chmod 440 /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+echo "Defaults !authenticate" >> /etc/sudoers
+chmod 440 /etc/sudoers
+
+mkdir /etc/sudoers.d/
+echo "Defaults !authenticate" >> /etc/sudoers.d/sudoers
+chmod 440 /etc/sudoers.d/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/ansible/shared.yml
@@ -1,0 +1,21 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Find /etc/sudoers.d/ files
+  find:
+    paths:
+      - /etc/sudoers.d/
+  register: sudoers
+
+- name: "Remove lines containing NOPASSWD from sudoers files"
+  replace:
+    regexp: '(^(?!#).*[\s]+NOPASSWD[\s]*\:.*$)'
+    replace: '# \g<1>'
+    path: "{{ item.path }}"
+    validate: /usr/sbin/visudo -cf %s
+  with_items:
+    - { path: /etc/sudoers }
+    - "{{ sudoers.files }}"

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/bash/shared.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+for f in $( ls /etc/sudoers /etc/sudoers.d/* 2> /dev/null ) ; do
+  nopasswd_list=$(grep -P '^(?!#).*[\s]+NOPASSWD[\s]*\:.*$' $f | uniq )
+  if ! test -z "$nopasswd_list"; then 
+    while IFS= read -r nopasswd_entry; do
+      # comment out "NOPASSWD:" matches to preserve user data
+      sed -i "s/^${nopasswd_entry}$/# &/g" $f
+    done <<< "$nopasswd_list"
+
+    /usr/sbin/visudo -cf $f &> /dev/null || echo "Fail to validate $f with visudo"
+  fi
+done

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/correct_value.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+rm -f /etc/sudoers
+echo "%wheel	ALL=(ALL)	ALL" > /etc/sudoers
+chmod 440 /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+chmod 440 /etc/sudoers
+
+mkdir /etc/sudoers.d/
+echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/sudoers
+chmod 440 /etc/sudoers.d/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/ansible/shared.yml
@@ -5,3 +5,5 @@
 # disruption = low
 
 {{{ ansible_sudo_remove_config("NOPASSWD", "NOPASSWD[\s]*\:") }}}
+
+{{{ ansible_sudo_remove_config("!authenticate", "!authenticate") }}}

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/bash/shared.sh
@@ -5,3 +5,5 @@
 # disruption = low
 
 {{{ bash_sudo_remove_config("NOPASSWD", "NOPASSWD[\s]*\:") }}}
+
+{{{ bash_sudo_remove_config("!authenticate", "!authenticate") }}}

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_e8
+
+rm -f /etc/sudoers
+echo "%wheel	ALL=(ALL)	ALL" > /etc/sudoers
+echo "Defaults authenticate" > /etc/sudoers
+chmod 440 /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_e8
+
+echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "Defaults !authenticate" >> /etc/sudoers
+chmod 440 /etc/sudoers
+
+mkdir /etc/sudoers.d/
+echo "%wheel        ALL=(ALL)       !authenticate ALL" >> /etc/sudoers.d/sudoers
+echo "Defaults !authenticate" >> /etc/sudoers.d/sudoers
+chmod 440 /etc/sudoers.d/sudoers

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -559,3 +559,22 @@ See official documentation: https://jinja.palletsprojects.com/en/2.11.x/template
     create: yes
     mode: 0644
 {{%- endmacro %}}
+
+{{%- macro ansible_sudo_remove_config(parameter, pattern) -%}}
+
+- name: Find /etc/sudoers.d/ files
+  find:
+    paths:
+      - /etc/sudoers.d/
+  register: sudoers
+
+- name: "Remove lines containing {{{ parameter }}} from sudoers files"
+  replace:
+    regexp: '(^(?!#).*[\s]+\{{{ pattern }}}.*$)'
+    replace: '# \g<1>'
+    path: "{{ item.path }}"
+    validate: /usr/sbin/visudo -cf %s
+  with_items:
+    - { path: /etc/sudoers }
+    - "{{ sudoers.files }}"
+{{%- endmacro -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -600,3 +600,17 @@ else
     fi
 fi
 {{%- endmacro %}}
+
+{{%- macro bash_sudo_remove_config(parameter, pattern) -%}}
+for f in $( ls /etc/sudoers /etc/sudoers.d/* 2> /dev/null ) ; do
+  matching_list=$(grep -P '^(?!#).*[\s]+\{{{ pattern }}}.*$' $f | uniq )
+  if ! test -z "$matching_list"; then
+    while IFS= read -r entry; do
+      # comment out "{{{ parameter }}}" matches to preserve user data
+      sed -i "s/^${entry}$/# &/g" $f
+    done <<< "$matching_list"
+
+    /usr/sbin/visudo -cf $f &> /dev/null || echo "Fail to validate $f with visudo"
+  fi
+done
+{{%- endmacro -%}}


### PR DESCRIPTION
#### Description:

The first question is, does it make sense to have remediation for this rule even though the file `/etc/sudoers` is supposed to be read-only? and to be changed only through `visudo` utility

- Add ansible remediation for sudo_remove_nopasswd.
- Add test scenarios for sudo_remove_nopasswd.

#### Rationale:

- Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71947?version=V1R4&compareto=v2r7