### PR TITLE
OCP4 - CIS 1.1.1 Add check

### DIFF
--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kube API Server Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="0644") }}}
 
 rationale: |-
     If the Kube specification file is writable by a group-owner or the
@@ -21,13 +21,15 @@ severity: medium
 references:
     cis: 1.1.1
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
 
-#template:
-#    name: file_permissions
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
-#        filemode: '0644'
+template:
+  name: file_permissions
+  vars:
+    filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
+    filepath_is_regex: "true"
+    missing_file_pass: "true"
+    filemode: '0644'


### PR DESCRIPTION
This checks for the file permissions of the kube-apiserver static pod
definition.