### PR TITLE
Remove the option to enable/disable "mask" a service

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1710,7 +1710,6 @@ service_disabled::
 ** *servicename* - name of the service.
 ** *packagename* - name of the package that provides this service. This argument is optional. If *packagename* is not specified it means the name of the package is the same as the name of service.
 ** *daemonname* - name of the daemon. This argument is optional. If *daemonname* is not specified it means the name of the daemon is the same as the name of service.
-** *mask_service* - Check if the service should be masked to prevent it from running. This argument is optional. Implicit value is "true".
 * Languages: Ansible, Bash, OVAL, Puppet, Ignition, Kubernetes
 
 service_enabled::

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -8,4 +8,5 @@
   systemd:
     name: ctrl-alt-del.target
     masked: yes
+    state: stopped
 

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -4,7 +4,7 @@
 # The process to disable ctrl+alt+del has changed in RHEL7. 
 # Reference: https://access.redhat.com/solutions/1123873
 {{% endif %}}
-systemctl mask ctrl-alt-del.target
+systemctl mask --now ctrl-alt-del.target
 {{%- else -%}}
 # If system does not contain control-alt-delete.override,
 if [ ! -f /etc/init/control-alt-delete.override ]; then

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora
 
-systemctl mask ctrl-alt-del.target
+systemctl mask --now ctrl-alt-del.target

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -379,9 +379,7 @@ ocil_clause: "the package is installed"
 
 {{%- macro systemd_describe_socket_disable(socket) %}}
     The <code>{{{ socket }}}</code> socket can be disabled with the following command:
-    <pre>$ sudo systemctl disable {{{ socket }}}.socket</pre>
-    The <code>{{{ socket }}}</code> socket can be masked with the following command:
-    <pre>$ sudo systemctl mask {{{ service }}}.socket</pre>
+    <pre>$ sudo systemctl mask {{{ socket }}}.socket</pre>
 {{%- endmacro %}}
 
 
@@ -401,8 +399,6 @@ ocil_clause: "the package is installed"
 
 {{%- macro systemd_describe_service_disable(service) %}}
     The <code>{{{ service }}}</code> service can be disabled with the following command:
-    <pre>$ sudo systemctl disable {{{ service }}}.service</pre>
-    The <code>{{{ service }}}</code> service can be masked with the following command:
     <pre>$ sudo systemctl mask {{{ service }}}.service</pre>
 {{%- endmacro %}}
 

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -256,7 +256,7 @@ ocil_clause: "no line is returned"
     If the socket is not running the command will return the following output:
     <pre>inactive</pre>
 
-    By default the socket will also be masked, to check that the <code>{{{ socket }}}</code> is masked, run the following command:
+    The socket will also be masked, to check that the <code>{{{ socket }}}</code> is masked, run the following command:
     <pre>$ systemctl show <code>{{{ socket }}}</code> | grep "LoadState\|UnitFileState"</pre>
 
     If the socket is masked the command will return the following outputs:
@@ -333,7 +333,7 @@ ocil_clause: "the package is installed"
     If the service is not running the command will return the following output:
     <pre>inactive</pre>
 
-    By default the service will also be masked, to check that the <code>{{{ service }}}</code> is masked, run the following command:
+    The service will also be masked, to check that the <code>{{{ service }}}</code> is masked, run the following command:
     <pre>$ systemctl show <code>{{{ service }}}</code> | grep "LoadState\|UnitFileState"</pre>
 
     If the service is masked the command will return the following outputs:
@@ -379,7 +379,7 @@ ocil_clause: "the package is installed"
 
 {{%- macro systemd_describe_socket_disable(socket) %}}
     The <code>{{{ socket }}}</code> socket can be disabled with the following command:
-    <pre>$ sudo systemctl mask {{{ socket }}}.socket</pre>
+    <pre>$ sudo systemctl mask --now {{{ socket }}}.socket</pre>
 {{%- endmacro %}}
 
 
@@ -399,7 +399,7 @@ ocil_clause: "the package is installed"
 
 {{%- macro systemd_describe_service_disable(service) %}}
     The <code>{{{ service }}}</code> service can be disabled with the following command:
-    <pre>$ sudo systemctl mask {{{ service }}}.service</pre>
+    <pre>$ sudo systemctl mask --now {{{ service }}}.service</pre>
 {{%- endmacro %}}
 
 

--- a/shared/templates/template_ANSIBLE_service_disabled
+++ b/shared/templates/template_ANSIBLE_service_disabled
@@ -14,9 +14,7 @@
       name: "{{{ DAEMONNAME }}}.service"
       enabled: "no"
       state: "stopped"
-{{%- if MASK_SERVICE %}}
       masked: "yes"
-{{%- endif %}}
     when: '"{{{ DAEMONNAME }}}.service" in ansible_facts.services'
 
 - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
@@ -33,9 +31,7 @@
     name: "{{{ DAEMONNAME }}}.socket"
     enabled: "no"
     state: "stopped"
-{{%- if MASK_SERVICE %}}
     masked: "yes"
-{{%- endif %}}
   when: '"{{{ DAEMONNAME }}}.socket" in socket_file_exists.stdout_lines[1]'
 {{% elif init_system == "upstart" %}}
 - name: Stop {{{ SERVICENAME }}}

--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -15,10 +15,7 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 # Disable socket activation if we have a unit file for it
 if "$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'; then
     "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
-    "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.socket'
-{{%- if MASK_SERVICE %}}
     "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
-{{%- endif %}}
 fi
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.

--- a/shared/templates/template_IGNITION_service_disabled
+++ b/shared/templates/template_IGNITION_service_disabled
@@ -14,6 +14,8 @@ spec:
       - name: {{{ DAEMONNAME }}}.service
         enabled: false
         mask: true
+        state: stopped
       - name: {{{ DAEMONNAME }}}.socket
         enabled: false
         mask: true
+        state: stopped

--- a/shared/templates/template_IGNITION_service_disabled
+++ b/shared/templates/template_IGNITION_service_disabled
@@ -13,11 +13,7 @@ spec:
       units:
       - name: {{{ DAEMONNAME }}}.service
         enabled: false
-{{%- if MASK_SERVICE %}}
         mask: true
-{{%- endif %}}
       - name: {{{ DAEMONNAME }}}.socket
         enabled: false
-{{%- if MASK_SERVICE %}}
         mask: true
-{{%- endif %}}

--- a/shared/templates/template_KUBERNETES_service_disabled
+++ b/shared/templates/template_KUBERNETES_service_disabled
@@ -14,6 +14,8 @@ spec:
       - name: {{{ DAEMONNAME }}}.service
         enabled: false
         mask: true
+        state: stopped
       - name: {{{ DAEMONNAME }}}.socket
         enabled: false
         mask: true
+        state: stopped

--- a/shared/templates/template_KUBERNETES_service_disabled
+++ b/shared/templates/template_KUBERNETES_service_disabled
@@ -13,11 +13,7 @@ spec:
       units:
       - name: {{{ DAEMONNAME }}}.service
         enabled: false
-{{%- if MASK_SERVICE %}}
         mask: true
-{{%- endif %}}
       - name: {{{ DAEMONNAME }}}.socket
         enabled: false
-{{%- if MASK_SERVICE %}}
         mask: true
-{{%- endif %}}

--- a/shared/templates/template_OVAL_service_disabled
+++ b/shared/templates/template_OVAL_service_disabled
@@ -12,38 +12,11 @@
       <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
       <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
         <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
-        {{%- if MASK_SERVICE %}}
         <criterion comment="Property LoadState of service {{{ SERVICENAME }}} is masked" test_ref="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" />
         <criterion comment="Property FragmentPath of service {{{ SERVICENAME }}} is set to /dev/null" test_ref="test_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" />
-        {{%- else %}}
-        <criterion comment="{{{ SERVICENAME }}} not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" />
-        <criterion comment="{{{ SERVICENAME }}} socket not wanted by multi-user.target" test_ref="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" />
-        {{%- endif %}}
       </criteria>
     </criteria>
   </definition>
-
-  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_{{{ SERVICENAME }}}_not_wanted_by_multi_user_target" version="1">
-    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_disabled" />
-    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_off"/>
-  </linux:systemdunitdependency_test>
-  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_disabled" comment="list of dependencies of multi-user.target" version="1">
-    <linux:unit>multi-user.target</linux:unit>
-  </linux:systemdunitdependency_object>
-  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_off" comment="{{{ SERVICENAME }}} service is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">{{{ SERVICENAME }}}.service</linux:dependency>
-  </linux:systemdunitdependency_state>
-
-  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_{{{ SERVICENAME }}}_socket_not_wanted_by_multi_user_target" version="1">
-    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_disabled" />
-    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_socket_off"/>
-  </linux:systemdunitdependency_test>
-  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_disabled" comment="list of dependencies of multi-user.target" version="1">
-    <linux:unit>multi-user.target</linux:unit>
-  </linux:systemdunitdependency_object>
-  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_socket_off" comment="{{{ SERVICENAME }}} socket is not listed in the dependencies" version="1">
-    <linux:dependency entity_check="none satisfy">{{{ SERVICENAME }}}.socket</linux:dependency>
-  </linux:systemdunitdependency_state>
 
   <linux:systemdunitproperty_test id="test_service_not_running_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the {{{ SERVICENAME }}} service is not running" version="1">
     <linux:object object_ref="obj_service_not_running_{{{ SERVICENAME }}}"/>
@@ -56,7 +29,6 @@
   <linux:systemdunitproperty_state id="state_service_not_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is not running">
       <linux:value>inactive</linux:value>
   </linux:systemdunitproperty_state>
-{{%- if MASK_SERVICE %}}
   <linux:systemdunitproperty_test id="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the property LoadState from the service {{{ SERVICENAME }}} is masked" version="1">
     <linux:object object_ref="obj_service_loadstate_is_masked_{{{ SERVICENAME }}}"/>
     <linux:state state_ref="state_service_loadstate_is_masked_{{{ SERVICENAME }}}"/>
@@ -80,8 +52,6 @@
   <linux:systemdunitproperty_state id="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" version="1" comment="FragmentPath is set to /dev/null">
       <linux:value>/dev/null</linux:value>
   </linux:systemdunitproperty_state>
-{{%- endif %}}
-
 
 {{% else %}}
 

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -301,8 +301,6 @@ def service_disabled(data, lang):
         data["packagename"] = data["servicename"]
     if "daemonname" not in data:
         data["daemonname"] = data["servicename"]
-    if "mask_service" not in data:
-        data["mask_service"] = "true"
     return data
 
 

--- a/utils/migrate_template_csv_to_rule.py
+++ b/utils/migrate_template_csv_to_rule.py
@@ -505,17 +505,12 @@ def services_disabled_csv_to_dict(csv_line, csv_data):
     service_name = csv_line[0]
     package_name = csv_line[1]
     daemon_name = csv_line[2]
-    mask_service = "true"
-    if len(csv_line) == 4:
-        mask_service = csv_line[3]
 
     rule_id = f"service_{service_name}_disabled"
 
     data_service_disabled["servicename"] = service_name
     data_service_disabled["packagename"] = package_name
     data_service_disabled["daemonname"] = daemon_name
-    if not mask_service:
-        data_service_disabled["mask_service"] = mask_service
     service_disabled["vars"] = data_service_disabled
 
     csv_data[rule_id] = service_disabled


### PR DESCRIPTION
#### Description:

- Remove the option to enable/disable `mask` a service and always mask the service on `service_disabled` related rules.

#### Rationale:

- We are not using `disable` option only in any of the rules. So it doesn't make sense to keep this since we use `mask` for all rules. This can cause confusion for users as the description says that the user can either `disable` or `mask`. This way is set in stone that they need to `mask` the service to be compliant with the rule.

- Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1891435
