### PR TITLE
Remove extra ocil statement from service_cockpit_disabled.

### DIFF
--- a/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
@@ -20,10 +20,6 @@ ocil: '{{{ ocil_service_disabled(service="cockpit") }}}'
 
 ocil_clause: 'it is not disabled'
 
-ocil: |-
-    To check the status of cockpit run the following command:
-    <pre>$ systemctl status cockpit.service cockpit.socket</pre>
-
 template:
     name: service_disabled
     vars:


### PR DESCRIPTION
#### Description:

- Remove extra ocil statement from service_cockpit_disabled.

#### Rationale:

- Favours macro `ocil_service_disabled(service="cockpit")` instead from line 19.
