### PR TITLE
fix conflicts of audit rules for privileged commands

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -28,7 +28,7 @@
 - name: Overwrites the rule in rules.d
   lineinfile:
     path: "{{ item.1.path }}"
-    line: '-a always,exit -F path={{ item.0.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.0.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
     create: no
     regexp: "^.*path={{ item.0.item }} .*$"
   with_subelements:
@@ -38,7 +38,7 @@
 - name: Adds the rule in rules.d
   lineinfile:
     path: /etc/audit/rules.d/privileged.rules
-    line: '-a always,exit -F path={{ item.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
     create: yes
   with_items:
     - "{{ files_result.results }}"
@@ -49,7 +49,7 @@
 - name: Inserts/replaces the rule in audit.rules
   lineinfile:
     path: /etc/audit/audit.rules
-    line: '-a always,exit -F path={{ item.item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
     create: yes
     regexp: "^.*path={{ item.item }} .*$"
   with_items:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -28,7 +28,7 @@
 - name: Overwrites the rule in rules.d
   lineinfile:
     path: "{{ item.1.path }}"
-    line: '-a always,exit -F path={{ item.0.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.0.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: no
     regexp: "^.*path={{ item.0.item }} .*$"
   with_subelements:
@@ -38,7 +38,7 @@
 - name: Adds the rule in rules.d
   lineinfile:
     path: /etc/audit/rules.d/privileged.rules
-    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: yes
   with_items:
     - "{{ files_result.results }}"
@@ -49,7 +49,7 @@
 - name: Inserts/replaces the rule in audit.rules
   lineinfile:
     path: /etc/audit/audit.rules
-    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=special-config-changes'
+    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: yes
     regexp: "^.*path={{ item.item }} .*$"
   with_items:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -68,7 +68,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arpc_suid_sgid_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]q|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -68,7 +68,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arpc_suid_sgid_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F perm=[r|w]?x -F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]q|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
   </ind:textfilecontent54_object>
@@ -92,7 +92,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arpc_suid_sgid_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F perm=[r|w]?x -F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -3,8 +3,8 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. To find the relevant setuid /
+    The audit system should collect information about usage of privileged
+    commands for all users and root. To find the relevant setuid /
     setgid programs, run the following command for each local partition
     <i>PART</i>:
     <pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2&gt;/dev/null</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -14,13 +14,13 @@ description: |-
     <tt>/etc/audit/rules.d</tt> for each setuid / setgid program on the system,
     replacing the <i>SETUID_PROG_PATH</i> part with the full path of that setuid /
     setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt> for each setuid / setgid program on the
     system, replacing the <i>SETUID_PROG_PATH</i> part with the full path of that
     setuid / setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_with_perm_x.fail.sh
@@ -2,5 +2,6 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
+sed -i -E 's/^(.*path=[[:graph:]]+ )(.*$)/\1-F perm=x \2/' /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -3,4 +3,4 @@
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# remediation = bash
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+
+mkdir -p /etc/audit/rules.d
+./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+sed -i -E 's/^(.*path=[[:graph:]]+ )(.*$)/\1-F perm=x \2/' /etc/audit/rules.d/privileged.rules
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -3,5 +3,5 @@
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -3,5 +3,5 @@
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 mkdir -p /etc/audit/rules.d
-echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/priv.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -4,5 +4,5 @@ AUID=$1
 KEY=$2
 RULEPATH=$3
 for file in $(find / -xdev -type f -perm -4000 -o -type f -perm -2000 2>/dev/null); do
-     echo "-a always,exit -F path=$file -F perm=x -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
+     echo "-a always,exit -F path=$file -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
 done

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -103,13 +103,12 @@ do
 		base_search=$(sed -e '/-a always,exit/!d' -e '/-F path='"${sbinary_esc}"'[^[:graph:]]/!d'		\
 				-e '/-F path=[^[:space:]]\+/!d'						\
 				-e '/-F auid>='"${min_auid}"'/!d' -e '/-F auid!=\(4294967295\|unset\)/!d'	\
+				-e '/-F perm=[rwxa]\+/d' \
 				-e '/-k \|-F key=/!d' "$afile")
 
 		# Increase the count of inspected files for this sbinary
 		count_of_inspected_files=$((count_of_inspected_files + 1))
 
-		# Require execute access type to be set for existing audit rule
-		exec_access='x'
 
 		# Search current audit rules file's content for presence of rule pattern for this sbinary
 		if [[ $base_search ]]

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -122,7 +122,7 @@ do
 			readarray -t handled_sbinaries < <(grep -o -e "-F path=[^[:space:]]\+" <<< "$concrete_rule")
 			handled_sbinaries=("${handled_sbinaries[@]//-F path=/}")
 
-			# 		Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
+			# Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
 			readarray -t sbinaries_to_skip < <(for i in "${sbinaries_to_skip[@]}" "${handled_sbinaries[@]}"; do echo "$i"; done | sort -du)
 
 			# if there is a -F perm flag, remove it

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -122,10 +122,10 @@ do
 			readarray -t handled_sbinaries < <(grep -o -e "-F path=[^[:space:]]\+" <<< "$concrete_rule")
 			handled_sbinaries=("${handled_sbinaries[@]//-F path=/}")
 
-		# 		Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
+			# 		Merge the list of such SUID/SGID binaries found in this iteration with global list ignoring duplicates
 			readarray -t sbinaries_to_skip < <(for i in "${sbinaries_to_skip[@]}" "${handled_sbinaries[@]}"; do echo "$i"; done | sort -du)
 
-			# if there is aa -F perm flag, remove it
+			# if there is a -F perm flag, remove it
 			if grep -q '.*-F\s\+perm=[rwxa]\+.*' <<< "$concrete_rule"; then
 
 				# Separate concrete_rule into three sections using hash '#'


### PR DESCRIPTION
#### Description:

- modify audit_rules_privileged_commands to unify with templated rules audit_rules_privileged_commands_*

    - remove checking for perm=x

    - remove remediationg of perm=x

    - unify checks and remediations to use -F key=privileged

#### Rationale:

The "automagic" rule audit_rules_privileged_commands and individual templated rules audit_rules_privileged_commands_*  were not cooperating together, although they are are often selected in one profile. It resulted in one of rules failing although the configuration was actually correct. It also resulted in duplicate Audit rule entries.

- fixes #5984 