### PR TITLE
Introduce machine and package platform conditionals to Bash remediations

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -273,9 +273,11 @@ class BashRemediation(Remediation):
         self.local_env_yaml.update(env_yaml)
         result = super(BashRemediation, self).parse_from_file_with_jinja(self.local_env_yaml)
 
-        # There can be repeated inherited platforms and rule platforms
-        rule_platforms = set(self.associated_rule.inherited_platforms)
-        rule_platforms.add(self.associated_rule.platform)
+        rule_platforms = set()
+        if self.associated_rule:
+            # There can be repeated inherited platforms and rule platforms
+            rule_platforms.update(self.associated_rule.inherited_platforms)
+            rule_platforms.add(self.associated_rule.platform)
 
         platform_conditionals = []
         for platform in rule_platforms:

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -306,6 +306,9 @@ class BashRemediation(Remediation):
             if not result.contents.startswith("\n"):
                 wrapped_fix_text.append("")
 
+            # It is possible to indent the original body of the remediation with textwrap.indent(),
+            # however, it is not supported by python2, and there is a risk of breaking remediations
+            # For example, remediations with a here-doc block could be affected.
             wrapped_fix_text.append("{0}".format(result.contents))
             wrapped_fix_text.append("")
             wrapped_fix_text.append("else")


### PR DESCRIPTION
#### Description:

- Trickle down the CPE Platform to the Bash remediations
  - When a rule has a `platform` be it `machine` or a `Package CPE` platform, the whole Bash remediation is wrapped around an `if` condition
  - Also adds conditionals for `machine` platform

#### Rationale:
When a rule has a Package CPE platform, like `platform: dconf` for example.
It is meant to be evaluated and remediated when the  systems has `dconf` package installed.
Evaluation and remediation done with OpenSCAP respects these CPEs, as the scanner understands the `CPE` and the `XCCDF:Platform` field.
But when the Bash scripts are generated, the Package applicability of the remediation is lost.

#### Rationale:

- Analogous to #6025
