### PR TITLE
fix typos in "references" section of RHEL7 rules

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
@@ -33,7 +33,7 @@ references:
     cis@rhel8: 3.2.1
     cui: 3.1.20
     disa: CCI-000366
-    nist: CM-7(a),CM-7(b),SC-5CM-6(a),SC-7(a)
+    nist: CM-7(a),CM-7(b),SC-5,CM-6(a),SC-7(a)
     nist-csf: DE.AE-1,DE.CM-1,ID.AM-3,PR.AC-5,PR.DS-4,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: RHEL-07-040610

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
@@ -31,7 +31,7 @@ references:
     cjis: 5.10.1.1
     cui: 3.1.20
     disa: CCI-000366
-    nist: CM-7(a),CM-7(b),SC-5CM-6(a),SC-7(a)
+    nist: CM-7(a),CM-7(b),SC-5,CM-6(a),SC-7(a)
     nist-csf: DE.AE-1,DE.CM-1,ID.AM-3,PR.AC-5,PR.DS-4,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: RHEL-07-040660

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
@@ -31,7 +31,7 @@ references:
     cjis: 5.10.1.1
     cui: 3.1.20
     disa: CCI-000366
-    nist: CM-7(a),CM-7(b),SC-5CM-6(a),SC-7(a)
+    nist: CM-7(a),CM-7(b),SC-5,CM-6(a),SC-7(a)
     nist-csf: DE.AE-1,DE.CM-1,ID.AM-3,PR.AC-5,PR.DS-4,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: RHEL-07-040650

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -27,7 +27,7 @@ references:
     cis@rhel8: 3.1.1.
     cui: 3.1.20
     disa: CCI-000366
-    nist: CM-7(a),CM-7(b),SC-5CM-6(a),SC-7(a)
+    nist: CM-7(a),CM-7(b),SC-5,CM-6(a),SC-7(a)
     nist-csf: DE.CM-1,PR.DS-4,PR.IP-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: RHEL-07-040740


### PR DESCRIPTION
#### Description:
- fix typos in "references" section of RHEL7 rules by adding commas.

#### Rationale:
- `SC-5CM-6(a)` is not a valid NIST SP 800 53 control ID, and `SC-5` and `CM-6(a)` are correct ones.
- No related issue exists.
