### PR TITLE
Removed profile from test metadata where not needed

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/service_disabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 yum -y install avahi
 

--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/socket_enabled.fail.sh
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/socket_enabled.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 yum -y install avahi
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.d
 chgrp root /etc/cron.d

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/tests/other_group.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.daily
 chgrp root /etc/cron.daily

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/tests/other_group.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.hourly
 chgrp root /etc/cron.hourly

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/tests/other_group.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.monthly
 chgrp root /etc/cron.monthly

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/tests/other_group.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.weekly
 chgrp root /etc/cron.weekly

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/tests/other_group.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/cron_and_at/file_groupowner_crontab/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_crontab/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/crontab
 chgrp root /etc/crontab

--- a/linux_os/guide/services/cron_and_at/file_groupowner_crontab/tests/other_group.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_crontab/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_d/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_d/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.d
 chown root /etc/cron.d

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_d/tests/other_user.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_d/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_daily/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_daily/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.daily
 chown root /etc/cron.daily

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_daily/tests/other_user.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_daily/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.hourly
 chown root /etc/cron.hourly

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/tests/other_user.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.monthly
 chown root /etc/cron.monthly

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/tests/other_user.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/cron.weekly
 chown root /etc/cron.weekly

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/tests/other_user.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/cron_and_at/file_owner_crontab/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_crontab/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /etc/crontab
 chown root /etc/crontab

--- a/linux_os/guide/services/cron_and_at/file_owner_crontab/tests/other_user.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_owner_crontab/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 0700 /etc/cron.d

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/tests/open_permissions.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/tests/open_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 777 /etc/cron.d

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 0700 /etc/cron.daily

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/tests/open_permissions.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/tests/open_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 777 /etc/cron.daily

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 0700 /etc/cron.hourly

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/tests/open_permissions.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/tests/open_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 777 /etc/cron.hourly

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 0700 /etc/cron.monthly

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/tests/open_permissions.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/tests/open_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 777 /etc/cron.monthly

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 0700 /etc/cron.weekly

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/tests/open_permissions.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/tests/open_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 777 /etc/cron.weekly

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 0600 /etc/crontab

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/tests/open_permissions.fail.sh
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/tests/open_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 chmod 777 /etc/crontab

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/tests/file_not_there.pass.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/tests/file_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/cron.allow

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 touch /etc/cron.allow
 chgrp root /etc/cron.allow

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/tests/other_group.fail.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/tests/file_not_there.pass.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/tests/file_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/cron.allow

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/tests/is_root.pass.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 touch /etc/cron.allow
 chown root /etc/cron.allow

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/tests/other_user.fail.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_standard
 
 yum -y install at
 systemctl disable atd.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_standard
 
 # this tesst ensures that only the atd.service is matched, not for example the service rpc-statd
 

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_standard
 
 yum -y install at
 systemctl enable atd.service

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/ldap_auth_and_start_tls.pass.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/ldap_auth_and_start_tls.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 AUTHCONFIG_REGEX="^[[:space:]]*USELDAPAUTH=yes[[:space:]]*$"
 grep -q "$AUTHCONFIG_REGEX" /etc/sysconfig/authconfig && \

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/not_using_ldap.fail.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/not_using_ldap.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y nss-pam-ldapd
 

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/tls_not_starting.fail.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/tls_not_starting.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y nss-pam-ldapd
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/krb_sec_set.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/krb_sec_set.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_all_krb_sec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_all_krb_sec.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/
 sed -i 's/,sec=krb5:krb5i:krb5p//' /etc/fstab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_krb_sec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_krb_sec.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/
 # delete sec=.. only from nfs4

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/no_nfs.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/no_nfs.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/
 sed -i '/nfs/d' /etc/fstab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_all_noexec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_all_noexec.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/
 sed -i 's/,noexec//' /etc/fstab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_noexec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_noexec.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/
 sed -i 's|\(.*nfs4.*\),noexec\(.*\)|\1\2|' /etc/fstab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/no_nfs.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/no_nfs.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/
 sed -i '/nfs/d' /etc/fstab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/noexec_set.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/noexec_set.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp $SHARED/fstab /etc/

--- a/linux_os/guide/services/ntp/chronyd_client_only/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/tests/chrony.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_client_only/tests/missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/tests/missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_client_only/tests/nonzero.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/tests/nonzero.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/chrony.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/nonzero.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/nonzero.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/tests/is_root.pass.sh
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 touch /etc/ssh/sshd_config
 chgrp root /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/tests/other_group.fail.sh
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/tests/is_root.pass.sh
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/tests/is_root.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 touch /etc/ssh/sshd_config
 chown root /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/tests/other_user.fail.sh
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chmod 0640 /etc/ssh/*_key

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/multiple_keys.fail.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/multiple_keys.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chmod 0777 $FAKE_KEY

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chmod 0777 $FAKE_KEY

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/comment.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/comment.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^HostbasedAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^HostbasedAuthentication.*/# HostbasedAuthentication yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^HostbasedAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^HostbasedAuthentication.*/HostbasedAuthentication no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/line_not_there.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/line_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^HostbasedAuthentication.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^HostbasedAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^HostbasedAuthentication.*/HostbasedAuthentication yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6-configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6-configured.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # Test targeted to RHEL 7.4
 yum downgrade -y openssh-6.6.1p1 openssh-clients-6.6.1p1 openssh-server-6.6.1p1

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # Test targeted to RHEL 7.4
 yum downgrade -y openssh-6.6.1p1 openssh-clients-6.6.1p1 openssh-server-6.6.1p1

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 
 yum install -y openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/comment.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/comment.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^GSSAPIAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^GSSAPIAuthentication.*/# GSSAPIAuthentication no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^GSSAPIAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^GSSAPIAuthentication.*/GSSAPIAuthentication no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/line_not_there.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/line_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^GSSAPIAuthentication.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^GSSAPIAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^GSSAPIAuthentication.*/GSSAPIAuthentication yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/comment.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/comment.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^KerberosAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^KerberosAuthentication.*/# KerberosAuthentication yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^KerberosAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^KerberosAuthentication.*/KerberosAuthentication no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/line_not_there.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/line_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^KerberosAuthentication.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^KerberosAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^KerberosAuthentication.*/KerberosAuthentication yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^PubkeyAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^PubkeyAuthentication.*/PubkeyAuthentication no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/missing_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/missing_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^PubkeyAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^PubkeyAuthentication.*/#PubkeyAuthentication yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^PubkeyAuthentication" /etc/ssh/sshd_config; then
 	sed -i "s/^PubkeyAuthentication.*/PubkeyAuthentication yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/comment.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/comment.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^IgnoreRhosts" /etc/ssh/sshd_config; then
 	sed -i "s/^IgnoreRhosts.*/# IgnoreRhosts no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^IgnoreRhosts" /etc/ssh/sshd_config; then
 	sed -i "s/^IgnoreRhosts.*/IgnoreRhosts yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/line_not_there.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/line_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^IgnoreRhosts.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^IgnoreRhosts" /etc/ssh/sshd_config; then
 	sed -i "s/^IgnoreRhosts.*/IgnoreRhosts no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/comment.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/comment.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^X11Forwarding" /etc/ssh/sshd_config; then
 	sed -i "s/^X11Forwarding.*/# X11Forwarding no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^X11Forwarding" /etc/ssh/sshd_config; then
 	sed -i "s/^X11Forwarding.*/X11Forwarding no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/line_not_there.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/line_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^X11Forwarding.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^X11Forwarding" /etc/ssh/sshd_config; then
 	sed -i "s/^X11Forwarding.*/X11Forwarding yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/comment.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/comment.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^StrictModes" /etc/ssh/sshd_config; then
 	sed -i "s/^StrictModes.*/# StrictModes no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^StrictModes" /etc/ssh/sshd_config; then
 	sed -i "s/^StrictModes.*/StrictModes yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/line_not_there.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/line_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^StrictModes.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^StrictModes" /etc/ssh/sshd_config; then
 	sed -i "s/^StrictModes.*/StrictModes no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/comment.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^Banner" /etc/ssh/sshd_config; then
 	sed -i "s|^Banner.*|# Banner /etc/issue/|" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^Banner" /etc/ssh/sshd_config; then
 	sed -i "s|^Banner.*|Banner /etc/issue|" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^Banner.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^Banner" /etc/ssh/sshd_config; then
 	sed -i "s/^Banner.*/Banner none/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/good_cipher.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/good_cipher.pass.sh
@@ -1,5 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora
-# profiles = e8
 
 sed -i 's/^\s*Ciphers\s.*//i' /etc/ssh/sshd_config
 echo "Ciphers aes256-ctr" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/no_ciphers.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/tests/no_ciphers.fail.sh
@@ -1,4 +1,3 @@
 # platform = multi_platform_rhel,multi_platform_fedora
-# profiles = e8
 
 sed -i 's/^\s*Ciphers\s/# &/i' /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
@@ -1,5 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora
-# profiles = e8
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config
 echo "MACs hmac-sha2-512" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/no_macs.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/no_macs.fail.sh
@@ -1,4 +1,3 @@
 # platform = multi_platform_rhel,multi_platform_fedora
-# profiles = e8
 
 sed -i 's/^\s*MACs\s/# &/i' /etc/ssh/sshd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ad_id_provider_and_reqcert_never.notapplicable.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ad_id_provider_and_reqcert_never.notapplicable.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/id_provider_is_set_to_ad.notapplicable.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/id_provider_is_set_to_ad.notapplicable.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_id_provider_and_reqcert_never.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_id_provider_and_reqcert_never.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_tls_reqcert_not_there.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_tls_reqcert_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ad_id_provider_and_tls_false.notapplicable.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ad_id_provider_and_tls_false.notapplicable.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/id_provider_is_set_to_ad.notapplicable.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/id_provider_is_set_to_ad.notapplicable.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_id_provider_and_tls_false.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_id_provider_and_tls_false.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_use_start_tls_not_there.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_use_start_tls_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
@@ -1,7 +1,6 @@
 
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 SSSD_SERVICES_REGEX_SHORT="^[[:space:]]*services.*$"
 SSSD_CONF="/etc/sssd/sssd.conf"

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/comment.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/comment.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_section.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/comment.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/comment.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # We will configure user to be sssd
 

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_section.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/commented.fail.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/commented.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/missing.fail.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/missing.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/present.pass.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/present.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/correct.pass.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/correct.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 source $SHARED/utils.sh
 

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_contains_only_whitespaces.fail.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_contains_only_whitespaces.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/usbguard/rules.conf
 mkdir /etc/usbguard

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/usbguard/rules.conf
 mkdir /etc/usbguard

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 source $SHARED/utils.sh
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ncp
 
 source $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ncp
 
 source $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/both-correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/both-correct.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set-up-pamd.sh
 
 set-up-pamd

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/missing-default-die-pam_faillock.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/missing-default-die-pam_faillock.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set-up-pamd.sh
 
 set-up-pamd

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/missing-required-pam_faillock.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/missing-required-pam_faillock.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set-up-pamd.sh
 
 set-up-pamd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/tests/correct_crypt_style.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/tests/correct_crypt_style.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # example libuser.conf has set 'crypt_style = sha512'
 cp libuser.conf /etc/

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/tests/no_crypt_style.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/tests/no_crypt_style.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp libuser.conf /etc/
 sed -i "/crypt_style/d" /etc/libuser.conf

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/tests/weak_algorithm.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_libuserconf/tests/weak_algorithm.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 cp libuser.conf /etc/
 sed -i "s/crypt_style = sha512/crypt_style = md5/" /etc/libuser.conf

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^CtrlAltDelBurstAction=" /etc/systemd/system.conf; then
 	sed -i "s/^CtrlAltDelBurstAction.*/CtrlAltDelBurstAction=none/" /etc/systemd/system.conf

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^CtrlAltDelBurstAction.*/d" /etc/systemd/system.conf

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^CtrlAltDelBurstAction=" /etc/systemd/system.conf; then
 	sed -i "s/^CtrlAltDelBurstAction.*/CtrlAltDelBurstAction=poweroff-immediate/" /etc/systemd/system.conf

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/disabled_interactive_boot.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/disabled_interactive_boot.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONFIRM_SPAWN_YES="systemd.confirm_spawn=\(1\|yes\|true\|on\)"
 

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/enabled_interactive_boot.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/enabled_interactive_boot.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONFIRM_SPAWN_OPT="systemd.confirm_spawn"
 CONFIRM_SPAWN_YES="systemd.confirm_spawn=yes"

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 service_file="/usr/lib/systemd/system/emergency.service"
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 service_file="/usr/lib/systemd/system/emergency.service"
 sulogin="/bin/bash"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 service_file="/usr/lib/systemd/system/rescue.service"
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 service_file="/usr/lib/systemd/system/rescue.service"
 sulogin="/bin/bash"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/file_empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/file_empty.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo > '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/line_commented.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo '# set -g lock-command vlock' >> '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/line_is_there.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/line_is_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo 'set -g lock-command vlock' >> '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo 'set -g lock-command locker' >> '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_all_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_all_disabled.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y pcsc-lite pam_pkcs11 esc
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y pcsc-lite pam_pkcs11 esc
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_socket_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_socket_disabled.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y pcsc-lite pam_pkcs11 esc
 

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/tests/service_disabled.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 systemctl disable debug-shell.service
 systemctl stop debug-shell.service

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/tests/service_enabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/tests/service_enabled.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 systemctl unmask debug-shell.service
 systemctl enable debug-shell.service

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/asterisks.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/asterisks.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 sed -i 's/^\([^:]*\):x:/\1:\*:/' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/exes.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/exes.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 sed -i 's/^\([^:]*\):\*:/\1:x:/' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i '/nullok/d' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 sed -i '/nullok/d' $SYSTEM_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_multiple_times.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_multiple_times.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 echo "auth  sufficient  pam_unix.so try_first_pass nullok" >> $SYSTEM_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "auth  sufficient  pam_unix.so try_first_pass nullok" >> /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_secure.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_secure.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 sed -i '/nullok/d' $SYSTEM_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/comment.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/comment.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^vc" /etc/securetty; then
 	sed -i "s;^vc.*;#vc/20;" /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/file_not_there.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/file_not_there.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/vc_in_securetty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/vc_in_securetty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^vc" /etc/securetty; then
 	sed -i "s;^vc.*;vc/20;" /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/vc_not_in_securetty.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/tests/vc_not_in_securetty.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/securetty
 touch /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/comment.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/comment.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then
 	sed -i "s/^CREATE_HOME.*/CREATE_HOME yes/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/line_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 sed -i "/.*CREATE_HOME.*/d" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 
 if grep -q "^CREATE_HOME" /etc/login.defs; then

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/correct_value.pass.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 #
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
+
 	sed -i "s/^UMASK.*/UMASK 077/" /etc/login.defs
 else
 	echo "UMASK 077" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/UMASK 077/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/super_compliance.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/super_compliance.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/UMASK 177/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/super_compliance.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/super_compliance.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/UMASK 177/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_configuration.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_configuration.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/umask 077/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_configuration.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_configuration.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/umask 077/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_value.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/UMASK 027/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/UMASK 027/" /etc/login.defs

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/correct_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
 echo "-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/tests/rules_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/correct_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-a always,exit -F arch=b32 -S rename -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
 echo "-a always,exit -F arch=b64 -S rename -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/tests/rules_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_multiple_per_arg.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_arg.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_line.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/default.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
 echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/one_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/tests/one_filter.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
 echo "-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/audit_o_creat_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/audit_o_creat_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open_o_creat.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/audit_o_trunc_write_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/audit_o_trunc_write_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open_o_trunc_write.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/open_before_last.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/open_before_last.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed 's/openat,open_by_handle_at/open,open_by_handle_at/' $SHARED/audit_open.rules > /etc/audit/rules.d/open_o_creat.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/open_last.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/open_last.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed 's/_by_handle_at//' $SHARED/audit_open.rules > /etc/audit/rules.d/open_o_creat.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/open_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/open_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/tests/rules-amis.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed '3,4d' $SHARED/audit_open.rules > /etc/audit/rules.d/open-o_creat.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_creat_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_creat_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open_o_creat.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_trunc_write_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_trunc_write_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open_o_trunc_write.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/open_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/rules-amis.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed '3,4d' $SHARED/audit_open_o_creat.rules > /etc/audit/rules.d/open-o_creat.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_creat_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_creat_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open_o_creat.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_trunc_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_trunc_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open_o_trunc_write.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/open_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/rules-amis.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed '3,4d' $SHARED/audit_open_o_trunc_write.rules > /etc/audit/rules.d/open-o_trunc_write.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/one_rule_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/one_rule_missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat $SHARED/audit_open_o_creat.rules $SHARED/audit_open_o_trunc_write.rules $SHARED/audit_open.rules > /etc/audit/rules.d/ordered_by_filter.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_arch.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_arch.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 grep -h 'arch=b32.*EACCES' $SHARED/audit_open_o_creat.rules $SHARED/audit_open_o_trunc_write.rules $SHARED/audit_open.rules > /etc/audit/rules.d/ordered_by_arch_error.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_filter.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_filter.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat $SHARED/audit_open_o_creat.rules $SHARED/audit_open_o_trunc_write.rules $SHARED/audit_open.rules > /etc/audit/rules.d/ordered_by_filter.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/sorted_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/sorted_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat $SHARED/audit_open_o_creat.rules $SHARED/audit_open_o_trunc_write.rules $SHARED/audit_open.rules > ./ordered_by_filter.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/unordered.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/unordered.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 # The rule without filter is less specific, and thus, catches more events than the more specific rules (with O_CREAT and O_TRUNC filters)

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_last.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_last.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed 's/_by_handle_at/at/' $SHARED/audit_openat_o_creat.rules > /etc/audit/rules.d/openat_o_creat.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_openat_o_creat.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_trunc_write.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_trunc_write.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_openat_o_trunc_write.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/open_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/rules-amis.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed '3,4d' $SHARED/audit_openat_o_creat.rules > /etc/audit/rules.d/openat-o_creat.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_creat.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_creat.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_openat_o_creat.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_trunc.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_trunc.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_openat_o_trunc_write.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/open_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cp $SHARED/audit_open.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/rules-amis.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 sed '3,4d' $SHARED/audit_openat_o_trunc_write.rules > /etc/audit/rules.d/openat-o_trunc_write.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_arch.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_arch.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 grep -h 'arch=b32.*EACCES' $SHARED/audit_openat_o_creat.rules $SHARED/audit_openat_o_trunc_write.rules $SHARED/audit_open.rules > /etc/audit/rules.d/ordered_by_arch_error.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_filter.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_filter.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat $SHARED/audit_openat_o_creat.rules $SHARED/audit_openat_o_trunc_write.rules $SHARED/audit_open.rules > /etc/audit/rules.d/ordered_by_filter.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/rule_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/rule_missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat $SHARED/audit_openat_o_creat.rules $SHARED/audit_openat_o_trunc_write.rules $SHARED/audit_open.rules > /etc/audit/rules.d/ordered_by_filter.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/sorted_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/sorted_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 cat $SHARED/audit_openat_o_creat.rules $SHARED/audit_openat_o_trunc_write.rules $SHARED/audit_open.rules > ./ordered_by_filter.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/unordered.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/unordered.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 # The rule without filter is less specific, and thus, catches more events than the more specific rules (with O_CREAT and O_TRUNC filters)

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/default.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
 echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/one_sys_with_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/one_sys_with_filter.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
 echo "-a always,exit -F arch=b64 -S unlink -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/only_eacces.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/only_eacces.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
 echo "-a always,exit -F arch=b64 -S unlink -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/two_sys_with_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/tests/two_sys_with_filter.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules
 echo "-a always,exit -F arch=b64 -S unlink,unlinkat -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-delete" >> /etc/audit/rules.d/unsuccessful-delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line_one_missing.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-a always,exit -F arch=b32 -S finit_module -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S finit_module -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-a always,exit -F arch=b32 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 echo "-w /var/log/tallylog -p wa -k logins" >> /etc/audit/rules.d/logins.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/empty.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # Remediation for this rule cannot remove the duplicates
 # remediation = none
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_auditctl_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_auditctl_default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 6
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_auditctl_rules_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 6
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_augenrules_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_augenrules_default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 6
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rhel6_augenrules_rules_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Red Hat Enterprise Linux 6
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_remove_all_rules.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
 echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
 echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
 echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
 echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
 echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
 echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/some.rules
 echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/some.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/rules_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
@@ -1,4 +1,3 @@
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
 echo "-w /etc/sudoers.d/ -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/empty.fail.sh
@@ -1,4 +1,3 @@
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
@@ -1,4 +1,3 @@
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
 echo "-w /etc/sudoers.d -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_cis
 
 rm -rf /etc/audit/rules.d/*.rules
 echo "-a always,exit -F arch=b32 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/syscall_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/syscall_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_cis
 
 rm -rf /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_cis
 
 rm -rf /etc/audit/rules.d/*.rules
 echo "-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_cis
 
 rm -rf /etc/audit/rules.d/*.rules
 echo "-a always,exit -F arch=b32 -S clock_settime -F a0=0x1 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_cis
 
 rm -rf /etc/audit/rules.d/*.rules
 echo "-a always,exit -F arch=b32 -S stime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
 	echo "-a always,exit -F arch=b32 -S settimeofday -k audit_time_rules" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
 	echo "-a always,exit -F arch=b32 -S stime -k audit_time_rules" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/encrypt_sent_records.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/encrypt_sent_records.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/encrypt_sent_records_not_activated.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/encrypt_sent_records_not_activated.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/encrypt_sent_records_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/encrypt_sent_records_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_bogus_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_bogus_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audisp_syslog_plugin_activated.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audisp_syslog_plugin_activated.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audisp_syslog_plugin_activated_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audisp_syslog_plugin_activated_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audisp_syslog_plugin_not_activated.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audisp_syslog_plugin_not_activated.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7
-# profiles = xccdf_org.ssgproject.content_profile_cui
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/commented.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/commented.pass.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 echo "#local_events = yes" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value.pass.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 echo "local_events = yes" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value_capital.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value_capital.pass.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 echo "LOCAL_EVENTS = YES" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/double_assignment.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/double_assignment.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 echo "local_events = yes" >> "/etc/audit/auditd.conf"
 echo "local_events = no" >> "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_file.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_file.pass.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 rm -f "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_value.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 touch "/etc/audit/auditd.conf"
 sed -i "/local_events/d" "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value.fail.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 echo "local_events = no" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value_capital.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value_capital.fail.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 echo "LOCAL_EVENTS = NO" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_etcdefaultgrub.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 
 # Removes audit argument from kernel command line in /etc/default/grub

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_etcdefaultgrub_recovery_disabled.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 # Removes audit argument from kernel command line in /etc/default/grub
 if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*audit=.*"'  '/etc/default/grub' ; then

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_rhel7.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_rhel7.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 # Removes audit argument from kernel command line in /boot/grub2/grub.cfg
 file="/boot/grub2/grub.cfg"

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_rhel8.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 8
 
 # Removes audit argument from kernel command line in /boot/grub2/grubenv

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_grubby.pass.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_grubby.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_grubenv.pass.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_grubenv.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 8
 
 grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) audit=1"

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_recovery_disabled.pass.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_recovery_disabled.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby
 if grep -q '^GRUB_CMDLINE_LINUX=.*audit=.*"'  '/etc/default/grub' ; then

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel7.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel7.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 
 # Break the audit argument in kernel command line in /boot/grub2/grub.cfg

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 8
 
 # Break the audit argument in kernel command line in /boot/grub2/grubenv

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_etcdefaultgrub.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 
 # Break the audit argument in kernel command line in /etc/default/grub

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 
 # Break the audit argument in kernel command line in /etc/default/grub

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel7.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel7.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 7
 
 # Break the audit argument in kernel command line in /boot/grub2/grub.cfg

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel8.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 8
 
 # Break the audit argument in kernel command line in /boot/grub2/grubenv

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/correct_rules.pass.sh
@@ -1,3 +1,2 @@
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp $SHARED/audit/10-base-config.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_missing.fail.sh
@@ -1,3 +1,2 @@
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/audit/rules.d/10-base-config.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_not_identical.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_not_identical.fail.sh
@@ -1,4 +1,3 @@
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp $SHARED/audit/10-base-config.rules /etc/audit/rules.d/
 echo "some additional text" >> /etc/audit/rules.d/10-base-config.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/no_rules.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/no_rules.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_changed.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_changed.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_configured.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_incomplete.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_incomplete.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/arg_not_there.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/arg_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 8
 
 # Removes pti argument from kernel command line in /boot/grub2/grubenv

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/correct.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 8
 
 grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) pti=on"

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # platform = Red Hat Enterprise Linux 8
 
 # Break the pti argument in kernel command line in /boot/grub2/grubenv

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/cron_set_rsyslog_conf.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/cron_set_rsyslog_conf.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/cron_set_rsyslog_d.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/cron_set_rsyslog_d.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/no_cron_logging.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/no_cron_logging.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 
 RSYSLOG_CONF='/etc/rsyslog.conf'
 RSYSLOG_D_FILES='/etc/rsyslog.d/*'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/no_rsyslog_file.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/no_rsyslog_file.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/rsyslog.conf
 rm -rf /etc/rsyslog.d

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/wrong_log_rsyslog_conf.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/wrong_log_rsyslog_conf.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui, xccdf_org.ssgproject.content_profile_ospp
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/IncludeConfig_is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/IncludeConfig_is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check rsyslog.conf with root group-owner log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/IncludeConfig_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/IncludeConfig_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check rsyslog.conf with root group-owner log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root group-owner log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root group-owner log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_root_IncludeConfig_is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_root_IncludeConfig_is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root group-owner log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_root_IncludeConfig_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_is_root_IncludeConfig_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root group-owner log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_multiline_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/include_multiline_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root group-owner log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check if log file with non root group-owner in rsyslog.conf fails.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check if log file with root group-owner in rsyslog.conf passes.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/IncludeConfig_is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/IncludeConfig_is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check rsyslog.conf with root user log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/IncludeConfig_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/IncludeConfig_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check rsyslog.conf with root user log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root user log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root user log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_root_IncludeConfig_is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_root_IncludeConfig_is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root user log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_root_IncludeConfig_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_is_root_IncludeConfig_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root user log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_multiline_is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/include_multiline_is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with root user log from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/is_other.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/is_other.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check if log file with non root user in rsyslog.conf fails.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/is_root.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check if log file with root user in rsyslog.conf passes.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_perms_0600.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check rsyslog.conf with log file permissions 0600 from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_perms_0601.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check rsyslog.conf with log file permissions 0600 from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_multiline_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_multiline_perms_0600.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with log file permissions 0600 from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with log file permissions 0600 from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_IncludeConfig_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_IncludeConfig_perms_0600.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with log file permisssions 0600 from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_IncludeConfig_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_IncludeConfig_perms_0601.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with log file permisssions 0600 from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0601.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8
 
 # Check rsyslog.conf with log file permissions 0600 from rules and

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0600.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check if log file with permissions 0600 in rsyslog.conf passes.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/perms_0601.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 # Check if log file with permissions 0601 in rsyslog.conf fails.

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_weekly.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_conf_weekly.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 sed -i "s/daily/weekly/" /etc/logrotate.conf

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 # fix logrotate config
 sed -i "s/weekly/daily/" /etc/logrotate.conf

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_config.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_config.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 sed -i "/^daily/d" /etc/logrotate.conf
 rm /etc/cron.daily/logrotate

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 # fix logrotate config
 sed -i "s/weekly/daily/" /etc/logrotate.conf

--- a/linux_os/guide/system/logging/package_rsyslog_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/tests/installed.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_common
 
 yum install -y rsyslog

--- a/linux_os/guide/system/logging/package_rsyslog_installed/tests/notinstalled.fail.sh
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/tests/notinstalled.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_common
 
 yum remove -y rsyslog

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/cacert_configured.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/cacert_configured.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo 'global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem")' >> /etc/rsyslog.conf

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/syntax_error.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/tests/syntax_error.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 echo 'global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem") *.*' >> /etc/rsyslog.conf

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_disabled.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_disabled.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y firewalld
 systemctl disable firewalld.service

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_enabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum install -y firewalld
 systemctl enable firewalld.service

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/tests/default.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/tests/default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^IPV6_PRIVACY=rfc3041$/d" /etc/sysconfig/network-scripts/ifcfg-*

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/tests/ipv6_privacy_enabled.pass.sh
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/tests/ipv6_privacy_enabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 for interface in /etc/sysconfig/network-scripts/ifcfg-*
 do

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/tests/default.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/tests/default.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 # default config has rpc enabled

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/tests/rpc_disabled.pass.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/tests/rpc_disabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash
 
 sed -i "/^tcp6[[:space:]]\+tpi_.*inet6.*/d" /etc/netconfig

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/commented-install.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/commented-install.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 source ./kernel_module_preparation.sh
 kernel_module_preparation "fire-wire"
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/different-module.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/different-module.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 source ./kernel_module_preparation.sh
 kernel_module_preparation "fire-wire"
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/lib-modprobed-file.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/lib-modprobed-file.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 source ./kernel_module_preparation.sh
 kernel_module_preparation "fire-wire"
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/modprobed-file.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/modprobed-file.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 source ./kernel_module_preparation.sh
 kernel_module_preparation "fire-wire"
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/modules-loadd-file.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/modules-loadd-file.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 source ./kernel_module_preparation.sh
 kernel_module_preparation "fire-wire"
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/no-install-present.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/no-install-present.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 source ./kernel_module_preparation.sh
 kernel_module_preparation "fire-wire"

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/tests/no_unpackaged_sgid.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/tests/no_unpackaged_sgid.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_standard
 # remediation = none
 
 for x in $(find / -perm /g=s) ; do

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/tests/unpackaged_sgid.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/tests/unpackaged_sgid.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_standard
 # remediation = none
 
 for x in $(find / -perm /g=s) ; do

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/tests/no_unpackaged_suid.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/tests/no_unpackaged_suid.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_standard
 # remediation = none
 
 for x in $(find / -perm /u=s) ; do

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/tests/unpackaged_suid.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/tests/unpackaged_suid.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_standard
 # remediation = none
 
 for x in $(find / -perm /u=s) ; do

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chgrp root /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/tests/other_group.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chgrp root /etc/gshadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/tests/other_group.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chgrp root /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/tests/other_group.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chgrp root /etc/shadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/tests/other_group.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/tests/other_group.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 GROUP=ssgttgroup
 
 groupadd ${GROUP}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chown root /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/tests/other_user.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chown root /etc/gshadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/tests/other_user.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chown root /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/tests/other_user.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/tests/is_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/tests/is_root.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chown root /etc/shadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/tests/other_user.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/tests/other_user.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 USER=ssgttuser
 
 useradd ${USER}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/combination_permission.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/combination_permission.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 446 /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 0644 /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/narrow_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/narrow_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 404 /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/wide_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/tests/wide_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 664 /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 0000 /etc/gshadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/tests/wide_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/tests/wide_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 123 /etc/gshadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/combination_permission.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/combination_permission.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 441 /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 0644 /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/narrow_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/narrow_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 404 /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/wide_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/tests/wide_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 664 /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 0000 /etc/shadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/tests/wide_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/tests/wide_permissions.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_rht-ccp
 
 chmod 123 /etc/shadow

--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_standard
 
 cat <<EOF > /etc/default/grub
 GRUB_TIMEOUT=5

--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/missing_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/missing_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_standard
 
 cat <<EOF > /etc/default/grub
 GRUB_TIMEOUT=5

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/correct_value.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 echo "install usb-storage /bin/true" > /etc/modprobe.d/usb-storage.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/wrong_value.fail.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/fstab.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/runtime.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/separate.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/fstab.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/runtime.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/tests/separate.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 # Remediating would mount /tmp, which would break the test environment.
 # remediation = none

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/configured_and_mounted.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/configured_and_mounted.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/just_configured.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/just_configured.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/just_mounted.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/just_mounted.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/separated_and_mounted.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/separated_and_mounted.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/wrong_bind.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/tests/wrong_bind.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/fstab.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/runtime.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/tests/separate.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_0.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_0.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo ProcessSizeMax=0 >> /etc/systemd/coredump.conf

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_default.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_default.fail.sh
@@ -1,2 +1,1 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_nonzero.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_nonzero.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo ProcessSizeMax=2G >> /etc/systemd/coredump.conf

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_default.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_default.fail.sh
@@ -1,2 +1,1 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_none.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_none.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo Storage=none >> /etc/systemd/coredump.conf

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_persistent.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_persistent.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo Storage=persistent >> /etc/systemd/coredump.conf

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/tests/coredumps_disabled.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/tests/coredumps_disabled.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SECURITY_LIMITS_FILE="/etc/security/limits.conf"
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/tests/enabled_coredumps.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/tests/enabled_coredumps.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SECURITY_LIMITS_FILE="/etc/security/limits.conf"
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/tests/no_coredumps_limit.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/tests/no_coredumps_limit.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -ir '/\*\s+hard\s+core/d' /etc/security/limits.conf

--- a/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/adequate.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/adequate.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
 
 sed -i 's/.*umask.*/umask 022/g' /etc/init.d/functions

--- a/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/comment.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
 
 sed -i 's/.*umask.*/# umask 077/g' /etc/init.d/functions

--- a/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/line_not_there.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
 
 sed -i '/.*umask.*/d' /etc/init.d/functions

--- a/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/strong_weak.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/strong_weak.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
 
 sed -i 's/.*umask.*/umask 007/g' /etc/init.d/functions

--- a/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/super_strong.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/daemon_umask/umask_for_daemons/tests/super_strong.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_NOTFOUND
 
 sed -i 's/.*umask.*/umask 077/g' /etc/init.d/functions

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled.fail.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_hipaa
 
 echo "GRUB_CMDLINE_LINUX=selinux=0 enforcing=0 audit=1" >> /etc/default/grub
 echo "selinux=0" >> /etc/grub2.cfg

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_enable.pass.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_enable.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_hipaa
 
 sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
 sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_not_up_to_date.fail.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_not_up_to_date.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_up_to_date.pass.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_up_to_date.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/no_db_files.fail.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/no_db_files.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/no_keyfiles.pass.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/no_keyfiles.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/comment.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/comment.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 yum -y install gdm
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/comment.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value_unlocked.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value_unlocked.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/setting_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/setting_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/comment.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_unlocked.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_unlocked.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/setting_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/setting_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/dconf_test_functions.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/absent.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/absent.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum install -y bind
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/bind_not_installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/bind_not_installed.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum remove -y bind || true

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/no_config_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/no_config_file.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # 
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 # We don't remediate anything if the config file is missing completely.
 # remediation = none
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/ok.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 BIND_CONF='/etc/named.conf'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/overrides.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/overrides.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum install -y bind
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_correct_policy.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_correct_policy.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm -f /etc/krb5.conf.d/crypto-policies
 ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_missing_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_missing_policy.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm -f /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_wrong_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_wrong_policy.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm -f /etc/krb5.conf.d/crypto-policies
 ln -s /etc/crypto-policies/back-ends/openssh.config /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/libreswan_not_installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/libreswan_not_installed.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum remove -y libreswan || true

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_commented.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum install -y libreswan
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_is_there.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_is_there.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum install -y libreswan
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum install -y libreswan
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 yum install -y libreswan
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/nothing.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/nothing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/ok.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/section_not_include.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/section_not_include.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/wrong.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/wrong.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/absent.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/absent.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/comment.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/comment.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/no_config_file.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/no_config_file.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/overrides.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/overrides.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/correct.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/correct_commented.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/empty_policy.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/incorrect_followed_by_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/incorrect_followed_by_correct.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/incorrect_policy.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/tests/missing_file.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_cipher.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_cipher.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_gssapi.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_gssapi.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_kex.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_kex.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_macs.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_macs.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_match.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_match.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "#Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_pubkey.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_pubkey.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_rekey.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/commented_rekey.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/config_before_match_all.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/config_before_match_all.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Ciphers aes256-ctr,aes256-cbc,aes128-ctr,aes128-cbc\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/correct.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 rm -f "$file"

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_ciphers.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_ciphers.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_gssapi.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_gssapi.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_kex.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_kex.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_macs.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_macs.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_match.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_match.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "RekeyLimit 512M 1h\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_pubkey.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_pubkey.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_rekey.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/missing_rekey.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/redefined_gssapi.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/redefined_gssapi.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/redefined_gssapi.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/redefined_gssapi.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_cipher.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_cipher.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_kex.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_kex.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_macs.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_macs.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_pubkey.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/supercompliant_pubkey.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_ciphers.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_ciphers.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_kex.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_kex.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_macs.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_macs.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_pubkey.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_ssh_client_crypto_policy/tests/wrong_pubkey.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 file="/etc/ssh/ssh_config.d/02-ospp.conf"
 echo -e "Match final all\n\

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/correct.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/correct_commented.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/empty_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/empty_file.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/empty_policy.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/incorrect_followed_by_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/incorrect_followed_by_correct.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/incorrect_policy.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/tests/missing_file.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/correct.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cat > /etc/profile.d/openssl-rand.sh <<- 'EOM'
 # provide a default -rand /dev/random option to openssl commands that

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_missing.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rm -f /etc/profile.d/openssl-rand.sh

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_modified.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_modified.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 echo "wrong data" > /etc/profile.d/openssl-rand.sh

--- a/linux_os/guide/system/software/integrity/disable_prelink/tests/initial.fail.sh
+++ b/linux_os/guide/system/software/integrity/disable_prelink/tests/initial.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 yum install -y prelink
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 # ensure aide is installed
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 # ensure aide is installed
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '@daily    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '21    21    1    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '21    21    *    *    1-2    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '21    21    *    *    3    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '@weekly    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '21    21    *    *    mon    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 echo '21    21    1    2    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 crontab -u root -r || true

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/default.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/default.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 # ensure aide is installed
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 yum install -y aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/installed.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 yum install -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/notinstalled.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/notinstalled.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 yum remove -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/bad_document.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/bad_document.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 # find all TODO files in /usr/share/doc and get first of them
 todo_file=$(find /usr/share/doc -name TODO | head -n 1)

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/fresh_system.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/tests/fresh_system.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 # verify (-V) all installed (-a) packages digests,
 # if digest differs from package metadata, then attribute '5' is printed

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/all_permissions_ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/all_permissions_ok.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 # Declare an associative array to hold list of RPM packages we need to correct permissions for
 declare -A SETPERMS_RPM_LIST

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/bad_permissions.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/bad_permissions.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_pci-dss
 
 # add read permission to /etc/shadow (default should be no perm. for everyone)
 chmod +r /etc/shadow

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 rm -f /etc/sudoers
 echo "Defaults authenticate" > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 echo "Defaults !authenticate" >> /etc/sudoers
 chmod 440 /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 rm -f /etc/sudoers
 echo "%wheel	ALL=(ALL)	ALL" > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 chmod 440 /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_e8
 
 rm -f /etc/sudoers
 echo "%wheel	ALL=(ALL)	ALL" > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_e8
 
 echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 echo "Defaults !authenticate" >> /etc/sudoers

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/commented.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/commented.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\n#apply_updates = yes" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\napply_updates = yes" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/multiple_in_section_and_correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/multiple_in_section_and_correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\nupgrade_type = default\napply_updates = yes" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/nonexistent_file.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/nonexistent_file.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 rm -f "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/wrong_section.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/wrong_section.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[base]\napply_updates = yes" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\napply_updates = no" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/commented.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/commented.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\n#upgrade_type = security" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\nupgrade_type = security" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/multiple_in_section_and_correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/multiple_in_section_and_correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\napply_updates = yes\nupgrade_type = security" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/nonexistent_file.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/nonexistent_file.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 rm -f "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/wrong_section.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/wrong_section.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[base]\nupgrade_type = security" > "$CONF"

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 CONF="/etc/dnf/automatic.conf"
 echo -e "[commands]\nupgrade_type = default" > "$CONF"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/comment.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^gpgcheck" /etc/yum.conf; then
 	sed -i "s/^gpgcheck.*/# gpgcheck=1/" /etc/yum.conf

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^gpgcheck" /etc/yum.conf; then
 	sed -i "s/^gpgcheck.*/gpgcheck=1/" /etc/yum.conf

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^gpgcheck.*/d" /etc/yum.conf

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^gpgcheck" /etc/yum.conf; then
 	sed -i "s/^gpgcheck.*/gpgcheck=0/" /etc/yum.conf

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/comment.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/group_updating_utils.sh
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/group_updating_utils.sh
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/line_not_there.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/group_updating_utils.sh
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 . $SHARED/group_updating_utils.sh
 

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/tests/fedora_key.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/tests/fedora_key.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 KEYS=$(rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\n')
 

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/tests/key_installed.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/tests/key_installed.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/tests/missing_key.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/tests/missing_key.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # remove all available keys
 

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_disabled.fail.sh
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_disabled.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 dnf -y install dnf-automatic
 systemctl disable --now dnf-automatic.timer

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_enabled.pass.sh
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_enabled.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 dnf -y install dnf-automatic
 systemctl enable --now dnf-automatic.timer


### PR DESCRIPTION
Historically, the profile had to be specified in test scenarios - oscap needs a profile that selects the rule to be able to scan for that rule using the `--rule` option. This became unnecessary when the `(alll)` virtual profile got introduced.

Nowadays, the `--profile` option is needed iff the rule is parametrized by an XCCDF variable that assigns a specific value to that variable. 

This PR removes the profile metadata from rules that have been identified as not parametrized using this thought: If a rule doesn't have `external` in their OVALs, or it doesn't have any `oval` directory at all, then the rule is not parametrized.

Here is the supportive bash code that was used to identify trees of test scenarios that have `profiles` metadata, but that don't need them.

```
test_trees_of_rules_with_profiles=$(grep -l profiles $(fd .pass.sh) $(fd .notapplicable.sh) $(fd .fail.sh) | sed -e 's|/tests/.*$|/tests|' | sort | uniq)
trees_with_external_vars=''
for tree in $test_trees_of_rules_with_profiles; do
    test -d "$tree/../oval" && grep -q external "$tree"/../oval/*.xml && trees_with_external_vars="$tree $trees_with_external_vars"
    grep -q '\<name:\s\+\(accounts_password\|mount_option_removable_partitions\|sebool\|sysctl\|yamlfile_value\)' "$tree"/../rule.yml && trees_with_external_vars="$tree $trees_with_external_vars"
done
trees_without_external_vars=
for tree in $test_trees_of_rules_with_profiles; do
    grep -q "\<$tree\>" <<< "$trees_with_external_vars" || trees_without_external_vars="$tree $trees_without_external_vars"
done
```