### PR TITLE
allow install_vm.py to create UEFI based machines

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,7 @@ To use Libvirt backend, you need to have:
   - `virt-manager`      (optional, to manage VMs via GUI)
   - `virt-viewer`       (optional, to access graphical console of VMs)
   - `ansible`           (required if remediating via Ansible)
+  - `edk2-ovmf`         (required if you want to install UEFI based machine)
 - A VM that fullfils following requirements:
   - Package `qemu-guest-agent` installed
   - Package `openscap` version 1.2.15 or higher installed
@@ -59,6 +60,12 @@ When installing a RHEL VM, you will still need to subscribe it. You can also run
 ```
 $ python install_vm.py --domain test-suite-rhel8 --distro rhel8 --url http://baseos_repo_addr --extra-repo http://appstream_repo_addr
 ```
+
+By default, the script creates a BIOS based machine. If you need to create UEFI
+based machine, supply the `--uefi normal` or `--uefi secureboot` command line
+argument. The script will create UEFI based machine and make necessary changes
+to partitioning scheme. Note that the Libvirt backend cannot make snapshots of
+UEFI based machines. Therefore, you can't use them with SSG test suite.
 
 *TIP*: Create a snapshot as soon as your VM is setup. This way, you can manually revert
 in case the test suite breaks something and fails to revert. Do not use snapshot names starting with `ssg_`.\

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -152,7 +152,10 @@ def main():
         else:
             content = content.replace("&&YUM_EXTRA_REPO&&", "")
         if data.uefi:
-            content = content.replace("part /boot --fstype=xfs --size=512", "part /boot --fstype=xfs --size=312\npart /boot/efi --fstype=efi --size=200")
+            content = content.replace(
+                "part /boot --fstype=xfs --size=512",
+                "part /boot --fstype=xfs --size=312\npart /boot/efi --fstype=efi --size=200"
+            )
         outfile.write(content)
     data.kickstart = tmp_kickstart
     print("Using kickstart file: {0}".format(data.kickstart))
@@ -170,7 +173,9 @@ def main():
     if data.uefi == "normal":
         command = command+" --boot uefi"
     if data.uefi == "secureboot":
-        command = command + " --boot uefi,loader_secure=yes,loader=/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd,nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd --features smm=on"
+        command = command + " --boot uefi,loader_secure=yes,\
+loader=/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd,\
+nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd --features smm=on"
 
     if data.dry:
         print("\nThe following command would be used for the VM installation:")


### PR DESCRIPTION
#### Description:

- add a new parameter to install_vm.py:

    - --uefi normal - will create UEFI based machine without secureboot

    - --uefi=secureboot will create UEFI based machine with secure boot

- kickstart is modified during this action, the  size of /boot partition is decreased and there is created extra /boot/efi partition

- this feature is mentioned in the documentation

- you need e2k-ovmf package to use this feature.

- Note that such machines can't be used with the test suite directly, because Libvirt does not support internal snapshots of UEFI machines

#### Rationale:

- this will help to test rules dealing with UEFI