### PR TITLE
Add api_server_auth_mode_node rule to ocp4/cis profile

### DIFF
--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -1,0 +1,38 @@
+prodtype: ocp4
+
+title: Must have authorization-mode Node set
+
+description: 'Restrict kubelet nodes to reading only objects associated with them.'
+
+rationale: |-
+  The Node authorization mode only allows kubelets to read Secret,
+  ConfigMap, PersistentVolume, and PersistentVolumeClaim objects
+  associated with their nodes.
+
+severity: medium
+
+references:
+    cis: 1.2.8
+
+ocil_clause: 'The Node authorization-mode is configured and enabled on the master node'
+
+ocil: |-
+    Run the following command on the master node(s):
+    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | grep '"authorization-mode":\[[^]]*"Node"'</pre>
+    The output should show that the "authorization-mode" list contains the "Node" authorizer.
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"authorization-mode":\[[^]]*"Node"'
+      operation: "pattern match"
+      type: "string"

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -32,6 +32,7 @@ selections:
     - api_server_kubelet_certificate_authority
   # 1.2.7 Ensure that the --authorization-mode argument is not set to AlwaysAllow 
   # 1.2.8 Ensure that the --authorization-mode argument includes Node
+    - api_server_auth_mode_node
   # 1.2.9 Ensure that the --authorization-mode argument includes RBAC
     - api_server_authorization_mode
   # 1.2.10 Ensure that the admission control plugin EventRateLimit is set


### PR DESCRIPTION
This rule checks that the authorization-mode is set to Node in the
api-server.