### PR TITLE
ocp4: Add --datastream-only flag to helpers

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -7,7 +7,7 @@ COPY . .
 
 RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 
-RUN ./build_product --debug ocp4 rhel7 rhcos4
+RUN ./build_product --datastream-only --debug ocp4 rhel7 rhcos4
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /

--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -3,7 +3,7 @@ FROM fedora:latest as builder
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content
 WORKDIR /content
-RUN ./build_product --debug ocp4 rhel7 rhcos4
+RUN ./build_product --datastream-only --debug ocp4 rhel7 rhcos4
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -313,7 +313,7 @@ def testFunc(args):
 
     if not args.skip_build:
         createTestProfile(args.rule)
-        ret_code, out = subprocess.getstatusoutput('./build_product ocp4')
+        ret_code, out = subprocess.getstatusoutput('./build_product --datastream-only ocp4')
         if ret_code != 0:
             print('build failed: %s' % out)
             return 1

--- a/utils/build_ds_container.sh
+++ b/utils/build_ds_container.sh
@@ -16,7 +16,7 @@ print_usage() {
     exit 0
 }
 
-parms=()
+parms=(--datastream-only)
 
 # Build container in specified namespace. Else default to
 # "openshift-compliance"


### PR DESCRIPTION
This flag allows us to build the content faster. So let's take it into
use.