### PR TITLE
ocp4: Add check for CIS 1.2.19

### DIFF
--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -11,7 +11,7 @@ description: |-
     has not been enabled, the <tt>insecure-port</tt> setting should not exist
 {{%- if product == "ocp4" %}}
     Edit the <tt>openshift-kube-apiserver</tt> configmap on the master node(s)
-    and remove the <tt>insecure-bind-address</tt> if it exists:
+    and remove the <tt>insecure-port</tt> if it exists:
     <pre>
     "apiServerArguments":{
       ...
@@ -42,8 +42,27 @@ ocil: |-
     Run the following command on the master node(s):
 {{%- if product == "ocp4" %}}
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["insecure-port"]'</pre>
-    The output should return <pre>false</pre>.
+    The output should return <pre>0</pre>.
 {{% else %}}
     <pre>$ sudo grep -A2 insecure-port /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     There should be no output returned.
+{{%- endif %}}
+
+{{%- if product == "ocp4" %}}
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+{{%- endif %}}
+
+# This will check that insecure-port is "0" or 0.
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "all"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"insecure-port":\[["?]0["?]\]'
+      operation: "pattern match"
+      type: "string"


### PR DESCRIPTION
This checks that the insecure-port option is set to 0 or "0" on the
apiserver configuration.