### PR TITLE
remove rngd related rules from rhel8 ospp and stig

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -182,7 +182,6 @@ selections:
     - package_iptables_installed
     - package_openscap-scanner_installed
     - package_policycoreutils_installed
-    - package_rng-tools_installed
     - package_sudo_installed
     - package_usbguard_installed
     - package_scap-security-guide_installed
@@ -229,9 +228,6 @@ selections:
     ### Application Whitelisting (RHEL 8)
     - package_fapolicyd_installed
     - service_fapolicyd_enabled
-
-    ### Enable the Hardware RNG Entropy Gatherer Service
-    - service_rngd_enabled
 
     ### Configure USBGuard
     - service_usbguard_enabled

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -145,7 +145,6 @@ selections:
 - package_openssh-server_installed
 - package_policycoreutils-python-utils_installed
 - package_policycoreutils_installed
-- package_rng-tools_installed
 - package_scap-security-guide_installed
 - package_sendmail_removed
 - package_subscription-manager_installed
@@ -165,7 +164,6 @@ selections:
 - service_debug-shell_disabled
 - service_fapolicyd_enabled
 - service_firewalld_enabled
-- service_rngd_enabled
 - service_systemd-coredump_disabled
 - service_usbguard_enabled
 - ssh_client_rekey_limit

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -166,7 +166,6 @@ selections:
 - package_openssh-server_installed
 - package_policycoreutils-python-utils_installed
 - package_policycoreutils_installed
-- package_rng-tools_installed
 - package_rsyslog-gnutls_installed
 - package_rsyslog_installed
 - package_scap-security-guide_installed
@@ -190,7 +189,6 @@ selections:
 - service_debug-shell_disabled
 - service_fapolicyd_enabled
 - service_firewalld_enabled
-- service_rngd_enabled
 - service_systemd-coredump_disabled
 - service_usbguard_enabled
 - smartcard_configure_cert_checking


### PR DESCRIPTION
#### Description:

- remove rules related to rngd from rhel8 ospp and stig profiles

#### Rationale:

- rngd is no longer required for sufficient entropy

- CC effort