### PR TITLE
Fix typo in the description

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/rule.yml
@@ -7,7 +7,7 @@ title: 'Configure NSS DB To Use opensc'
 description: |-
     The <tt>opensc</tt> module should be configured for use over the
     <tt>Coolkey PKCS#11</tt> module in the NSS database. To configure the
-    NSS database ot use the <tt>opensc</tt> module, run the following
+    NSS database to use the <tt>opensc</tt> module, run the following
     command:
     <pre>$ sudo pkcs11-switch opensc</pre>
 


### PR DESCRIPTION
#### Description:

Fix typo in description of a rule

#### Rationale:

- There is a typo and it should be fixed
