### PR TITLE
Set the OVAL ID of templated OVALs to the rule ID

### DIFF
--- a/shared/templates/template_OVAL_accounts_password
+++ b/shared/templates/template_OVAL_accounts_password
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_pam_{{{ VARIABLE }}}" version="3">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="3">
     {{{ oval_metadata("The password " + VARIABLE + " should meet minimum requirements") }}}
 {{% if product == "rhel6" %}}
     <criteria>

--- a/shared/templates/template_OVAL_audit_rules_dac_modification
+++ b/shared/templates/template_OVAL_audit_rules_dac_modification
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The changing of file permissions and attributes should be audited.") }}}
     <criteria operator="OR">
 

--- a/shared/templates/template_OVAL_audit_rules_file_deletion_events
+++ b/shared/templates/template_OVAL_audit_rules_file_deletion_events
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_file_deletion_events_{{{ NAME }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The deletion of files should be audited.") }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_login_events
+++ b/shared/templates/template_OVAL_audit_rules_login_events
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_login_events_{{{ NAME }}}" version="2">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata("Audit rules should be configured to log successful and unsuccessful login and logout events.") }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_path_syscall
+++ b/shared/templates/template_OVAL_audit_rules_path_syscall
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_{{{ PATHID }}}_{{{ SYSCALL }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Audit rules about the write events to " + PATH) }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_privileged_commands
+++ b/shared/templates/template_OVAL_audit_rules_privileged_commands
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="{{{ ID }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Audit rules about the information on the use of " + NAME + " is enabled.") }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ NAME }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Audit rules about the unauthorized access attempts to files (unsuccessful) are enabled.") }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_creat
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_o_creat" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Audit rules about the information on the unsuccessful use of " + SYSCALL + " O_CREAT is enabled.") }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_o_trunc_write
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_o_trunc_write" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Audit rules about the information on the unsuccessful use of " + SYSCALL + " O_TRUNC is enabled.") }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_rule_order
+++ b/shared/templates/template_OVAL_audit_rules_unsuccessful_file_modification_rule_order
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_unsuccessful_file_modification_{{{ SYSCALL }}}_rule_order" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Audit rules about the information on the unsuccessful use of " + SYSCALL + " is configured in the proper rule order.") }}}
 
     <criteria operator="OR">

--- a/shared/templates/template_OVAL_audit_rules_usergroup_modification
+++ b/shared/templates/template_OVAL_audit_rules_usergroup_modification
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_usergroup_modification_{{{ NAME }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Audit user/group modification.") }}}
     <criteria operator="OR">
       <criteria operator="AND">

--- a/shared/templates/template_OVAL_file_groupowner
+++ b/shared/templates/template_OVAL_file_groupowner
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="file_groupowner{{{ FILEID }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("This test makes sure that " + FILEPATH + " is group owned by " + FILEGID + ".") }}}
     <criteria>
       <criterion comment="Check file group ownership of {{{ FILEPATH }}}" test_ref="test_file_groupowner{{{ FILEID }}}" />

--- a/shared/templates/template_OVAL_file_owner
+++ b/shared/templates/template_OVAL_file_owner
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="file_owner{{{ FILEID }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("This test makes sure that " + FILEPATH + " is owned by " + FILEUID + ".") }}}
     <criteria>
       <criterion comment="Check file ownership of {{{ FILEPATH }}}" test_ref="test_file_owner{{{ FILEID }}}" />

--- a/shared/templates/template_OVAL_file_permissions
+++ b/shared/templates/template_OVAL_file_permissions
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="file_permissions{{{ FILEID }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("This test makes sure that " + FILEPATH + " has mode " + FILEMODE + ".
       If the target file or directory has an extended ACL, then it will fail the mode check.
       ") }}}

--- a/shared/templates/template_OVAL_mount
+++ b/shared/templates/template_OVAL_mount
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="partition_for{{{ POINTID }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("If stored locally, create a separate partition for
       {{{ MOUNTPOINT }}}. If {{{ MOUNTPOINT }}} will be mounted from another
       system such as an NFS server, then creating a separate partition is not

--- a/shared/templates/template_OVAL_mount_option
+++ b/shared/templates/template_OVAL_mount_option
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_{{{ POINTID }}}_{{{ MOUNTOPTION }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata(MOUNTPOINT + " should be mounted with mount option " + MOUNTOPTION + ".") }}}
     <criteria>
       <criterion comment="{{{ MOUNTOPTION }}} on {{{ MOUNTPOINT }}}" test_ref="test_{{{ POINTID }}}_partition_{{{ MOUNTOPTION }}}" />

--- a/shared/templates/template_OVAL_mount_option_removable_partitions
+++ b/shared/templates/template_OVAL_mount_option_removable_partitions
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="mount_option_{{{ MOUNTOPTION }}}_removable_partitions" version="5">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="5">
     {{{ oval_metadata("The " + MOUNTOPTION + " option should be enabled for all removable devices mounts in /etc/fstab.") }}}
     <criteria operator="OR">
       <!-- First check if specified removable partition truly exists on the system. If not, don't check /etc/fstab

--- a/shared/templates/template_OVAL_package_installed
+++ b/shared/templates/template_OVAL_package_installed
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="package_{{{ PKGNAME }}}_installed"
+  <definition class="compliance" id="{{{ _RULE_ID }}}"
   version="1">
     {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be installed.", affected_platforms=["multi_platform_all"]) }}}
     <criteria>

--- a/shared/templates/template_OVAL_package_removed
+++ b/shared/templates/template_OVAL_package_removed
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="package_{{{ PKGNAME }}}_removed"
+  <definition class="compliance" id="{{{ _RULE_ID }}}"
   version="1">
     {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be removed.", affected_platforms=["multi_platform_all"]) }}}
     <criteria>

--- a/shared/templates/template_OVAL_permissions
+++ b/shared/templates/template_OVAL_permissions
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="permissions{{{ FILEID }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("Checks for correct UNIX permissions on " + FILEPATH + ".") }}}
     <criteria operator="AND">
       {{% if FILEGID != "" %}}

--- a/shared/templates/template_OVAL_sebool
+++ b/shared/templates/template_OVAL_sebool
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="sebool_{{{ SEBOOLID }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The SELinux '" + SEBOOLID + "' boolean should be set in the system configuration.") }}}
     <criteria>
       <criterion comment="{{{ SEBOOLID }}} is configured correctly" test_ref="test_sebool_{{{ SEBOOLID }}}" />

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -6,7 +6,7 @@
 
   {{# we are using systemd and our target OVAL version does support the systemd related tests #}}
 
-  <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
     <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
       <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
@@ -86,10 +86,9 @@
 {{% else %}}
 
   {{% if init_system != "systemd" %}}
-
   {{# we are not using systemd, it doesn't matter if we can or cannot use OVAL 5.11, let us just use the runlevel test #}}
 
-  <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled"
+  <definition class="compliance" id="{{{ _RULE_ID }}}"
   version="1">
     {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
    <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
@@ -184,7 +183,7 @@
 
   {{# fallback if we are using systemd but can't use the new systemd features of OVAL 5.11 #}}
 
-  <definition class="compliance" id="service_{{{ SERVICENAME }}}_disabled" version="2">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
     <criteria comment="package {{{ PACKAGENAME }}} removed or service and socket {{{ SERVICENAME }}} are not configured to start" operator="OR">
       <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />

--- a/shared/templates/template_OVAL_service_enabled
+++ b/shared/templates/template_OVAL_service_enabled
@@ -4,7 +4,7 @@
 
 {{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
 
-  <definition class="compliance" id="service_{{{ SERVICENAME }}}_enabled" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
     <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
@@ -54,7 +54,7 @@
 
 {{% else %}}
 
-  <definition class="compliance" id="service_{{{ SERVICENAME }}}_enabled"
+  <definition class="compliance" id="{{{ _RULE_ID }}}"
   version="1">
     {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">

--- a/shared/templates/template_OVAL_timer_enabled
+++ b/shared/templates/template_OVAL_timer_enabled
@@ -2,7 +2,7 @@
 
 {{% if target_oval_version >= [5, 11] %}}
 
-  <definition class="compliance" id="timer_{{{ TIMERNAME }}}_enabled" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + TIMERNAME + " timer should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and timer {{{ TIMERNAME }}} is configured to start" operator="AND">
       <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />
@@ -40,7 +40,7 @@
 
 {{# fallback if we are using systemd but can't use the new systemd features of OVAL 5.11 #}}
 
-  <definition class="compliance" id="timer_{{{ TIMERNAME }}}_enabled" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + TIMERNAME + " service should be enabled if possible.") }}}
     <criteria comment="package {{{ PACKAGENAME }}} installed and timer {{{ TIMERNAME }}} is configured to start" operator="AND">
       <extend_definition comment="{{{ PACKAGENAME }}} installed" definition_ref="package_{{{ PACKAGENAME }}}_installed" />

--- a/shared/templates/template_OVAL_yamlfile_value
+++ b/shared/templates/template_OVAL_yamlfile_value
@@ -1,6 +1,6 @@
 {{% if target_oval_version >= [5, 11] %}}
 <def-group>
-  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("
         The file '" + FILEPATH + "' should " + "not " if NEGATE else "" + "contain value '" + VALUE + "' " + ("of type " + TYPE + " ") if TYPE else "" + "at '" + YAMLPATH + "'.") }}}
     <criteria>


### PR DESCRIPTION
Provide a fallback if the rule ID is not known - this may happen in cases when the OVAL is generated using the template for another reason than because a rule needs it.