### PR TITLE
ocp4/e2e - WORKAROUND: Use suffix to detect scan type

### DIFF
--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -200,6 +200,12 @@ func (ctx *e2econtext) getScanType() (cmpv1alpha1.ComplianceScanType, error) {
 		return "", fmt.Errorf("Can't read product definition: %s", err)
 	}
 
+	// FIXME(jaosorior): We should ditch this in favor of using
+	// scansettingbindings.
+	if strings.HasSuffix(ctx.Profile, "-node") {
+		return cmpv1alpha1.ScanTypeNode, nil
+	}
+
 	if strings.HasSuffix(profileInfo.BenchmarkRoot, "applications") {
 		return cmpv1alpha1.ScanTypePlatform, nil
 	}


### PR DESCRIPTION
The e2e tests were written before we had scansettingbinding objects
created. Hence, it uses the benchmark directory to determine the scan
type.

This takes into account the "-node" suffix to determine if it's a node
or a platform scan. This way, we can make the cis-node profile work.

In the long run, we should rewrite the tests to stop using
ComplianceSuites directly and use ScanSettingBindings instead.