### PR TITLE
Disable OVAL backend from file_permissions grub2_cfg rules

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1773,7 +1773,7 @@ yamlfile_value::
 ** *yamlpath* - OVAL's link:https://github.com/OpenSCAP/yaml-filter/wiki/YAML-Path-Definition[YAML Path] expression.
 ** *entity_check* (link:https://github.com/OVALProject/Language/blob/master/docs/oval-common-schema.md#CheckEnumeration[CheckEnumeration]) - entity_check value for state's value_of, optional. If omitted, entity_check attribute would not be set and will be treated by OVAL as 'all'. +
     Possible options are `all`, `at least one`, `none satisfy` and `only one`.
-** *check_existence* (link:https://github.com/OVALProject/Language/blob/master/docs/oval-common-schema.md#ExistenceEnumeration[ExistenceEnumeration]) - `check_existence` value for the `yamlfilecontent_test`, optional. If omitted, check_existence attribute will defalut to 'only_one_exists'. +
+** *check_existence* (link:https://github.com/OVALProject/Language/blob/master/docs/oval-common-schema.md#ExistenceEnumeration[ExistenceEnumeration]) - `check_existence` value for the `yamlfilecontent_test`, optional. If omitted, check_existence attribute will default to 'only_one_exists'. +
    Possible options are `all_exist`, `any_exist`, `at_least_one_exists`, `none_exist`, `only_one_exists`.
 ** *values* - a list of dictionaries with values to check, where:
 **   *key* - the yaml key to check, optional. Used when the yamlpath expression yields a map.

--- a/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_groupowner_efi_grub2_cfg/rule.yml
@@ -57,4 +57,7 @@ template:
     name: file_groupowner
     vars:
         filepath: /boot/efi/EFI/redhat/grub.cfg
+        filepath@fedora: /boot/efi/EFI/fedora/grub.cfg
         filegid: '0'
+    backends:
+        oval: 'off'

--- a/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_owner_efi_grub2_cfg/rule.yml
@@ -55,4 +55,7 @@ template:
     name: file_owner
     vars:
         filepath: /boot/efi/EFI/redhat/grub.cfg
+        filepath@fedora: /boot/efi/EFI/fedora/grub.cfg
         fileuid: '0'
+    backends:
+        oval: 'off'

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/bash/shared.sh
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/bash/shared.sh
@@ -1,2 +1,0 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
-chmod 700 /boot/efi/EFI/redhat/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
@@ -50,6 +50,7 @@ template:
     name: file_permissions
     vars:
         filepath: /boot/efi/EFI/redhat/grub.cfg
+        filepath@fedora: /boot/efi/EFI/fedora/grub.cfg
         filemode: '0700'
     backends:
         oval: 'off'

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/rule.yml
@@ -51,3 +51,5 @@ template:
     vars:
         filepath: /boot/efi/EFI/redhat/grub.cfg
         filemode: '0700'
+    backends:
+        oval: 'off'

--- a/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/rule.yml
@@ -46,4 +46,5 @@ template:
     vars:
         filepath: /boot/grub2/grub.cfg
         filemode: '0600'
-        filemode@rhel8: '600'
+    backends:
+        oval: 'off'

--- a/shared/checks/oval/installed_env_has_grub2_package.xml
+++ b/shared/checks/oval/installed_env_has_grub2_package.xml
@@ -44,7 +44,7 @@
   </linux:dpkginfo_object>
 {{% endif %}}
 
-  <unix:file_test check="all" check_existence="all_exist" comment="Check if /sys/firware/opal exists" id="test_system_using_opal" version="1">
+  <unix:file_test check="all" check_existence="all_exist" comment="Check if /sys/firmware/opal exists" id="test_system_using_opal" version="1">
     <unix:object object_ref="object_system_using_opal" />
   </unix:file_test>
   <unix:file_object id="object_system_using_opal" version="1">


### PR DESCRIPTION
#### Description:

- Disable OVAL template for file_permissions grub2_cfg rules and fix a typo in installed_env_has_grub2_package.xml

#### Rationale:

- There is not need to let OVAL template enabled for these rules since they have custom [shared1](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/bootloader-grub2/file_permissions_efi_grub2_cfg/oval/shared.xml) [shared2](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/bootloader-grub2/file_permissions_grub2_cfg/oval/shared.xml) OVAL
