### PR TITLE
 Implemented packages metadata to the test suite

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/service_disabled.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = avahi
 #
 
-yum -y install avahi
 
 systemctl stop avahi-daemon.service
 systemctl disable avahi-daemon.service

--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/socket_enabled.fail.sh
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/socket_enabled.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = avahi
 #
 
-yum -y install avahi
 
 systemctl unmask avahi-daemon
 systemctl disable avahi-daemon.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = at
 #
 
-yum -y install at
 systemctl disable atd.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = nfs-utils at
 #
 
 # this tesst ensures that only the atd.service is matched, not for example the service rpc-statd
 
-yum -y install nfs-utils at
 systemctl disable atd.service
 systemctl add-wants default.target rpc-statd.service

--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_enabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = at
 #
 
-yum -y install at
 systemctl enable atd.service

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/ldap_auth_and_start_tls.pass.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/ldap_auth_and_start_tls.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = nss-pam-ldapd
 #
 
 AUTHCONFIG_REGEX="^[[:space:]]*USELDAPAUTH=yes[[:space:]]*$"
@@ -6,7 +7,6 @@ grep -q "$AUTHCONFIG_REGEX" /etc/sysconfig/authconfig && \
 	sed -i "s/$AUTHCONFIG_REGEX/USELDAPAUTH=yes/" /etc/sysconfig/authconfig || \
 	echo "USELDAPAUTH=yes" >> /etc/sysconfig/authconfig
 
-yum install -y nss-pam-ldapd
 
 START_TLS_REGEX="^[[:space:]]*ssl[[:space:]]*start_tls[[:space:]]*$"
 grep -q "$START_TLS_REGEX" /etc/nslcd.conf && \

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/not_using_ldap.fail.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/not_using_ldap.fail.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 #
 
-yum install -y nss-pam-ldapd
 
 AUTHCONFIG_REGEX="^[[:space:]]*USELDAPAUTH=yes[[:space:]]*$"
 grep -q "$AUTHCONFIG_REGEX" /etc/sysconfig/authconfig && \
 	sed -i "s/$AUTHCONFIG_REGEX//" /etc/sysconfig/authconfig
 
-yum install -y nss-pam-ldapd
 
 START_TLS_REGEX="^[[:space:]]*ssl[[:space:]]*start_tls[[:space:]]*$"
 grep -q "$START_TLS_REGEX" /etc/nslcd.conf && \

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/tls_not_starting.fail.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/tests/tls_not_starting.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = nss-pam-ldapd
 #
 
-yum install -y nss-pam-ldapd
 
 sed -i "/$START_TLS_REGEX/d" /etc/nslcd.conf || true

--- a/linux_os/guide/services/ntp/chronyd_client_only/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/tests/chrony.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 #
 
-yum install -y chrony
 systemctl enable chronyd.service
 
 echo "port 0" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_client_only/tests/missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/tests/missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 #
 
-yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_client_only/tests/nonzero.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/tests/nonzero.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 #
 
-yum install -y chrony
 systemctl enable chronyd.service
 
 echo "port 124" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/chrony.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 #
 
-yum install -y chrony
 systemctl enable chronyd.service
 
 echo "cmdport 0" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 #
 
-yum install -y chrony
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/nonzero.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/tests/nonzero.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 #
 
-yum install -y chrony
 systemctl enable chronyd.service
 
 echo "cmdport 324" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = chrony
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum install -y chrony
 yum remove -y ntp
 
 if ! grep "^server" /etc/chrony.conf ; then

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_nothing_done.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_nothing_done.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = chrony
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Red Hat Enterprise Linux 7
 
-yum install -y chrony
 yum remove -y ntp
 
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_server_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_server_misconfigured.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = chrony
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum install -y chrony
 yum remove -y ntp
 
 if ! grep "^server.*maxpoll 10" /etc/chrony.conf; then

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = ntp
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Red Hat Enterprise Linux 7
 
-yum install -y ntp
 yum remove -y chrony
 
 if ! grep "^server.*maxpoll 10" /etc/ntp.conf; then

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_wrong_maxpoll.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_wrong_maxpoll.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = ntp
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Red Hat Enterprise Linux 7
 
-yum install -y ntp
 yum remove -y chrony
 
 sed -i "s/^server.*/& maxpoll 17/" /etc/ntp.conf

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/correct.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 
-yum -y install chrony
 
 echo 'OPTIONS="-u chrony"' > /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/correct_multiple_options.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/correct_multiple_options.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 
-yum -y install chrony
 
 echo 'OPTIONS="-g -u chrony"' > /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 
-yum -y install chrony
 
 echo "" > /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty_options.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty_options.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 
-yum -y install chrony
 
 echo 'OPTIONS=""' > /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/file_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 
-yum -y install chrony
 
 rm -f /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/wrong_line.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/wrong_line.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 
-yum -y install chrony
 
 echo 'OPTIONS="-u root:root"' > /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/wrong_line_2.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/wrong_line_2.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = chrony
 
-yum -y install chrony
 
 echo 'OPTIONS="-g"' > /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
 
-yum -y install chrony
 
 echo "server 0.pool.ntp.org" > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct_pool.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct_pool.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
 
-yum -y install chrony
 
 echo "pool 0.pool.ntp.org" > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_empty.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = chrony
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum -y install chrony
 
 echo "" > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = chrony
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum -y install chrony
 
 rm -f /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum -y install chrony
 
 echo "some line" > /etc/chrony.conf
 echo "another line" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_servers.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = chrony
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum -y install chrony
 
 echo "server 0.pool.ntp.org" > /etc/chrony.conf
 echo "server 1.pool.ntp.org" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/server_not_specified.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/server_not_specified.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = chrony
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum -y install chrony
 
 echo "server " > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/correct.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "restrict -4 default kod nomodify notrap nopeer noquery" > /etc/ntp.conf
 echo "restrict -6 default kod nomodify notrap nopeer noquery" >> /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/file_empty.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "" > /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/file_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 rm -f /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/more_restrictions.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/more_restrictions.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "restrict -4 default kod nomodify notrap nopeer noquery" > /etc/ntp.conf
 echo "restrict -6 default kod nomodify notrap nopeer noquery" >> /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/restriction_missing.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/restriction_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "restrict -4 default kod nomodify notrap nopeer noquery" > /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/restriction_not_complete.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/restriction_not_complete.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "restrict -4 default kod nomodify notrap nopeer noquery" > /etc/ntp.conf
 # this one is not complete

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/restrictions_different_order.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/tests/restrictions_different_order.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "restrict -4 default kod nomodify notrap nopeer noquery" > /etc/ntp.conf
 # last two are swapped

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/correct_both.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/correct_both.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo 'OPTIONS="-u ntp:ntp"' > /etc/sysconfig/ntpd
 echo 'ExecStart=/usr/sbin/ntpd -u ntp:ntp $OPTIONS' > /usr/lib/systemd/system/ntpd.service

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/correct_etc_sysconfig_ntpd.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/correct_etc_sysconfig_ntpd.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo 'OPTIONS="-u ntp:ntp"' > /etc/sysconfig/ntpd
 rm -f /usr/lib/systemd/system/ntpd.service

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/correct_systemd.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/correct_systemd.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo 'ExecStart=/usr/sbin/ntpd -u ntp:ntp $OPTIONS' > /usr/lib/systemd/system/ntpd.service
 rm -f /etc/sysconfig/ntpd

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/empty_both.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/empty_both.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "" > /etc/sysconfig/ntpd
 echo "" > /usr/lib/systemd/system/ntpd.service

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/empty_etc_sysconfig_ntpd.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/empty_etc_sysconfig_ntpd.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "" > /etc/sysconfig/ntpd
 rm -f /usr/lib/systemd/system/ntpd.service

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/empty_systemd.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/empty_systemd.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo "" > /usr/lib/systemd/system/ntpd.service
 rm -f /etc/sysconfig/ntpd

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/files_missing.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/files_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 rm -f /etc/sysconfig/ntpd
 rm -f /usr/lib/systemd/system/ntpd.service

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/sysconfig_empty_options.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/sysconfig_empty_options.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo 'OPTIONS=""' > /etc/sysconfig/ntpd
 rm -f /usr/lib/systemd/system/ntpd.service

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/wrong_line_etc_sysconfig_ntpd.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/wrong_line_etc_sysconfig_ntpd.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo 'OPTIONS="-u root:root"' > /etc/sysconfig/ntpd
 rm -f /usr/lib/systemd/system/ntpd.service

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/wrong_line_systemd.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/tests/wrong_line_systemd.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = ntp
 
-yum -y install ntp
 
 echo 'ExecStart=/usr/sbin/ntpd -u root:root $OPTIONS' > /usr/lib/systemd/system/ntpd.service
 rm -f /etc/sysconfig/ntpd

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/tests/correct.pass.sh
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/tests/correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = tftp-server
 
-yum -y install tftp-server
 
 if grep -q 'server_args' /etc/xinetd.d/tftp; then
 	sed -i 's/.*server_args.*/server_args = -s \/var\/lib\/tftpboot/' /etc/xinetd.d/tftp

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/tests/line_missing.fail.sh
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/tests/line_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = tftp-server
 
-yum -y install tftp-server
 
 if grep -q 'server_args' /etc/xinetd.d/tftp; then
 	sed -i '/.*server_args.*/d' /etc/xinetd.d/tftp

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/tests/wrong.fail.sh
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/tests/wrong.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = tftp-server
 
-yum -y install tftp-server
 
 if grep -q 'server_args' /etc/xinetd.d/tftp; then
 	sed -i 's/.*server_args.*/server_args = --something/' /etc/xinetd.d/tftp

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/both.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/both.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = net-snmp
 
-yum -y install net-snmp
 
 echo "something public" >> /etc/snmp/snmpd.conf
 echo "something private" >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/commented.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/commented.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = net-snmp
 
-yum -y install net-snmp
 
 sed -i '/.*public.*/d' /etc/snmp/snmpd.conf
 sed -i '/.*private.*/d' /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/correct.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = net-snmp
 
-yum -y install net-snmp
 
 sed -i '/.*public.*/d' /etc/snmp/snmpd.conf
 sed -i '/.*private.*/d' /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/private.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/private.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = net-snmp
 
-yum -y install net-snmp
 
 echo "something private" >> /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/public.fail.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/public.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = net-snmp
 
-yum -y install net-snmp
 
 echo "something public" >> /etc/snmp/snmpd.conf
 

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/no_nic_in_ssh_zone.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/no_nic_in_ssh_zone.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = firewalld
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 # ensure firewalld installed
-yum install -y firewalld
 
 # Make sure there is a zone with ssh service enabled
 firewall-cmd --permanent --zone=work --add-service=ssh

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/no_ssh_zone.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/no_ssh_zone.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = firewalld
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 
 # ensure firewalld installed
-yum install -y firewalld
 
 all_zones=$(firewall-cmd --get-zones)
 for zone in $all_zones;do

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/ssh_zone_and_nic_mismatch.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/ssh_zone_and_nic_mismatch.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = firewalld
 #
 # remediation = none
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # ensure firewalld installed
-yum install -y firewalld
 
 # Make sure there is only one zone with ssh service enabled
 all_zones=$(firewall-cmd --get-zones)

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/ssh_zone_nic_bounded.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/ssh_zone_nic_bounded.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = firewalld
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 # ensure firewalld installed
-yum install -y firewalld
 
 firewall-cmd --permanent --zone=public --add-service=ssh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1
 #
 
 
-yum install -y openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/domain_not_there.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/domain_not_there.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i '/\[domain/d' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir.pass.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_bad_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_bad_value.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i 's:\(ldap_tls_cacertdir = \).*:\1/tmp/etc/openldap/cacerts:g' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_not_absolute_path.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_not_absolute_path.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i 's:\(ldap_tls_cacertdir = \)/:\1:g' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_not_there.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_not_there.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i '/ldap_tls_cacertdir/d' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ad_id_provider_and_tls_false.notapplicable.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ad_id_provider_and_tls_false.notapplicable.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i 's/ldap_id_use_start_tls = true/ldap_id_use_start_tls = false/I' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/id_provider_is_set_to_ad.notapplicable.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/id_provider_is_set_to_ad.notapplicable.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i 's/id_provider = ldap/id_provider = ad/I' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_id_provider_and_tls_false.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_id_provider_and_tls_false.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i 's/ldap_id_use_start_tls = true/ldap_id_use_start_tls = false/I' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_use_start_tls_not_there.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_use_start_tls_not_there.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 
 sed -i '/ldap_id_use_start_tls/d' /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
@@ -1,8 +1,8 @@
 
+# packages = /usr/lib/systemd/system/sssd.service
 #!/bin/bash
 #
 
-yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/
 mkdir -p /etc/sssd/conf.d/
 SSSD_CONF="/etc/sssd/conf.d/sssd.conf"

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 #
 
-yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/
 mkdir -p /etc/sssd/conf.d/
 SSSD_CONF="/etc/sssd/conf.d/sssd.conf"

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.pass.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 #
 
 SSSD_SERVICES_REGEX_SHORT="^[[:space:]]*services.*$"
 SSSD_CONF="/etc/sssd/sssd.conf"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/
 rm -f SSSD_CONF
 cat <<EOF > $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 #
 
-yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/
 SSSD_CONF="/etc/sssd/sssd.conf"
 cp wrong_sssd.conf $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 #
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 rm -rf /etc/sssd/conf.d/
 rm -f SSSD_CONF
 cat <<EOF > $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/comment.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/comment.fail.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
@@ -7,7 +8,6 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # this should pass for every product which contains ospp profile
 TIMEOUT="180"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/wrong_section.fail.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
@@ -8,7 +9,6 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # Let's put there a higher value to fail
 TIMEOUT="99999"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/comment.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/comment.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd/conf.d
 echo -e "[sssd]\n# user = sssd" >> /etc/sssd/conf.d/ospp.conf

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/correct_value.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 
 # We will configure user to be sssd
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd/conf.d
 echo -e "[sssd]\nuser = sssd" >> /etc/sssd/conf.d/ospp.conf

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_section.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd/conf.d
 echo -e "[pam]\nuser = sssd" >> /etc/sssd/conf.d/ospp.conf

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd/conf.d
 echo -e "[sssd]\nuser = sssd\nuser = bob" >> /etc/sssd/conf.d/ospp.conf

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/comment.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/comment.fail.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
@@ -7,7 +8,6 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # this should pass for every product which contains ospp profile
 TIMEOUT="180"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/wrong_section.fail.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 TIMEOUT="180"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
 
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
@@ -8,7 +9,6 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 # Let's put there a different value to fail
 TIMEOUT="99999"
 
-yum -y install /usr/lib/systemd/system/sssd.service
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_all_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_all_disabled.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = pcsc-lite pam_pkcs11 esc
 
 
-yum install -y pcsc-lite pam_pkcs11 esc
 
 systemctl disable pcscd.socket
 systemctl disable pcscd.service

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = pcsc-lite pam_pkcs11 esc
 
 
-yum install -y pcsc-lite pam_pkcs11 esc
 
 systemctl enable pcscd.socket
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_socket_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_socket_disabled.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = pcsc-lite pam_pkcs11 esc
 
 
-yum install -y pcsc-lite pam_pkcs11 esc
 
 systemctl disable pcscd.socket
 

--- a/linux_os/guide/system/logging/package_rsyslog_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/tests/installed.pass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
+# packages = rsyslog
 
-yum install -y rsyslog

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_disabled.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_disabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = firewalld
 
 
-yum install -y firewalld
 systemctl disable firewalld.service

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/tests/installed_enabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = firewalld
 
 
-yum install -y firewalld
 systemctl enable firewalld.service

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_two_wrong_rules.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_two_wrong_rules.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = firewalld
 # platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 
 # ensure firewalld installed
-yum install -y firewalld
 # add wrong rules
 firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j ACCEPT
 firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j DROP

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_wrong_rule.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/chain_contains_wrong_rule.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = firewalld
 # platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 
 # ensure firewalld installed
-yum install -y firewalld
 # add wrong rule
 firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j ACCEPT
 firewall-cmd --reload

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/correct.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = firewalld
 # platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 
 # ensure firewalld installed
-yum install -y firewalld
 
 # add correct rule
 firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/file_missing.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = firewalld
 # platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 
 # ensure firewalld installed
-yum install -y firewalld
 
 rm -f /etc/firewalld/direct.xml

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/rule_in_wrong_chain.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/tests/rule_in_wrong_chain.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = firewalld
 # platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux
 
 # ensure firewalld installed
-yum install -y firewalld
 # put rule into wrong chain
 firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES
 firewall-cmd --reload

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/comment.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-yum -y install gdm
+# packages = gdm
 
 if grep -q "^AutomaticLoginEnable=" /etc/gdm/custom.conf ; then
 	sed -i "s/^AutomaticLoginEnable=.*/#AutomaticLoginEnable=False/g" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-yum -y install gdm
+# packages = gdm
 
 if grep -q "^AutomaticLoginEnable=" /etc/gdm/custom.conf ; then
 	sed -i "s/^AutomaticLoginEnable=.*/AutomaticLoginEnable=False/g" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
-yum -y install gdm
+# packages = gdm
 
 sed -i "/^AutomaticLoginEnable=.*/d" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/tests/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = gdm
 
-yum -y install gdm
 
 if grep -q "^AutomaticLoginEnable=" /etc/gdm/custom.conf ; then
 	sed -i "s/^AutomaticLoginEnable=.*/AutomaticLoginEnable=True/g" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = gdm
 
-yum -y install gdm
 
 if grep -q "^TimedLoginEnable=" /etc/gdm/custom.conf ; then
 	sed -i "s/^TimedLoginEnable=.*/#TimedLoginEnable=False/g" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-yum -y install gdm
+# packages = gdm
 
 if grep -q "^TimedLoginEnable=" /etc/gdm/custom.conf ; then
 	sed -i "s/^TimedLoginEnable=.*/TimedLoginEnable=False/g" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
-yum -y install gdm
+# packages = gdm
 
 sed -i "/^TimedLoginEnable=.*/d" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-yum -y install gdm
+# packages = gdm
 
 if grep -q "^TimedLoginEnable=" /etc/gdm/custom.conf ; then
 	sed -i "s/^TimedLoginEnable=.*/TimedLoginEnable=True/g" /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/empty.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/empty.fail.sh
@@ -1,5 +1,3 @@
-# platform = multi_platform_all
-
-dnf install -y gdm
+# packages = gdm
 
 printf '%s\n' "# comment" "[xdmcp]" > /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/enabled.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/enabled.fail.sh
@@ -1,6 +1,4 @@
-# platform = multi_platform_all
-
-dnf install -y gdm
+# packages = gdm
 
 mkdir -p /etc/gdm
 printf '%s\n' "# comment" "[xdmcp]" "Enable=true" > /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/missing.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/missing.fail.sh
@@ -1,6 +1,4 @@
-# platform = multi_platform_all
-
-dnf install -y gdm
+# packages = gdm
 
 mkdir -p /etc/gdm
 rm -f /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/simple.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/tests/simple.pass.sh
@@ -1,6 +1,4 @@
-# platform = multi_platform_all
-
-dnf install -y gdm
+# packages = gdm
 
 mkdir -p /etc/gdm
 printf '%s\n' "# comment" "[xdmcp]" "# Enable=true" "Enable=false" > /etc/gdm/custom.conf

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/comment.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = dconf
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
 clean_dconf_settings
 add_dconf_setting "org/gnome/desktop/screensaver" "#lock-enabled" "true" "local.d" "00-security-settings"
 add_dconf_lock "org/gnome/desktop/screensaver" "lock-enabled" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value.pass.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = dconf
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
 clean_dconf_settings
 add_dconf_setting "org/gnome/desktop/screensaver" "lock-enabled" "true" "local.d" "00-security-settings"
 add_dconf_lock "org/gnome/desktop/screensaver" "lock-enabled" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value_unlocked.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value_unlocked.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = dconf
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
 clean_dconf_settings
 add_dconf_setting "org/gnome/desktop/screensaver" "lock-enabled" "true" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/setting_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/setting_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = dconf
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
 clean_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/wrong_value.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# packages = dconf
 
 . $SHARED/dconf_test_functions.sh
 
-yum -y install dconf
 clean_dconf_settings
 add_dconf_setting "org/gnome/desktop/screensaver" "lock-enabled" "false" "local.d" "00-security-settings"
 add_dconf_lock "org/gnome/desktop/screensaver" "lock-enabled" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/absent.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/absent.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = bind
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum install -y bind
 
 BIND_CONF='/etc/named.conf'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/no_config_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/no_config_file.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+# packages = bind
 # 
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 # We don't remediate anything if the config file is missing completely.
 # remediation = none
 
-yum install -y bind
 
 BIND_CONF='/etc/named.conf'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/ok.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# packages = bind
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
 BIND_CONF='/etc/named.conf'
 
-yum install -y bind
 
 cat << EOF > "$BIND_CONF"
 options {

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/overrides.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/overrides.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = bind
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum install -y bind
 
 BIND_CONF='/etc/named.conf'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_commented.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = libreswan
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum install -y libreswan
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_is_there.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_is_there.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = libreswan
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum install -y libreswan
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_not_there.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = libreswan
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum install -y libreswan
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = libreswan
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
-yum install -y libreswan
 
 cp ipsec.conf /etc
 config_file="/etc/ipsec.conf"

--- a/linux_os/guide/system/software/integrity/disable_prelink/tests/initial.fail.sh
+++ b/linux_os/guide/system/software/integrity/disable_prelink/tests/initial.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+# packages = prelink
 #
 
-yum install -y prelink
 
 : > /etc/sysconfig/prelink

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
+# packages = aide
 
 # ensure aide is installed
-yum install -y aide
-
 
 DB=/var/lib/aide/aide.db.gz
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# ensure aide is installed
-yum install -y aide
+# packages = aide
 
 DB=/var/lib/aide/aide.db.gz
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# ensure aide is installed
-yum install -y aide
+# packages = aide
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' > /etc/cron.weekly/aidescan

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# ensure aide is installed
-yum install -y aide
+# packages = aide
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# ensure aide is installed
-yum install -y aide
+# packages = aide
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/default.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/default.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# ensure aide is installed
-yum install -y aide
+# packages = aide
 
 # default instalation
 true

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# ensure aide is installed
-yum install -y aide
+# packages = aide
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' >> /var/spool/cron/root

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = aide
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 
-yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = aide
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 
-yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+acl+xattrs+selinux

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = aide
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 
-yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = aide
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 
-yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+xattrs+selinux

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = aide
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 
-yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+# packages = aide
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_ol
 
-yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+selinux

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/installed.pass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
+# packages = aide
 
-yum install -y aide

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_disabled.fail.sh
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_disabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = dnf-automatic
 
 
-dnf -y install dnf-automatic
 systemctl disable --now dnf-automatic.timer

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_enabled.pass.sh
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_enabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
+# packages = dnf-automatic
 
 
-dnf -y install dnf-automatic
 systemctl enable --now dnf-automatic.timer

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -35,8 +35,14 @@ class CombinedChecker(rule.RuleChecker):
         super(CombinedChecker, self).__init__(test_env)
         self._matching_rule_found = False
 
+        self.rules_not_tested_yet = set()
         self.results = list()
         self._current_result = None
+
+    def _rule_should_be_tested(self, rule, rules_to_be_tested):
+        if rule.short_id not in rules_to_be_tested:
+            return False
+        return True
 
     def _modify_parameters(self, script, params):
         # If there is no profiles metadata for a script we add the tested
@@ -52,31 +58,22 @@ class CombinedChecker(rule.RuleChecker):
         return params
 
     def _test_target(self, target):
-        try:
-            remote_dir = common.send_scripts(self.test_env.domain_ip)
-        except RuntimeError as exc:
-            msg = "Unable to upload test scripts: {more_info}".format(more_info=str(exc))
-            raise RuntimeError(msg)
+        self.rules_not_tested_yet = set(target)
 
-        self._matching_rule_found = False
+        super(CombinedChecker, self)._test_target(target)
 
-        with test_env.SavedState.create_from_environment(self.test_env, "tests_uploaded") as state:
-            for rule in common.iterate_over_rules():
-                if rule.short_id not in target:
-                    continue
-                # In combined mode there is no expectations of matching substrings,
-                # every entry in the target is expected to be unique.
-                # Let's remove matched targets, so we can track rules not tested
-                target.remove(rule.short_id)
-                remediation_available = self._is_remediation_available(rule)
-                self._check_rule(rule, remote_dir, state, remediation_available)
-
-        if len(target) != 0:
-            target.sort()
+        if len(self.rules_not_tested_yet) != 0:
+            not_tested = sorted(list(self.rules_not_tested_yet))
             logging.info("The following rule(s) were not tested:")
-            for rule in target:
+            for rule in not_tested:
                 logging.info("{0}".format(rule))
 
+    def test_rule(self, state, rule, scenarios):
+        super(CombinedChecker, self).test_rule(state, rule, scenarios)
+        # In combined mode there is no expectations of matching substrings,
+        # every entry in the target is expected to be unique.
+        # Let's remove matched targets, so we can track rules not tested
+        self.rules_not_tested_yet.discard(rule.short_id)
 
 def perform_combined_check(options):
     checker = CombinedChecker(options.test_env)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -242,6 +242,31 @@ def create_tarball():
         return fp.name
 
 
+def execute_remote_command(machine, args, log_file, error_msg=""):
+    if not error_msg:
+        error_msg = (
+            "Failed to execute '{cmd}' on {machine}"
+            .format(cmd=" ".join(args), machine=machine))
+    try:
+        run_with_stdout_logging("ssh", SSH_ADDITIONAL_OPTS + (machine,) + args, log_file)
+    except Exception as exc:
+        logging.error(error_msg + ": " + str(exc))
+        raise RuntimeError(error_msg)
+
+
+def copy_file_to(machine, what, dest, log_file, error_msg=""):
+    scp_dest = "{machine}:{dest}".format(machine=machine, dest=dest)
+    if not error_msg:
+        error_msg = (
+            "Failed to copy {what} to {scp_dest}"
+            .format(what=what, scp_dest=scp_dest))
+    try:
+        run_with_stdout_logging("scp", SSH_ADDITIONAL_OPTS + (what, scp_dest), log_file)
+    except Exception:
+        logging.error(error_msg)
+        raise RuntimeError(error_msg)
+
+
 def send_scripts(domain_ip):
     remote_dir = REMOTE_TEST_SCENARIOS_DIRECTORY
     archive_file = create_tarball()
@@ -249,35 +274,23 @@ def send_scripts(domain_ip):
     remote_archive_file = os.path.join(remote_dir, archive_file_basename)
     machine = "{0}@{1}".format(REMOTE_USER, domain_ip)
     logging.debug("Uploading scripts.")
-    log_file_name = os.path.join(LogHelper.LOG_DIR, "data.upload.log")
+    log_file_name = os.path.join(LogHelper.LOG_DIR, "env-preparation.log")
 
     with open(log_file_name, 'a') as log_file:
-        args = SSH_ADDITIONAL_OPTS + (machine, "mkdir", "-p", remote_dir)
-        try:
-            run_with_stdout_logging("ssh", args, log_file)
-        except Exception:
-            msg = "Cannot create directory {0}.".format(remote_dir)
-            logging.error(msg)
-            raise RuntimeError(msg)
+        print("Setting up test setup scripts", file=log_file)
 
-        args = (SSH_ADDITIONAL_OPTS
-                + (archive_file, "{0}:{1}".format(machine, remote_dir)))
-        try:
-            run_with_stdout_logging("scp", args, log_file)
-        except Exception:
-            msg = ("Cannot copy archive {0} to the target machine's directory {1}."
-                   .format(archive_file, remote_dir))
-            logging.error(msg)
-            raise RuntimeError(msg)
+        execute_remote_command(
+            machine, ("mkdir", "-p", remote_dir),
+            log_file, "Cannot create directory {0}".format(remote_dir))
 
-        args = (SSH_ADDITIONAL_OPTS
-                + (machine, "tar xf {0} -C {1}".format(remote_archive_file, remote_dir)))
-        try:
-            run_with_stdout_logging("ssh", args, log_file)
-        except Exception:
-            msg = "Cannot extract data tarball {0}.".format(remote_archive_file)
-            logging.error(msg)
-            raise RuntimeError(msg)
+        copy_file_to(
+            machine, archive_file, remote_dir,
+            log_file, "Cannot copy archive {0} to the target machine's directory {1}"
+            .format(archive_file, remote_dir))
+
+        execute_remote_command(
+            machine, ("tar", "xf", remote_archive_file, "-C", remote_dir),
+            log_file, "Cannot extract data tarball {0}".format(remote_archive_file))
     os.unlink(archive_file)
     return remote_dir
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -327,6 +327,27 @@ def iterate_over_rules():
             yield result
 
 
+def get_cpe_of_tested_os(domain_ip, logfile_name):
+    os_release_file = "/etc/os-release"
+    ret, cpe_line = run_cmd_remote(
+            "grep CPE_NAME {os_release_file}".format(os_release_file=os_release_file),
+            domain_ip, logfile_name)
+    # We are parsing an assignment that is possibly quoted
+    cpe = re.match(r'''CPE_NAME=(["']?)(.*)\1''', cpe_line)
+    if cpe and cpe.groups()[1]:
+        return cpe.groups()[1]
+    msg = ["Unable to get a CPE of the system running tests"]
+    if cpe_line:
+        msg.append(
+                "Retreived a CPE line that we couldn't parse: {cpe_line}"
+                .format(cpe_line=cpe_line))
+    else:
+        msg.append(
+                "Couldn't get CPE entry from '{os_release_file}'"
+                .format(os_release_file=os_release_file))
+    raise RuntimeError("\n".join(msg))
+
+
 INSTALL_COMMANDS = dict(
         fedora=("dnf", "install", "-y"),
         rhel7=("yum", "install", "-y"),
@@ -334,25 +355,31 @@ INSTALL_COMMANDS = dict(
 )
 
 
-def install_packages(domain_ip, platform, packages):
+def install_packages(domain_ip, packages):
     machine = "{0}@{1}".format(REMOTE_USER, domain_ip)
     log_file_name = os.path.join(LogHelper.LOG_DIR, "env-preparation.log")
 
+    platform_cpe = get_cpe_of_tested_os(domain_ip, log_file_name)
+    platform = cpes_to_platform([platform_cpe])
+
     with open(log_file_name, 'a') as log_file:
         print("Installing packages", file=log_file)
+        log_file.flush()
         execute_remote_command(
                 machine, INSTALL_COMMANDS[platform] + tuple(packages), log_file,
                 "Couldn't install required packages {packages}".format(packages=packages))
 
 
-def benchmark_cpes_to_platform(cpes):
+def cpes_to_platform(cpes):
     for cpe in cpes:
         if "fedora" in cpe:
             return "fedora"
         if "redhat:enterprise_linux" in cpe:
-            version = re.match(r"enterprise_linux:(\d)+:", cpe).groups()[1]
-            return "rhel" + version
+            match = re.search(r":enterprise_linux:([^:]+):", cpe)
+            if match:
+                major_version = match.groups()[0].split(".")[0]
+                return "rhel" + major_version
     msg = (
-            "Unable to deduce a platform from these benchmark CPEs: {cpes}"
+            "Unable to deduce a platform from these CPEs: {cpes}"
             .format(cpes=cpes))
     raise ValueError(msg)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -349,9 +349,9 @@ def get_cpe_of_tested_os(domain_ip, logfile_name):
 
 
 INSTALL_COMMANDS = dict(
-        fedora=("dnf", "install", "-y"),
-        rhel7=("yum", "install", "-y"),
-        rhel8=("yum", "install", "-y"),
+    fedora=("dnf", "install", "-y"),
+    rhel7=("yum", "install", "-y"),
+    rhel8=("yum", "install", "-y"),
 )
 
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -330,8 +330,8 @@ def iterate_over_rules():
 def get_cpe_of_tested_os(domain_ip, logfile_name):
     os_release_file = "/etc/os-release"
     ret, cpe_line = run_cmd_remote(
-            "grep CPE_NAME {os_release_file}".format(os_release_file=os_release_file),
-            domain_ip, logfile_name)
+        "grep CPE_NAME {os_release_file}".format(os_release_file=os_release_file),
+        domain_ip, logfile_name)
     # We are parsing an assignment that is possibly quoted
     cpe = re.match(r'''CPE_NAME=(["']?)(.*)\1''', cpe_line)
     if cpe and cpe.groups()[1]:
@@ -339,12 +339,12 @@ def get_cpe_of_tested_os(domain_ip, logfile_name):
     msg = ["Unable to get a CPE of the system running tests"]
     if cpe_line:
         msg.append(
-                "Retreived a CPE line that we couldn't parse: {cpe_line}"
-                .format(cpe_line=cpe_line))
+            "Retreived a CPE line that we couldn't parse: {cpe_line}"
+            .format(cpe_line=cpe_line))
     else:
         msg.append(
-                "Couldn't get CPE entry from '{os_release_file}'"
-                .format(os_release_file=os_release_file))
+            "Couldn't get CPE entry from '{os_release_file}'"
+            .format(os_release_file=os_release_file))
     raise RuntimeError("\n".join(msg))
 
 
@@ -366,8 +366,8 @@ def install_packages(domain_ip, packages):
         print("Installing packages", file=log_file)
         log_file.flush()
         execute_remote_command(
-                machine, INSTALL_COMMANDS[platform] + tuple(packages), log_file,
-                "Couldn't install required packages {packages}".format(packages=packages))
+            machine, INSTALL_COMMANDS[platform] + tuple(packages), log_file,
+            "Couldn't install required packages {packages}".format(packages=packages))
 
 
 def cpes_to_platform(cpes):
@@ -379,7 +379,5 @@ def cpes_to_platform(cpes):
             if match:
                 major_version = match.groups()[0].split(".")[0]
                 return "rhel" + major_version
-    msg = (
-            "Unable to deduce a platform from these CPEs: {cpes}"
-            .format(cpes=cpes))
+    msg = "Unable to deduce a platform from these CPEs: {cpes}".format(cpes=cpes)
     raise ValueError(msg)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 from __future__ import print_function
 
 import logging
@@ -108,6 +107,7 @@ class RuleChecker(oscap.Checker):
 
         self.results = list()
         self._current_result = None
+        self.remote_dir = ""
 
     def _run_test(self, profile, test_data):
         scenario = test_data["scenario"]
@@ -210,32 +210,64 @@ class RuleChecker(oscap.Checker):
                     return True
             return False
 
-    def _test_target(self, target):
+    def _ensure_package_present_for_all_scenarios(self, scenarios_by_rule):
+        packages_required = set()
+        for rule, scenarios in scenarios_by_rule.items():
+            for s in scenarios:
+                scenario_packages = s.script_params["packages"]
+                packages_required.update(scenario_packages)
+        if packages_required:
+            packaging_platform = common.benchmark_cpes_to_platform(self.benchmark_cpes)
+            common.install_packages(self.test_env.domain_ip, packaging_platform, packages_required)
+
+    def _prepare_environment(self, scenarios_by_rule):
+        domain_ip = self.test_env.domain_ip
         try:
-            remote_dir = common.send_scripts(self.test_env.domain_ip)
+            self.remote_dir = common.send_scripts(domain_ip)
         except RuntimeError as exc:
             msg = "Unable to upload test scripts: {more_info}".format(more_info=str(exc))
             raise RuntimeError(msg)
 
-        self._matching_rule_found = False
+        self._ensure_package_present_for_all_scenarios(scenarios_by_rule)
+
+    def _get_rules_to_test(self, target):
+        rules_to_test = []
+        for rule in common.iterate_over_rules():
+            if not self._rule_should_be_tested(rule.id, target):
+                continue
+            if not xml_operations.find_rule_in_benchmark(
+                    self.datastream, self.benchmark_id, rule.id):
+                logging.error(
+                    "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
+                    .format(rule.id, self.benchmark_id, self.datastream))
+                continue
+            rules_to_test.append(rule)
+        return rules_to_test
+
+    def _test_target(self, target):
+
+        rules_to_test = self._get_rules_to_test(target)
+        if not rules_to_test:
+            self._matching_rule_found = False
+            logging.error("No matching rule ID found for '{0}'".format(target))
+            return
+        self._matching_rule_found = True
+
+        scenarios_by_rule = dict()
+        for rule in rules_to_test:
+            rule_scenarios = self._get_scenarios(
+                rule.directory, rule.files, self.scenarios_regex,
+                self.benchmark_cpes)
+            scenarios_by_rule[rule.id] = rule_scenarios
+
+        self._prepare_environment(scenarios_by_rule)
 
         with test_env.SavedState.create_from_environment(self.test_env, "tests_uploaded") as state:
-            for rule in common.iterate_over_rules():
-                if not self._rule_should_be_tested(rule.id, target):
-                    continue
-                self._matching_rule_found = True
-                if not xml_operations.find_rule_in_benchmark(
-                        self.datastream, self.benchmark_id, rule.id):
-                    logging.error(
-                        "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
-                        .format(rule.id, self.benchmark_id, self.datastream))
-                    continue
+            for rule in rules_to_test:
                 remediation_available = self._is_remediation_available(rule)
-
-                self._check_rule(rule, remote_dir, state, remediation_available)
-
-        if not self._matching_rule_found:
-            logging.error("No matching rule ID found for '{0}'".format(target))
+                self._check_rule(
+                    rule, scenarios_by_rule[rule.id],
+                    self.remote_dir, state, remediation_available)
 
     def _modify_parameters(self, script, params):
         if self.scenarios_profile:
@@ -252,6 +284,7 @@ class RuleChecker(oscap.Checker):
         """Parse parameters from script header"""
         params = {'profiles': [],
                   'templates': [],
+                  'packages': [],
                   'platform': ['multi_platform_all'],
                   'remediation': ['all']}
         with open(script, 'r') as script_file:
@@ -292,17 +325,14 @@ class RuleChecker(oscap.Checker):
 
         return scenarios
 
-    def _check_rule(self, rule, remote_dir, state, remediation_available):
+    def _check_rule(self, rule, scenarios, remote_dir, state, remediation_available):
         remote_rule_dir = os.path.join(remote_dir, rule.short_id)
         logging.info(rule.id)
 
         logging.debug("Testing rule directory {0}".format(rule.directory))
 
         args_list = [
-            (s, remote_rule_dir, rule.id, remediation_available)
-            for s in self._get_scenarios(
-                rule.directory, rule.files, self.scenarios_regex,
-                self.benchmark_cpes)
+            (s, remote_rule_dir, rule.id, remediation_available) for s in scenarios
         ]
         state.map_on_top(self._check_and_record_rule_scenario, args_list)
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -217,8 +217,7 @@ class RuleChecker(oscap.Checker):
                 scenario_packages = s.script_params["packages"]
                 packages_required.update(scenario_packages)
         if packages_required:
-            packaging_platform = common.benchmark_cpes_to_platform(self.benchmark_cpes)
-            common.install_packages(self.test_env.domain_ip, packaging_platform, packages_required)
+            common.install_packages(self.test_env.domain_ip, packages_required)
 
     def _prepare_environment(self, scenarios_by_rule):
         domain_ip = self.test_env.domain_ip


### PR DESCRIPTION
This PR centralises installation of packages that are used to test scenarios.
As some checks now require packages installed in order to be applicable, it could be that if 5 scenarios required a package that was not present in the test suite image, it had to be downloaded and installed 5 times, which is wasteful and takes a long time too.

Using the new approach, all scenarios are examined prior to the test execution, and list of all packages to install is gathered.
Those packages are installed to the base `tests_upladed` snapshot using an SSH command that is deduced according to CPEs of the datastream benchmark, so Fedora ends up with dnf, while RHEL7 with yum.

What this PR consists of:

1. Refactored  `send_scripts` - two functions were extracted, and one of those is then reused. Similar functions already exist in the module, but I think that further refactoring in this regard is out of scope of this PR.
2. The "CPE to platform" function along to the "platform to install command" dictionaries were added. This is not the most elegant solution, but it seems to fit the purpose.
3. Test prep in the rule mode has been reworked - as all scenarios are now enumerated early on, the code has been slightly refactored, and the installation of packages has been introduced. The `data.upload.log` log file has been renamed to `env-preparation.log`.