### PR TITLE
Merge dev shm rules into one STIG item.

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -10,12 +10,14 @@ description: |-
     It can be dangerous to allow the execution of binaries
     from world-writable temporary storage directories such as <tt>/dev/shm</tt>.
     {{{ describe_mount(option="noexec", part="/dev/shm") }}}
+    {{{ describe_mount(option="nodev", part="/dev/shm") }}}
+    {{{ describe_mount(option="nosuid", part="/dev/shm") }}}
 
 rationale: |-
     Allowing users to execute binaries from world-writable directories
     such as <tt>/dev/shm</tt> can expose the system to potential compromise.
 
-{{{ complete_ocil_entry_mount_option("/dev/shm", "noexec") }}}
+{{{ complete_ocil_entry_mount_option("/dev/shm", "noexec nodev nosuid") }}}
 
 severity: medium
 

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -297,7 +297,5 @@ selections:
     - audit_rules_usergroup_modification_opasswd
     - sysctl_net_ipv4_conf_all_accept_redirects
     - wireless_disable_interfaces
-    - mount_option_dev_shm_nodev
     - mount_option_dev_shm_noexec
-    - mount_option_dev_shm_nosuid
     - audit_rules_privileged_commands_mount


### PR DESCRIPTION
- This is a discussion starter pull request, do not merge as it is.

#### Description:

- Rules `mount_option_dev_shm_nodev` and `mount_option_dev_shm_nosuid` were merged together with `mount_option_dev_shm_noexec`. Do we want to combine them into one single rule or should we keep as it is? but then which STIG id should we use for other rules, do keep it like it is right now?

#### Rationale:

- Reference: https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-81013?version=V2R7&compareto=v2r8
