### PR TITLE
Fix regex in aide rules to consider first letter as uppercase.

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
@@ -5,7 +5,7 @@
 aide_conf="/etc/aide.conf"
 forbidden_hashes=(sha1 rmd160 sha256 whirlpool tiger haval gost crc32)
 
-groups=$(LC_ALL=C grep "^[A-Za-z]\+" $aide_conf | cut -f1 -d ' ' | tr -d ' ' | sort -u)
+groups=$(LC_ALL=C grep "^[A-Z][A-Za-z_]*" $aide_conf | cut -f1 -d ' ' | tr -d ' ' | sort -u)
 
 for group in $groups
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
@@ -18,7 +18,7 @@
   <ind:textfilecontent54_object id="object_aide_non_fips_hashes"
   version="1">
     <ind:filepath>/etc/aide.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[a-zA-Z]*[\s]*=[\s]*.*(sha1|rmd160|sha256|whirlpool|tiger|haval|gost|crc32).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[A-Z][a-zA-Z_]*[\s]*=[\s]*.*(sha1|rmd160|sha256|whirlpool|tiger|haval|gost|crc32).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">0</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -31,7 +31,7 @@
   <ind:textfilecontent54_object id="object_aide_use_fips_hashes"
   version="1">
     <ind:filepath>/etc/aide.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[a-zA-Z]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^[A-Z][A-Za-z_]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_aide_use_fips_hashes" version="1">

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/correct_value.pass.sh
@@ -5,6 +5,7 @@ yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+option = yes
 /bin All # apply the custom rule to the files in bin 
 /sbin All # apply the same custom rule to the files in sbin 
 EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/tests/wrong_value.fail.sh
@@ -5,6 +5,8 @@ yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+acl+xattrs+selinux
+option = yes
+Group = selinux
 /bin All # apply the custom rule to the files in bin 
 /sbin All # apply the same custom rule to the files in sbin 
 EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
@@ -4,7 +4,7 @@
 
 aide_conf="/etc/aide.conf"
 
-groups=$(LC_ALL=C grep "^[A-Za-z]\+" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
+groups=$(LC_ALL=C grep "^[A-Z][A-Za-z_]*" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
 
 for group in $groups
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/oval/shared.xml
@@ -16,7 +16,7 @@
   <ind:textfilecontent54_object id="object_aide_verify_acls"
   version="2">
     <ind:filepath>/etc/aide.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!ALLXTRAHASHES)[a-zA-Z]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!ALLXTRAHASHES)[A-Z][a-zA-Z_]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/correct_value.pass.sh
@@ -5,6 +5,7 @@ yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+option = yes
 /bin All # apply the custom rule to the files in bin 
 /sbin All # apply the same custom rule to the files in sbin 
 EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/tests/wrong_value.fail.sh
@@ -5,6 +5,7 @@ yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+xattrs+selinux
+option = yes
 /bin All # apply the custom rule to the files in bin 
 /sbin All # apply the same custom rule to the files in sbin 
 EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
@@ -4,7 +4,7 @@
 
 aide_conf="/etc/aide.conf"
 
-groups=$(LC_ALL=C grep "^[A-Za-z]\+" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
+groups=$(LC_ALL=C grep "^[A-Z][A-Za-z_]*" $aide_conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u)
 
 for group in $groups
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/oval/shared.xml
@@ -16,7 +16,7 @@
   <ind:textfilecontent54_object id="object_aide_verify_ext_attributes"
   version="2">
     <ind:filepath>/etc/aide.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!ALLXTRAHASHES)[a-zA-Z]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!ALLXTRAHASHES)[A-Z][a-zA-Z_]*[\s]*=[\s]*([a-zA-Z0-9\+]*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/correct_value.pass.sh
@@ -5,6 +5,7 @@ yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+option = yes
 /bin All # apply the custom rule to the files in bin 
 /sbin All # apply the same custom rule to the files in sbin 
 EOL

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/tests/wrong_value.fail.sh
@@ -5,6 +5,7 @@ yum install -y aide
 
 cat >/etc/aide.conf <<EOL
 All = p+i+n+u+g+s+m+S+sha512+acl+selinux
+option = yes
 /bin All # apply the custom rule to the files in bin 
 /sbin All # apply the same custom rule to the files in sbin 
 EOL


### PR DESCRIPTION
#### Description:

- Fix regex in aide rules to consider first letter as uppercase because it's the conventional way of detecting groups in `aide` configuration.

#### Rationale:

- Regular `aide` options always start with lowercase letters and in this case it was wrongly remediating `aide.conf`

- Fixes #6150