### PR TITLE
Add OCP4 1.3.7 Benchmark

### DIFF
--- a/applications/openshift/controller/controller_bind_address/rule.yml
+++ b/applications/openshift/controller/controller_bind_address/rule.yml
@@ -60,8 +60,25 @@ ocil: |-
 references:
     cis: 1.3.7
 
+{{%- if product == "ocp4" %}}
 warnings:
-  - functionality: |-
-      The associated value must be reachable by the rest of the cluster, and by
-      CLI/web clients. If blank all interfaces will be used (<tt>0.0.0.0</tt> for IPv4
-      and ``::`` for IPv6).
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+{{% else %}}
+warnings:
+- functionality: |-
+    The associated value must be reachable by the rest of the cluster, and by
+    CLI/web clients. If blank all interfaces will be used (<tt>0.0.0.0</tt> for IPv4
+    and ``::`` for IPv6).
+{{%- endif %}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '(\"port\":\[\"0\"\]).*(\"secure-port\":\[\"10257\"\])'
+      operation: "pattern match"
+      type: "string"


### PR DESCRIPTION
This benchmark checks that the API server is running with a secure port.

#### Description:

- This benchmark checks that the API server is running with a secure port.

#### Rationale:

- Ensure OCP is run on a secure port

