### PR TITLE
Fix load of product platform package map

### DIFF
--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -13,6 +13,7 @@ from .constants import (PKG_MANAGER_TO_SYSTEM,
                         PKG_MANAGER_TO_CONFIG_FILE,
                         XCCDF_PLATFORM_TO_PACKAGE)
 from .constants import DEFAULT_UID_MIN
+from .utils import merge_dicts
 
 try:
     from yaml import CSafeLoader as yaml_SafeLoader
@@ -139,10 +140,11 @@ def open_raw(yaml_file):
 
 def open_environment(build_config_yaml, product_yaml):
     contents = open_raw(build_config_yaml)
-    # Load common platform package mappings,
-    # any specific mapping in product_yaml will override the default
-    contents["platform_package_overrides"] = XCCDF_PLATFORM_TO_PACKAGE
     contents.update(open_raw(product_yaml))
+    platform_package_overrides = contents.get("platform_package_overrides", {})
+    # Merge common platform package mappings, while keeping product specific mappings
+    contents["platform_package_overrides"] = merge_dicts(XCCDF_PLATFORM_TO_PACKAGE,
+                                                         platform_package_overrides)
     contents.update(_get_implied_properties(contents))
     return contents
 


### PR DESCRIPTION
#### Description:

The product specific mappings were overriding the common mappings, instead of being merged with them.

#### Rationale:

- Follow up from #6047 
