### PR TITLE
Create custom OVAL check for uefi_no_removeable_media

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/oval/shared.xml
@@ -6,7 +6,7 @@
 
 <def-group>
   <definition class="compliance" id="uefi_no_removeable_media" version="1">
-    {{{ oval_metadata("Ensure 'set root' is configured with value '(?!fd)(?!cd)(?!usb).*' in /boot/efi/EFI/redhat/grub.cfg") }}}
+    {{{ oval_metadata("Ensure the system is not configured to use a boot loader on removable media.") }}}
     <criteria comment="The respective application or service is configured correctly or system boot mode is not UEFI" operator="OR">
       <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
       <criterion comment="Check the set root in {{{ grub_cfg_prefix + "/grub.cfg" }}}" test_ref="test_uefi_no_removeable_media" />

--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/oval/shared.xml
@@ -1,1 +1,35 @@
-{{{ oval_check_config_file(path='/boot/efi/EFI/redhat/grub.cfg', prefix_regex='^[ \\t]*', parameter='set root', separator_regex='=', value="'(?!fd)(?!cd)(?!usb).*'", missing_parameter_pass=false, missing_config_file_fail=true) }}}
+{{% if product == "fedora" %}}
+{{% set grub_cfg_prefix = "/boot/efi/EFI/fedora" %}}
+{{% else %}}
+{{% set grub_cfg_prefix = "/boot/efi/EFI/redhat" %}}
+{{% endif %}}
+
+<def-group>
+  <definition class="compliance" id="uefi_no_removeable_media" version="1">
+    {{{ oval_metadata("Ensure 'set root' is configured with value '(?!fd)(?!cd)(?!usb).*' in /boot/efi/EFI/redhat/grub.cfg") }}}
+    <criteria comment="The respective application or service is configured correctly or system boot mode is not UEFI" operator="OR">
+      <extend_definition definition_ref="system_boot_mode_is_uefi" negate="true" comment="Pass if system boot mode is not UEFI" />
+      <criterion comment="Check the set root in {{{ grub_cfg_prefix + "/grub.cfg" }}}" test_ref="test_uefi_no_removeable_media" />
+      {{{ oval_file_absent_criterion(grub_cfg_prefix + "/grub.cfg") }}}
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the value of set root setting in the {{{ grub_cfg_prefix + "/grub.cfg" }}} file"
+  id="test_uefi_no_removeable_media" version="1">
+  <ind:object object_ref="obj_uefi_no_removeable_media" />
+  <ind:state state_ref="state_uefi_no_removeable_media" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_uefi_no_removeable_media" version="1">
+    <ind:filepath>{{{ grub_cfg_prefix + "/grub.cfg" }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*set root=(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_uefi_no_removeable_media" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^'(?!fd)(?!cd)(?!usb).*'$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  {{{ oval_file_absent(grub_cfg_prefix + "/grub.cfg") }}}
+</def-group>

--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/tests/hard_disk_set.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/tests/hard_disk_set.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# remediation = none
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+# make the check applicable since it tries to detect this directory first
+# mkdir -p /sys/firmware/efi
+
+set_root_unquoted "'hd0,msdos1'"

--- a/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/tests/removable_media_set.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/uefi_no_removeable_media/tests/removable_media_set.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# remediation = none
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+# make the check applicable since it tries to detect this directory first
+# mkdir -p /sys/firmware/efi
+
+set_root_unquoted "'usb0,msdos1'"

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -25,7 +25,7 @@
 {{%- endif -%}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("Ensure '" + parameter + "' is configured with value '" + value | replace("(?i)", "") | replace("(?-i)", "") + (" in section '" + section if section else "") + "' in '" + path) }}}
+    {{{ oval_metadata("Ensure '" + parameter + "' is configured with value '" + value | replace("(?i)", "") | replace("(?-i)", "") + (" in section '" + section if section else "") + "' in " + path) }}}
     {{%- if missing_config_file_fail %}}
     <criteria comment="{{{ application }}} is configured correctly and configuration file exists"
     operator="AND">

--- a/tests/shared/grub2.sh
+++ b/tests/shared/grub2.sh
@@ -25,3 +25,9 @@ function set_superusers_unquoted {
 	mkdir -p "$GRUB_CFG_ROOT"
 	echo "set superusers=$1" > "$GRUB_CFG_ROOT/grub.cfg"
 }
+
+
+function set_root_unquoted {
+	mkdir -p "$GRUB_CFG_ROOT"
+	echo "set root=$1" > "$GRUB_CFG_ROOT/grub.cfg"
+}


### PR DESCRIPTION
#### Description:

- Create custom OVAL check for uefi_no_removeable_media.
- Add the extended definition [system_boot_mode_is_uefi](https://github.com/ComplianceAsCode/content/blob/master/shared/checks/oval/system_boot_mode_is_uefi.xml) to check if the system is UEFI or not

#### Rationale:

- With current approach CPE applicability is implemented, we cannot easily assign multiple platform checks, and since other rules ([file_permissions_efi_grub2_cfg](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml#L5)) are already using this approach to make the rule pass on systems that are not UEFI we can keep this way until better support for CPE applicability language is supported.

- Fixes #6028
