### PR TITLE
OCP4: Verify CIS 1.3 section

### DIFF
--- a/applications/openshift/controller/controller_bind_address/rule.yml
+++ b/applications/openshift/controller/controller_bind_address/rule.yml
@@ -34,11 +34,15 @@ ocil_clause: |-
     <tt>bind-address</tt> is not configured to a secure IP address
 
 ocil: |-
-    To verify that <tt>bind-address</tt> is configured correctly,
+    To verify that <tt>secure-port</tt> is configured correctly,
     run the following command:
-    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["bind-address"]'</pre>
-    Verify that the <tt>bind-address</tt> argument is set to a secure
-    IP address.
+    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson |   jq -r '.data["config.yaml"]' | jq '.extendedArguments["secure-port"][]'</pre>
+    Verify that it's using an appropriate port (the value is not <pre>0</pre>).
+
+    To verify that <tt>port</tt> is configured correctly,
+    run the following command:
+    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson |   jq -r '.data["config.yaml"]' | jq '.extendedArguments["port"][]'</pre>
+    Verify that it's disabled (the value is <pre>0</pre>).
 
 references:
     cis: 1.3.7

--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -2,20 +2,18 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Ensure Controller bind-address argument is set'
+title: 'Ensure Controller insecure port argument is unset'
 
 description: |-
     To ensure the Controller Manager service is bound to secure loopback
-    address,
+    address and a secure port,
     set the <tt>RotateKubeletServerCertificate</tt> option to <tt>true</tt>
     in the <tt>openshift-kube-controller-manager</tt> configmap on the master
     node(s):
     <pre>
     "extendedArguments": {
     ...
-      "bind-address": [
-        "127.0.0.1",
-      ],
+      "port": ["0"],
     ...
     </pre>
 
@@ -31,14 +29,9 @@ severity: low
 #    cce@ocp4:
 
 ocil_clause: |-
-    <tt>bind-address</tt> is not configured to a secure IP address
+    <tt>port</tt> is not disabled
 
 ocil: |-
-    To verify that <tt>secure-port</tt> is configured correctly,
-    run the following command:
-    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson |   jq -r '.data["config.yaml"]' | jq '.extendedArguments["secure-port"][]'</pre>
-    Verify that it's using an appropriate port (the value is not <pre>0</pre>).
-
     To verify that <tt>port</tt> is configured correctly,
     run the following command:
     <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson |   jq -r '.data["config.yaml"]' | jq '.extendedArguments["port"][]'</pre>
@@ -58,6 +51,6 @@ template:
     filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
     yamlpath: '.data["config.yaml"]'
     values:
-    - value: '(\"port\":\[\"0\"\]).*(\"secure-port\":\[\"10257\"\])'
+    - value: '(\"port\":\[\"0\"\])'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/controller/controller_secure_port/rule.yml
+++ b/applications/openshift/controller/controller_secure_port/rule.yml
@@ -1,0 +1,56 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Ensure Controller secure-port argument is set'
+
+description: |-
+    To ensure the Controller Manager service is bound to secure loopback
+    address using a secure port,
+    set the <tt>RotateKubeletServerCertificate</tt> option to <tt>true</tt>
+    in the <tt>openshift-kube-controller-manager</tt> configmap on the master
+    node(s):
+    <pre>
+    "extendedArguments": {
+    ...
+      "secure-port": ["10257"],
+    ...
+    </pre>
+
+rationale: |-
+    The Controller Manager API service is used for health and metrics
+    information and is available without authentication or encryption. As such, it
+    should only be bound to a localhost interface to minimize the cluster's
+    attack surface.
+
+severity: low
+
+#identifiers:
+#    cce@ocp4:
+
+ocil_clause: |-
+    <tt>secure-port</tt> is not configured to use a secure port
+
+ocil: |-
+    To verify that <tt>secure-port</tt> is configured correctly,
+    run the following command:
+    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson |   jq -r '.data["config.yaml"]' | jq '.extendedArguments["secure-port"][]'</pre>
+    Verify that it's using an appropriate port (the value is not <pre>0</pre>).
+
+references:
+    cis: 1.3.7
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '(\"secure-port\":\[\"10257\"\])'
+      operation: "pattern match"
+      type: "string"

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -42,7 +42,7 @@ ocil_clause: '<tt>use-service-account-credentials</tt> is set to <tt>false</tt>'
 ocil: |-
     To verify that <tt>service-account-credentials</tt> is configured correctly,
     run the following command:
-    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["service-account-credentials"]'</pre>
+    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson | jq -r '.data["config.yaml"]' | jq -r '.extendedArguments["use-service-account-credentials"]'</pre>
     The value of <tt>use-service-account-credentials</tt> should be <tt>true</tt>.
 
 warnings:

--- a/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
+++ b/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
@@ -21,7 +21,10 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-84182-5
 
-severity: unknown
+references:
+  cis: 1.3.2
+
+severity: medium
 
 warnings:
 - general: |-

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -105,7 +105,8 @@ selections:
   # 1.3.6 Ensure that the RotateKubeletServerCertificate argument is set to true
     - controller_rotate_kubelet_server_certs
   # 1.3.7 Ensure that the --bind-address argument is set to 127.0.0.1
-    - controller_bind_address
+    - controller_secure_port
+    - controller_insecure_port_disabled
   #### 1.4 Scheduler
   # 1.4.1 Ensure that the --profiling argument is set to false  (info only)
     - scheduler_profiling_argument

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -93,8 +93,8 @@ selections:
   # 1.2.35 Ensure that the API Server only makes use of Strong Cryptographic Ciphers
     - api_server_tls_cipher_suites
   #### 1.3 Controller Manager
-  # 1.3.1 Ensure that the --terminated-pod-gc-threshold argument is set as appropriate
-  # 1.3.2 Ensure that the --profiling argument is set to false (info only)
+  # 1.3.1 Ensure that garbage collection is configured as appropriate (Manual)
+  # 1.3.2 Ensure that controller manager healthz endpoints are protected by RBAC. (Automated)
     - rbac_debug_role_protects_pprof
   # 1.3.3 Ensure that the --use-service-account-credentials argument is set to true
     - controller_use_service_account


### PR DESCRIPTION
This pass fixes some minor issues about the section:

* Set references where needed
* Fix OCIL strings to use appropriate commands
* Fix comments to reflect new titles used in the draft