### PR TITLE
Force shutdown of VM if it cannot be shutdown gracefully

### DIFF
--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -180,9 +180,10 @@ def reboot_domain(domain, domain_ip, ssh_port):
     while domain.isActive():
         time.sleep(1)
         if time.time() >= end_time:
-            str_err = "Timeout reached: '{0}' domain failed to shutdown.".format(domain.name())
-            logging.debug(str_err)
-            raise TimeoutException(str_err)
+            str_err = ("Timeout reached: '{0}' domain failed to shutdown. "
+                       "Forcing the shutdown...".format(domain.name()))
+            logging.warning(str_err)
+            domain.destroy()
 
     logging.debug("Starting domain '{0}'".format(domain.name()))
     domain.create()


### PR DESCRIPTION
#### Description:
If a VM cannot be gracefully shutdown, then force the shutdown with `destroy` https://libvirt.org/sources/virshcmdref/html/sect-destroy.html

Currently, SSGTS waits 5 minutes for domain to shutdown and it still happens that a VM fails to do so. We don't want to increase the timeout because 5 minutes is already a long time of waiting for shutdown. However, we want to get the SSGTS results from the VM thus this PR removes raising of an exception and just forces the shutdown.

#### Rationale:
In some cases, when a VM has high CPU usage, it is not possible to shutdown it.
This issue - https://github.com/systemd/systemd/issues/13667 - describes the same problem we are facing when running SSGTS on certain profiles (OSPP-based profiles).
