### PR TITLE
SSGTS: update combined/rule mode to skip not applicable scenarios

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -39,9 +39,16 @@ class CombinedChecker(rule.RuleChecker):
         self._current_result = None
 
     def _modify_parameters(self, script, params):
-        # Override any metadata in test scenario, wrt to profile to test
-        # We already know that all target rules are part of the target profile
-        params['profiles'] = [self.profile]
+        # If there is no profiles metadata for a script we add the tested
+        # profile id into it. Otherwise we check the metadata and set it
+        # to self.profile (the tested profile) only if the  metadata
+        # contains self.profile - otherwise scenario is not supposed to be
+        # tested using the self.profile and we return empty profiles
+        # metadata.
+        if not params["profiles"]:
+            params['profiles'] = [self.profile]
+        else:
+            params['profiles'] = [item for item in params['profiles'] if re.search(self.profile, item)]
         return params
 
     def _test_target(self, target):

--- a/tests/ssg_test_suite/log.py
+++ b/tests/ssg_test_suite/log.py
@@ -13,7 +13,7 @@ class LogHelper(object):
     the output itself.
     """
     FORMATTER = logging.Formatter('%(levelname)s - %(message)s')
-    INTERMEDIATE_LOGS = {'pass': [], 'fail': []}
+    INTERMEDIATE_LOGS = {'pass': [], 'fail': [], 'notapplicable': []}
     LOG_DIR = None
     LOG_FILE = None
 

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -366,7 +366,7 @@ class GenericRunner(object):
                 finally:
                     self._filenames_to_clean_afterwards.remove(fname)
 
-        if result:
+        if result == 1:
             LogHelper.log_preloaded('pass')
             if self.clean_files:
                 files_to_remove = [self.verbose_path]
@@ -381,6 +381,8 @@ class GenericRunner(object):
                         logging.error(
                             "Failed to cleanup file '{0}'"
                             .format(fname))
+        elif result == 2:
+            LogHelper.log_preloaded('notapplicable')
         else:
             LogHelper.log_preloaded('fail')
             if self.manual_debug:
@@ -526,12 +528,19 @@ class RuleRunner(GenericRunner):
         return match[-1]
 
     def _analyze_output_of_oscap_call(self):
-        local_success = True
+        local_success = 1
         # check expected result
         rule_result = self._find_rule_result_in_output()
 
+        if rule_result == "notapplicable":
+            msg = (
+                'Rule {0} evaluation resulted in {1}'
+                .format(self.rule_id, rule_result))
+            LogHelper.preload_log(logging.WARNING, msg, 'notapplicable')
+            local_success = 2
+            return local_success
         if rule_result != self.context:
-            local_success = False
+            local_success = 0
             if rule_result == 'notselected':
                 msg = (
                     'Rule {0} has not been evaluated! '

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -118,6 +118,9 @@ class RuleChecker(oscap.Checker):
             logging.INFO, "Script {0} using profile {1} OK".format(scenario.script, profile),
             log_target='pass')
         LogHelper.preload_log(
+            logging.WARNING, "Script {0} using profile {1} notapplicable".format(scenario.script, profile),
+            log_target='notapplicable')
+        LogHelper.preload_log(
             logging.ERROR,
             "Script {0} using profile {1} found issue:".format(scenario.script, profile),
             log_target='fail')

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -129,8 +129,12 @@ class RuleChecker(oscap.Checker):
         runner = runner_cls(
             self.test_env, oscap.process_profile_id(profile), self.datastream, self.benchmark_id,
             rule_id, scenario.script, self.dont_clean, self.manual_debug)
-        if not self._initial_scan_went_ok(runner, rule_id, scenario.context):
+        initial_scan_res = self._initial_scan_went_ok(runner, rule_id, scenario.context)
+        if not initial_scan_res:
             return False
+        if initial_scan_res == 2:
+            # notapplicable
+            return True
 
         supported_and_available_remediations = self._get_available_remediations(scenario)
         if (scenario.context not in ['fail', 'error']


### PR DESCRIPTION
In case test scenario has profile metadata set and the tested profile
in combined mode is not in this metadata we skip the test scenario
as it is not supposed to be tested with such a profile and usually
it produces errorring results.

Another commit changes asserts of notapplicable rule results from errors to warnings.