### PR TITLE
ocp4: Add checkf or CIS 1.2.18

### DIFF
--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -45,8 +45,24 @@ ocil: |-
     Run the following command on the master node(s):
 {{%- if product == "ocp4" %}}
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["insecure-bind-address"]'</pre>
-    The output should return <pre>false</pre>.
+    The output should return <pre>null</pre>.
 {{% else %}}
     <pre>$ sudo grep -A2 insecure-bind-address /etc/origin/master/master-config.yaml</pre>
 {{%- endif %}}
     No output should be returned.
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "none exist"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: 'insecure-bind-address'
+      operation: "pattern match"
+      type: "string"


### PR DESCRIPTION
This was missing the template and warning for it to be checked by the
compliance-operator.