### PR TITLE
use xccdf variable in audit_audispd_network_failure_action

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
@@ -14,6 +14,7 @@ description: |-
     <tt>halt</tt>. For certain systems, the need for availability
     outweighs the need to log all actions, and a different setting should be
     determined.
+    This profile configures the <i>action</i> to be {{{ sub_var_value("var_audispd_network_failure_action") }}}.
 
 rationale: |-
     Taking appropriate action when there is an error sending audit records to a
@@ -35,11 +36,7 @@ ocil_clause: 'the system is not configured to switch to single user mode for cor
 
 ocil: |-
     Inspect <tt>/etc/audisp/audisp-remote.conf</tt> and locate the following line to
-    determine if the system is configured to either send to syslog, switch to single user mode,
-    or halt when there is a network failure with audispd:
+    determine if the system is configured to perform a correct action according to the policy:
     <pre>grep -i network_failure_action /etc/audisp/audisp-remote.conf</pre>
-    The output should return something similar to:
-    <pre>network_failure_action = single</pre>
-    Acceptable values also include <tt>syslog</tt> and
-    <tt>halt</tt>.
-
+    The output should return:
+    <pre>network_failure_action = {{{ sub_var_value("var_audispd_network_failure_action") }}}</pre>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
@@ -14,7 +14,7 @@ description: |-
     <tt>halt</tt>. For certain systems, the need for availability
     outweighs the need to log all actions, and a different setting should be
     determined.
-    This profile configures the <i>action</i> to be {{{ sub_var_value("var_audispd_network_failure_action") }}}.
+    This profile configures the <i>action</i> to be <tt>{{{ xccdf_value("var_audispd_network_failure_action") }}}</tt>.
 
 rationale: |-
     Taking appropriate action when there is an error sending audit records to a
@@ -39,4 +39,4 @@ ocil: |-
     determine if the system is configured to perform a correct action according to the policy:
     <pre>grep -i network_failure_action /etc/audisp/audisp-remote.conf</pre>
     The output should return:
-    <pre>network_failure_action = {{{ sub_var_value("var_audispd_network_failure_action") }}}</pre>
+    <pre>network_failure_action = {{{ xccdf_value("var_audispd_network_failure_action") }}}</pre>


### PR DESCRIPTION
#### Description:

- use XCCDF variable in the rule description and ocil

#### Rationale:

- STIG effort

Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-73163?version=v2r7