### PR TITLE
Add --key-file check for OCP4 CIS 2.1 benchmark

### DIFF
--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -33,3 +33,19 @@ ocil: |-
     Run the following command on the master node(s):
     <pre>$ grep ETCD_KEY_FILE=/etc/etcd/etcd.conf</pre>
     Verify that there is a key file configured.
+
+{{%- if product == "ocp4" %}}
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+{{%- endif %}}
+
+template:
+    name: yamlfile_value
+    vars:
+        ocp_data: "true"
+        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
+        yamlpath: ".data['pod.yaml']"
+        values:
+          - value: ".*--key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key\\.*"
+            operation: "pattern match"


### PR DESCRIPTION
This commit ensures the `--key-file` necessary for TLS communication to
etcd is configured properly.

This check only confirms the configuration via the config map object.
Additional validation of each component would make this check more
robust.
