### PR TITLE
Add grub2 cpe entry to rhcos4 cpe dicitionary.

### DIFF
--- a/rhcos4/cpe/rhcos4-cpe-dictionary.xml
+++ b/rhcos4/cpe/rhcos4-cpe-dictionary.xml
@@ -61,4 +61,9 @@
             <title xml:lang="en-us">System uses zipl</title>
             <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_zipl_package</check>
       </cpe-item>
+      <cpe-item name="cpe:/a:grub2">
+            <title xml:lang="en-us">Package grub2 is installed</title>
+            <!-- the check references an OVAL file that contains an inventory definition -->
+            <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="filename">installed_env_has_grub2_package</check>
+      </cpe-item>
 </cpe-list>


### PR DESCRIPTION
#### Description:

- Add grub2 cpe entry to rhcos4 cpe dicitionary.

#### Rationale:

- Fix scapval validation of RHCOS4 content.
```
Testing ssg-rhcos4-ds.xml ...
    SRC-15: FAIL
ssg-rhcos4-ds.xml: FAIL
```
From: https://jenkins.complianceascode.io/job/scap-security-guide-scapval-scap-1.3/322/console
