### PR TITLE
Parametrize rule for login.defs hashing algorithm

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
@@ -3,10 +3,12 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+{{{ ansible_instantiate_variables("var_password_hashing_algorithm") }}}
+
 - name: Set Password Hashing Algorithm in /etc/login.defs
   lineinfile:
       dest: /etc/login.defs
       regexp: ^#?ENCRYPT_METHOD
-      line: ENCRYPT_METHOD SHA512
+      line: ENCRYPT_METHOD {{ var_password_hashing_algorithm }}
       state: present
       create: yes

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/bash/shared.sh
@@ -1,7 +1,10 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+. /usr/share/scap-security-guide/remediation_functions
+{{{ bash_instantiate_variables("var_password_hashing_algorithm") }}}
+
 if grep --silent ^ENCRYPT_METHOD /etc/login.defs ; then
-	sed -i 's/^ENCRYPT_METHOD.*/ENCRYPT_METHOD SHA512/g' /etc/login.defs
+	sed -i "s/^ENCRYPT_METHOD .*/ENCRYPT_METHOD $var_password_hashing_algorithm/g" /etc/login.defs
 else
 	echo "" >> /etc/login.defs
-	echo "ENCRYPT_METHOD SHA512" >> /etc/login.defs
+	echo "ENCRYPT_METHOD $var_password_hashing_algorithm" >> /etc/login.defs
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/oval/shared.xml
@@ -35,7 +35,8 @@
   <!-- Define corresponding variable state (the requirement) for the variable object -->
   <!-- The check should PASS if retrieved last ENCRYPT_METHOD value is equal to the requirement -->
   <ind:variable_state id="state_last_encrypt_method_instance_value" version="1">
-    <ind:value operation="equals" datatype="string">SHA512</ind:value>
+    <ind:value operation="equals" datatype="string" var_ref="var_password_hashing_algorithm"/>
   </ind:variable_state>
 
+  <external_variable comment="defined hashing algorithm" datatype="string" id="var_password_hashing_algorithm" version="1" />
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/tests/default_sha256.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/tests/default_sha256.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Make sure ENCRYPT_METHOD is SHA256
+if grep -q "^ENCRYPT_METHOD" /etc/login.defs; then
+	sed -i "s/^ENCRYPT_METHOD\b.*/ENCRYPT_METHOD SHA256/" /etc/login.defs
+else
+	echo "ENCRYPT_METHOD SHA256" >> /etc/login.defs
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/tests/default_sha512.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/tests/default_sha512.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Make sure ENCRYPT_METHOD is SHA512
+if grep -q "^ENCRYPT_METHOD" /etc/login.defs; then
+	sed -i "s/^ENCRYPT_METHOD\b.*/ENCRYPT_METHOD SHA512/" /etc/login.defs
+else
+	echo "ENCRYPT_METHOD SHA512" >> /etc/login.defs
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/var_password_hashing_algorithm.var
+++ b/linux_os/guide/system/accounts/accounts-pam/var_password_hashing_algorithm.var
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: Password Hashing algorithm
+
+description: |-
+    Specify the system default encryption algorithm for encrypting passwords.
+    Defines the value set as ENCRYPT_METHOD in /etc/login.defs.
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: SHA512
+    SHA512: SHA512
+    SHA256: SHA256


### PR DESCRIPTION
#### Description:

- Parametrize rule `set_password_hashing_algorithm_logindefs`.
  - Allow choice between `SHA512` and `SHA256`.
- Add simple tests.

#### Rationale:

- More flexibility for the rule.
