### PR TITLE
ocp4: Don't fail on transcient error

### DIFF
--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -406,7 +406,7 @@ func (ctx *e2econtext) waitForMachinePoolUpdate(name string) error {
 		pool := &mcfgv1.MachineConfigPool{}
 		lastErr = ctx.dynclient.Get(goctx.TODO(), mcKey, pool)
 		if lastErr != nil {
-			ctx.t.Errorf("Could not get the pool %s post update", name)
+			ctx.t.Logf("Could not get the pool %s post update. Retrying.", name)
 			return false, nil
 		}
 


### PR DESCRIPTION
When checking for updates on the MachineConfigPools, we were failing if
an error happened while getting the current satus. This is not ideal as
there might be transcient issues (e.g. AWS having a flaky network).

Instead of failing, this logs the error and continues. The error is
captured in the end, and will be reflected if there is indeed an issue
that the cluster can't recover from.