### PR TITLE
Update package_rsyslog_installed in RHEL6 to consider both rsyslog and rsyslog7 package

### DIFF
--- a/linux_os/guide/system/logging/package_rsyslog_installed/oval/rhel6.xml
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/oval/rhel6.xml
@@ -1,0 +1,14 @@
+<def-group>
+    <definition class="compliance" id="package_rsyslog_installed"
+    version="1">
+      {{{ oval_metadata("The " + pkg_system|upper + " package rsyslog or rsyslog7 should be installed.") }}}
+      <criteria operator="OR">
+        <criterion comment="package rsyslog is installed"
+        test_ref="test_package_rsyslog_installed" />
+        <criterion comment="package rsyslog7 is installed"
+        test_ref="test_package_rsyslog7_installed" />
+      </criteria>
+    </definition>
+    {{{ oval_test_package_installed(package="rsyslog", test_id="test_package_rsyslog_installed") }}}
+    {{{ oval_test_package_installed(package="rsyslog7", test_id="test_package_rsyslog7_installed") }}}
+  </def-group>

--- a/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
@@ -38,4 +38,5 @@ template:
     name: package_installed
     vars:
         pkgname: rsyslog
-        pkgname@rhel6: rsyslog7
+    backends:
+        oval@rhel6: "off"

--- a/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
@@ -38,3 +38,4 @@ template:
     name: package_installed
     vars:
         pkgname: rsyslog
+        pkgname@rhel6: rsyslog7


### PR DESCRIPTION
#### Description:

- Update package_rsyslog_installed in RHEL6 to consider both rsyslog and rsyslog7 package
#### Rationale:

- Relates to #2642
