### PR TITLE
ocp4: Add api_server_admission_control_plugin_NamespaceLifecycle rule

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -5,6 +5,9 @@ prodtype: ocp3,ocp4
 title: 'Enable the NamespaceLifecyle Admission Control Plugin'
 
 description: |-
+{{%- if product == "ocp4" %}}
+    OpenShift enables the <tt>NamespaceLifecycle</tt> plugin by default.
+{{% else %}}
     To enable <tt>NamespaceLifecycle</tt>, edit the API Server pod specification
     file <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
     and set the <tt>admissionConfig</tt> to include <tt>NamespaceLifecyle</tt>:
@@ -15,6 +18,7 @@ description: |-
           kind: DefaultAdmissionConfig
           apiVersion: v1
           disable: false</pre>
+{{%- endif %}}
 
 rationale: |-
     Setting admission control policy to <tt>NamespaceLifecycle</tt> ensures that
@@ -31,6 +35,30 @@ references:
 ocil_clause: '<tt>admissionConfig</tt> does not contain <tt>NamespaceLifecycle</tt>'
 
 ocil: |-
+{{%- if product == "ocp4" %}}
+    The ServiceAccount plugin should be enabled in the list of enabled plugins in
+    the apiserver configuration:
+    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | grep 'NamespaceLifecycle'</pre>
+{{% else %}}
     Run the following command on the master node(s):
     <pre>$ sudo grep -A4 NamespaceLifecycle /etc/origin/master/master-config.yaml</pre>
     The output should return <pre>disable: false</pre>.
+{{%- endif %}}
+
+{{%- if product == "ocp4" %}}
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+{{%- endif %}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"enable-admission-plugins":\[[^]]*"NamespaceLifecycle"'
+      operation: "pattern match"
+      type: "string"


### PR DESCRIPTION
This rule didn't work in ocp4. Now it does!