### PR TITLE
Fix ocp datastream build configuration

### DIFF
--- a/ocp-resources/ds-build.yaml
+++ b/ocp-resources/ds-build.yaml
@@ -18,7 +18,6 @@ spec:
       WORKDIR /
       COPY ssg-ocp4-ds.xml .
       COPY ssg-rhel7-ds.xml .
-      COPY ssg-rhel8-ds.xml .
       COPY ssg-rhcos4-ds.xml .
   strategy: 
     dockerStrategy:


### PR DESCRIPTION
When building a container image using the build_ds_container.sh, the
script uses an openShift BuildConfig to trigger a build. This was still
expecting the RHEL8 content to be available, though now it isn't used.