### PR TITLE
Add a test for missing CCEs

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -600,6 +600,14 @@ macro(ssg_build_sds PRODUCT)
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
     )
 
+    if("${PRODUCT}" MATCHES "rhel(6|7|8)")
+        add_test(
+            NAME "missing-cces-${PRODUCT}"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/missing_cces.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+        )
+        set_tests_properties("missing-cces-${PRODUCT}" PROPERTIES LABELS quick)
+    endif()
+
     define_validate_product("${PRODUCT}")
     if ("${VALIDATE_PRODUCT}" OR "${FORCE_VALIDATE_EVERYTHING}")
         add_test(

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -600,7 +600,7 @@ macro(ssg_build_sds PRODUCT)
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
     )
 
-    if("${PRODUCT}" MATCHES "rhel(6|7|8)")
+    if("${PRODUCT}" MATCHES "rhel(6|7|8|9)")
         add_test(
             NAME "missing-cces-${PRODUCT}"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/missing_cces.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"

--- a/tests/missing_cces.py
+++ b/tests/missing_cces.py
@@ -26,11 +26,15 @@ def check_all_rules(root):
         selected_rules = get_selected_rules(benchmark)
         for rule in benchmark.findall(".//{%s}Rule" % (XCCDF12_NS)):
             rule_id = rule.get("id")
-            if rule_id in selected_rules:
-                match = rule.find(
-                    "{%s}ident[@system='%s']" % (XCCDF12_NS, cce_uri))
-                if match is None:
-                    rules_missing_cce.append(rule_id)
+            if rule_id not in selected_rules:
+                continue
+            match = False
+            for ident in rule.findall("{%s}ident" % (XCCDF12_NS)):
+                if ident.get("system") == cce_uri:
+                    match = True
+                    break
+            if not match:
+                rules_missing_cce.append(rule_id)
     return rules_missing_cce
 
 

--- a/tests/missing_cces.py
+++ b/tests/missing_cces.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+
+import argparse
+import os.path
+import sys
+
+import ssg.xml
+from ssg.constants import cce_uri, OSCAP_RULE, XCCDF12_NS
+
+
+def get_selected_rules(benchmark):
+    rules = set()
+    for profile in benchmark.findall(".//{%s}Profile" % (XCCDF12_NS)):
+        for selection in profile.findall(".//{%s}select" % (XCCDF12_NS)):
+            idref = selection.get("idref")
+            selected = selection.get("selected")
+            if idref.startswith(OSCAP_RULE) and selected == "true":
+                rules.add(idref)
+    return rules
+
+
+def check_all_rules(root):
+    rules_missing_cce = []
+    root = ssg.xml.parse_file(args.datastream_path)
+    for benchmark in root.findall(".//{%s}Benchmark" % (XCCDF12_NS)):
+        selected_rules = get_selected_rules(benchmark)
+        for rule in benchmark.findall(".//{%s}Rule" % (XCCDF12_NS)):
+            rule_id = rule.get("id")
+            if rule_id in selected_rules:
+                match = rule.find(
+                    "{%s}ident[@system='%s']" % (XCCDF12_NS, cce_uri))
+                if match is None:
+                    rules_missing_cce.append(rule_id)
+    return rules_missing_cce
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Checks the all rules that are part of at least one "
+        "profile have a CCE assigned.")
+    parser.add_argument(
+        "datastream_path", help="Path to a SCAP source datastream")
+    args = parser.parse_args()
+    root = ssg.xml.parse_file(args.datastream_path)
+    rules_missing_cce = check_all_rules(root)
+    ds = os.path.basename(args.datastream_path)
+    if len(rules_missing_cce) > 0:
+        print("The following rules in %s are missing CCEs:" % (ds))
+        for rule in rules_missing_cce:
+            print(rule)
+        sys.exit(1)
+    else:
+        print("%s is OK" % (ds))


### PR DESCRIPTION
#### Description:
This test checks if all rules that are a part of a profile have a CCE identifier properly assigned. It checks the built datastream. It will check RHEL 6, RHEL 7 and RHEL 8. The test is a part of CTest. It will be executed on every PR. 

#### Rationale:
It will prevent introducing rules without CCEs, so it will prevent last-minute PRs eg. https://github.com/ComplianceAsCode/content/pull/6079
