### PR TITLE
Fix bash remediation for rule accounts_no_uid_except_zero.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/bash/rhel6.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/bash/rhel6.sh
@@ -1,2 +1,0 @@
-# platform = Red Hat Enterprise Linux 6
-awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd | xargs passwd -l

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/bash/shared.sh
@@ -1,2 +1,2 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_rhv
-awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd | xargs passwd -l
+# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 6,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_rhv
+awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd | xargs --max-lines=1 passwd -l


### PR DESCRIPTION
#### Help needed
~~- This remediation doesn't fix the problem because it just `soft` locks offending accounts, it doesn't change the UID of them as suggested by the fix text. Do you have any suggestions on how to improve this remediation?~~

#### Description:
 - Fix bash remediation for rule accounts_no_uid_except_zero.
   - When multiple offending accounts were found in the system, xargs
couldn't process properly each account found.

#### Rationale:

- Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72005?version=v2r7
