### PR TITLE
Update snmpd_no_default_password

### DIFF
--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/ansible/shared.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/ansible/shared.yml
@@ -1,0 +1,21 @@
+# platform = debian 10,debian 9,multi_platform_fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,WRLinux 1019
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+{{{ ansible_instantiate_variables("var_snmpd_ro_string", "var_snmpd_rw_string") }}}
+
+- name: "Replace all instances of SNMP RO strings"
+  replace:
+    path: "/etc/snmp/snmpd.conf"
+    #regexp: '^[#](.*)public(.*)$'
+    regexp: 'public'
+    replace: '{{ var_snmpd_ro_string }}'
+
+- name: "Replace all instances of SNMP RW strings"
+  replace:
+    path: "/etc/snmp/snmpd.conf"
+    #regexp: '^[#](.*)private(.*)$'
+    regexp: 'private'
+    replace: '{{ var_snmpd_rw_string }}'

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/ansible/shared.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/ansible/shared.yml
@@ -9,13 +9,11 @@
 - name: "Replace all instances of SNMP RO strings"
   replace:
     path: "/etc/snmp/snmpd.conf"
-    #regexp: '^[#](.*)public(.*)$'
     regexp: 'public'
     replace: '{{ var_snmpd_ro_string }}'
 
 - name: "Replace all instances of SNMP RW strings"
   replace:
     path: "/etc/snmp/snmpd.conf"
-    #regexp: '^[#](.*)private(.*)$'
     regexp: 'private'
     replace: '{{ var_snmpd_rw_string }}'

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/bash/shared.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/bash/shared.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = debian 10,debian 9,multi_platform_fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,WRLinux 1019
+
+. /usr/share/scap-security-guide/remediation_functions
+
+{{{ bash_instantiate_variables("var_snmpd_ro_string", "var_snmpd_rw_string") }}}
+
+# remediate read-only community string
+if grep -q 'public' /etc/snmp/snmpd.conf; then
+    sed -i "s/public/$var_snmpd_ro_string/" /etc/snmp/snmpd.conf
+fi
+
+# remediate read-write community string
+if grep -q 'private' /etc/snmp/snmpd.conf; then
+    sed -i "s/private/$var_snmpd_rw_string/" /etc/snmp/snmpd.conf
+fi

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/bash/shared.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/bash/shared.sh
@@ -1,5 +1,0 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
-
-if grep -s "public\|private" /etc/snmp/snmpd.conf | grep -qv "^#"; then
-	sed -i "/^\s*#/b;/public\|private/ s/^/#/" /etc/snmp/snmpd.conf
-fi

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/oval/shared.xml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/oval/shared.xml
@@ -17,7 +17,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_snmp_default_communities" version="1">
     <ind:filepath>/etc/snmp/snmpd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(com2se|rocommunity|rwcommunity|createUser).*(public|private)</ind:pattern>
+    <ind:pattern operation="pattern match">^((?!#).)*(public|private).*</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
@@ -7,6 +7,7 @@ title: 'Ensure Default SNMP Password Is Not Used'
 description: |-
     Edit <tt>/etc/snmp/snmpd.conf</tt>, remove or change the default community strings of
     <tt>public</tt> and <tt>private</tt>.
+    This profile configures new read-only community string to <tt>{{{ sub_var_value("var_snmpd_ro_string") }}}</tt> and read-write community string to <tt>{{{ sub_var_value("var_snmpd_rw_string") }}}</tt>.
     Once the default community strings have been changed, restart the SNMP service:
     <pre>$ sudo service snmpd restart</pre>
 

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/both.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/both.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+yum -y install net-snmp
+
+echo "something public" >> /etc/snmp/snmpd.conf
+echo "something private" >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/commented.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/commented.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+yum -y install net-snmp
+
+sed -i '/.*public.*/d' /etc/snmp/snmpd.conf
+sed -i '/.*private.*/d' /etc/snmp/snmpd.conf
+echo '# public' >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/correct.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+yum -y install net-snmp
+
+sed -i '/.*public.*/d' /etc/snmp/snmpd.conf
+sed -i '/.*private.*/d' /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/private.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/private.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+yum -y install net-snmp
+
+echo "something private" >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/public.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/public.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+yum -y install net-snmp
+
+echo "something public" >> /etc/snmp/snmpd.conf
+

--- a/linux_os/guide/services/snmp/snmp_configure_server/var_snmpd_ro_string.var
+++ b/linux_os/guide/services/snmp/snmp_configure_server/var_snmpd_ro_string.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'SNMP read-only community string'
+
+description: "Specify the SNMP community string used for read-only access."
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+    default: changemero

--- a/linux_os/guide/services/snmp/snmp_configure_server/var_snmpd_rw_string.var
+++ b/linux_os/guide/services/snmp/snmp_configure_server/var_snmpd_rw_string.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'SNMP read-write community string'
+
+description: "Specify the SNMP community string used for read-write access."
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+    default: changemerw


### PR DESCRIPTION
#### Description:

- add tests

- make oval stricter

- add two xccdf variables for public and private community strings

- update Bash reemdiation

- add Ansible remediation

#### Rationale:

- stig effort

reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72313?version=v2r7

STIG is more stricter, it searches for all occurences of "private" and "public". Therefore I hardened the check.

I added two interactive variables which specify new public / private community strings.