### PR TITLE
Add machine platform for rule kernel_trust_cpu_rng

### DIFF
--- a/linux_os/guide/system/software/integrity/kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/software/integrity/kernel_trust_cpu_rng/rule.yml
@@ -49,6 +49,8 @@ ocil: |-
     If the command does not return any output, then the boot parameter is
     missing.
 
+platform: machine
+
 template:
     name: grub2_bootloader_argument
     vars:


### PR DESCRIPTION
It is not possible (nor recommended) to modify kernel parameters
from containers when using standard configuration, therefore disable
the rule evaluation in container env.