### PR TITLE
Remove platform net-snmp from the group and use it in individual rules.

### DIFF
--- a/linux_os/guide/services/snmp/snmp_configure_server/group.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/group.yml
@@ -18,4 +18,3 @@ description: |-
     <li>ensure that permissions on the <tt>snmpd.conf</tt> configuration file (by default, in <tt>/etc/snmp</tt>) are 640 or more restrictive</li>
     <li>ensure that any MIB files' permissions are also 640 or more restrictive</li></ul>
 
-platform: net-snmp

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_no_rwusers/rule.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_no_rwusers/rule.yml
@@ -27,3 +27,5 @@ ocil: |-
     To ensure there are no read-write users, run the following command:
     <pre>$ sudo grep -v "^#" /etc/snmp/snmpd.conf| grep 'rwuser'</pre>
     There should be no output.
+
+platform: net-snmp

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
@@ -45,3 +45,5 @@ ocil: |-
     To ensure the default password is not set, run the following command:
     <pre>$ sudo grep -v "^#" /etc/snmp/snmpd.conf| grep -E 'public|private'</pre>
     There should be no output.
+
+platform: net-snmp

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/rule.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/rule.yml
@@ -30,3 +30,5 @@ ocil: |-
     To ensure only SNMPv3 or newer is used, run the following command:
     <pre>$ sudo grep 'rocommunity\|rwcommunity\|com2sec' /etc/snmp/snmpd.conf | grep -v "^#"</pre>
     There should be no output.
+
+platform: net-snmp


### PR DESCRIPTION
#### Description:

- Remove platform net-snmp from the group and use it in individual rules.

#### Rationale:

- This was causing the platform being introduced in every datastream, since the `group.yml` doesn't use `prodtype`, we produce but the respective CPE dictionaries didn't contain the platform definition. I guess restricting the platform to individual rules is the most reasonable way to fix the issue, instead of adding the CPE definition to every CPE dictionary we have in the project.

- Fixes failing jobs from:
  - https://jenkins.complianceascode.io/view/All%20Green/job/scap-security-guide-scapval-scap-1.2/
  - https://jenkins.complianceascode.io/view/All%20Green/job/scap-security-guide-scapval-scap-1.3/
