### PR TITLE
The pigz package was prohibited on RHEL-8.1 because of bug 1624161

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -198,7 +198,6 @@ selections:
     - package_abrt-cli_removed
     - package_tuned_removed
     - package_abrt_removed
-    - package_pigz_removed
 
     ### Login
     - disable_users_coredumps

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -143,7 +143,6 @@ selections:
 - package_openscap-scanner_installed
 - package_openssh-clients_installed
 - package_openssh-server_installed
-- package_pigz_removed
 - package_policycoreutils-python-utils_installed
 - package_policycoreutils_installed
 - package_rng-tools_installed

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -164,7 +164,6 @@ selections:
 - package_openscap-scanner_installed
 - package_openssh-clients_installed
 - package_openssh-server_installed
-- package_pigz_removed
 - package_policycoreutils-python-utils_installed
 - package_policycoreutils_installed
 - package_rng-tools_installed


### PR DESCRIPTION
[That bug](https://bugzilla.redhat.com/show_bug.cgi?id=1624161) has been fixed, there is no reason to mark the package as not wanted.

Resolves: [RHBZ#1872675](https://bugzilla.redhat.com/show_bug.cgi?id=1872675)