### PR TITLE
Anaconda moved to pykickstart

### DIFF
--- a/rhel6/kickstart/ssg-rhel6-pci-dss-with-gui-ks.cfg
+++ b/rhel6/kickstart/ssg-rhel6-pci-dss-with-gui-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2015-04-11
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
@@ -55,7 +55,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -79,7 +79,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel6/kickstart/ssg-rhel6-stig-ks.cfg
+++ b/rhel6/kickstart/ssg-rhel6-stig-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2015-04-08
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 #
@@ -58,7 +58,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -82,7 +82,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 
@@ -91,7 +91,7 @@ zerombr
 
 # The following partition layout scheme assumes disk of size 20GB or larger
 # Modify size of partitions appropriately to reflect actual machine's hardware
-# 
+#
 # Remove Linux partitions from the system prior to creating new ones (optional)
 # --linux	erase all Linux partitions
 # --initlabel	initialize the disk label to the default based on the underlying architecture

--- a/rhel6/kickstart/ssg-rhel6-usgcb-server-with-gui-ks.cfg
+++ b/rhel6/kickstart/ssg-rhel6-usgcb-server-with-gui-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2014-10-23
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
@@ -48,7 +48,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -72,7 +72,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel7/kickstart/ssg-rhel7-cis-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-cis-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2020-03-30
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 
 # Install a fresh new system (optional)
@@ -57,7 +57,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -86,7 +86,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel7/kickstart/ssg-rhel7-e8-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-e8-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2019-11-13
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 
 # Install a fresh new system (optional)
@@ -57,7 +57,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -86,7 +86,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel7/kickstart/ssg-rhel7-hipaa-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-hipaa-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2020-05-25
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 
 # Install a fresh new system (optional)
@@ -57,7 +57,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -86,7 +86,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2015-11-19
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
@@ -58,7 +58,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -87,7 +87,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-pci-dss-server-with-gui-oaa-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2015-08-02
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
@@ -53,7 +53,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -77,7 +77,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2020-03-30
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
 
 # Install a fresh new system (optional)
@@ -57,7 +57,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -86,7 +86,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
@@ -1,7 +1,7 @@
 # SCAP Security Guide CUI profile kickstart for Red Hat Enterprise Linux 8
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
 # Install a fresh new system (optional)

--- a/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2019-11-13
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
 
 # Install a fresh new system (optional)
@@ -57,7 +57,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -86,7 +86,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
@@ -3,7 +3,7 @@
 # Date: 2020-05-25
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
 
 # Install a fresh new system (optional)
@@ -57,7 +57,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 
@@ -86,7 +86,7 @@ timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
 # Plaintext password is: password
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$rhel6usgcb$kOzIfC4zLbuo3ECp1er99NRYikN419wxYMmons8Vm/37Qtg0T8aB9dKxHwqapz8wWAFuVkuI/UJqQBU92bA5C0
 

--- a/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
@@ -1,7 +1,7 @@
 # SCAP Security Guide OSPP profile kickstart for Red Hat Enterprise Linux 8
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
 # Install a fresh new system (optional)

--- a/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
@@ -1,7 +1,7 @@
 # SCAP Security Guide PCI-DSS profile kickstart for Red Hat Enterprise Linux 8
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
 # Install a fresh new system (optional)

--- a/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
@@ -1,7 +1,7 @@
 # SCAP Security Guide STIG profile kickstart for Red Hat Enterprise Linux 8
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
 # Install a fresh new system (optional)

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -6,7 +6,7 @@
 # - Fedora
 #
 # Based on:
-# http://fedoraproject.org/wiki/Anaconda/Kickstart
+# https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
@@ -34,7 +34,7 @@ network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)
 # Plaintext password is: server
-# Refer to e.g. http://fedoraproject.org/wiki/Anaconda/Kickstart#rootpw to see how to create
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
 rootpw --iscrypted $6$rhel6usgcb$aS6oPGXcPKp3OtFArSrhRwu6sN8q2.yEGY7AIwDOQd23YCtiz9c5mXbid1BzX9bmXTEZi.hCzTEXFosVBI5ng0
 


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

#### Description:

http://fedoraproject.org/wiki/Anaconda/Kickstart has moved to https://pykickstart.readthedocs.io/en/latest/

#### Rationale:

- Closes https://github.com/ComplianceAsCode/content/issues/6254
