### PR TITLE
Improve the description of ocp_allowed_registries tests

### DIFF
--- a/applications/openshift/registry/ocp_allowed_registries/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries/rule.yml
@@ -8,6 +8,17 @@ description: |-
     and pods. This configuration setting ensures that all registries other than
     those specified are blocked.
 
+    You can set the allowed repositories by applying the following manifest using
+    <pre>oc patch</pre>, e.g. if you save the following snippet to
+    <pre>/tmp/allowed-registries-patch.yaml</pre>
+    <pre>
+    spec:
+      registrySources:
+        allowedRegistries:
+        - my-trusted-registry.internal.example.com
+    </pre> you would call
+    <pre>oc patch image.config.openshift.io cluster --patch="$(cat /tmp/allowed-registries-patch.yaml)" --type=merge</pre>
+
 rationale: |-
     Allowed registries should be configured to restrict the registries that the
     OpenShift container runtime can access, and all other registries should be

--- a/applications/openshift/registry/ocp_allowed_registries_for_import/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries_for_import/rule.yml
@@ -7,6 +7,16 @@ description: |-
     image registries from which normal users may import images. This is important
     to control, as a user who can stand up a malicious registry can then import
     content which claims to include the SHAs of legimitate content layers.
+    You can set the allowed repositories for import by applying the following
+    manifest using <pre>oc patch</pre>, e.g. if you save the following snippet to
+    <pre>/tmp/allowed-import-registries-patch.yaml</pre>
+    <pre>
+    spec:
+      allowedRegistriesForImport:
+      - domainName: my-trusted-registry.internal.example.com
+        insecure: false
+    </pre> you would call
+    <pre>oc patch image.config.openshift.io cluster --patch="$(cat /tmp/allowed-import-registries-patch.yaml)" --type=merge</pre>
 
 rationale: |-
     Allowed registries for import should be specified to limit the registries 


### PR DESCRIPTION
It was unclear how the admin is supposed to remediate the issue
without poking at the warning or the tests.