### PR TITLE
Remove platform all from kubernetes remediation templates.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/kubernetes/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/kubernetes/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/kubernetes/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/shared/templates/template_IGNITION_service_disabled
+++ b/shared/templates/template_IGNITION_service_disabled
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp,multi_platform_rhcos
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable
 # complexity = low
@@ -12,12 +12,12 @@ spec:
     systemd:
       units:
       - name: {{{ DAEMONNAME }}}.service
-        enabled: false 
+        enabled: false
 {{%- if MASK_SERVICE %}}
         mask: true
 {{%- endif %}}
       - name: {{{ DAEMONNAME }}}.socket
-        enabled: false 
+        enabled: false
 {{%- if MASK_SERVICE %}}
         mask: true
 {{%- endif %}}

--- a/shared/templates/template_KUBERNETES_audit_rules_dac_modification
+++ b/shared/templates/template_KUBERNETES_audit_rules_dac_modification
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable
 # complexity = low

--- a/shared/templates/template_KUBERNETES_audit_rules_login_events
+++ b/shared/templates/template_KUBERNETES_audit_rules_login_events
@@ -1,9 +1,8 @@
-# platform = multi_platform_all
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable
 # complexity = low
 # disruption = medium
-
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/shared/templates/template_KUBERNETES_audit_rules_privileged_commands
+++ b/shared/templates/template_KUBERNETES_audit_rules_privileged_commands
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable
 # complexity = low

--- a/shared/templates/template_KUBERNETES_service_disabled
+++ b/shared/templates/template_KUBERNETES_service_disabled
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp,multi_platform_rhcos4
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable
 # complexity = low
@@ -12,12 +12,12 @@ spec:
     systemd:
       units:
       - name: {{{ DAEMONNAME }}}.service
-        enabled: false 
+        enabled: false
 {{%- if MASK_SERVICE %}}
         mask: true
 {{%- endif %}}
       - name: {{{ DAEMONNAME }}}.socket
-        enabled: false 
+        enabled: false
 {{%- if MASK_SERVICE %}}
         mask: true
 {{%- endif %}}

--- a/shared/templates/template_KUBERNETES_sshd_lineinfile
+++ b/shared/templates/template_KUBERNETES_sshd_lineinfile
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

- Remove platform `all` from kubernetes remediation templates.

#### Rationale:

- Do we really want to include kubernetes remediation in all product datastreams? Some rules (e.g. [sshd_enable_strictmodes](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_enable_strictmodes/rule.yml)) don't have `prodtype` set, then it will be included in every datastream increasing their size.
