### PR TITLE
Set a lower bound value for accounts_passwords_pam_faillock_deny check.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/shared.xml
@@ -45,9 +45,10 @@
   <!-- step 1 and 3 test -->
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_numeric_default_check_system-auth"
   check="all" check_existence="all_exist"
-  comment="Checks if pam_faillock authfail is hit even if pam_unix skips lines by defaulting, and also authfail deny value" version="1">
+  comment="Checks if pam_faillock authfail is hit even if pam_unix skips lines by defaulting, and also authfail deny value" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_when_lines_skipped_system-auth" />
-    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_upper_bound" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_lower_bound" />
   </ind:textfilecontent54_test>
 
   <!-- step 1 and 4 object -->
@@ -78,9 +79,10 @@
   <!-- step 1 and 3 test -->
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_numeric_default_check_password-auth"
   check="all" check_existence="all_exist"
-  comment="Checks if pam_faillock authfail is hit even if pam_unix skips lines by defaulting, and also authfail deny value" version="1">
+  comment="Checks if pam_faillock authfail is hit even if pam_unix skips lines by defaulting, and also authfail deny value" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_when_lines_skipped_password-auth" />
-    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_upper_bound" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_lower_bound" />
   </ind:textfilecontent54_test>
 
   <!-- step 1 and 4 object -->
@@ -113,17 +115,22 @@
   <external_variable id="var_accounts_passwords_pam_faillock_deny" datatype="int"
   comment="number of failed login attempts allowed" version="1" />
 
-  <ind:textfilecontent54_state id="state_var_accounts_passwords_pam_faillock_deny_value" version="1">
+  <ind:textfilecontent54_state id="state_var_accounts_passwords_pam_faillock_deny_value_upper_bound" version="1">
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_accounts_passwords_pam_faillock_deny" />
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_var_accounts_passwords_pam_faillock_deny_value_lower_bound" version="1">
+    <ind:subexpression datatype="int" operation="greater than">0</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <!-- Check for preauth silent in /etc/pam.d/system-auth -->
   <!-- Also check the 'deny' option value matches the number of failed login attempts allowed -->
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_preauth_silent_system-auth"
   check="all" check_existence="all_exist"
-  comment="Check pam_faillock.so preauth silent present, with correct deny value, and is followed by pam_unix." version="1">
+  comment="Check pam_faillock.so preauth silent present, with correct deny value, and is followed by pam_unix." version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_preauth_silent_system-auth" />
-    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_upper_bound" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_lower_bound" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_silent_system-auth" version="1">
@@ -138,9 +145,10 @@
   <!-- Check for authfail deny in /etc/pam.d/system-auth -->
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_authfail_deny_system-auth"
   check="all" check_existence="all_exist"
-  comment="Check control values of pam_unix, that it is followed by pam_faillock.so authfail and deny value of pam_faillock.so authfail" version="1">
+  comment="Check control values of pam_unix, that it is followed by pam_faillock.so authfail and deny value of pam_faillock.so authfail" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_authfail_deny_system-auth" />
-    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_upper_bound" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_lower_bound" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authfail_deny_system-auth" version="1">
@@ -170,9 +178,10 @@
   <!-- Also check the 'deny' option value matches the number of failed login attempts allowed -->
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_preauth_silent_password-auth"
   check="all" check_existence="all_exist"
-  comment="Check pam_faillock.so preauth silent present in /etc/pam.d/password-auth, has correct deny value, and is followed by pam_unix" version="1">
+  comment="Check pam_faillock.so preauth silent present in /etc/pam.d/password-auth, has correct deny value, and is followed by pam_unix" version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_preauth_silent_password-auth" />
-    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_upper_bound" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_lower_bound" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_preauth_silent_password-auth" version="1">
@@ -187,9 +196,10 @@
   <!-- Check for authfail deny in /etc/pam.d/password-auth -->
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_faillock_authfail_deny_password-auth"
   check="all" check_existence="all_exist"
-  comment="Check pam_faillock authfail is present after pam_unix, check pam_unix has proper control values, and authfail deny value is correct." version="1">
+  comment="Check pam_faillock authfail is present after pam_unix, check pam_unix has proper control values, and authfail deny value is correct." version="2">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_authfail_deny_password-auth" />
-    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_upper_bound" />
+    <ind:state state_ref="state_var_accounts_passwords_pam_faillock_deny_value_lower_bound" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_faillock_authfail_deny_password-auth" version="1">

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_config_deny_zero
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_config_deny_zero
@@ -1,0 +1,26 @@
+# This pam config is an example of a pam_faillock and pam_unix configured correctly
+# without skipping any module
+
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        required      pam_faillock.so preauth silent deny=0 unlock_time=1200
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        [default=die] pam_faillock.so authfail deny=0 unlock_time=1200
+auth        required      pam_deny.so
+
+account     required      pam_faillock.so
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_deny_zero.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_deny_zero.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+cp pam_config_deny_zero /etc/pam.d/system-auth
+cp pam_config_deny_zero /etc/pam.d/password-auth


### PR DESCRIPTION
#### Description:

- Set a lower bound value (greater than zero) for `accounts_passwords_pam_faillock_deny` check.

#### Rationale:
- `pam` option `deny` shouldn't be set to zero.

- Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71943?version=V2R8

`If the "deny" parameter is set to "0" or a value greater than "3" on both "auth" lines with the "pam_faillock.so" module, or is missing from these lines, this is a finding.`
