### PR TITLE
utils/build_ds_container: Fix creating profilebundles

### DIFF
--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -114,7 +114,7 @@ while true; do
 
         if [ "$create_profile_bundles" == "true" ]; then
             echo "Creating profile bundles"
-            for prod in "${products[@]}"
+            for prod in ${products[@]}
             do
                 sed "s/\$PRODUCT/$prod/g" "$root_dir/ocp-resources/profile-bundle.yaml.tpl" | oc apply -n "$namespace" -f -
             done


### PR DESCRIPTION
With the recent changes to the script, the creation of profilebundles
broke. This fixes it.