### PR TITLE
SSGTS various test scenarios metadata updates (part 2)

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/config_without_skip.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/config_without_skip.pass.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp pam_config_without_skip /etc/pam.d/system-auth
 cp pam_config_without_skip /etc/pam.d/password-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/default_die_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/default_die_pam_unix.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = none
 # Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario
 # The remediation would need to detect and remove default=die from pam_unix.so module

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/disablefaillock_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/disablefaillock_authconfig.fail.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 authconfig --disablefaillock --updateall

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_deny_zero.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_deny_zero.fail.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp pam_config_deny_zero /etc/pam.d/system-auth
 cp pam_config_deny_zero /etc/pam.d/password-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_sssd_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_sssd_authconfig.fail.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 authconfig --enablesssdauth --updateall

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_correctly.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_correctly.pass.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp pam_config_skip_correctly /etc/pam.d/system-auth
 cp pam_config_skip_correctly /etc/pam.d/password-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_correctly_short.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_correctly_short.pass.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 cp pam_config_skip_correctly_short /etc/pam.d/system-auth
 cp pam_config_skip_correctly_short /etc/pam.d/password-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_longer.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_longer.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
-#
 # remediation = none
 # Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario
 # The remediation would need to calculate number of modules to skip

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_longer_comment.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/skip_longer_comment.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
-#
 # remediation = none
 # Remediation for accounts_passwords_pam_faillock_deny cannot remediate this scenario
 # The remediation would need to calculate number of modules to skip

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/comment.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/comment.fail.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^INACTIVE" /etc/default/useradd; then
 	sed -i "s/^INACTIVE.*/# INACTIVE=35/" /etc/default/useradd

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/correct_value.pass.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 if grep -q "^INACTIVE" /etc/default/useradd; then
 	sed -i "s/^INACTIVE.*/INACTIVE=35/" /etc/default/useradd

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/tests/line_not_there.fail.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^INACTIVE.*/d" /etc/default/useradd

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_alias.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_alias.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_email.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_email.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_root.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_root.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_email.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_email.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_exec.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_exec.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_ignore.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_rotate.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_rotate.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_single.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_single.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_suspend.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_suspend.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_syslog.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_syslog.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_greater_than_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_greater_than_minimum_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_minimum_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_enough.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_enough.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_ignore.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_keep_logs.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_keep_logs.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_rotate.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_rotate.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_suspend.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_suspend.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_syslog.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_syslog.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_C2S
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_greater_than_minimum.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_greater_than_minimum.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_minimum_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_enough.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_enough.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_email.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_email.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_exec.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_exec.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_halt.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_halt.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_ignore.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_single.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_single.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_suspend.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_suspend.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_syslog.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_syslog.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_cui
+#
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
-# packages = aide
+
+yum remove -y aide
 
 echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 echo '@daily    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 echo '21    21    1    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 echo '21    21    *    *    1-2    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 echo '21    21    *    *    3    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 echo '@weekly    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 echo '21    21    *    *    mon    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 echo '21    21    1    2    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+#
+# packages = aide
 
 crontab -u root -r || true


### PR DESCRIPTION
Mostly removes unneeded `profiles` metadata from test scenarios and also fixes scenarios for `aide_periodic_cron_checking` rule which were missing `aide` package and that made OVAL check to fail all the time (package got added through the new `packages` metadata which is introduced in https://github.com/ComplianceAsCode/content/pull/6126).