### PR TITLE
Fix PCRE_ERROR_MATCHLIMIT in PASS_MAX_DAYS

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/oval/shared.xml
@@ -13,7 +13,6 @@
 
   <ind:textfilecontent54_object id="object_last_pass_max_days_from_etc_login_defs" version="1">
     <!-- Read whole /etc/login.defs as single line so we can retrieve last PASS_MAX_DAYS directive occurrence -->
-    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
     <!-- Retrieve last (uncommented) occurrence of PASS_MAX_DAYS directive -->
     <ind:pattern operation="pattern match">^(?:.*\n)*\s*[^#]*(PASS_MAX_DAYS\s+\d+)\s*\n</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig_double.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig_double.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+rm -f /etc/login.defs
+echo "PASS_MAX_DAYS        60" > /etc/login.defs
+echo "PASS_MAX_DAYS        30" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig_double.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig_double.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+rm -f /etc/login.defs
+echo "PASS_MAX_DAYS        60" > /etc/login.defs
+echo "PASS_MAX_DAYS        120" >> /etc/login.defs


### PR DESCRIPTION
#### Description:

- Fix memory limit match error when scanning an actual /etc/login.defs
file, which is much larger than the test files.
- Removed the single line behavior and added tests to check whether it is
matching the last PASS_MAX_DAYS.

#### Rationale:

-  Fixes #6056