### PR TITLE
OCP4: Enhance e2e tests to check individual rules

### DIFF
--- a/applications/openshift/controller/controller_use_service_account/tests/ocp4/e2e.yml
+++ b/applications/openshift/controller/controller_use_service_account/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS 

--- a/tests/ocp4e2e/e2e_test.go
+++ b/tests/ocp4e2e/e2e_test.go
@@ -55,7 +55,7 @@ func TestE2e(t *testing.T) {
 		ctx.waitForComplianceSuite(suite)
 		numberOfRemediations = ctx.getRemediationsForSuite(suite)
 		numberOfFailuresInit = ctx.getFailuresForSuite(suite)
-		numberOfCheckResultsInit = ctx.getCheckResultsForSuite(suite)
+		numberOfCheckResultsInit = ctx.verifyCheckResultsForSuite(suite, false)
 		numberOfInvalidResults = ctx.getInvalidResultsFromSuite(suite)
 	})
 
@@ -71,7 +71,7 @@ func TestE2e(t *testing.T) {
 			ctx.doRescan(suite)
 			ctx.waitForComplianceSuite(suite)
 			numberOfFailuresEnd = ctx.getFailuresForSuite(suite)
-			numberOfCheckResultsEnd = ctx.getCheckResultsForSuite(suite)
+			numberOfCheckResultsEnd = ctx.verifyCheckResultsForSuite(suite, true)
 		})
 
 		t.Run("We should have the same number of check results in each scan", func(t *testing.T) {


### PR DESCRIPTION
This enhances the e2e tests to be able to checkf or individual rules.

This requires folks to create a `/tests/ocp4` directory in the rule
that's to be tested. If the directory doesn't exist, the verification
will be skipped.

If the directory exists, it'll then look for a `e2e.yml` file that
contains the test definition.

The current format is:

```
---
default_result: <result>
result_after_remediation: <result>
```

With result being either `PASS` or `FAIL`.

If there were remediations applied the test will either check the value
of `result_after_remediation` if it's not empty or `default_result`.

This enables us to test that rules don't regress and that they issue the
expected results.