### PR TITLE
remove package_iptables_installed from rhel8 ospp and stig

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -179,7 +179,6 @@ selections:
     - package_subscription-manager_installed
     - package_dnf-plugin-subscription-manager_installed
     - package_firewalld_installed
-    - package_iptables_installed
     - package_openscap-scanner_installed
     - package_policycoreutils_installed
     - package_rng-tools_installed

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -137,7 +137,6 @@ selections:
 - package_firewalld_installed
 - package_gssproxy_removed
 - package_iprutils_removed
-- package_iptables_installed
 - package_krb5-workstation_removed
 - package_nfs-utils_removed
 - package_openscap-scanner_installed

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -157,7 +157,6 @@ selections:
 - package_firewalld_installed
 - package_gssproxy_removed
 - package_iprutils_removed
-- package_iptables_installed
 - package_krb5-workstation_removed
 - package_libcap-ng-utils_installed
 - package_nfs-utils_removed


### PR DESCRIPTION
#### Description:

- remove package_iptables_installed from ospp, propagated to stig

- modify profile stability test to reflect that

#### Rationale:

rhel8 uses nftables and iptables is no longer used