### PR TITLE
add_platform_rule.py: Use the newer openscap release

### DIFF
--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -58,7 +58,7 @@ COMPLIANT
 ''')
 
 PLATFORM_RULE_DIR = 'applications/openshift'
-OSCAP_TEST_IMAGE = 'quay.io/compliance-operator/openscap-ocp:1.3.3'
+OSCAP_TEST_IMAGE = 'quay.io/compliance-operator/openscap-ocp:1.3.4'
 OSCAP_CMD_OPTS = 'oscap xccdf eval --verbose INFO --fetch-remote-resources --profile xccdf_org.ssgproject.content_profile_test --results-arf /tmp/report-arf.xml /content/ssg-ocp4-ds.xml'
 PROFILE_PATH = 'ocp4/profiles/test.profile'
 


### PR DESCRIPTION
#### Description:

The helper script now uses the quay.io image with the latest release.

#### Rationale:

Otherwise the test would traceback as it doesn't understand the content
generated by the new release.