### PR TITLE
Adopt changes in yamlfilecontent_* check for yamlfile_value template

### DIFF
--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -64,11 +64,11 @@ warnings:
 template:
     name: yamlfile_value
     vars:
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
-        yamlpath: ".data['config.yaml']"
-        value: "basic-auth"
-        type: "string"
-        operation: "pattern match"
-        entity_check: "none satisfy"
         ocp_data: "true"
-
+        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        yamlpath: '.data["config.yaml"]'
+        entity_check: "none satisfy"
+        values:
+            - value: 'basic-auth'
+              type: "string"
+              operation: "pattern match"

--- a/applications/openshift/ocp_idp_no_htpasswd/rule.yml
+++ b/applications/openshift/ocp_idp_no_htpasswd/rule.yml
@@ -18,9 +18,9 @@ warnings:
 template:
     name: yamlfile_value
     vars:
+        ocp_data: 'true'
         filepath: /apis/config.openshift.io/v1/oauths/cluster
         yamlpath: ".spec.identityProviders[:].type"
-        value: "HTPasswd"
-        entity_check: "at least one"
-        negate: 'true'
-        ocp_data: 'true'
+        entity_check: "none satisfy"
+        values:
+            - value: "HTPasswd"

--- a/applications/openshift/registry/ocp_allowed_registries/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries/rule.yml
@@ -22,9 +22,10 @@ warnings:
 template:
     name: yamlfile_value
     vars:
+        ocp_data: 'true'
         filepath: /apis/config.openshift.io/v1/images/cluster
         yamlpath: ".spec.registrySources.allowedRegistries[:]"
-        value: ".*"
         entity_check: "at least one"
-        operation: "pattern match"
-        ocp_data: 'true'
+        values:
+            - value: ".*"
+              operation: "pattern match"

--- a/applications/openshift/registry/ocp_allowed_registries_for_import/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries_for_import/rule.yml
@@ -21,9 +21,10 @@ warnings:
 template:
     name: yamlfile_value
     vars:
+        ocp_data: 'true'
         filepath: /apis/config.openshift.io/v1/images/cluster
         yamlpath: ".spec.allowedRegistriesForImport[:].domainName"
-        value: ".*"
         entity_check: "at least one"
-        operation: "pattern match"
-        ocp_data: 'true'
+        values:
+            - value: ".*"
+              operation: "pattern match"

--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1765,14 +1765,14 @@ timer_enabled::
 yamlfile_value::
 * Check if value(s) of certain type is (are) present in a YAML (or JSON) file at a given path.
 * Parameters:
+** *ocp_data* - if set to `"true"` then the filepath would be treated as a part of the dump of OCP configuration with the `ocp_data_root` prefix; optional.
 ** *filepath* - full path to the file to check
 ** *yamlpath* - OVAL's link:https://github.com/OpenSCAP/yaml-filter/wiki/YAML-Path-Definition[YAML Path] expression.
-** *value* - the value to check.
-** *type* (SimpleDatatypeEnumeration) - datatype for state's value_of, optional. If omitted, datatype would be treated as OVAL's default 'string'.
 ** *entity_check* (CheckEnumeration) - entity_check value for state's value_of, optional. If omitted, entity_check attribute would not be set and will be treated by OVAL as 'all'.
-** *operation* (OperationEnumeration) - operation value for state's value_of, optional. If omitted, operation attribute would not be set. OVAL's default operation is 'equals'.
-** *negate* - if set to `"true"` the meaning of the value check criterion would be inverted, optional.
-** *ocp_data* - if set to `"true"` then the filepath would be treated as a part of the dump of OCP configuration with the `ocp_data_root` prefix; optional.
+** *values* - a list of dictionaries with values to check, where:
+**   *value* - the value to check.
+**   *type* (SimpleDatatypeEnumeration) - datatype for state's value_of, optional. If omitted, datatype would be treated as OVAL's default 'string'.
+**   *operation* (OperationEnumeration) - operation value for state's value_of, optional. If omitted, operation attribute would not be set. OVAL's default operation is 'equals'.
 * Languages: OVAL
 
 

--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -37,6 +37,8 @@
   </ind:yamlfilecontent_object>
 
   <ind:yamlfilecontent_state id="state_ocp4" version="1">
-      <ind:value_of datatype="string" operation="pattern match">4\..*</ind:value_of>
+      <ind:value datatype="record">
+          <field name="#" datatype="string" operation="pattern match">4\..*</field>
+      </ind:value>
   </ind:yamlfilecontent_state>
 </def-group>

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -595,6 +595,6 @@
 {{%- else %}}
         {{{ oval_affected(products) | indent -}}}
 {{%- endif %}}
-        <description>{{{ description }}}</description>
+        <description>{{{ description }}}{{{ caller() if caller else '' }}}</description>
     </metadata>
 {{%- endmacro %}}

--- a/shared/templates/template_OVAL_yamlfile_value
+++ b/shared/templates/template_OVAL_yamlfile_value
@@ -1,11 +1,15 @@
 {{% if target_oval_version >= [5, 11] %}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
-    {{{ oval_metadata("
-        The file '" + FILEPATH + "' should " + "not " if NEGATE else "" + "contain value '" + VALUE + "' " + ("of type " + TYPE + " ") if TYPE else "" + "at '" + YAMLPATH + "'.") }}}
+    {{% call oval_metadata("In the YAML/JSON file '" + FILEPATH + "' at path '" + YAMLPATH + "' " + (ENTITY_CHECK if ENTITY_CHECK else "all") + ": ") %}}
+      {{%- for val in VALUES -%}}
+        {{{- "key '" + key + "' " if key in val else "" }}}value{{{ (" of type '" + val.type + "' ") if type in val else " " }}}
+          {{{- val.operation if operation in val else "equals" }}} '{{{ val.value }}}'{{% if not loop.last %}} and{{% endif %}}
+      {{%- endfor -%}}
+    {{%- endcall -%}}
     <criteria>
-        <criterion comment="Make sure that {{% if NEGATE %}}no {{% endif %}}{{% if ENTITY_CHECK %}}({{{ ENTITY_CHECK }}}) {{% endif %}} element(s) of '{{{ YAMLPATH }}}' contain value '{{{ VALUE }}}'{{% if TYPE %}} of type {{{ TYPE }}}{{% endif %}}."{{% if NEGATE %}} negate="true"{{% endif %}} test_ref="test_{{{ rule_id }}}"/>
-        {{% if NEGATE %}}
+        <criterion {{{ {'comment': "In the YAML/JSON file '" + FILEPATH + "' at path '" + YAMLPATH + "' " + (ENTITY_CHECK if ENTITY_CHECK else "all")}|xmlattr }}} test_ref="test_{{{ rule_id }}}"/>
+        {{% if OCP_DATA %}}
         <criterion comment="Make sure that the file '{{{ FILEPATH }}}' exists." test_ref="test_file_for_{{{ rule_id }}}"/>
         {{% endif %}}
     </criteria>
@@ -23,12 +27,12 @@
   </local_variable>
 
   <ind:yamlfilecontent_test id="test_{{{ rule_id }}}" check="all" check_existence="only_one_exists" 
-    comment="Find only one '{{{ FILEPATH }}}' with '{{{ VALUE }}}' at '{{{ YAMLPATH }}}'." version="1">
+    {{{ {'comment': "In the file '" + FILEPATH + "' find only one object at path '" + YAMLPATH + "'."}|xmlattr }}} version="1">
     <ind:object object_ref="object_{{{ rule_id }}}"/>
     <ind:state state_ref="state_{{{ rule_id }}}"/>
   </ind:yamlfilecontent_test>
 
-  {{% if NEGATE %}}
+  {{% if OCP_DATA %}}
   <unix:file_test id="test_file_for_{{{ rule_id }}}" check="all" check_existence="only_one_exists"
     comment="Find the file to be checked ('{{{ FILEPATH }}}')." version="1">
     <unix:object object_ref="object_file_for_{{{ rule_id }}}"/>
@@ -45,11 +49,16 @@
   </ind:yamlfilecontent_object>
 
   <ind:yamlfilecontent_state id="state_{{{ rule_id }}}" version="1">
-    <ind:value_of{{% if TYPE %}} datatype="{{{ TYPE }}}"{{% endif %}}{{% if ENTITY_CHECK %}} entity_check="{{{ ENTITY_CHECK }}}"{{% endif %}}{{% if OPERATION %}} operation="{{{ OPERATION }}}"{{% endif %}}>{{{ VALUE }}}</ind:value_of>
+    <ind:value datatype="record"{{% if ENTITY_CHECK %}} entity_check="{{{ ENTITY_CHECK }}}"{{% endif %}}>
+      {{% for val in VALUES %}}
+      <field {{{ {'name': key if key in val else "#", 'datatype': val.type,  'operation':  val.operation}|xmlattr }}}>{{{ val.value }}}</field>
+      {{% endfor %}}
+    </ind:value>
   </ind:yamlfilecontent_state>
 
   {{% if OCP_DATA %}}
   <external_variable comment="Root of OCP data dump" datatype="string" id="ocp_data_root" version="1" />
   {{% endif %}}
+
 </def-group>
 {{% endif %}}

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -358,7 +358,6 @@ def timer_enabled(data, lang):
 
 @template(["oval"])
 def yamlfile_value(data, lang):
-    data["negate"] = data.get("negate", "false") == "true"
     data["ocp_data"] = data.get("ocp_data", "false") == "true"
     return data
 

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -89,11 +89,11 @@ warnings:
 template:
     name: yamlfile_value
     vars:
+        ocp_data: "true"{ENTITY_CHECK}
         filepath: {URL}
         yamlpath: "{YAMLPATH}"
-        value: "{MATCH}"
-        negate: "{NEGATE}"
-        ocp_data: "true"{CHECK_TYPE}{ENTITY_CHECK}
+        values:
+            - value: "{MATCH}"{CHECK_TYPE}
 
 ''')
 


### PR DESCRIPTION
These changes would allow to use `yamlfile_value` macro with the new version of the YAML check (openscap 1.3.4).