### PR TITLE
fix srgs for new rhel8 stig rules

### DIFF
--- a/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
@@ -26,7 +26,7 @@ references:
     cis@rhel8: 2.2.1.1
     ism: 0988,1405
     ospp: FMT_SMF_EXT.1
-    srg: SRG-OS-000355-GPOS-00143,SRG-OS-000356-GPOS-00144
+    srg: SRG-OS-000355-GPOS-00143
 
 {{{ complete_ocil_entry_package(package="chrony") }}}
 

--- a/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
@@ -25,7 +25,8 @@ references:
     cis@rhel7: 2.2.1.1
     cis@rhel8: 2.2.1.1
     ism: 0988,1405
-    ospp: package_audispd-plugins_installed
+    ospp: FMT_SMF_EXT.1
+    srg: SRG-OS-000355-GPOS-00143,SRG-OS-000356-GPOS-00144
 
 {{{ complete_ocil_entry_package(package="chrony") }}}
 

--- a/linux_os/guide/system/software/integrity/kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/software/integrity/kernel_trust_cpu_rng/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 
 references:
     ospp: FCS_RBG_EXT.1.1
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: 'the kernel is not configured to trust the CPU RNG'
 


### PR DESCRIPTION
#### Description:

- adds SRG to package_chrony_installed and kernel_trust_cpu_rng rules

#### Rationale:

- these rules were added to rhel8 ospp and because stig extends ospp, they appear also in stig. However, srgs were not added.

- fixes #6275 