### PR TITLE
OCP4: Turn off documentation complete for CIS profile

### DIFF
--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -1,4 +1,4 @@
-documentation_complete: true
+documentation_complete: false
 
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 


### PR DESCRIPTION
This profile is not actually complete nor usable. So let's only enable
it when it's ready.