### PR TITLE
1.2.31 add client-ca-file api server arg check for ocp4

### DIFF
--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -44,15 +44,40 @@ references:
 identifiers:
     cce@ocp3: CCE-81152-1
 
-ocil_clause: '<tt>clientCA</tt> is not set as appropriate for <tt>servingInfo</tt>'
+ocil_clause: >
+{{%- if product == "ocp4" %}}
+    '<tt>client-ca-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
+{{% else %}}
+    '<tt>clientCA</tt> is not set as appropriate for <tt>servingInfo</tt>'
+{{%- endif %}}
 
 ocil: |-
     Run the following command on the master node(s):
 {{%- if product == "ocp4" %}}
-    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.servingInfo["clientCA"]'</pre>
+    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["client-ca-file"]'</pre>
     The output should return a configured TLS CA certificate file.
 {{% else %}}
     <pre>$ sudo grep clientCA /etc/origin/master/master-config.yaml</pre>
     The output should contain something similar to:
     <pre>clientCA: ca.crt</pre>
+{{%- endif %}}
+
+{{%- if product == "ocp4" %}}
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+{{%- endif %}}
+
+{{%- if product == "ocp4" %}}
+template:
+    name: yamlfile_value
+    vars:
+        ocp_data: "true"
+        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        yamlpath: '.data["config.yaml"]'
+        entity_check: "all"
+        values:
+            - value: '.apiServerArguments.*"client-ca-file":\["/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt"\]'
+              operation: "pattern match"
+              type: "string"
 {{%- endif %}}

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -10,12 +10,14 @@ description: |-
     <tt>clientCA</tt> must be configured. Verify
     that <tt>servingInfo</tt> has the <tt>clientCA</tt> configured in
 {{%- if product == "ocp4" %}}
-    the <tt>openshift-kube-apiserver</tt> configmap on the master
+    the <tt>openshift-kube-apiserver</tt> <tt>config</tt> configmap on the master
     node(s) to something similar to:
     <pre>
-    "servingInfo":{
+    "apiServerArguments": {
       ...
-      "clientCA":"/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt",
+        "client-ca-file": [
+          "/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt"
+        ],
       ...
     </pre>
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Add test for api server arg contains proper value for client-ca-file on OCP 4

#### Rationale:

- Ensure proper value is defined for location of client CA certificate

**Note:** _Existence of file is not validated._