### PR TITLE
OCP4 CIS profile placeholder and comments

### DIFF
--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -43,4 +43,4 @@ identifiers:
 
 references:
     cis@ocp3: 2.1.5
-    cis@ocp4: 4.2.3
+    cis@ocp4: 4.2.4

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -44,4 +44,4 @@ identifiers:
 
 references:
     cis@ocp3: 2.1.6
-    cis@ocp4: 4.2.4
+    cis@ocp4: 4.2.5

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -4,132 +4,195 @@ title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, v1.0.0, currently unreleased.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V0.3, currently unreleased.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
 
+    Note that this part of the profile is meant to run on the Platform that
+    Red Hat OpenShift Container Platform 4 runs on top of.
 selections:
-    - scc_limit_process_id_namespace
-    - scc_limit_privilege_escalation
-    - scc_limit_net_raw_capability
-    - scc_limit_ipc_namespace
-    - scc_limit_root_containers
-    - scc_limit_container_allowed_capabilities
-    - scc_limit_network_namespace
-    - scc_drop_container_capabilities
-    - scc_limit_privileged_containers
-    - kubelet_enable_client_cert_rotation
-    - kubelet_enable_streaming_connections
-    - kubelet_anonymous_auth
-    - kubelet_configure_client_ca
-    - kubelet_configure_tls_cert
-    - kubelet_authorization_mode
-    - kubelet_configure_event_creation
-    - kubelet_enable_server_cert_rotation
-    - kubelet_configure_tls_key
-    - kubelet_disable_readonly_port
+  ### 1 Control Plane Components
+  ###
+  #### 1.2 API Server
+  # 1.2.1 Ensure that the --anonymous-auth argument is set to false
+    - api_server_anonymous_auth
+  # 1.2.2 Ensure that the --basic-auth-file argument is not set
+    - api_server_basic_auth
+  # 1.2.3 Ensure that the --token-auth-file parameter is not set 
+    - api_server_token_auth
+  # 1.2.4 Ensure that the --kubelet-https argument is set to true
+    - api_server_kubelet_https
+  # 1.2.5 Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate
+    - api_server_kubelet_client_cert
+    - api_server_kubelet_client_key
+  # 1.2.6 Ensure that the --kubelet-certificate-authority argument is set as appropriate
+    - api_server_kubelet_certificate_authority
+  # 1.2.7 Ensure that the --authorization-mode argument is not set to AlwaysAllow 
+  # 1.2.8 Ensure that the --authorization-mode argument includes Node
+  # 1.2.9 Ensure that the --authorization-mode argument includes RBAC
+    - api_server_authorization_mode
+  # 1.2.10 Ensure that the admission control plugin EventRateLimit is set
+    - api_server_admission_control_plugin_EventRateLimit
+  # 1.2.11 Ensure that the admission control plugin AlwaysAdmit is not set
+    - api_server_admission_control_plugin_AlwaysAdmit
+  # 1.2.12 Ensure that the admission control plugin AlwaysPullImages is set
+    - api_server_admission_control_plugin_AlwaysPullImages
+  # 1.2.13 Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used
+    - api_server_admission_control_plugin_SecurityContextDeny
+  # 1.2.14 Ensure that the admission control plugin ServiceAccount is set
+    - api_server_admission_control_plugin_ServiceAccount
+  # 1.2.15 Ensure that the admission control plugin NamespaceLifecycle is set
+    - api_server_admission_control_plugin_NamespaceLifecycle
+  # 1.2.16 Ensure that the admission control plugin PodSecurityPolicy is set (Automated)
+    - api_server_admission_control_plugin_PodSecurityPolicy
+  # 1.2.17 Ensure that the admission control plugin NodeRestriction is set (Automated)
+    - api_server_admission_control_plugin_NodeRestriction
+  # 1.2.18 Ensure that the --insecure-bind-address argument is not set 
+    - api_server_insecure_bind_address
+  # 1.2.19 Ensure that the --insecure-port argument is set to 0
+    - api_server_insecure_port
+  # 1.2.20 Ensure that the --secure-port argument is not set to 0
+    - api_server_secure_port
+  # 1.2.21 Ensure that the --profiling argument is set to false
+    - api_server_profiling
+  # 1.2.22 Ensure that the --audit-log-path argument is set
+    - api_server_audit_log_path
+  # 1.2.23 Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
+    - api_server_audit_log_maxage
+  # 1.2.24 Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate
+    - api_server_audit_log_maxbackup
+  # 1.2.25 Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate
+    - api_server_audit_log_maxsize
+  # 1.2.26 Ensure that the --request-timeout argument is set as appropriate
+    - api_server_request_timeout
+  # 1.2.27 Ensure that the --service-account-lookup argument is set to true
+  # 1.2.28 Ensure that the --service-account-key-file argument is set as appropriate
+    - api_server_service_account_public_key
+  # 1.2.29 Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate
+    - api_server_etcd_cert
+    - api_server_etcd_key
+  # 1.2.30 Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
+    - api_server_tls_cert
+    - api_server_tls_private_key
+  # 1.2.31 Ensure that the --client-ca-file argument is set as appropriate
+    - api_server_client_ca
+  # 1.2.32 Ensure that the --etcd-cafile argument is set as appropriate
+    - api_server_etcd_ca
+  # 1.2.33 Ensure that the --encryption-provider-config argument is set as appropriate
+    - api_server_encryption_provider_config
+  # 1.2.34 Ensure that encryption providers are appropriately configured
+    - api_server_encryption_provider_cipher
+  # 1.2.35 Ensure that the API Server only makes use of Strong Cryptographic Ciphers 
+    - api_server_tls_cipher_suites
+  #### 1.3 Controller Manager
+  # 1.3.1 Ensure that the --terminated-pod-gc-threshold argument is set as appropriate
+  # 1.3.2 Ensure that the --profiling argument is set to false (info only)
+  # 1.3.3 Ensure that the --use-service-account-credentials argument is set to true
+    - controller_use_service_account
+  # 1.3.4 Ensure that the --service-account-private-key-file argument is set as appropriate
+    - controller_service_account_private_key
+  # 1.3.5 Ensure that the --root-ca-file argument is set as appropriate
+    - controller_service_account_ca
+  # 1.3.6 Ensure that the RotateKubeletServerCertificate argument is set to true
+    - controller_rotate_kubelet_server_certs
+  # 1.3.7 Ensure that the --bind-address argument is set to 127.0.0.1
+    - controller_bind_address
+  #### 1.4 Scheduler
+  # 1.4.1 Ensure that the --profiling argument is set to false  (info only)
+    - scheduler_profiling_argument
+  # 1.4.2 Ensure that the --bind-address argument is set to 127.0.0.1
+
+  ### 2 etcd
+  # 2.1 Ensure that the --cert-file and --key-file arguments are set as appropriate
+    - etcd_cert_file
+    - etcd_key_file
+  # 2.2 Ensure that the --client-cert-auth argument is set to true
+    - etcd_client_cert_auth
+  # 2.3 Ensure that the --auto-tls argument is not set to true
+    - etcd_auto_tls
+  # 2.4 Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate
     - etcd_peer_cert_file
     - etcd_peer_key_file
-    - etcd_key_file
-    - etcd_unique_ca
-    - etcd_auto_tls
-    - etcd_cert_file
+  # 2.5 Ensure that the --peer-client-cert-auth argument is set to true 
     - etcd_peer_client_cert_auth
+  # 2.6 Ensure that the --peer-auto-tls argument is not set to true
     - etcd_peer_auto_tls
-    - etcd_client_cert_auth
-    - rbac_limit_secrets_access
+  # 2.7 Ensure that a unique Certificate Authority is used for etcd 
+    - etcd_unique_ca
+
+  ### 3 Control Plane Configuration
+  ###
+  #### 3.1 Authentication and Authorization
+  # 3.1.1 Client certificate authentication should not be used for users
+  #### 3.2 Logging
+  # 3.2.1 Ensure that a minimal audit policy is created
+  # 3.2.2 Ensure that the audit policy covers key security concerns
+
+  ### 4 Worker Nodes
+  ###
+  #### 4.2 Kubelet
+  # 4.2.4 Ensure that the --read-only-port argument is set to 0
+    - kubelet_disable_readonly_port
+  # 4.2.5 Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (??)
+    - kubelet_enable_streaming_connections
+  # 4.2.6 Ensure that the --protect-kernel-defaults argument is set to true (??)
+  # 4.2.7 Ensure that the --make-iptables-util-chains argument is set to true
+  # 4.2.8 Ensure that the --hostname-override argument is not set
+  # 4.2.9 Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture
+    - kubelet_configure_event_creation
+  # 4.2.10 Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
+    - kubelet_configure_tls_cert
+    - kubelet_configure_tls_key
+  # 4.2.11 Ensure that the --rotate-certificates argument is not set to false
+    - kubelet_enable_client_cert_rotation
+  # 4.2.12 Verify that the RotateKubeletServerCertificate argument is set to true
+    - kubelet_enable_server_cert_rotation
+  # 4.2.13 Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+
+  ### 5 Policies
+  ###
+  #### 5.1 RBAC and Service Accounts
+  # 5.1.1 Ensure that the cluster-admin role is only used where required
     - rbac_limit_cluster_admin
+  # 5.1.2 Minimize access to secrets (info)
+    - rbac_limit_secrets_access
+  # 5.1.3 Minimize wildcard use in Roles and ClusterRoles (info)
     - rbac_wildcard_use
+  # 5.1.4 Minimize access to create pods (info)
     - rbac_pod_creation_access
-    - controller_rotate_kubelet_server_certs
-    - controller_use_service_account
-    - controller_service_account_private_key
-    - controller_service_account_ca
-    - controller_bind_address
-    - general_configure_imagepolicywebhook
-    - scheduler_profiling_argument
-    - secrets_no_environment_variables
-    - configure_network_policies_namespaces
-    - configure_network_policies
-    - file_groupowner_controller_manager_kubeconfig
-    - file_owner_controller_manager_kubeconfig
-    - file_owner_openvswitch
-    - file_groupowner_kube_apiserver
-    - file_owner_kube_controller_manager
-    - file_owner_var_lib_etcd
-    - file_owner_cni_conf
-    - file_owner_kube_scheduler
-    - file_owner_etcd_member
-    - file_permissions_openvswitch
-    - file_permissions_kubeconfig
-    - file_permissions_controller_manager_kubeconfig
-    - file_owner_scheduler_kubeconfig
-    - file_permissions_var_lib_etcd
-    - file_permissions_kube_apiserver
-    - file_permissions_cni_conf
-    - file_groupowner_etcd_member
-    - file_groupowner_scheduler_kubeconfig
-    - file_permissions_etcd_member
-    - file_owner_kubeconfig
-    - file_groupowner_cni_conf
-    - file_owner_kube_apiserver
-    - file_groupowner_kube_scheduler
-    - file_permissions_scheduler_kubeconfig
-    - file_groupowner_kube_controller_manager
-    - file_permissions_kube_scheduler
-    - file_groupowner_openvswitch
-    - file_groupowner_kubeconfig
-    - file_permissions_kube_controller_manager
-    - accounts_restrict_service_account_tokens
+  # 5.1.5 Ensure that default service accounts are not actively used. (info)
     - accounts_unique_service_account
-    - api_server_tls_cipher_suites
-    - api_server_etcd_cert
-    - api_server_encryption_provider_config
-    - api_server_audit_log_maxsize
-    - api_server_admission_control_plugin_SecurityContextDeny
-    - api_server_admission_control_plugin_ServiceAccount
-    - api_server_insecure_port
-    - api_server_client_ca
-    - api_server_encryption_provider_cipher
-    - api_server_admission_control_plugin_NamespaceLifecycle
-    - api_server_authorization_mode
-    - api_server_etcd_key
-    - api_server_tls_cert
-    - api_server_kubelet_client_key
-    - api_server_secure_port
-    - api_server_token_auth
-    - api_server_admission_control_plugin_AlwaysPullImages
-    - api_server_admission_control_plugin_NodeRestriction
-    - api_server_service_account_public_key
-    - api_server_basic_auth
-    - api_server_kubelet_client_cert
-    - api_server_tls_private_key
-    - api_server_request_timeout
-    - api_server_etcd_ca
-    - api_server_audit_log_maxbackup
-    - api_server_anonymous_auth
-    - api_server_audit_log_maxage
-    - api_server_insecure_bind_address
-    - api_server_admission_control_plugin_PodSecurityPolicy
-    - api_server_admission_control_plugin_EventRateLimit
-    - api_server_kubelet_certificate_authority
-    - api_server_profiling
-    - api_server_admission_control_plugin_AlwaysAdmit
-    - api_server_kubelet_https
-    - api_server_audit_log_path
-    - file_groupowner_proxy_kubeconfig
-    - file_groupowner_kubelet_conf
-    - file_owner_worker_ca
-    - file_groupowner_worker_ca
-    - file_permissions_worker_kubeconfig
-    - file_groupowner_worker_service
-    - file_permissions_proxy_kubeconfig
-    - file_groupowner_worker_kubeconfig
-    - file_owner_kubelet_conf
-    - file_owner_worker_kubeconfig
-    - file_owner_worker_service
-    - file_owner_proxy_kubeconfig
-    - file_permissions_worker_ca
-    - file_permissions_worker_service
-    - file_permissions_kubelet_conf
+  # 5.1.6 Ensure that Service Account Tokens are only mounted where necessary (info)
+    - accounts_restrict_service_account_tokens
+  #### 5.2 Pod Security Policies / Security Context Constraints
+  # 5.2.1 Minimize the admission of privileged containers (info)
+    - scc_limit_privileged_containers
+  # 5.2.2 Minimize the admission of containers wishing to share the host process ID namespace (info)
+    - scc_limit_process_id_namespace
+  # 5.2.3 Minimize the admission of containers wishing to share the host IPC namespace (info)
+    - scc_limit_ipc_namespace
+  # 5.2.4 Minimize the admission of containers wishing to share the host network namespace (info)
+    - scc_limit_network_namespace
+  # 5.2.5 Minimize the admission of containers with allowPrivilegeEscalation (info)
+    - scc_limit_privilege_escalation
+  # 5.2.6 Minimize the admission of root containers (info)
+    - scc_limit_root_containers
+  # 5.2.7 Minimize the admission of containers with the NET_RAW capability (info)
+    - scc_limit_net_raw_capability
+  # 5.2.8 Minimize the admission of containers with added capabilities (info)
+    - scc_drop_container_capabilities
+  # 5.2.9 Minimize the admission of containers with capabilities assigned (info)
+    - scc_limit_container_allowed_capabilities
+  #### 5.3 Network Policies and CNI
+  # 5.3.1 Ensure that the CNI in use supports Network Policies (info)
+    - configure_network_policies
+  # 5.3.2 Ensure that all Namespaces have Network Policies defined (info)
+    - configure_network_policies_namespaces
+  #### 5.4 Secrets Management
+  # 5.4.1 Prefer using secrets as files over secrets as environment variables (info)
+    - secrets_no_environment_variables
+  # 5.4.2 Consider external secret storage (info)
+  #### 5.5 Extensible Admission Control
+  # 5.5.1 Configure Image Provenance using ImagePolicyWebhook admission controller
+    - general_configure_imagepolicywebhook


### PR DESCRIPTION
This includes the CIS profiles for OCP4. The rules that aren't able to be
done as a platform check, through the Kube API, have been removed.
    
The existing rules that do apply to this profile have been placed in order,
under the comment where the rule should be. Note that they currently
won't work on OCP4 and will be fixed as part of the hackathon.