### PR TITLE
rpm_verify_permissions - update shared.sh to handle files managed by more the one RPM and use --restore rather then --setperms

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/bash/shared.sh
@@ -13,14 +13,18 @@ readarray -t FILES_WITH_INCORRECT_PERMS < <(rpm -Va --nofiledigest | awk '{ if (
 
 for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
 do
-	RPM_PACKAGE=$(rpm -qf "$FILE_PATH")
-	# Use an associative array to store packages as it's keys, not having to care about duplicates.
-	SETPERMS_RPM_DICT["$RPM_PACKAGE"]=1
+        # NOTE: some files maybe controlled by more then one package
+        readarray -t RPM_PACKAGES < <(rpm -qf "${FILE_PATH}")
+        for RPM_PACKAGE in "${RPM_PACKAGES[@]}"
+        do
+                # Use an associative array to store packages as it's keys, not having to care about duplicates.
+                SETPERMS_RPM_DICT["$RPM_PACKAGE"]=1
+        done
 done
 
 # For each of the RPM packages left in the list -- reset its permissions to the
 # correct values
 for RPM_PACKAGE in "${!SETPERMS_RPM_DICT[@]}"
 do
-	rpm --setperms "${RPM_PACKAGE}"
+	rpm --restore "${RPM_PACKAGE}"
 done


### PR DESCRIPTION
#### Description:

If a file, like /var/log/lastlog, is managed by more then one RPM the current script can't handle it.
Also, the man pages for rpm suggest using `--restore` rather then `--setperms` to fix not just perms but ownership.

#### Rationale:

* fixes a bug
* better remediates issues
