### PR TITLE
ocp4: Use Fedora 33 for container files

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -1,5 +1,5 @@
 # This dockerfile builds the content in the current repo for OCP4
-FROM registry.fedoraproject.org/fedora-minimal:32 as builder
+FROM registry.fedoraproject.org/fedora-minimal:33 as builder
 
 WORKDIR /content
 

--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -1,4 +1,4 @@
-FROM fedora:32 as builder
+FROM fedora:33 as builder
 
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content


### PR DESCRIPTION
Fedora 33 now has OpenSCAP 1.3.4 which is what we need to build. So we
can take it into use. This updates the image tag to use 33 specifically
as opposed to using "latest" in order to avoid stability issues that
might come wit upgrades.