### PR TITLE
remove rngd related rules from rhcos profiles

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -192,7 +192,6 @@ selections:
     #- package_libcap-ng-utils_installed
     #- package_openscap-scanner_installed
     #- package_policycoreutils_installed
-    #- package_rng-tools_installed
     - package_sudo_installed
     - package_usbguard_installed
     ####
@@ -234,9 +233,6 @@ selections:
     - selinux_state
     - var_selinux_policy_name=targeted
     - selinux_policytype
-
-    ### Enable the Hardware RNG Entropy Gatherer Service
-    - service_rngd_enabled
 
     ### Configure SSSD
     - sssd_run_as_sssd_user

--- a/rhcos4/profiles/ncp.profile
+++ b/rhcos4/profiles/ncp.profile
@@ -197,7 +197,6 @@ selections:
     #- package_libcap-ng-utils_installed
     #- package_openscap-scanner_installed
     #- package_policycoreutils_installed
-    #- package_rng-tools_installed
     - package_sudo_installed
     - package_usbguard_installed
     ####
@@ -244,9 +243,6 @@ selections:
     ### Application Whitelisting (RHEL 8)
     - package_fapolicyd_installed
     - service_fapolicyd_enabled
-
-    ### Enable the Hardware RNG Entropy Gatherer Service
-    - service_rngd_enabled
 
     ### Configure SSSD
     - sssd_run_as_sssd_user


### PR DESCRIPTION
Description:

* Remove rules related to rngd from rhel8 ospp and stig profiles
* Similar to #6157

Rationale:

* rngd not longer required for sufficient entropy