### PR TITLE
ocp4: fix api_server_admission_control_plugin_ServiceAccount rule

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -7,7 +7,12 @@ title: 'Enable the ServiceAccount Admission Control Plugin'
 description: |-
     To ensure <tt>ServiceAccount</tt> objects must be created and granted
     before pod creation is allowed, follow the documentation and create
-    <tt>ServiceAccount</tt> objects as per your environment. Then, edit the
+    <tt>ServiceAccount</tt> objects as per your environment.
+{{%- if product == "ocp4" %}}
+    Ensure that the plugin is enabled in the api-server configuration:
+    <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data."config.yaml"' | jq '.apiServerArguments."enable-admission-plugins"'</pre>
+{{% else %}}
+    Then, edit the
     API Server pod specification file
     <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
     set the <tt>admissionConfig</tt> to include <tt>ServiceAccount</tt>:
@@ -18,6 +23,7 @@ description: |-
           kind: DefaultAdmissionConfig
           apiVersion: v1
           disable: false</pre>
+{{%- endif %}}
 
 rationale: |-
     When a pod is created, if a service account is not specified, the pod
@@ -30,9 +36,33 @@ severity: medium
 references:
     cis: 1.2.14
 
-ocil_clause: '<tt>admissionConfig</tt> does not contain <tt>ServiceAccount</tt>'
+ocil_clause: '<tt>admissionConfig</tt> contains <tt>ServiceAccount</tt>'
 
 ocil: |-
+{{%- if product == "ocp4" %}}
+    The ServiceAccount plugin should be enabled in the list of enabled plugins in
+    the apiserver configuration:
+    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | grep 'ServiceAccount'</pre>
+{{% else %}}
     Run the following command on the master node(s):
     <pre>$ sudo grep -A4 ServiceAccount /etc/origin/master/master-config.yaml</pre>
     The output should return <pre>disable: false</pre>.
+{{%- endif %}}
+
+{{%- if product == "ocp4" %}}
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+{{%- endif %}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"enable-admission-plugins":\[[^]]*"ServiceAccount"'
+      operation: "pattern match"
+      type: "string"


### PR DESCRIPTION
This now takes into account the appropriate configmap that applies to
ocp4