### PR TITLE
ocp4 utils: Create ImageStream with local lookup policy

### DIFF
--- a/ocp-resources/ds-build.yaml
+++ b/ocp-resources/ds-build.yaml
@@ -2,6 +2,9 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
   name: "openscap-ocp4-ds" 
+spec:
+  lookupPolicy:
+    local: true
 ---
 kind: BuildConfig
 apiVersion: build.openshift.io/v1


### PR DESCRIPTION
This makes it easier for folks building their own content containers for
testing to take the imagestream into use by only needing to reference
the imagestream name instead of the whole image path.