### PR TITLE
add service_kdump_disabled to rhel8 ospp

### DIFF
--- a/linux_os/guide/services/base/service_kdump_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_kdump_disabled/rule.yml
@@ -38,6 +38,7 @@ references:
     cobit5: APO13.01,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.05,DSS06.06
     iso27001-2013: A.11.2.6,A.12.1.2,A.12.5.1,A.12.6.2,A.13.1.1,A.13.2.1,A.14.1.3,A.14.2.2,A.14.2.3,A.14.2.4,A.6.2.1,A.6.2.2,A.9.1.2
     cis-csc: 11,12,14,15,3,8,9
+    ospp: FMT_SMF_EXT.1.1
 
 ocil: '{{{ ocil_service_disabled(service="kdump") }}}'
 

--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -147,6 +147,7 @@ selections:
     - sysctl_user_max_user_namespaces.severity=info
     - sysctl_kernel_unprivileged_bpf_disabled
     - sysctl_net_core_bpf_jit_harden
+    - service_kdump_disabled
 
     ## File System Settings
     - sysctl_fs_protected_hardlinks

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -171,6 +171,7 @@ selections:
 - service_debug-shell_disabled
 - service_fapolicyd_enabled
 - service_firewalld_enabled
+- service_kdump_disabled
 - service_systemd-coredump_disabled
 - service_usbguard_enabled
 - ssh_client_rekey_limit

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -191,6 +191,7 @@ selections:
 - service_debug-shell_disabled
 - service_fapolicyd_enabled
 - service_firewalld_enabled
+- service_kdump_disabled
 - service_systemd-coredump_disabled
 - service_usbguard_enabled
 - smartcard_configure_cert_checking


### PR DESCRIPTION
#### Description:

- add rule service_kdump_disabled to rhel8 ospp

#### Rationale:

rhel8 CC effort