### PR TITLE
Use resolved profiles in rule playbooks

### DIFF
--- a/build-scripts/build_rule_playbooks.py
+++ b/build-scripts/build_rule_playbooks.py
@@ -29,6 +29,13 @@ def parse_args():
         "--ssg-root."
     )
     p.add_argument(
+        "--resolved-profiles-dir",
+        help="Directory that contains preprocessed profiles in YAML format "
+        "eg. ~/scap-security-guide/build/fedora/profiles. "
+        "If --resolved-profiles-dir is not specified, it is derived from "
+        "--ssg-root."
+    )
+    p.add_argument(
         "--ssg-root", required=True,
         help="Directory containing the source tree. "
         "e.g. ~/scap-security-guide/"
@@ -74,8 +81,14 @@ def main():
         resolved_rules_dir = os.path.join(
             args.ssg_root, "build", args.product, "rules"
         )
+    if args.resolved_profiles_dir:
+        resolved_profiles_dir = args.resolved_profiles_dir
+    else:
+        resolved_profiles_dir = os.path.join(
+            args.ssg_root, "build", args.product, "profiles"
+        )
     playbook_builder = ssg.playbook_builder.PlaybookBuilder(
-        product_yaml, input_dir, output_dir, resolved_rules_dir
+        product_yaml, input_dir, output_dir, resolved_rules_dir, resolved_profiles_dir
     )
     playbook_builder.build(args.profile, args.rule)
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -271,7 +271,7 @@ macro(ssg_build_ansible_playbooks PRODUCT)
     set(ANSIBLE_PLAYBOOKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/playbooks")
     add_custom_command(
         OUTPUT "${ANSIBLE_PLAYBOOKS_DIR}"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --ssg-root "${CMAKE_SOURCE_DIR}" --product "${PRODUCT}" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --output-dir "${ANSIBLE_PLAYBOOKS_DIR}"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --ssg-root "${CMAKE_SOURCE_DIR}" --product "${PRODUCT}" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --resolved-profiles-dir "${CMAKE_CURRENT_BINARY_DIR}/profiles" --output-dir "${ANSIBLE_PLAYBOOKS_DIR}"
         DEPENDS "${ANSIBLE_FIXES_DIR}"
         DEPENDS generate-internal-${PRODUCT}-ansible-all-fixes
         DEPENDS "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py"

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -16,7 +16,7 @@ COMMENTS_TO_PARSE = ["strategy", "complexity", "disruption"]
 
 
 class PlaybookBuilder():
-    def __init__(self, product_yaml_path, input_dir, output_dir, rules_dir):
+    def __init__(self, product_yaml_path, input_dir, output_dir, rules_dir, profiles_dir):
         self.input_dir = input_dir
         self.output_dir = output_dir
         self.rules_dir = rules_dir
@@ -26,10 +26,7 @@ class PlaybookBuilder():
                                                     "benchmark_root")
         self.guide_dir = os.path.abspath(os.path.join(product_dir,
                                                       relative_guide_dir))
-        relative_profiles_dir = ssg.utils.required_key(product_yaml,
-                                                       "profiles_root")
-        self.profiles_dir = os.path.abspath(
-            os.path.join(product_dir, relative_profiles_dir))
+        self.profiles_dir = profiles_dir
         additional_content_directories = product_yaml.get("additional_content_directories", [])
         self.add_content_dirs = [os.path.abspath(os.path.join(product_dir, rd)) for rd in additional_content_directories]
 
@@ -176,7 +173,7 @@ class PlaybookBuilder():
                 % (profile_path, ext)
             )
 
-        profile = ssg.build_yaml.ResolvableProfile.from_yaml(profile_path)
+        profile = ssg.build_yaml.Profile.from_yaml(profile_path)
         if not profile:
             raise RuntimeError("Could not parse profile %s.\n" % profile_path)
         return profile
@@ -265,7 +262,6 @@ class PlaybookBuilder():
 
         for p in to_process:
             profile = profiles[p]
-            profile.resolve(profiles)
             if rule_id:
                 self.create_playbook_for_single_rule(profile, rule_id,
                                                      variables)

--- a/tests/unit/ssg-module/test_playbook_builder.py
+++ b/tests/unit/ssg-module/test_playbook_builder.py
@@ -15,6 +15,7 @@ product_yaml = os.path.join(DATADIR, "product.yml")
 input_dir = os.path.join(DATADIR, "fixes")
 output_dir = os.path.join(DATADIR, "playbooks")
 resolved_rules_dir = os.path.join(DATADIR, "rules")
+resolved_profiles_dir = os.path.join(DATADIR, "profiles")
 rule = "selinux_state"
 profile = "ospp"
 
@@ -24,7 +25,7 @@ expected_output_filepath = os.path.join(DATADIR, "selinux_state.yml")
 
 def test_build_rule_playbook():
     playbook_builder = ssg.playbook_builder.PlaybookBuilder(
-        product_yaml, input_dir, output_dir, resolved_rules_dir
+        product_yaml, input_dir, output_dir, resolved_rules_dir, resolved_profiles_dir
     )
     playbook_builder.build(profile, rule)
 


### PR DESCRIPTION

#### Description:
Use resolved profiles in rule playbooks generator.

#### Rationale:
The profiles are resolved in previous build steps and saved to build/product/profiles. We don't need to resolve the profiles again when generating the playbooks. We can use the resolved profiles instead.

