### PR TITLE
fix remediation of audit_rules_privileged_commands

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -4,14 +4,57 @@
 # complexity = low
 # disruption = low
 
-- name: Search for privileged commands
-  shell: find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null
-  args:
-    warn: False
-    executable: /bin/bash
-  check_mode: no
-  register: find_result
-  changed_when: false
+- name: "Configure excluded (non local) file systems"
+  set_fact:
+    excluded_fstypes:
+      - afs
+      - ceph
+      - cifs
+      - smb3
+      - smbfs
+      - sshfs
+      - ncpfs
+      - ncp
+      - nfs
+      - nfs4
+      - gfs
+      - gfs2
+      - glusterfs
+      - gpfs
+      - pvfs2
+      - ocfs2
+      - lustre
+      - davfs
+      - fuse.sshfs
+
+- name: "Create empty list of excluded paths"
+  set_fact:
+    excluded_paths: []
+
+- name: "Create empty list of suid / sgid binaries"
+  set_fact:
+    suid_sgid_binaries: []
+
+- name: "Detect nonlocal file systems and add them to excluded paths"
+  set_fact: 
+    excluded_paths: "{{ excluded_paths | union([item.mount]) }}"
+  loop: "{{ ansible_mounts }}"
+  when: item.fstype in excluded_fstypes
+
+- name: "Find all files excluding non-local partitions"
+  find:
+    paths: "/"
+    excludes: excluded_paths
+    file_type: file
+    hidden: yes
+    recurse: yes
+  register: found_files
+
+- name: "construct list of suid or sgid binaries"
+  set_fact:
+    suid_sgid_binaries: "{{ suid_sgid_binaries | union([item.path]) }}"
+  when: item.mode is match("2.*")
+  loop: '{{ found_files.files }}'
 
 # Inserts/replaces the rule in /etc/audit/rules.d
 
@@ -21,8 +64,7 @@
     recurse: no
     contains: "^.*path={{ item }} .*$"
     patterns: "*.rules"
-  with_items:
-    - "{{ find_result.stdout_lines }}"
+  loop: "{{ suid_sgid_binaries }}"
   register: files_result
 
 - name: Overwrites the rule in rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 
 - name: Search for privileged commands
-  shell: find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null
+  shell: find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null
   args:
     warn: False
     executable: /bin/bash

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -53,7 +53,7 @@
 - name: "construct list of suid or sgid binaries"
   set_fact:
     suid_sgid_binaries: "{{ suid_sgid_binaries | union([item.path]) }}"
-  when: item.mode is match("2.*")
+  when: item.mode is match("2.*") or item.mode is match("4.*")
   loop: '{{ found_files.files }}'
 
 # Inserts/replaces the rule in /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -3,6 +3,6 @@
 AUID=$1
 KEY=$2
 RULEPATH=$3
-for file in $(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null); do
+for file in $(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null); do
      echo "-a always,exit -F path=$file -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -3,6 +3,6 @@
 AUID=$1
 KEY=$2
 RULEPATH=$3
-for file in $(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null); do
+for file in $(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null); do
      echo "-a always,exit -F path=$file -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
 done

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -57,7 +57,7 @@ fi
 # Obtain the list of SUID/SGID binaries on the particular system (split by newline)
 # into privileged_binaries array
 privileged_binaries=()
-readarray -t privileged_binaries < <(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null)
+readarray -t privileged_binaries < <(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null)
 
 # Keep list of SUID/SGID binaries that have been already handled within some previous iteration
 declare -a sbinaries_to_skip=()

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -57,7 +57,7 @@ fi
 # Obtain the list of SUID/SGID binaries on the particular system (split by newline)
 # into privileged_binaries array
 privileged_binaries=()
-readarray -t privileged_binaries < <(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null)
+readarray -t privileged_binaries < <(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null)
 
 # Keep list of SUID/SGID binaries that have been already handled within some previous iteration
 declare -a sbinaries_to_skip=()


### PR DESCRIPTION
#### Description:

- change command which searches for suid and sgid binaries to ignore remote file systems. The list of file systems is the same as in Openscap (https://github.com/OpenSCAP/openscap/blob/58415789b5a2dd48c0cb0b7cff0fc1dbcb26b4ab/src/OVAL/probes/fsdev.c#L109)

- this is fixed in Bash and Ansible remediations and in tests.

#### Rationale:

- up to now, the command which searched for privileged binaries started in the root file system and did not traverse any other file systems. But there might be setups where for example the /usr folder is on a different file system. In this cases the remediation would not work properly.

- This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1886037