### PR TITLE
Cis 5.2.7

### DIFF
--- a/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
+++ b/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
@@ -43,10 +43,11 @@ template:
     vars:
         ocp_data: "true"
         filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['requiredDropCapabilities']"
+        yamlpath: ".items[:]['requiredDropCapabilities','#'][:]"
         check_existence: "at_least_one_exists"
         entity_check: "at least one"
         values:
-          - type: "string"
-            value: "NET_RAW"
-            value: "ALL"
+          - key: "requiredDropCapabilities"
+            value: "^NET_RAW|ALL$"
+            entity_check: "at least one"
+            operation: "pattern match"

--- a/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
+++ b/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
@@ -27,7 +27,26 @@ ocil_clause: 'NET_RAW does not exist or is configured in defaultAddCapabilities 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that <tt>NET_RAW</tt> is either
+    Review each SCC and determine that either <tt>NET_RAW</tt> or <tt>ALL</tt> is either
     completely disabled as a list entry under <tt>requiredDropCapabilities</tt>,
-    or that <tt>NET_RAW</tt> is only enabled to a small set of
+    or that either <tt>NET_RAW</tt> or <tt>ALL</tt> is only enabled to a small set of
     containers and SCCs.
+
+{{%- if product == "ocp4" %}}
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
+{{%- endif %}}
+
+template:
+    name: yamlfile_value
+    vars:
+        ocp_data: "true"
+        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+        yamlpath: ".items[:]['requiredDropCapabilities']"
+        check_existence: "at_least_one_exists"
+        entity_check: "at least one"
+        values:
+          - type: "string"
+            value: "NET_RAW"
+            value: "ALL"


### PR DESCRIPTION
#### Description:

- Add template to scc_limit_net_raw_capability to check if NET_RAW or ALL are dropped in at least one SCC

#### Rationale:

- Critical to drop dangerous capabilities

NOTE: We aren't yet compliant with this.

@redhatrises @jhrozek @yuumasato PTAL