### PR TITLE
add mandatory packages to rhel8 ospp

### DIFF
--- a/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
@@ -25,6 +25,7 @@ references:
     cis@rhel7: 2.2.1.1
     cis@rhel8: 2.2.1.1
     ism: 0988,1405
+    ospp: package_audispd-plugins_installed
 
 {{{ complete_ocil_entry_package(package="chrony") }}}
 

--- a/linux_os/guide/system/auditing/package_audispd-plugins_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audispd-plugins_installed/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000342-GPOS-00133
+    ospp: FMT_SMF_EXT.1
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/software/system-tools/package_gnutls-utils_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gnutls-utils_installed/rule.yml
@@ -20,7 +20,7 @@ identifiers:
     cce@rhel8: CCE-82395-5
 
 references:
-    ospp: FMT_SMF_EXT.1
+    ospp: FIA_X509_EXT
     srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: 'the package is not installed'

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -191,6 +191,9 @@ selections:
     - package_policycoreutils-python-utils_installed
     - package_rsyslog_installed
     - package_rsyslog-gnutls_installed
+    - package_audispd-plugins_installed
+    - package_chrony_installed
+    - package_gnutls-utils_installed
 
     ### Remove Prohibited Packages
     - package_sendmail_removed

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -130,12 +130,15 @@ selections:
 - package_abrt-plugin-sosreport_removed
 - package_abrt_removed
 - package_aide_installed
+- package_audispd-plugins_installed
 - package_audit_installed
+- package_chrony_installed
 - package_crypto-policies_installed
 - package_dnf-automatic_installed
 - package_dnf-plugin-subscription-manager_installed
 - package_fapolicyd_installed
 - package_firewalld_installed
+- package_gnutls-utils_installed
 - package_gssproxy_removed
 - package_iprutils_removed
 - package_krb5-workstation_removed

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -21,6 +21,7 @@ description: 'This profile contains configuration checks that align to the
 
     - Red Hat Containers with a Red Hat Enterprise Linux 8 image'
 documentation_complete: true
+reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 selections:
 - account_disable_post_pw_expiration
 - account_temp_expire_date
@@ -150,11 +151,13 @@ selections:
 - package_aide_installed
 - package_audispd-plugins_installed
 - package_audit_installed
+- package_chrony_installed
 - package_crypto-policies_installed
 - package_dnf-automatic_installed
 - package_dnf-plugin-subscription-manager_installed
 - package_fapolicyd_installed
 - package_firewalld_installed
+- package_gnutls-utils_installed
 - package_gssproxy_removed
 - package_iprutils_removed
 - package_krb5-workstation_removed


### PR DESCRIPTION
#### Description:

- add rules to rhel8 ospp:

    - package_audispd-plugins_installed

    - package_gnutls-utils_installed

    - package_chrony_installed

- updated ospp references

#### Rationale:

CC 8.4 report