### PR TITLE
Implement OVAL check for scc_limit_root_containers

### DIFF
--- a/applications/openshift/scc/scc_limit_root_containers/oval/shared.xml
+++ b/applications/openshift/scc/scc_limit_root_containers/oval/shared.xml
@@ -3,60 +3,91 @@
   <definition class="compliance" id="scc_limit_root_containers" version="1">
     <metadata>
         <title>Limit Container Running As Root User</title>
-        
     <affected family="unix">
     <platform>Red Hat OpenShift Container Platform 4</platform>
     </affected>
-        <description>In the YAML/JSON file '/apis/security.openshift.io/v1/securitycontextconstraints' at path '.items[:]['runAsUser']' at least one: key 'type' value equals 'MustRunAsNonRoot'</description>
-    </metadata><criteria>
-        <criterion  comment="In the YAML/JSON file &#39;/apis/security.openshift.io/v1/securitycontextconstraints&#39; at path &#39;.items[:][&#39;runAsUser&#39;]&#39; at least one" test_ref="test_scc_limit_root_containers"/>
-        
+        <description>Check SCCs runAsUser and Namespaces UID ranges</description>
+        </metadata>
+        <criteria>
+            <criteria operator="OR">
+                <criterion  comment="In the YAML/JSON file &#39;/apis/security.openshift.io/v1/securitycontextconstraints&#39; at path &#39;.items[:][&#39;runAsUser&#39;]&#39; at least one MustRunAsNonRoot" test_ref="test_scc_limit_root_containers_non_root"/>
+                <criteria>
+                    <criterion  comment="In the YAML/JSON file &#39;/apis/security.openshift.io/v1/securitycontextconstraints&#39; at path &#39;.items[:][&#39;runAsUser&#39;]&#39; at least one MustRunAs" test_ref="test_scc_limit_root_containers_run_as"/>
+                    <criterion  comment="In the YAML/JSON file &#39;/api/v1/namespaces&#39; at path &#39;openshift.io/sa.scc.uid-range&#39; at least one namespace doesn&#39;t allow UID 0" test_ref="test_scc_limit_root_containers_non_root_uid_range"/>
+                </criteria>
+            </criteria>
+
         <criterion comment="Make sure that the file '/apis/security.openshift.io/v1/securitycontextconstraints' exists." test_ref="test_file_for_scc_limit_root_containers"/>
-        
     </criteria>
   </definition>
 
-  <local_variable id="scc_limit_root_containers_file_location" datatype="string" comment="The actual path of the file to scan." version="1">
-      
+  <local_variable id="scc_limit_root_containers_file_location_namespace" datatype="string" comment="Path to namespaces resources" version="1">
+      <concat>
+        <variable_component var_ref="ocp_data_root"/>
+        <literal_component>/api/v1/namespaces</literal_component>
+      </concat>
+  </local_variable>
+
+  <local_variable id="scc_limit_root_containers_file_location" datatype="string" comment="Path to SSCs resources" version="1">
       <concat>
         <variable_component var_ref="ocp_data_root"/>
         <literal_component>/apis/security.openshift.io/v1/securitycontextconstraints</literal_component>
       </concat>
-      
   </local_variable>
 
-  <ind:yamlfilecontent_test id="test_scc_limit_root_containers" check="all" check_existence="at_least_one_exists"
+  <ind:yamlfilecontent_test id="test_scc_limit_root_containers_non_root" check="all" check_existence="at_least_one_exists"
      comment="In the file &#39;/apis/security.openshift.io/v1/securitycontextconstraints&#39; find only one object at path &#39;.items[:][&#39;runAsUser&#39;]&#39;." version="1">
-    <ind:object object_ref="object_scc_limit_root_containers"/>
-    <ind:state state_ref="state_scc_limit_root_containers"/>
+    <ind:object object_ref="object_scc_limit_root_containers_non_root"/>
+    <ind:state state_ref="state_scc_limit_root_containers_non_root"/>
   </ind:yamlfilecontent_test>
+  <ind:yamlfilecontent_object id="object_scc_limit_root_containers_non_root" version="1">
+    <ind:filepath var_ref="scc_limit_root_containers_file_location"/>
+    <ind:yamlpath>.items[:]['runAsUser']</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+  <ind:yamlfilecontent_state id="state_scc_limit_root_containers_non_root" version="1">
+    <ind:value datatype="record" entity_check="at least one">
+      <field  name="type" datatype="string">MustRunAsNonRoot</field>
+    </ind:value>
+  </ind:yamlfilecontent_state>
 
-  
+  <ind:yamlfilecontent_test id="test_scc_limit_root_containers_run_as" check="all" check_existence="at_least_one_exists"
+     comment="In the file &#39;/apis/security.openshift.io/v1/securitycontextconstraints&#39; find only one object at path &#39;.items[:][&#39;runAsUser&#39;]&#39;." version="1">
+    <ind:object object_ref="object_scc_limit_root_containers_run_as"/>
+    <ind:state state_ref="state_scc_limit_root_containers_run_as"/>
+  </ind:yamlfilecontent_test>
+  <ind:yamlfilecontent_object id="object_scc_limit_root_containers_run_as" version="1">
+    <ind:filepath var_ref="scc_limit_root_containers_file_location"/>
+    <ind:yamlpath>.items[:]['runAsUser']</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+  <ind:yamlfilecontent_state id="state_scc_limit_root_containers_run_as" version="1">
+    <ind:value datatype="record" entity_check="at least one">
+      <field  name="type" datatype="string">MustRunAs</field>
+    </ind:value>
+  </ind:yamlfilecontent_state>
+
+  <ind:yamlfilecontent_test id="test_scc_limit_root_containers_non_root_uid_range" check="all" check_existence="at_least_one_exists"
+     comment="In the YAML/JSON file &#39;/api/v1/namespaces&#39; at path &#39;openshift.io/sa.scc.uid-range&#39; at least one namespace doesn&#39;t allow UID 0" version="1">
+    <ind:object object_ref="object_scc_limit_root_containers_non_root_uid_range"/>
+    <ind:state state_ref="state_scc_limit_root_containers_non_root_uid_range"/>
+  </ind:yamlfilecontent_test>
+  <ind:yamlfilecontent_object id="object_scc_limit_root_containers_non_root_uid_range" version="1">
+      <ind:filepath var_ref="scc_limit_root_containers_file_location_namespace"/>
+    <ind:yamlpath>.items[:]['metadata']['annotations']['openshift.io/sa.scc.uid-range']</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+  <ind:yamlfilecontent_state id="state_scc_limit_root_containers_non_root_uid_range" version="1">
+    <ind:value datatype="record" >
+        <field  name="#" datatype="string" operation="pattern match"
+            entity_check="at least one">^(?!0*\/).*$</field>
+    </ind:value>
+  </ind:yamlfilecontent_state>
+
   <unix:file_test id="test_file_for_scc_limit_root_containers" check="all" check_existence="only_one_exists"
     comment="Find the file to be checked ('/apis/security.openshift.io/v1/securitycontextconstraints')." version="1">
     <unix:object object_ref="object_file_for_scc_limit_root_containers"/>
   </unix:file_test>
-  
-
   <unix:file_object id="object_file_for_scc_limit_root_containers" version="1">
     <unix:filepath var_ref="scc_limit_root_containers_file_location"/>
   </unix:file_object>
 
-  <ind:yamlfilecontent_object id="object_scc_limit_root_containers" version="1">
-    <ind:filepath var_ref="scc_limit_root_containers_file_location"/>
-    <ind:yamlpath>.items[:]['runAsUser']</ind:yamlpath>
-  </ind:yamlfilecontent_object>
-
-  <ind:yamlfilecontent_state id="state_scc_limit_root_containers" version="1">
-    <ind:value datatype="record" entity_check="at least one">
-      
-      <field  name="type" datatype="string">MustRunAsNonRoot</field>
-      
-    </ind:value>
-  </ind:yamlfilecontent_state>
-
-  
   <external_variable comment="Root of OCP data dump" datatype="string" id="ocp_data_root" version="1" />
-  
-
 </def-group>

--- a/applications/openshift/scc/scc_limit_root_containers/oval/shared.xml
+++ b/applications/openshift/scc/scc_limit_root_containers/oval/shared.xml
@@ -1,0 +1,62 @@
+
+<def-group>
+  <definition class="compliance" id="scc_limit_root_containers" version="1">
+    <metadata>
+        <title>Limit Container Running As Root User</title>
+        
+    <affected family="unix">
+    <platform>Red Hat OpenShift Container Platform 4</platform>
+    </affected>
+        <description>In the YAML/JSON file '/apis/security.openshift.io/v1/securitycontextconstraints' at path '.items[:]['runAsUser']' at least one: key 'type' value equals 'MustRunAsNonRoot'</description>
+    </metadata><criteria>
+        <criterion  comment="In the YAML/JSON file &#39;/apis/security.openshift.io/v1/securitycontextconstraints&#39; at path &#39;.items[:][&#39;runAsUser&#39;]&#39; at least one" test_ref="test_scc_limit_root_containers"/>
+        
+        <criterion comment="Make sure that the file '/apis/security.openshift.io/v1/securitycontextconstraints' exists." test_ref="test_file_for_scc_limit_root_containers"/>
+        
+    </criteria>
+  </definition>
+
+  <local_variable id="scc_limit_root_containers_file_location" datatype="string" comment="The actual path of the file to scan." version="1">
+      
+      <concat>
+        <variable_component var_ref="ocp_data_root"/>
+        <literal_component>/apis/security.openshift.io/v1/securitycontextconstraints</literal_component>
+      </concat>
+      
+  </local_variable>
+
+  <ind:yamlfilecontent_test id="test_scc_limit_root_containers" check="all" check_existence="at_least_one_exists"
+     comment="In the file &#39;/apis/security.openshift.io/v1/securitycontextconstraints&#39; find only one object at path &#39;.items[:][&#39;runAsUser&#39;]&#39;." version="1">
+    <ind:object object_ref="object_scc_limit_root_containers"/>
+    <ind:state state_ref="state_scc_limit_root_containers"/>
+  </ind:yamlfilecontent_test>
+
+  
+  <unix:file_test id="test_file_for_scc_limit_root_containers" check="all" check_existence="only_one_exists"
+    comment="Find the file to be checked ('/apis/security.openshift.io/v1/securitycontextconstraints')." version="1">
+    <unix:object object_ref="object_file_for_scc_limit_root_containers"/>
+  </unix:file_test>
+  
+
+  <unix:file_object id="object_file_for_scc_limit_root_containers" version="1">
+    <unix:filepath var_ref="scc_limit_root_containers_file_location"/>
+  </unix:file_object>
+
+  <ind:yamlfilecontent_object id="object_scc_limit_root_containers" version="1">
+    <ind:filepath var_ref="scc_limit_root_containers_file_location"/>
+    <ind:yamlpath>.items[:]['runAsUser']</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
+  <ind:yamlfilecontent_state id="state_scc_limit_root_containers" version="1">
+    <ind:value datatype="record" entity_check="at least one">
+      
+      <field  name="type" datatype="string">MustRunAsNonRoot</field>
+      
+    </ind:value>
+  </ind:yamlfilecontent_state>
+
+  
+  <external_variable comment="Root of OCP data dump" datatype="string" id="ocp_data_root" version="1" />
+  
+
+</def-group>

--- a/applications/openshift/scc/scc_limit_root_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_root_containers/rule.yml
@@ -9,24 +9,31 @@ description: |-
     to run and should very rarely be run as root user. To prevent
     containers from running as root user,
     the appropriate Security Context Constraints (SCCs) should set
-    <tt>allowPrivilegedContainer</tt> to <tt>false</tt>.
+    <tt>runAsUser</tt> to <tt>MustRunAsNonRoot</tt> or <tt>MustRunAs</tt>
+    with a range of UIDs that does not include 0.
 
 rationale: |-
-    Privileged containers have access to all Linux Kernel
-    capabilities and devices. If a privileged container were
-    compromised, an attacker would have full access to the container
-    and host.
+    Containers may run as any Linux user. Containers which run as the root user,
+    whilst constrained by Container Runtime security features still have an escalated
+    likelihood of container breakout.
 
 severity: medium
 
 references:
     cis: 5.2.6
 
-ocil_clause: 'allowPrivilegedContainer is set to true or too many SCCs have allowPrivilegedContainer enabled'
+ocil_clause: 'no SCC has runAsUser set to MustRunAsNonRoot or MustRunAs'
 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that <tt>allowPrivilegedContainer</tt> is either
-    completely disabled, or that <tt>allowPrivilegedContainer</tt> is only enabled to
-    a small set of containers and SCCs.
+    Review each SCC and determine that <tt>runAsUser</tt> is either
+    set to <tt>MustRunAsNonRoot</tt> or <tt>MustRunAs</tt> with a
+    range of UIDs that does not include 0, or only a small set of
+    containers and SCCs don't run as root.
+
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
+        {{{ openshift_cluster_setting("/api/v1/namespaces") | indent(8) }}}
+

--- a/shared/templates/template_OVAL_yamlfile_value
+++ b/shared/templates/template_OVAL_yamlfile_value
@@ -49,9 +49,9 @@
   </ind:yamlfilecontent_object>
 
   <ind:yamlfilecontent_state id="state_{{{ rule_id }}}" version="1">
-    <ind:value datatype="record">
+    <ind:value datatype="record"{{% if ENTITY_CHECK %}} entity_check="{{{ ENTITY_CHECK }}}"{{% endif %}}>
       {{% for val in VALUES %}}
-      <field {{{ {'name': val.key|default("#")|escape_yaml_key, 'datatype': val.type,  'operation':  val.operation}|xmlattr }}}{{% if ENTITY_CHECK %}} entity_check="{{{ ENTITY_CHECK }}}"{{% endif %}}>{{{ val.value }}}</field>
+      <field {{{ {'name': val.key|default("#")|escape_yaml_key, 'datatype': val.type,  'operation':  val.operation}|xmlattr }}}>{{{ val.value }}}</field>
       {{% endfor %}}
     </ind:value>
   </ind:yamlfilecontent_state>


### PR DESCRIPTION
#### Description:

- Copy the check generated by the OVAL `yamlfile_value` template for SCC at path `MustRunAsNonRoot`and:
  - Add a second check for the SCC at path `MustRunAs`
  - Add a third check for Namespaces' UID ranges  
- Developed together with:
  @jhrozek @lsm5 @nkinder @vakwetu Jonathan Rickard

#### Rationale:

- Checks for multiple yamlpaths is not covered by the template
- The template fix (07d0211) had to be undone for the template to work.


