### PR TITLE
OCP: Enhancements for platform checks

### DIFF
--- a/ocp-resources/ds-build.yaml
+++ b/ocp-resources/ds-build.yaml
@@ -19,9 +19,7 @@ spec:
     dockerfile: |
       FROM registry.access.redhat.com/ubi8/ubi-minimal
       WORKDIR /
-      COPY ssg-ocp4-ds.xml .
-      COPY ssg-rhel7-ds.xml .
-      COPY ssg-rhcos4-ds.xml .
+      COPY *-ds.xml .
   strategy: 
     dockerStrategy:
       noCache: true

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -225,7 +225,9 @@ def clusterTestFunc(args):
 
     print('* Testing rule %s in-cluster' % args.rule)
 
-    if not os.path.exists(PLATFORM_RULE_DIR + '/' + args.rule):
+    findout = subprocess.getoutput(
+        "find %s -name '%s' -type d" % (PLATFORM_RULE_DIR, args.rule))
+    if findout == "":
         print('ERROR: no rule for %s, run "create" first' % args.rule)
         return 1
 

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -270,7 +270,7 @@ def clusterTestFunc(args):
             return 1
 
     # poll for the DONE result
-    timeout = time.time() + 60   # A minute is generous for the platform scan.
+    timeout = time.time() + 120   # A couple of minutes is generous for the platform scan.
     scan_result = None
     while True:
         ret_code, output = subprocess.getstatusoutput(

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -222,7 +222,6 @@ def createTestProfile(rule):
 @needs_oc
 @needs_working_cluster
 def clusterTestFunc(args):
-    build_cmd = 'utils/build_ds_container.sh'
 
     print('* Testing rule %s in-cluster' % args.rule)
 
@@ -237,7 +236,8 @@ def clusterTestFunc(args):
         createTestProfile(args.rule)
         print('* Pushing image build to cluster')
         # execute the build_ds_container script
-        buildp = subprocess.run(build_cmd)
+        buildp = subprocess.run(
+            ['utils/build_ds_container.sh', '-P', 'ocp4', '-P', 'rhcos4'])
         if buildp.returncode != 0:
             try:
                 os.remove(PROFILE_PATH)

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -181,6 +181,14 @@ def createFunc(args):
     if args.namespace is not None:
         namespace_flag = '-n ' + args.namespace
 
+    group_path = os.path.join(PLATFORM_RULE_DIR, args.group)
+    if args.group:
+        if not os.path.isdir(group_path):
+            print("ERROR: The specified group '%s' doesn't exist in the '%s' directory" % (
+                args.group, PLATFORM_RULE_DIR))
+            return 0
+
+    rule_path = os.path.join(group_path, args.rule)
     while url is None and retries < 5:
         retries += 1
         ret_code, output = subprocess.getstatusoutput(
@@ -198,8 +206,7 @@ def createFunc(args):
 
     print('* Creating check for "%s" with yamlpath "%s" satisfying match of "%s"' % (
         url, args.yamlpath, args.match))
-    rule_path = PLATFORM_RULE_DIR + '/' + args.rule
-    rule_yaml_path = rule_path + '/rule.yml'
+    rule_yaml_path = os.path.join(rule_path, 'rule.yml')
 
     pathlib.Path(rule_path).mkdir(parents=True, exist_ok=True)
     with open(rule_yaml_path, 'w') as f:
@@ -328,6 +335,8 @@ def main():
         'create', help='Bootstrap the XML and YML files under %s for a new check.' % PLATFORM_RULE_DIR)
     create_parser.add_argument(
         '--rule', required=True, help='The name of the rule to create. Required.')
+    create_parser.add_argument(
+        '--group', default="", help='The group directory of the rule to create.')
     create_parser.add_argument(
         '--name', required=True, help='The name of the Kubernetes object to check. Required.')
     create_parser.add_argument(

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -302,10 +302,6 @@ def testFunc(args):
 
 
 def main():
-    if os.getenv('KUBECONFIG') == None:
-        print('export KUBECONFIG needed')
-        return 1
-
     parser = argparse.ArgumentParser(
         prog="add_platform_rule.py",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -367,6 +363,11 @@ def main():
     test_parser.set_defaults(func=testFunc)
 
     args = parser.parse_args()
+
+    if os.getenv('KUBECONFIG') == None:
+        print('export KUBECONFIG needed')
+        return 1
+
     return args.func(args)
 
 

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -133,7 +133,7 @@ spec:
     profile: {PROFILE}
     content: ssg-ocp4-ds.xml
     contentImage: image-registry.openshift-image-registry.svc:5000/openshift-compliance/openscap-ocp4-ds:latest
-    debug: True
+    debug: true
 ''')
 
 

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -196,7 +196,7 @@ def createFunc(args):
         print('there was a problem finding the URL from the oc debug output. Hint: override this automatic check with --url')
         return 1
 
-    print('creating check for "%s" with yamlpath "%s" satisfying match of "%s"' % (
+    print('* Creating check for "%s" with yamlpath "%s" satisfying match of "%s"' % (
         url, args.yamlpath, args.match))
     rule_path = PLATFORM_RULE_DIR + '/' + args.rule
     rule_yaml_path = rule_path + '/rule.yml'
@@ -208,8 +208,7 @@ def createFunc(args):
                                      NEGATE=str(args.negate).lower(),
                                      CHECK_TYPE=operation_value(args.regex),
                                      ENTITY_CHECK=entity_value(args.match_entity)))
-    print('wrote ' + rule_yaml_path)
-
+    print('* Wrote ' + rule_yaml_path)
     return 0
 
 

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -65,9 +65,9 @@ PROFILE_PATH = 'ocp4/profiles/test.profile'
 MOCK_VERSION = ('''status:
   versions:
   - name: operator
-    version: 4.5.0-0.ci-2020-06-15-112708
+    version: 4.6.0-0.ci-2020-06-15-112708
   - name: openshift-apiserver
-    version: 4.5.0-0.ci-2020-06-15-112708
+    version: 4.6.0-0.ci-2020-06-15-112708
 ''')
 
 RULE_TEMPLATE = ('''prodtype: ocp4

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -226,7 +226,7 @@ def clusterTestFunc(args):
         if ret_code != 0:
             print(output)
             try:
-                os.remove(profile_path)
+                os.remove(PROFILE_PATH)
             except OSError:
                 pass
             return 1
@@ -247,7 +247,7 @@ def clusterTestFunc(args):
         if proc.returncode != 0:
             print('error applying scan object: %s' % err)
             try:
-                os.remove(profile_path)
+                os.remove(PROFILE_PATH)
             except OSError:
                 pass
             return 1

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -12,7 +12,7 @@ print_usage() {
     echo "    $cmdname -n [namespace]          Build image in the given namespace (Defaults to 'openshift-compliance')."
     echo "    $cmdname -p                      Create ProfileBundle objects for the image."
     echo "    $cmdname -d                      Build content using the --debug flag."
-    echo "    $cmdname -P [product] (-P ...)   Specify applicable product(s) to build. This option can be specified multiple times. (Defaults to 'ocp4' 'rhel7' 'rhcos4')"
+    echo "    $cmdname -P [product] (-P ...)   Specify applicable product(s) to build. This option can be specified multiple times. (Defaults to 'ocp4' 'rhcos4')"
     exit 0
 }
 
@@ -23,7 +23,7 @@ parms=()
 namespace="openshift-compliance"
 create_profile_bundles="false"
 products=()
-default_products=(ocp4 rhcos4 rhel7)
+default_products=(ocp4 rhcos4)
 
 while getopts ":hdpn:P:" opt; do
     case ${opt} in

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -6,10 +6,12 @@ display_description() {
 }
 
 print_usage() {
+    cmdname=$(basename $0)
     echo "Usage:"
-    echo "    $0 -h                      Display this help message."
-    echo "    $0 -n [namespace]          Build image in the given namespace (Defaults to 'openshift-compliance')."
-    echo "    $0 -p                      Create ProfileBundle objects for the image."
+    echo "    $cmdname -h                      Display this help message."
+    echo "    $cmdname -n [namespace]          Build image in the given namespace (Defaults to 'openshift-compliance')."
+    echo "    $cmdname -p                      Create ProfileBundle objects for the image."
+    echo "    $cmdname -d                      Build content using the --debug flag."
     exit 0
 }
 

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -12,6 +12,7 @@ print_usage() {
     echo "    $cmdname -n [namespace]          Build image in the given namespace (Defaults to 'openshift-compliance')."
     echo "    $cmdname -p                      Create ProfileBundle objects for the image."
     echo "    $cmdname -d                      Build content using the --debug flag."
+    echo "    $cmdname -P [product] (-P ...)   Specify applicable product(s) to build. This option can be specified multiple times. (Defaults to 'ocp4' 'rhel7' 'rhcos4')"
     exit 0
 }
 
@@ -21,9 +22,10 @@ parms=()
 # "openshift-compliance"
 namespace="openshift-compliance"
 create_profile_bundles="false"
-products=(ocp4 rhel7 rhcos4)
+products=()
+default_products=(ocp4 rhcos4 rhel7)
 
-while getopts ":hdpn:" opt; do
+while getopts ":hdpn:P:" opt; do
     case ${opt} in
         n ) # Set the namespace
             namespace=$OPTARG
@@ -38,11 +40,18 @@ while getopts ":hdpn:" opt; do
             display_description
             print_usage
             ;;
+        P ) # A product to build
+            products+=($OPTARG)
+            ;;
         \? ) 
             print_usage
             ;;
     esac
 done
+
+if [ ${#products[@]} -eq 0 ]; then
+    products=${default_products[@]}
+fi
 
 echo "* Pushing datastream content image to namespace: $namespace"
 
@@ -53,7 +62,7 @@ pushd $root_dir
 echo "* Building $(echo ${products[@]} | sed 's/ /, /g') products"
 
 # build the product's content
-"$root_dir/build_product" "${products[@]}" "${params[@]}"
+"$root_dir/build_product" ${products[@]} "${params[@]}"
 result=$?
 
 if [ "$result" != "0" ]; then


### PR DESCRIPTION
When writing new rules using the `utils/add_platform_rule.py` utility, this:
* Adds support for writing rules in groups
* Ups timeout for scan to two minutes (for slow deployments)
* Reduces default products built (for faster testing)
* Updates the OCP version to test with
* Does various fixes