### PR TITLE
Remove accounts_user_interactive_home_directory_defined from RHEL7 STIG.

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -127,7 +127,6 @@ selections:
     - accounts_no_uid_except_zero
     - no_files_unowned_by_user
     - file_permissions_ungroupowned
-    - accounts_user_interactive_home_directory_defined
     - accounts_have_homedir_login_defs
     - accounts_user_interactive_home_directory_exists
     - file_permissions_home_directories


### PR DESCRIPTION
#### Description:
- Remove accounts_user_interactive_home_directory_defined from RHEL7 STIG.
  - Rule has been removed from latest release (v2r8).

#### Rationale:

- Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-72011?version=V2R7&compareto=v2r8
