### PR TITLE
Refactor rpminfo_state so that all rpminfo tests for valid version

### DIFF
--- a/jre/checks/oval/installed_app_is_java.xml
+++ b/jre/checks/oval/installed_app_is_java.xml
@@ -20,6 +20,7 @@
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Oracle JRE is installed" id="test_oracle_java" version="1">
     <linux:object object_ref="obj_oracle_java" />
+    <linux:state state_ref="state_java_version" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_oracle_java" version="1">
     <linux:name datatype="string" operation="pattern match">^jre.*$</linux:name>
@@ -27,6 +28,7 @@
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Oracle JRE from Red Hat is installed" id="test_oracle_java_rhel" version="1">
     <linux:object object_ref="obj_oracle_java_rhel" />
+    <linux:state state_ref="state_java_version" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_oracle_java_rhel" version="1">
     <linux:name datatype="string" operation="pattern match">^java.*oracle.*$</linux:name>
@@ -34,28 +36,23 @@
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="IBM JRE is installed" id="test_ibm_java" version="1">
     <linux:object object_ref="obj_ibm_java" />
-    <linux:state state_ref="state_ibm_java" />
+    <linux:state state_ref="state_java_version" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_ibm_java" version="1">
     <linux:name datatype="string" operation="pattern match">^ibm-java.*$</linux:name>
   </linux:rpminfo_object>
-  <linux:rpminfo_state id="state_ibm_java" version="1">
-    <linux:evr datatype="evr_string" operation="greater than or equal">.*1.8.0.*</linux:evr>
-  </linux:rpminfo_state>
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="IBM JRE from Red Hat is installed" id="test_ibm_java_rhel" version="1">
     <linux:object object_ref="obj_ibm_java_rhel" />
-    <linux:state state_ref="state_ibm_java_rhel" />
+    <linux:state state_ref="state_java_version" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_ibm_java_rhel" version="1">
     <linux:name datatype="string" operation="pattern match">^java.*ibm.*$</linux:name>
   </linux:rpminfo_object>
-  <linux:rpminfo_state id="state_ibm_java_rhel" version="1">
-    <linux:evr datatype="evr_string" operation="greater than or equal">.*1.8.0.*</linux:evr>
-  </linux:rpminfo_state>
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Sun JRE from Red Hat is installed" id="test_sun_java_rhel" version="1">
     <linux:object object_ref="obj_sun_java_rhel" />
+    <linux:state state_ref="state_java_version" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_sun_java_rhel" version="1">
     <linux:name datatype="string" operation="pattern match">^java.*sun.*$</linux:name>
@@ -63,8 +60,13 @@
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Red Hat OpenJDK is installed" id="test_openjdk_java" version="1">
     <linux:object object_ref="obj_openjdk_java" />
+    <linux:state state_ref="state_java_version" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_openjdk_java" version="1">
     <linux:name datatype="string" operation="pattern match">^java.*openjdk.*$</linux:name>
   </linux:rpminfo_object>
+
+  <linux:rpminfo_state id="state_java_version" version="1">
+    <linux:evr datatype="evr_string" operation="greater than or equal">.*1.8.0.*</linux:evr>
+  </linux:rpminfo_state>
 </def-group>


### PR DESCRIPTION
Refactoring JRE oval checks to ensure each type of java product found checks for valid version of 1.8+ to be inline with new draft JRE updates.
