### PR TITLE
Swap OCP4 CIS 5.2.8 and 5.2.9 rules

### DIFF
--- a/applications/openshift/scc/scc_drop_container_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_drop_container_capabilities/rule.yml
@@ -2,13 +2,14 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Limit Container Capabilities'
+title: 'Drop Container Capabilities'
 
 description: |-
     Containers should not enable more capabilites than needed as this
-    opens the door for malicious use. To enable only the
-    required capabilities, the appropriate Security Context Constraints (SCCs)
-    should set capabilities as a list in <tt>allowedCapabilities</tt>.
+    opens the door for malicious use. To disable the
+    capabilities, the appropriate Security Context Constraints (SCCs)
+    should set all capabilities as <tt>*</tt> or a list of capabilities in
+    <tt>requiredDropCapabilities</tt>.
 
 rationale: |-
     By default, containers run with a default set of capabilities as assigned
@@ -20,13 +21,13 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.2.8
+    cis@ocp4: 5.2.9
 
-ocil_clause: 'allowed capabilities are not configured or limited in allowedCapabilities'
+ocil_clause: 'requiredDropCapabilities are not configured or configured correctly'
 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that only required capabilities are either
-    completely added as a list entry under <tt>allowedCapabilities</tt>,
+    Review each SCC and determine that all capabilities are either
+    completely disabled as a list entry under <tt>requiredDropCapabilities</tt>,
     or that all the un-required capabilities are dropped for containers and SCCs.

--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
@@ -2,14 +2,13 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Drop Container Capabilities'
+title: 'Limit Container Capabilities'
 
 description: |-
     Containers should not enable more capabilites than needed as this
-    opens the door for malicious use. To disable the
-    capabilities, the appropriate Security Context Constraints (SCCs)
-    should set all capabilities as <tt>*</tt> or a list of capabilities in
-    <tt>requiredDropCapabilities</tt>.
+    opens the door for malicious use. To enable only the
+    required capabilities, the appropriate Security Context Constraints (SCCs)
+    should set capabilities as a list in <tt>allowedCapabilities</tt>.
 
 rationale: |-
     By default, containers run with a default set of capabilities as assigned
@@ -21,13 +20,13 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.2.9
+    cis@ocp4: 5.2.8
 
-ocil_clause: 'requiredDropCapabilities are not configured or configured correctly'
+ocil_clause: 'allowed capabilities are not configured or limited in allowedCapabilities'
 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that all capabilities are either
-    completely disabled as a list entry under <tt>requiredDropCapabilities</tt>,
+    Review each SCC and determine that only required capabilities are either
+    completely added as a list entry under <tt>allowedCapabilities</tt>,
     or that all the un-required capabilities are dropped for containers and SCCs.

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -178,9 +178,9 @@ selections:
   # 5.2.7 Minimize the admission of containers with the NET_RAW capability (info)
     - scc_limit_net_raw_capability
   # 5.2.8 Minimize the admission of containers with added capabilities (info)
-    - scc_drop_container_capabilities
-  # 5.2.9 Minimize the admission of containers with capabilities assigned (info)
     - scc_limit_container_allowed_capabilities
+  # 5.2.9 Minimize the admission of containers with capabilities assigned (info)
+    - scc_drop_container_capabilities
   #### 5.3 Network Policies and CNI
   # 5.3.1 Ensure that the CNI in use supports Network Policies (info)
     - configure_network_policies


### PR DESCRIPTION
#### Description:

- The current rules for OCP4 CIS 5.2.8 and 5.2.9 are incorrect.  The rule contents do not match
the rule names (they are swapped).  In addition, the CIS profile has the wrong rule for the
associated comment that refers to the CIS identifier.  This corrects the mismatch.

#### Rationale:

- Rules need to match their identifier.
