### PR TITLE
Add OCP4 1.3.5 benchmark

### DIFF
--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -35,3 +35,20 @@ ocil: |-
     run the following command:
     <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["root-ca-file"]'</pre>
     The output should return a configured certificate authority file.
+
+{{%- if product == "ocp4" %}}
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+{{%- endif %}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '\"root-ca-file\":\[\"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"\]'
+      operation: "pattern match"
+      type: "string"


### PR DESCRIPTION
The OCP4 1.3.5 benchmark checks that the controller is properly
configured with a certificate, which is necessary for TLS connections to
the API server.

This commit adds a check to ensure --root-ca-file is configured,
fulfilling the 1.3.5 benchmark.

#### Description:

Add a check to ensure API server is configured to use TLS.

#### Rationale:

This compliance benchmark ensures the API server has the necessary certificate bundle to deploy TLS.
