### PR TITLE
OCP: Remove jinja references to ocp4 in ocp3 OVAL files

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/oval/ocp3.xml
@@ -17,17 +17,9 @@
     <ind:object object_ref="object_api_server_admission_control_plugin_AlwaysAdmit" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_admission_control_plugin_AlwaysAdmit" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"serviceAccountPublicKeyFiles":[\s]*\[.*"(\S+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_admission_control_plugin_AlwaysAdmit" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*admissionConfig\:(?:[^\n]*\n+)+?[\s]*pluginConfig\:(?:[^\n]*\n+)+?[\s]*AlwaysAdmit\:[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 </def-group>

--- a/applications/openshift/api-server/api_server_anonymous_auth/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_anonymous_auth" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_anonymous_auth" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"apiServerArguments":[\s]*{.*"anonymous-auth":[\s]*\[.*"(\S+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_anonymous_auth" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubernetesMasterConfig\:(?:[^\n]*\n+)+?[\s]*apiServerArguments\:(?:[^\n]*\n+)+?[\s]*anonymous-auth\:[\s]*[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_anonymous_auth" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^'false'$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_audit_log_maxage/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxage/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_audit_log_maxage" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_audit_log_maxage" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"auditConfig":[\s]*{.*"maximumFileRetentionDays":[\s]*(\d+),.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_audit_log_maxage" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*maximumFileRetentionDays:[\s]+(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_audit_log_maxage" version="1">
     <ind:subexpression datatype="int" operation="less than or equal">30</ind:subexpression>

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_audit_log_maxbackup" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_audit_log_maxbackup" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"auditConfig":[\s]*{.*"maximumRetainedFiles":[\s]*(\d+),.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_audit_log_maxbackup" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*maximumRetainedFiles:[\s]+(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_audit_log_maxbackup" version="1">
     <ind:subexpression datatype="int" operation="greater than or equal">10</ind:subexpression>

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_audit_log_maxsize" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_audit_log_maxsize" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"auditConfig":[\s]*{.*"maximumFileSizeMegabytes":[\s]*(\d+),.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_audit_log_maxsize" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*maximumFileSizeMegabytes:[\s]+(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_audit_log_maxsize" version="1">
     <ind:subexpression datatype="int" operation="greater than or equal">100</ind:subexpression>

--- a/applications/openshift/api-server/api_server_audit_log_path/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_audit_log_path/oval/ocp3.xml
@@ -16,19 +16,11 @@
     <ind:state state_ref="state_api_server_audit_log_path" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_audit_log_path" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"auditConfig":[\s]*{.*"auditFilePath":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_audit_log_path" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*auditConfig:(?:[^\n]*\n+)+?[\s]*auditFilePath:[\s"']+([^\s"']+)[\s"']*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_audit_log_path" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(\/.*)$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_authorization_mode/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_authorization_mode/oval/ocp3.xml
@@ -28,19 +28,11 @@
     <ind:object object_ref="object_api_server_authorization_mode_webhook" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_authorization_mode_webhook" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"apiServerArguments":[\s]*{.*"authorization-mode":[\s]*\[.*"Webhook".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_authorization_mode_webhook" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*authorization-mode\:[\n]+[\s*]-[\s]+Webhook[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
   <!-- end test for default configuration value -->
 
 </def-group>

--- a/applications/openshift/api-server/api_server_client_ca/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_client_ca/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_client_ca" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_client_ca" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"servingInfo":[\s]*{.*"clientCA":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_client_ca" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*servingInfo\:(?:[^\n]*\n+)+?[\s]*clientCA\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_client_ca" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^ca.crt|/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_etcd_ca/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_etcd_ca/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_etcd_ca" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_etcd_ca" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"storageConfig":[\s]*{.*"ca":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_etcd_ca" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*etcdClientInfo\:(?:[^\n]*\n+)+?[\s]*ca\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_etcd_ca" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^master.etcd-ca.crt|/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_etcd_cert/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_etcd_cert/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_etcd_cert" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_etcd_cert" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"storageConfig":[\s]*{.*"certFile":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_etcd_cert" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*etcdClientInfo\:(?:[^\n]*\n+)+?[\s]*certFile\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_etcd_cert" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^master.etcd-client.crt|/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.crt$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_etcd_key/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_etcd_key/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_etcd_key" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_etcd_key" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"storageConfig":[\s]*{.*"keyFile":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_etcd_key" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*etcdClientInfo\:(?:[^\n]*\n+)+?[\s]*keyFile\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_etcd_key" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^master.etcd-client.key|/etc/kubernetes/static-pod-resources/secrets/etcd-client/tls.key$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_insecure_bind_address/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/oval/ocp3.xml
@@ -14,17 +14,9 @@
     <ind:object object_ref="object_api_server_insecure_bind_address" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_insecure_bind_address" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"insecure-bind-address"\:[\s]*\[.*"(\S+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_insecure_bind_address" version="1">
     <ind:filepath>/etc/origin/node/node-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubernetesMasterConfig\:(?:[^\n]*\n+)+?[\s]*apiServerArguments\:(?:[^\n]*\n+)+?[\s]*insecure-bind-address\:[\s]*[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 </def-group>

--- a/applications/openshift/api-server/api_server_insecure_port/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_insecure_port/oval/ocp3.xml
@@ -15,17 +15,9 @@
     <ind:object object_ref="object_api_server_insecure_port" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_insecure_port" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"insecure-port"\:[\s]*\[.*"(\S+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_insecure_port" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubernetesMasterConfig\:(?:[^\n]*\n+)+?[\s]*apiServerArguments\:(?:[^\n]*\n+)+?[\s]*insecure-port\:[\s]*[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 </def-group>

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_kubelet_certificate_authority" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_kubelet_certificate_authority" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"kubeletClientInfo":[\s]*{.*"ca":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_kubelet_certificate_authority" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubeletClientInfo\:(?:[^\n]*\n+)+?[\s]*ca\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_kubelet_certificate_authority" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^ca-bundle.crt|/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_kubelet_client_cert" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_kubelet_client_cert" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">>^.*"kubeletClientInfo":[\s]*{.*"certFile":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_kubelet_client_cert" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubeletClientInfo\:(?:[^\n]*\n+)+?[\s]*certFile\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_kubelet_client_cert" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^master.kubelet-client.crt|/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_kubelet_client_key/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_kubelet_client_key" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_kubelet_client_key" version="1">
-   <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"kubeletClientInfo":[\s]*{.*"keyFile":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_kubelet_client_key" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubeletClientInfo\:(?:[^\n]*\n+)+?[\s]*keyFile\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_kubelet_client_key" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^master.kubelet-client.key|/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_kubelet_https/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_kubelet_https/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_kubelet_https" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_kubelet_https" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"apiServerArguments":[\s]*{.*"kubelet-https":[\s]*\[.*"(\d+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_kubelet_https" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubernetesMasterConfig\:(?:[^\n]*\n+)+?[\s]*apiServerArguments\:(?:[^\n]*\n+)+?[\s]*kubelet-https\:[\s]*[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_kubelet_https" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^'false'$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_request_timeout/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_request_timeout/oval/ocp3.xml
@@ -16,19 +16,11 @@
     <ind:state state_ref="state_api_server_request_timeout" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_request_timeout" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"apiServerArguments":[\s]*{.*"request-timeout":[\s]*\[.*"(\d+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_request_timeout" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubernetesMasterConfig\:(?:[^\n]*\n+)+?[\s]*apiServerArguments\:(?:[^\n]*\n+)+?[\s]*request-timeout\:[\s]*[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_request_timeout" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^300$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_secure_port/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_secure_port/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_secure_port" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_secure_port" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"apiServerArguments":[\s]*{.*"authorization-mode":[\s]*\[.*"(\d+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_secure_port" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*kubernetesMasterConfig\:(?:[^\n]*\n+)+?[\s]*apiServerArguments\:(?:[^\n]*\n+)+?[\s]*secure-port\:[\s]*[\n]+[\s]*-[\s]+(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_secure_port" version="1">
     <ind:subexpression datatype="int" operation="greater than">0</ind:subexpression>

--- a/applications/openshift/api-server/api_server_service_account_public_key/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_service_account_public_key" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_service_account_public_key" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"serviceAccountPublicKeyFiles":[\s]*\[.*"(\S+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_service_account_public_key" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*serviceAccountConfig\:(?:[^\n]*\n+)+?[\s]*publicKeyFiles\:[\n]+[\s]*-[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_service_account_public_key" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^.*\.key$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_tls_cert/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_tls_cert/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_tls_cert" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_tls_cert" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">>^.*"servingInfo":[\s]*{.*"certFile":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_tls_cert" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*servingInfo\:(?:[^\n]*\n+)+?[\s]*certFile\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_tls_cert" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^master.server.crt|/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_tls_private_key/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_tls_private_key/oval/ocp3.xml
@@ -15,19 +15,11 @@
     <ind:state state_ref="state_api_server_tls_private_key" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_tls_private_key" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">>^.*"servingInfo":[\s]*{.*"keyFile":[\s]*"([^\s"']+)",.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_tls_private_key" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*servingInfo\:(?:[^\n]*\n+)+?[\s]*keyFile\:[\s]+(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
   <ind:textfilecontent54_state id="state_api_server_tls_private_key" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^master.server.key|/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key$</ind:subexpression>

--- a/applications/openshift/api-server/api_server_token_auth/oval/ocp3.xml
+++ b/applications/openshift/api-server/api_server_token_auth/oval/ocp3.xml
@@ -14,18 +14,10 @@
     <ind:object object_ref="object_api_server_token_auth" />
   </ind:textfilecontent54_test>
 
-{{%- if product == "ocp4" %}}
-  <ind:textfilecontent54_object id="object_api_server_token_auth" version="1">
-    <ind:filepath>/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml</ind:filepath>
-    <ind:pattern operation="pattern match">^.*"apiServerArguments":[\s]*{.*"token-auth-file":[\s]*\[.*"(\S+)".*\][,]*.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% else %}}
   <ind:textfilecontent54_object id="object_api_server_token_auth" version="1">
     <ind:filepath>/etc/origin/master/master-config.yaml</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*token-auth-file\:[\n]+[\s*]-[\s]*(\S+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-{{%- endif %}}
 
 </def-group>

--- a/applications/openshift/etcd/etcd_cert_file/oval/ocp3.xml
+++ b/applications/openshift/etcd/etcd_cert_file/oval/ocp3.xml
@@ -29,10 +29,6 @@
     <ind:subexpression datatype="string" operation="pattern match">^/etc/etcd/server.crt|/etc/ssl/etcd/system\:etcd-server-\:.*\.crt$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-{{%- if product == "ocp4" %}}
-  {{{ oval_ocp_service_runtime_config(command="etcd", option="--cert-file", value="/etc/ssl/etcd/system\:etcd-server\:.*\.crt", option_id="cert_file") }}}
-{{% else %}}
   {{{ oval_ocp_service_runtime_config(command="etcd", option="--cert-file", value="/etc/etcd/server.crt", option_id="cert_file") }}}
-{{%- endif %}}
 
 </def-group>

--- a/applications/openshift/etcd/etcd_key_file/oval/ocp3.xml
+++ b/applications/openshift/etcd/etcd_key_file/oval/ocp3.xml
@@ -29,10 +29,6 @@
     <ind:subexpression datatype="string" operation="pattern match">^/etc/etcd/server.key|/etc/ssl/etcd/system\:etcd-.*\:.*\.key$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-{{%- if product == "ocp4" %}}
-  {{{ oval_ocp_service_runtime_config(command="etcd", option="--key-file", value="/etc/ssl/etcd/system\:etcd-server\:.*\.key", option_id="key_file") }}}
-{{% else %}}
   {{{ oval_ocp_service_runtime_config(command="etcd", option="--key-file", value="/etc/etcd/server.key", option_id="key_file") }}}
-{{%- endif %}}
 
 </def-group>

--- a/applications/openshift/etcd/etcd_peer_cert_file/oval/ocp3.xml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/oval/ocp3.xml
@@ -29,10 +29,6 @@
     <ind:subexpression datatype="string" operation="pattern match">^/etc/etcd/peer.crt|/etc/ssl/etcd/system\:etcd-peer\:.*\.crt$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-{{%- if product == "ocp4" %}}
-  {{{ oval_ocp_service_runtime_config(command="etcd", option="--peer-cert-file", value="/etc/ssl/etcd/system\:etcd-peer\:.*\.crt", option_id="peer_cert_file") }}}
-{{% else %}}
   {{{ oval_ocp_service_runtime_config(command="etcd", option="--peer-cert-file", value="/etc/etcd/peer.crt", option_id="peer_cert_file") }}}
-{{%- endif %}}
 
 </def-group>

--- a/applications/openshift/etcd/etcd_peer_key_file/oval/ocp3.xml
+++ b/applications/openshift/etcd/etcd_peer_key_file/oval/ocp3.xml
@@ -29,10 +29,6 @@
     <ind:subexpression datatype="string" operation="pattern match">^/etc/etcd/peer.key|/etc/ssl/etcd/system\:etcd-peer\:.*\.key$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-{{%- if product == "ocp4" %}}
-  {{{ oval_ocp_service_runtime_config(command="etcd", option="--peer-key-file", value="/etc/ssl/etcd/system\:etcd-peer\:.*\.key", option_id="peer_key_file") }}}
-{{% else %}}
   {{{ oval_ocp_service_runtime_config(command="etcd", option="--peer-key-file", value="/etc/etcd/peer.key", option_id="peer_key_file") }}}
-{{%- endif %}}
 
 </def-group>

--- a/applications/openshift/etcd/etcd_unique_ca/oval/ocp3.xml
+++ b/applications/openshift/etcd/etcd_unique_ca/oval/ocp3.xml
@@ -25,10 +25,6 @@
     <ind:subexpression datatype="string" operation="pattern match">^/etc(|/ssl)/etcd/ca.crt$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-{{%- if product == "ocp4" %}}
-  {{{ oval_ocp_service_runtime_config(command="etcd", option="--trusted-ca-file", value="/etc/ssl/etcd/ca.crt", option_id="trusted_ca_file") }}}
-{{% else %}}
   {{{ oval_ocp_service_runtime_config(command="etcd", option="--trusted-ca-file", value="/etc/etcd/ca.crt", option_id="trusted_ca_file") }}}
-{{%- endif %}}
 
 </def-group>


### PR DESCRIPTION
These were leftovers from a previous commit that made these files
ocp3-specific.