### PR TITLE
Small fixes of OCP rules used in CIS profile that cover the 1.1 section

### DIFF
--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The Kube API Server Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.2
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 
-#template:
-#    name: file_groupowner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
-#        filegid: '0'
+template:
+    name: file_groupowner
+    vars:
+        filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
+        filepath_is_regex: "true"
+        missing_file_pass: "true"
+        filegid: '0'

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The Kube Controller Manager Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.4
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 
-#template:
-#    name: file_groupowner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
-#        fileuid: '0'
+template:
+    name: file_groupowner
+    vars:
+        filepath: '^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml$'
+        filepath_is_regex: 'true'
+        missing_file_pass: 'true'
+        filegid: '0'

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Kube API Server Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.2
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 
-#template:
-#    name: file_owner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-apiserver-pod.yaml
-#        fileuid: '0'
+template:
+    name: file_owner
+    vars:
+        filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
+        filepath_is_regex: "true"
+        missing_file_pass: "true"
+        fileuid: '0'

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Kube Controller Manager Pod Specificiation File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.4
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
-#template:
-#    name: file_owner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml
-#        fileuid: '0'
+template:
+    name: file_owner
+    vars:
+        filepath: '^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml$'
+        filepath_is_regex: 'true'
+        missing_file_pass: 'true'
+        fileuid: '0'

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kube Controller Manager Pod Specificiation File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", perms="0644") }}}
 
 rationale: |-
     If the Kube specification file is writable by a group-owner or the
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.3
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions


### PR DESCRIPTION
#### Description:

- Mostly the fixes change the filepath in the OCIL macros and descriptions to
  match what is being tested by the template. In some cases the template was
  not enabled (probably because the wildcard template was not available when the
  rule was written)

#### Rationale:

- Post-hackfest cleanup