### PR TITLE
yaml loading: Change loader to use the default one

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -431,8 +431,11 @@ class Value(object):
                 % (value.operator, yaml_file, ", ".join(possible_operators))
             )
 
-        value.interactive = \
-            yaml_contents.pop("interactive", "false").lower() == "true"
+        interactive = yaml_contents.pop("interactive", False)
+        if isinstance(interactive, str):
+            value.interactive = interactive.lower() == "true"
+        else:
+            value.interactive = interactive
 
         value.options = required_key(yaml_contents, "options")
         del yaml_contents["options"]

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -47,7 +47,7 @@ def _open_yaml(stream, original_file=None, substitutions_dict={}):
     Return None if it contains "documentation_complete" key set to "false".
     """
     try:
-        yaml_contents = yaml.load(stream, Loader=yaml_SafeLoader)
+        yaml_contents = yaml.load(stream, Loader=yaml.Loader)
 
         if yaml_contents.pop("documentation_complete", "true") == "false" and \
                 substitutions_dict.get("cmake_build_type") != "Debug":


### PR DESCRIPTION
This should address some python2 issues.

per https://github.com/yaml/pyyaml/issues/266