### PR TITLE
remove deprecated Follow argument from ansible remediations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -8,13 +8,11 @@
 - name: "Do not allow users to reuse recent passwords - system-auth (change)"
   replace:
     dest: /etc/pam.d/system-auth
-    follow: yes
     regexp: '^(password\s+sufficient\s+pam_unix\.so\s.*remember\s*=\s*)(\S+)(.*)$'
     replace: '\g<1>{{ var_password_pam_unix_remember }}\g<3>'
 
 - name: "Do not allow users to reuse recent passwords - system-auth (add)"
   replace:
     dest: /etc/pam.d/system-auth
-    follow: yes
     regexp: '^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$'
     replace: '\g<0> remember={{ var_password_pam_unix_remember }}'

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -8,13 +8,11 @@
 - name: "Set Password Retry Prompts Permitted Per-Session - system-auth (change)"
   replace:
     dest: /etc/pam.d/system-auth
-    follow: yes
     regexp: '(^.*\spam_pwquality.so\s.*retry\s*=\s*)(\S+)(.*$)'
     replace: '\g<1>{{ var_password_pam_retry }}\g<3>'
 
 - name: "Set Password Retry Prompts Permitted Per-Session - system-auth (add)"
   replace:
     dest: /etc/pam.d/system-auth
-    follow: yes
     regexp: '^.*\spam_pwquality.so\s(?!.*retry\s*=\s*).*$'
     replace: '\g<0> retry={{ var_password_pam_retry }}'

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -6,12 +6,9 @@
 - name: "Prevent Log In to Accounts With Empty Password - system-auth"
   replace:
     dest: /etc/pam.d/system-auth
-    follow: yes
     regexp: 'nullok'
 
 - name: "Prevent Log In to Accounts With Empty Password - password-auth"
   replace:
     dest: /etc/pam.d/password-auth
-    follow: yes
     regexp: 'nullok'
-


### PR DESCRIPTION
#### Description:

- remove the "follow:" parameter from instances lf "Replace" tasks in Ansible remediations.

#### Rationale:

- This argument was deprecated in 2.5, effectively in 2.10.

- Fixes #6138
