### PR TITLE
Add an automated check for OCP4 benchmark 1.3.5

### DIFF
--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -35,3 +35,20 @@ ocil: |-
     run the following command:
     <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["root-ca-file"]'</pre>
     The output should return a configured certificate authority file.
+
+{{%- if product == "ocp4" %}}
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+{{%- endif %}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '\"root-ca-file\":\[\"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"\]'
+      operation: "pattern match"
+      type: "string"


### PR DESCRIPTION
Benchmark 1.3.5 ensure the API server is configured to use TLS. This
commit automates the check.

#### Description:

- Add an automated check for benchmark 1.3.5

#### Rationale:

- This benchmark ensures the API server is configured to use TLS.
