### PR TITLE
Fixes for the cis-node profile

### DIFF
--- a/applications/openshift/worker/file_owner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_service/rule.yml
@@ -4,10 +4,20 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift Node Service File'
 
-description: '{{{ describe_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+description: |-
+{{%- if product == "ocp4" %}}
+  '{{{ describe_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}'
+{{% else %}}
+  '{{{ describe_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+{{%- endif %}}
 
 rationale: |-
-    The <tt>/etc/systemd/system/atomic-openshift-node.service</tt> file contains information about the configuration of the
+{{%- if product == "ocp4" %}}
+    The <tt>/etc/systemd/system/kubelet.service</tt>
+{{% else %}}
+    The <tt>/etc/systemd/system/atomic-openshift-node.service</tt>
+{{%- endif %}}
+    file contains information about the configuration of the
     OpenShift node service that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
@@ -19,12 +29,31 @@ severity: medium
 references:
     cis: 4.1.2
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+ocil_clause: |-
+{{%- if product == "ocp4" %}}
+  '{{{ ocil_clause_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}'
+{{% else %}}
+  '{{{ ocil_clause_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+{{%- endif %}}
 
-ocil: '{{{ ocil_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+ocil:
+{{%- if product == "ocp4" %}}
+  '{{{ ocil_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}'
+{{% else %}}
+  '{{{ ocil_file_owner(file="/etc/systemd/system/atomic-openshift-node.service", owner="root") }}}'
+{{%- endif %}}
 
+
+{{%- if product == "ocp4" %}}
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/systemd/system/kubelet.service
+        fileuid: '0'
+{{% else %}}
 template:
     name: file_owner
     vars:
         filepath: /etc/systemd/system/atomic-openshift-node.service
         fileuid: '0'
+{{%- endif %}}

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -55,6 +55,7 @@ selections:
   #### 4.1 Worker Node Configuration Files
   # 4.1.1 Ensure that the kubelet service file permissions are set to 644 or more restrictive
   # 4.1.2 Ensure that the kubelet service file ownership is set to root:root
+    - file_owner_worker_service
   # 4.1.3 If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive
   # 4.1.4 If proxy kubeconfig file exists ensure ownership is set to root:root
   # 4.1.5 Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -2,6 +2,8 @@ documentation_complete: true
 
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
+platform: ocp4
+
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
     Red Hat OpenShift Container Platform 4 Benchmark™, V0.3, currently unreleased.

--- a/ocp4/profiles/e8.profile
+++ b/ocp4/profiles/e8.profile
@@ -8,6 +8,8 @@ reference: https://www.cyber.gov.au/acsc/view-all-content/publications/essential
 
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
+platform: ocp4
+
 description: |-
     This profile contains configuration checks for Red Hat OpenShift Container Platform
     that align to the Australian Cyber Security Centre (ACSC) Essential Eight.

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -10,6 +10,8 @@ reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
 
 title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift'
 
+platform: ocp4
+
 description: |-
     This compliance profile reflects the core set of Moderate-Impact Baseline
     configuration settings for deployment of Red Hat OpenShift Container

--- a/ocp4/profiles/ncp.profile
+++ b/ocp4/profiles/ncp.profile
@@ -6,6 +6,8 @@ metadata:
 
 title: 'NIST National Checklist for Red Hat OpenShift Container Platform'
 
+platform: ocp4
+
 description: |-
     This compliance profile reflects the core set of security
     related configuration settings for deployment of Red Hat OpenShift

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -213,6 +213,7 @@ PRODUCT_TO_CPE_MAPPING = {
     ],
     "ocp4": [
         "cpe:/a:redhat:openshift_container_platform:4.1",
+        "cpe:/o:redhat:openshift_container_platform_node:4",
     ],
     "ocp4-node": [
         "cpe:/o:redhat:openshift_container_platform_node:4",

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -121,6 +121,8 @@ PROFILE_TEMPLATE = ('''documentation_complete: true
 
 title: 'Test Profile for {RULE_NAME}'
 
+platform: ocp4
+
 description: Test Profile
 selections:
 - {RULE_NAME}


### PR DESCRIPTION
#### Description:

- The cis-node profile used to only check for the OCP4 kubernetes CPE which
  relies on fetching an object from OCP. Some checks are node-only though.

#### Rationale:

- Enabled OCP node checks. There is also one example rule, more to follow.