### PR TITLE
Fix ansible remediation for dconf gnome rules.

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: disable-restart-buttons
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME disablement of Login Restart and Shutdown Buttons"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: enable-smartcard-authentication
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 disablement of Smartcard Authentication"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: allowed-failures
     value: "3"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 Login Number of Failures"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: disable-all
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 Thumbnailers"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: disable-wifi-create
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: suppress-wireless-networks-available
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: authentication-methods
     value: "['vnc']"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 Credential Prompting for Remote Access"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: require-encryption
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 Encryption for Remote Access"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: idle_activation_enabled
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME idle_activation_enabled"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -12,6 +12,7 @@
     option: idle-delay
     value: "{{ inactivity_timeout_value }}"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME idle-delay"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: lock-delay
     value: uint32 5
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME lock-delay"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: lock-enabled
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME lock-enabled"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: picture-uri
     value: string ''
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME picture-uri"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: show-full-name-in-top-bar
     value: "false"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME show-full-name-in-top-bar"
   lineinfile:

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: enabled
     value: "false"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Disable Geolocation in GNOME3 - clock location tracking"
   ini_file:

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
@@ -10,6 +10,7 @@
     option: user-administration-disabled
     value: "true"
     create: yes
+    no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME3 Thumbnailers"
   lineinfile:


### PR DESCRIPTION
#### Description:

- Fix ansible remediation for dconf gnome rules.

#### Rationale:

- The OVAL check of these rules doesn't allow space between the equals
sign character thus we have to be sure that the ansible remediation
doesn't add any extra white space between the separator.

- I went through all ansible remediation files that use `ini_file` module and that the corresponding OVAL check doesn't allow spaces between the separator (`=`).