### PR TITLE
Remove rhel8 from OCP container images

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -7,7 +7,7 @@ COPY . .
 
 RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 
-RUN ./build_product --debug ocp4 rhel7 rhel8 rhcos4
+RUN ./build_product --debug ocp4 rhel7 rhcos4
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /

--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -3,7 +3,7 @@ FROM fedora:latest as builder
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content
 WORKDIR /content
-RUN ./build_product --debug ocp4 rhel7 rhel8 rhcos4
+RUN ./build_product --debug ocp4 rhel7 rhcos4
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -10,9 +10,9 @@ root_dir=$(git rev-parse --show-toplevel)
 
 pushd $root_dir
 
-echo "* Building ocp4, rhel7, rhel8, rhcos4 products"
+echo "* Building ocp4, rhel7, rhcos4 products"
 # build the product's content
-"$root_dir/build_product" ocp4 rhel7 rhel8 rhcos4
+"$root_dir/build_product" ocp4 rhel7 rhcos4
 
 if [ "$namespace" == "openshift-compliance" ]; then
     # Ensure openshift-compliance namespace exists. If it already exists, this


### PR DESCRIPTION
RHEL8 is not supported, and RHCOS is encouraged instead.