### PR TITLE
WIP: Enable "alternative groups" for products

### DIFF
--- a/applications/openshift/group.yml
+++ b/applications/openshift/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3,ocp4,ocp4-node
 
 title: 'OpenShift Settings'
 

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: ocp4-node
 
 title: 'Verify Group Who Owns The Kube API Server Pod Specification File'
 
@@ -23,8 +23,8 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 
 ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", group="root") }}}'
 
-#template:
-#    name: file_groupowner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
-#        filegid: '0'
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
+        filegid: '0'

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: ocp4-node
 
 title: 'Verify Group Who Owns The Kube Controller Manager Pod Specificiation File'
 
@@ -23,8 +23,8 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 
 ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", group="root") }}}'
 
-#template:
-#    name: file_groupowner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
-#        fileuid: '0'
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
+        filegid: '0'

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: ocp4-node
 
 title: 'Verify User Who Owns The Kube API Server Pod Specification File'
 
@@ -23,8 +23,8 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 
 ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", owner="root") }}}'
 
-#template:
-#    name: file_owner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
-#        fileuid: '0'
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
+        fileuid: '0'

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: ocp4-node
 
 title: 'Verify User Who Owns The Kube Controller Manager Pod Specificiation File'
 
@@ -23,8 +23,8 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 
 ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", owner="root") }}}'
 
-#template:
-#    name: file_owner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
-#        fileuid: '0'
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
+        fileuid: '0'

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: ocp4-node
 
 title: 'Verify Permissions on the Kube API Server Pod Specification File'
 
@@ -26,8 +26,8 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
 
-#template:
-#    name: file_permissions
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
-#        filemode: '0644'
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
+        filemode: '0644'

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: ocp4-node
 
 title: 'Verify Permissions on the Kube Controller Manager Pod Specificiation File'
 
@@ -26,8 +26,8 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}
 
-#template:
-#    name: file_permissions
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
-#        filemode: '0644'
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
+        filemode: '0644'

--- a/applications/openshift/master/group.yml
+++ b/applications/openshift/master/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: ocp4,ocp4-node
 
 title: 'OpenShift - Master Node Settings'
 

--- a/ocp4/product.yml
+++ b/ocp4/product.yml
@@ -1,4 +1,6 @@
 product: ocp4
+alternative_products:
+  - ocp4-node
 full_name: Red Hat OpenShift Container Platform 4
 type: platform
 


### PR DESCRIPTION
In the case of OCP, we have checks that will run by checking the Kube
API, and other checks will need OS access. We are separating these
checks in different profiles, since they'll run with different
permissions.

The ability to add a different platform to a profile merged recently
(https://github.com/ComplianceAsCode/content/pull/6124), however, taking this into use is currently not possible since
rules will only build for a benchmark's product.

This adds an optional field called "alternative_products" which
specifies that a benchmark can use rules from alternative products.