### PR TITLE
remove package_tuned_removed from rhel8 ospp

### DIFF
--- a/rhel8/profiles/ospp.profile
+++ b/rhel8/profiles/ospp.profile
@@ -208,7 +208,6 @@ selections:
     - package_abrt-plugin-logger_removed
     - package_abrt-plugin-sosreport_removed
     - package_abrt-cli_removed
-    - package_tuned_removed
     - package_abrt_removed
 
     ### Login

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -155,7 +155,6 @@ selections:
 - package_subscription-manager_installed
 - package_sudo_installed
 - package_tmux_installed
-- package_tuned_removed
 - package_usbguard_installed
 - partition_for_home
 - partition_for_var

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -175,7 +175,6 @@ selections:
 - package_subscription-manager_installed
 - package_sudo_installed
 - package_tmux_installed
-- package_tuned_removed
 - package_usbguard_installed
 - partition_for_home
 - partition_for_var


### PR DESCRIPTION
#### Description:

- remove the rule from rhel8 ospp profile

#### Rationale:

- rhel8 CC effort