### PR TITLE
Fix rules so no there are no "missing extend_definition" warnings during the build

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhel7
+prodtype: fedora,ol7,rhel7
 
 title: 'Install Smart Card Packages For Multifactor Authentication'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="smartcard_auth" version="3">
     {{{ oval_metadata("Enable Smart Card logins") }}}
     <criteria comment="smart card authentication is configured" operator="AND">
-      <extend_definition comment="pam_pkcs11 package is installed" definition_ref="package_pam_pkcs11_installed" />
+      <extend_definition comment="packages needed for smartcard support are installed" definition_ref="install_smartcard_packages" />
       <extend_definition comment="pcscd service is enabled" definition_ref="service_pcscd_enabled" />
       <criteria operator="OR">
         <extend_definition comment="esc package is installed" definition_ref="package_esc_installed" />

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel6,rhel7,rhel8,rhv4
+prodtype: fedora,rhcos4,rhel6,rhel7,rhel8,rhv4
 
 title: 'Install the Host Intrusion Prevention System (HIPS) Module'
 


### PR DESCRIPTION
This PR addresses Fedora, RHEL7,8 and RHCOS4 products.

- The rule `install_smartcard_packages` has been renamed to `package_pam_pkcs11_installed`. The former rule didn't have an OVAL check associated, and the new ID reflect what the rule does more accurately. If this change is rejected, an alternative solution would be to fix references, and reference `install_smartcard_packages` rather than `package_pam_pkcs11_installed`.
- Prodtypes were added to pass the build without dropped OVALs on Fedora and CoreOS.

See also: #6185