### PR TITLE
ocp4: Use ScanSettingBindings for e2e tests

### DIFF
--- a/tests/ocp4e2e/go.mod
+++ b/tests/ocp4e2e/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/cenkalti/backoff/v3 v3.2.2
-	github.com/openshift/compliance-operator v0.1.17
+	github.com/openshift/compliance-operator v0.1.19
 	github.com/openshift/machine-config-operator v0.0.1-0.20200913004441-7eba765c69c9
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.0

--- a/tests/ocp4e2e/go.sum
+++ b/tests/ocp4e2e/go.sum
@@ -876,8 +876,8 @@ github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf/go.mod h1:M3xexPhgM8
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
-github.com/openshift/compliance-operator v0.1.17 h1:rhJXCoa1jx7dNlHnv2CPSSVyu9S+Bf6PXW59r7TxjmE=
-github.com/openshift/compliance-operator v0.1.17/go.mod h1:OnAsYciqgrUxSjupAHhU42a4YFpUKs8mXPcuCoc1ZAE=
+github.com/openshift/compliance-operator v0.1.19 h1:Rtk8z1TD0g4gdm6GJ0EijJFUeKNHEMNl1Xa85oUHON8=
+github.com/openshift/compliance-operator v0.1.19/go.mod h1:OnAsYciqgrUxSjupAHhU42a4YFpUKs8mXPcuCoc1ZAE=
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/library-go v0.0.0-20200831114015-2ab0c61c15de/go.mod h1:6vwp+YhYOIlj8MpkQKkebTTSn2TuYyvgiAFQ206jIEQ=
 github.com/openshift/machine-config-operator v0.0.1-0.20200913004441-7eba765c69c9 h1:O9mVxLtdsSVzYEv4WGtBamzhLOjKipD0nEZungMug+E=

--- a/tests/ocp4e2e/vendor/modules.txt
+++ b/tests/ocp4e2e/vendor/modules.txt
@@ -32,7 +32,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/openshift/api v0.0.0-20200829102639-8a3a835f1acf
 github.com/openshift/api/config/v1
-# github.com/openshift/compliance-operator v0.1.17
+# github.com/openshift/compliance-operator v0.1.19
 ## explicit
 github.com/openshift/compliance-operator/pkg/apis
 github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1


### PR DESCRIPTION
These are the objects we recommend folks to use instead of raw
ComplianceSuites. It also allows us for auto-detection of platform/node
checks.