### PR TITLE
tests/ocp4e2e: Wait for MCP to update

### DIFF
--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -57,6 +57,8 @@ func TestE2e(t *testing.T) {
 		t.Run("Wait for Remediations to apply", func(t *testing.T) {
 			// Lets wait for the MachineConfigs to start applying
 			time.Sleep(30 * time.Second)
+			ctx.waitForMachinePoolUpdate("master")
+			ctx.waitForMachinePoolUpdate("worker")
 			ctx.waitForNodesToBeReady()
 		})
 


### PR DESCRIPTION
#### Description:

This should prevent running the second suite while the first is still
updating.

#### Rationale:

We were looking only at node status but what can happen is that all the nodes
report ready for a bit before the next one even has a chance to start updating.