### PR TITLE
Add option to enable filepath regex in file permissions template.

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1614,6 +1614,7 @@ file_groupowner::
 * Check group that owns the given file.
 * Parameters:
 ** *filepath* - File path to be checked. If the file path ends with `/` it describes a directory.
+** *filepath_is_regex* - If set to `"true"` the OVAL will consider the value of *filepath* as a regular expression.
 ** *missing_file_pass* - If set to `"true"` the OVAL check will pass when file is absent. Default value is `"false"`.
 ** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory. Note: Applies to base name of files, so if a file `/foo/bar/file.txt` is processed, only `file.txt` is tested against *file_regex*.
 ** *filegid* - group ID (GID)
@@ -1623,6 +1624,7 @@ file_owner::
 * Check user that owns the given file.
 * Parameters:
 ** *filepath* - File path to be checked. If the file path ends with `/` it describes a directory.
+** *filepath_is_regex* - If set to `"true"` the OVAL will consider the value of *filepath* as a regular expression.
 ** *missing_file_pass* - If set to `"true"` the OVAL check will pass when file is absent. Default value is `"false"`.
 ** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory. Note: Applies to base name of files, so if a file `/foo/bar/file.txt` is processed, only `file.txt` is tested against *file_regex*.
 ** *fileuid* - user ID (UID)
@@ -1632,6 +1634,7 @@ file_permissions::
 * Checks permissions (mode) on a given file.
 * Parameters:
 ** *filepath* - File path to be checked. If the file path ends with `/` it describes a directory.
+** *filepath_is_regex* - If set to `"true"` the OVAL will consider the value of *filepath* as a regular expression.
 ** *missing_file_pass* - If set to `"true"` the OVAL check will pass when file is absent. Default value is `"false"`.
 ** *file_regex* - Regular expression that matches file names in a directory specified by *filepath*. Can be set only if *filepath* parameter specifies a directory. Note: Applies to base name of files, so if a file `/foo/bar/file.txt` is processed, only `file.txt` is tested against *file_regex*.
 ** *filemode* - File permissions in a hexadecimal format, eg. `'0640'`.

--- a/shared/templates/template_OVAL_file_groupowner
+++ b/shared/templates/template_OVAL_file_groupowner
@@ -28,7 +28,7 @@
         <unix:filename xsi:nil="true" />
       {{%- endif -%}}
     {{%- else -%}}
-      <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
     {{%- endif -%}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_owner
+++ b/shared/templates/template_OVAL_file_owner
@@ -28,7 +28,7 @@
         <unix:filename xsi:nil="true" />
       {{%- endif -%}}
     {{%- else -%}}
-      <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
     {{%- endif -%}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_permissions
+++ b/shared/templates/template_OVAL_file_permissions
@@ -30,7 +30,7 @@
         <unix:filename xsi:nil="true" />
       {{%- endif -%}}
     {{%- else -%}}
-      <unix:filepath{{% if FILEPATH_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
+      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
     {{%- endif -%}}
   </unix:file_object>
 </def-group>

--- a/shared/templates/template_OVAL_file_permissions
+++ b/shared/templates/template_OVAL_file_permissions
@@ -30,7 +30,7 @@
         <unix:filename xsi:nil="true" />
       {{%- endif -%}}
     {{%- else -%}}
-      <unix:filepath>{{{ FILEPATH }}}</unix:filepath>
+      <unix:filepath{{% if FILEPATH_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
     {{%- endif -%}}
   </unix:file_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- Add option to enable filepath regex in file permissions template. Also adds the same option to groupowner and owner templates.

#### Rationale:

- Enable template to check multiple files with same pattern but from different directories.