### PR TITLE
ocp4: Add option to create profile bundles for the build_ds_container.sh script

### DIFF
--- a/ocp-resources/profile-bundle.yaml.tpl
+++ b/ocp-resources/profile-bundle.yaml.tpl
@@ -1,0 +1,11 @@
+# This is a template that is meant to create a profilebundle
+# for a specified product
+# Note that this is hardcoded to use the imagestream created by the
+# build_ds_container.sh script in the utils directory.
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ProfileBundle
+metadata:
+  name: usptream-$PRODUCT
+spec:
+  contentImage: openscap-ocp4-ds:latest
+  contentFile: ssg-$PRODUCT-ds.xml


### PR DESCRIPTION
ProfileBundles are how the compliance-operator is able to track content
images, parse them and expose the profiles and rules to users. This adds
a small piece of automation, when building content images for OCP, to be
able to create the relevant profilebundles when running that script.
This would be useful when developing content.