### PR TITLE
Fix regex in ansible_sudo_remove_config macro

### DIFF
--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -570,7 +570,7 @@ See official documentation: https://jinja.palletsprojects.com/en/2.11.x/template
 
 - name: "Remove lines containing {{{ parameter }}} from sudoers files"
   replace:
-    regexp: '(^(?!#).*[\s]+\{{{ pattern }}}.*$)'
+    regexp: '(^(?!#).*[\s]+{{{ pattern }}}.*$)'
     replace: '# \g<1>'
     path: "{{ item.path }}"
     validate: /usr/sbin/visudo -cf %s


### PR DESCRIPTION
#### Description:
Variable in the macro had `\` prefix causing `ansbile-playbook` failure in [sudo_require_authentication](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/software/sudo/sudo_require_authentication/ansible/shared.yml#L7) rule.

#### Rationale:
Fix https://github.com/ComplianceAsCode/content/issues/6076 - `...sre_constants.error: bad escape \\N at position 14\r\n...`
