### PR TITLE
ocp4/utils: specify the namespace when creating the profilebundles

### DIFF
--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -105,7 +105,7 @@ while true; do
             echo "Creating profile bundles"
             for prod in "${products[@]}"
             do
-                sed "s/\$PRODUCT/$prod/g" "$root_dir/ocp-resources/profile-bundle.yaml.tpl" | oc apply -f -
+                sed "s/\$PRODUCT/$prod/g" "$root_dir/ocp-resources/profile-bundle.yaml.tpl" | oc apply -n "$namespace" -f -
             done
         fi
         exit 0


### PR DESCRIPTION
This is needed in case we're using a custom namespace.