### PR TITLE
Add key escaping for yamlfile_value macro, fix keys

### DIFF
--- a/shared/templates/template_OVAL_yamlfile_value
+++ b/shared/templates/template_OVAL_yamlfile_value
@@ -3,8 +3,8 @@
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{% call oval_metadata("In the YAML/JSON file '" + FILEPATH + "' at path '" + YAMLPATH + "' " + (ENTITY_CHECK if ENTITY_CHECK else "all") + ": ") %}}
       {{%- for val in VALUES -%}}
-        {{{- "key '" + key + "' " if key in val else "" }}}value{{{ (" of type '" + val.type + "' ") if type in val else " " }}}
-          {{{- val.operation if operation in val else "equals" }}} '{{{ val.value }}}'{{% if not loop.last %}} and{{% endif %}}
+        {{{- "key '" + val.key + "' " if val.key is defined else "" }}}value{{{ (" of type '" + val.type + "' ") if type in val else " " }}}
+          {{{- val.operation if operation in val else "equals" }}} '{{{ val.value }}}'{{% if not loop.last %}} and {{% endif %}}
       {{%- endfor -%}}
     {{%- endcall -%}}
     <criteria>
@@ -26,7 +26,7 @@
       {{% endif %}}
   </local_variable>
 
-  <ind:yamlfilecontent_test id="test_{{{ rule_id }}}" check="all" check_existence="{{{ CHECK_EXISTENCE|default("only_one_exists") }}}" 
+  <ind:yamlfilecontent_test id="test_{{{ rule_id }}}" check="all" check_existence="{{{ CHECK_EXISTENCE|default("only_one_exists") }}}"
     {{{ {'comment': "In the file '" + FILEPATH + "' find only one object at path '" + YAMLPATH + "'."}|xmlattr }}} version="1">
     <ind:object object_ref="object_{{{ rule_id }}}"/>
     <ind:state state_ref="state_{{{ rule_id }}}"/>
@@ -51,7 +51,7 @@
   <ind:yamlfilecontent_state id="state_{{{ rule_id }}}" version="1">
     <ind:value datatype="record"{{% if ENTITY_CHECK %}} entity_check="{{{ ENTITY_CHECK }}}"{{% endif %}}>
       {{% for val in VALUES %}}
-      <field {{{ {'name': key if key in val else "#", 'datatype': val.type,  'operation':  val.operation}|xmlattr }}}>{{{ val.value }}}</field>
+      <field {{{ {'name': val.key|default("#")|escape_yaml_key, 'datatype': val.type,  'operation':  val.operation}|xmlattr }}}>{{{ val.value }}}</field>
       {{% endfor %}}
     </ind:value>
   </ind:yamlfilecontent_state>

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -25,7 +25,8 @@ from .utils import (required_key,
                     banner_regexify,
                     banner_anchor_wrap,
                     escape_id,
-                    escape_regex
+                    escape_regex,
+                    escape_yaml_key
                     )
 
 
@@ -91,6 +92,7 @@ def _get_jinja_environment(substitutions_dict):
         _get_jinja_environment.env.filters['banner_anchor_wrap'] = banner_anchor_wrap
         _get_jinja_environment.env.filters['escape_regex'] = escape_regex
         _get_jinja_environment.env.filters['escape_id'] = escape_id
+        _get_jinja_environment.env.filters['escape_yaml_key'] = escape_yaml_key
 
     return _get_jinja_environment.env
 

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -267,6 +267,14 @@ def escape_id(text):
     return re.sub(r"[^\w]+", "_", text).strip("_")
 
 
+def escape_yaml_key(text):
+    # Due to the limitation of OVAL's name argument of the filed type
+    # we have to avoid using uppercase letters for keys. The probe would escape
+    # them with '^' symbol.
+    # myCamelCase^Key -> my^camel^case^^^key
+    return re.sub(r'([A-Z^])', '^\\1', text).lower()
+
+
 def banner_regexify(banner_text):
     return escape_regex(banner_text) \
         .replace("\n", "BFLMPSVZ") \


### PR DESCRIPTION
Cherry-picked fixes from #6215, automatic escaping of field names.