### PR TITLE
Add workround to skip non-package CPEs

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -298,6 +298,12 @@ class BashRemediation(Remediation):
                 if platform in self.local_env_yaml["platform_package_overrides"]:
                     platform = self.local_env_yaml["platform_package_overrides"].get(platform)
 
+                    # Workaround for plaforms that are not Package CPEs
+                    # Skip platforms that are not about packages installed
+                    # These should be handled in the remediation itself
+                    if not platform:
+                        continue
+
                 # Adjust package check command according to the pkg_manager
                 pkg_manager = self.local_env_yaml["pkg_manager"]
                 pkg_check_command = PKG_MANAGER_TO_PACKAGE_CHECK_COMMAND[pkg_manager]
@@ -451,6 +457,12 @@ class AnsibleRemediation(Remediation):
 
                 if platform in self.local_env_yaml["platform_package_overrides"]:
                     platform = self.local_env_yaml["platform_package_overrides"].get(platform)
+
+                    # Workaround for plaforms that are not Package CPEs
+                    # Skip platforms that are not about packages installed
+                    # These should be handled in the remediation itself
+                    if not platform:
+                        continue
 
                 additional_when.append('"' + platform + '" in ansible_facts.packages')
                 # After adding the conditional, we need to make sure package_facts are collected.

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -464,6 +464,7 @@ XCCDF_PLATFORM_TO_PACKAGE = {
   "login_defs": "login",
   "sssd": "sssd-common",
   "zipl": "s390utils-base",
+  "sssd-ldap": None,  # Force package check wrapping skip
 }
 
 # _version_name_map = {


### PR DESCRIPTION

#### Description:

- Do not add checks for package installed for CPEs that are not related to
package installed.

#### Rationale:

- Avoid adding check for package `sssd-ldap` installed due to `platform: sssd-ldap`.
  The [CPE](https://github.com/ComplianceAsCode/content/blob/master/shared/checks/oval/sssd_conf_uses_ldap.xml) checks for sssd configuration.
- The remediations also need platform checks, but the [Ansible macro](https://github.com/ggbecker/content/blob/9d0b609ec99c58ae300891bf828633323ff0e981/shared/macros-ansible.jinja#L508) and [Bash macro](https://github.com/ggbecker/content/blob/9d0b609ec99c58ae300891bf828633323ff0e981/shared/macros-bash.jinja#L618) already handle this.

