### PR TITLE
Remove disable_prelink rule from Fedora and RHEL8 profiles

### DIFF
--- a/fedora/profiles/pci-dss.profile
+++ b/fedora/profiles/pci-dss.profile
@@ -84,7 +84,6 @@ selections:
     - rsyslog_files_groupownership
     - ensure_logrotate_activated
     - package_aide_installed
-    - disable_prelink
     - aide_build_database
     - aide_periodic_cron_checking
     - account_unique_name

--- a/fedora/profiles/standard.profile
+++ b/fedora/profiles/standard.profile
@@ -7,7 +7,6 @@ description: |-
     Regardless of your system's workload all of these checks should pass.
 
 selections:
-    - disable_prelink
     - aide_build_database
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled

--- a/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel6,rhel7,rhv4,sle15
+prodtype: ol7,rhel6,rhel7,rhv4,sle15
 
 title: 'Disable Prelinking'
 

--- a/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ol7,ol8,rhel6,rhel7,rhv4,sle15
+
 title: 'Disable Prelinking'
 
 description: |-

--- a/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhel6,rhel7,rhv4,sle15
+prodtype: ol7,rhel6,rhel7
 
 title: 'Disable Prelinking'
 

--- a/ol8/profiles/cjis.profile
+++ b/ol8/profiles/cjis.profile
@@ -120,7 +120,6 @@ selections:
     - var_password_pam_ucredit=1
     - var_password_pam_lcredit=1
     - package_aide_installed
-    - disable_prelink
     - aide_build_database
     - aide_periodic_cron_checking
     - rpm_verify_permissions

--- a/ol8/profiles/pci-dss.profile
+++ b/ol8/profiles/pci-dss.profile
@@ -105,7 +105,6 @@ selections:
     - ensure_logrotate_activated
     - sshd_idle_timeout_value=15_minutes
     - sshd_set_idle_timeout
-    - disable_prelink
     - display_login_attempts
     - gid_passwd_group_same
     - grub2_audit_argument

--- a/rhel8/profiles/cjis.profile
+++ b/rhel8/profiles/cjis.profile
@@ -128,7 +128,6 @@ selections:
     - var_password_pam_ucredit=1
     - var_password_pam_lcredit=1
     - package_aide_installed
-    - disable_prelink
     - aide_build_database
     - aide_periodic_cron_checking
     - rpm_verify_permissions

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -90,7 +90,6 @@ selections:
     - rsyslog_files_groupownership
     - ensure_logrotate_activated
     - package_aide_installed
-    - disable_prelink
     - aide_build_database
     - aide_periodic_cron_checking
     - account_unique_name

--- a/rhv4/profiles/rhvh-stig.profile
+++ b/rhv4/profiles/rhvh-stig.profile
@@ -315,7 +315,6 @@ selections:
     - aide_use_fips_hashes
     - aide_verify_acls
     - aide_verify_ext_attributes
-    - disable_prelink
     - enable_fips_mode
     - install_antivirus
     - install_hids

--- a/sle15/profiles/cis.profile
+++ b/sle15/profiles/cis.profile
@@ -172,9 +172,6 @@ selections:
     ### 1.6.3 Ensure address space layout randomization (ASLR) is enabled
     - sysctl_kernel_randomize_va_space
 
-    ### 1.6.4 Ensure prelink is disabled (Scored)
-    - disable_prelink
-
     ## 1.7 Mandatory Access Control
 
     ### 1.7.1 Ensure Mandatory Access Control Software is Installed

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -80,7 +80,6 @@ selections:
 - dconf_gnome_screensaver_idle_delay
 - dconf_gnome_screensaver_lock_enabled
 - dconf_gnome_screensaver_mode_blank
-- disable_prelink
 - display_login_attempts
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_never_disabled


### PR DESCRIPTION
#### Description:

The `prelink` package doesn't exist in Fedora/RHEL8 anymore. It has
been replaced with the `execstack` package which is built from
`prelink` sources but contains just the `execstack` binary.
Therefore, removing the rule from Fedora and RHEL8 profiles.

Fixes #6187 
