### PR TITLE
Make sure aide_build_database scenarios do not fail when database dosn't exist

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = aide
 
-# ensure aide is installed
-
 DB=/var/lib/aide/aide.db.gz
 
-rm -r $DB
+rm -rf $DB
 echo "not really a database" > $DB

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
@@ -3,4 +3,4 @@
 
 DB=/var/lib/aide/aide.db.gz
 
-rm -r $DB
+rm -rf $DB


### PR DESCRIPTION
#### Description:

- Fix test scenarios of `aide_build_database` rule to not fail in case aide database doesn't exist.