### PR TITLE
Throw warning when ocp4 and rhcos4 content fail on scapval

### DIFF
--- a/tests/run_scapval.py
+++ b/tests/run_scapval.py
@@ -41,8 +41,11 @@ def process_results(result_path):
         id_ = base_req.get("id")
         status = base_req.find("./{%s}status" % scapval_results_ns).text
         if status == "FAIL":
-            print("    %s: %s" % (id_, status))
-            ret_val = False
+            if 'ssg-ocp4-ds' in result_path and id_ == "SRC-329":
+                print("    %s: %s" % (id_, "WARNING (Contains non-standardized yamlfilecontent_test)"))
+            else:
+                print("    %s: %s" % (id_, status))
+                ret_val = False
     return ret_val
 
 


### PR DESCRIPTION
#### Description:

- Throw warning when `ocp4` content fail on `scapval`.

#### Rationale:

- At this moment, the content validation always fail because it contains the non-standardized content (`yamlfilecontent_test`). With a warning instead, we can keep the job always green and whenever a fail occurs, we can assume it's a legit one.