### PR TITLE
remove deprecated sshd config from e8 profile

### DIFF
--- a/rhcos4/profiles/e8.profile
+++ b/rhcos4/profiles/e8.profile
@@ -129,7 +129,6 @@ selections:
   - sshd_disable_root_login
   - sshd_disable_gssapi_auth
   - sshd_print_last_log
-  - sshd_use_priv_separation
   - sshd_do_not_permit_user_env
   - sshd_disable_rhosts
   - sshd_set_loglevel_info

--- a/rhel7/profiles/e8.profile
+++ b/rhel7/profiles/e8.profile
@@ -127,7 +127,6 @@ selections:
   - sshd_disable_gssapi_auth
   - sshd_use_strong_ciphers
   - sshd_print_last_log
-  - sshd_use_priv_separation
   - sshd_do_not_permit_user_env
   - sshd_disable_rhosts_rsa
   - sshd_disable_rhosts

--- a/rhel7/profiles/hipaa.profile
+++ b/rhel7/profiles/hipaa.profile
@@ -71,7 +71,6 @@ selections:
     - sshd_enable_strictmodes
     - sshd_enable_warning_banner
     - sshd_set_keepalive
-    - sshd_use_priv_separation
     - encrypt_partitions
     - sshd_use_approved_ciphers
     - sshd_use_approved_macs

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -129,7 +129,6 @@ selections:
   - sshd_disable_root_login
   - sshd_disable_gssapi_auth
   - sshd_print_last_log
-  - sshd_use_priv_separation
   - sshd_do_not_permit_user_env
   - sshd_disable_rhosts
   - sshd_set_loglevel_info

--- a/rhel8/profiles/hipaa.profile
+++ b/rhel8/profiles/hipaa.profile
@@ -65,7 +65,6 @@ selections:
     - sshd_enable_strictmodes
     - sshd_enable_warning_banner
     - sshd_set_keepalive
-    - sshd_use_priv_separation
     - encrypt_partitions
     - var_system_crypto_policy=fips
     - configure_crypto_policy

--- a/tests/data/profile_stability/rhel7/e8.profile
+++ b/tests/data/profile_stability/rhel7/e8.profile
@@ -95,7 +95,6 @@ selections:
 - sshd_enable_strictmodes
 - sshd_print_last_log
 - sshd_set_loglevel_info
-- sshd_use_priv_separation
 - sshd_use_strong_ciphers
 - sshd_use_strong_macs
 - sudo_remove_no_authenticate

--- a/tests/data/profile_stability/rhel8/e8.profile
+++ b/tests/data/profile_stability/rhel8/e8.profile
@@ -98,7 +98,6 @@ selections:
 - sshd_enable_strictmodes
 - sshd_print_last_log
 - sshd_set_loglevel_info
-- sshd_use_priv_separation
 - sudo_remove_no_authenticate
 - sudo_remove_nopasswd
 - sudo_require_authentication


### PR DESCRIPTION
#### Description:

- The sshd_config UsePrivilegeSeparation option is deprecated, per https://www.openssh.com/txt/release-7.5
