### PR TITLE
remove package_screen_installed from rhel7 stig

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -66,7 +66,6 @@ selections:
     - dconf_gnome_screensaver_lock_locked
     - dconf_gnome_enable_smartcard_auth
     - dconf_gnome_screensaver_idle_delay
-    - package_screen_installed
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_idle_activation_locked
     - dconf_gnome_screensaver_lock_delay


### PR DESCRIPTION
#### Description:

- remove rule from profile

#### Rationale:

- STIG effort (v2r8)

Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-71897?version=V1R4&compareto=v2r8