### PR TITLE
drop inconsistently supported 'required' flag from argparse add_subpa…

### DIFF
--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -336,7 +336,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=textwrap.dedent(PROG_DESC))
     subparser = parser.add_subparsers(
-        dest='subcommand', title='subcommands', help='pick one', required=True)
+        dest='subcommand', title='subcommands', help='pick one')
     create_parser = subparser.add_parser(
         'create', help='Bootstrap the XML and YML files under %s for a new check.' % PLATFORM_RULE_DIR)
     create_parser.add_argument(


### PR DESCRIPTION

#### Description:

- Enable compatibility with default argparser in stock python3 pkg.

#### Rationale:

- Makes utils more useful in default environments
- Fixes #6205
