### PR TITLE
Update accounts_tmout rule with regards to latest RHEL7 STIG revision.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -26,11 +26,11 @@ identifiers:
 references:
     stigid@ol7: OL07-00-040160
     cui: 3.1.11
-    disa: CCI-000361,CCI-001133
+    disa: CCI-002361,CCI-001133
     nist: AC-12,SC-10,AC-2(5),CM-6(a)
     nist-csf: PR.AC-7
     ospp: FMT_MOF_EXT.1
-    srg: SRG-OS-000163-GPOS-00072
+    srg: SRG-OS-000163-GPOS-00072,SRG-OS-000029-GPOS-00010
     vmmsrg: SRG-OS-000163-VMM-000700,SRG-OS-000279-VMM-001010
     stigid@rhel7: RHEL-07-040160
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -47,7 +47,7 @@ selections:
     - var_accounts_user_umask=077
     - var_password_pam_retry=3
     - var_accounts_max_concurrent_login_sessions=10
-    - var_accounts_tmout=10_min
+    - var_accounts_tmout=15_min
     - var_time_service_set_maxpoll=system_default
     - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
     - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled


### PR DESCRIPTION
#### Description:
- Update `accounts_tmout` rule with regards to latest RHEL7 STIG revision (v2r8).
  - Select 15 minutes as new timeout value.
  - Fix CCI and SRG identifiers.

#### Rationale:

- Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72223?version=V1R4&compareto=v2r8
