### PR TITLE
Change type of var_tftpd_secure_directory variable in tftpd_uses_secure_mode rule

### DIFF
--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/oval/shared.xml
@@ -26,7 +26,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_tftpd_uses_secure_mode" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_check="all"
+    <ind:subexpression datatype="string" operation="equals" var_check="all"
     var_ref="var_tftpd_secure_directory" />
   </ind:textfilecontent54_state>
 


### PR DESCRIPTION
#### Description:
Fix wrong variable type in tftpd_uses_secure_mode rule.

#### Rationale:
The variable type is [string](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/obsolete/tftp/var_tftpd_secure_directory.var#L7), not `int`.
