### PR TITLE
ocp4: Add check for CIS 1.2.20

### DIFF
--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: Ensure that the bindAddress is set to a relevant secure port
+
+description: "The bindAddress is set by default to <tt>0.0.0.0:6443</tt>, and listening with TLS enabled."
+
+rationale: |-
+  The OpenShift API server is served over HTTPS with authentication and authorization;
+  the secure API endpoint is bound to <tt>0.0.0.0:6443</tt> by default. In OpenShift, the only
+  supported way to access the API server pod is through the load balancer and then through
+  the internal service.  The value is set by the bindAddress argument under the servingInfo
+  parameter.
+
+identifiers: {}
+
+severity: low
+
+references:
+    cis: 1.2.20
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "all"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"servingInfo":{.*"bindAddress":"0.0.0.0:6443"'
+      operation: "pattern match"
+      type: "string"

--- a/applications/openshift/api-server/api_server_secure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_secure_port/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp3,ocp4
+prodtype: ocp3
 
 title: 'Enable the Secure Port for the API Server'
 
@@ -9,16 +9,6 @@ description: |-
     edit the <tt>openshift-kube-apiserver</tt> configmap on the master node(s)
     and either remove the <tt>secure-port</tt>  or set it to a different
     (non-zero) desired port.
-{{%- if product == "ocp4" %}}
-    <pre>
-    "apiServerArguments":{
-      ...
-      "secure-port":[
-        "8443"
-      ],
-      ...
-    </pre>
-{{% else %}}
     edit the API Server pod specification
     file <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s)
     and either remove the <tt>secure-port</tt>  or set it to a different
@@ -27,7 +17,6 @@ description: |-
       apiServerArguments:
         secure-port:
         - 8443</pre>
-{{%- endif %}}
 
 rationale: |-
     The secure port is used to serve HTTPS with authentication and authorization.
@@ -43,9 +32,5 @@ ocil_clause: '<tt>secure-port</tt> is set with a value greater than <tt>0</tt>'
 
 ocil: |-
     Run the following command on the master node(s):
-{{%- if product == "ocp4" %}}
-    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["secure-port"]'</pre>
-{{% else %}}
     <pre>$ sudo grep -A2 secure-port /etc/origin/master/master-config.yaml</pre>
-{{%- endif %}}
     The output should not return <pre>0</pre>.

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -55,7 +55,7 @@ selections:
   # 1.2.19 Ensure that the --insecure-port argument is set to 0
     - api_server_insecure_port
   # 1.2.20 Ensure that the --secure-port argument is not set to 0
-    - api_server_secure_port
+    - api_server_bind_address
   # 1.2.21 Ensure that the --profiling argument is set to false
     - api_server_profiling
   # 1.2.22 Ensure that the --audit-log-path argument is set


### PR DESCRIPTION
This checks that the bindAddress parameter is correctly set to the
expected default.

The check that was verifying the secure-port address is no longer
applicable since that parameter is not set, in favor of setting the
complete address.