### PR TITLE
OCP4: Add manual remediation capabilities to e2e tests

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_config/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/api-server/api_server_encryption_provider_config/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# This applies the remediation needed for this rule. Which enables etcd encryption
+# This rule wasn't able to be done via a standard remediation since we only need to
+# apply a partial part of the Kubernetes object. PATCH support for the
+# compliance-operator would be needed to make this work
+#
+# This patch sets the encryption setting and waits for it to be applied
+
+oc patch apiservers cluster -p '{"spec":{"encryption":{"type":"aescbc"}}}' --type=merge
+
+while true; do
+    status=$(oc get openshiftapiserver -o=jsonpath='{range .items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}')
+
+    echo "Current Encryption Status:"
+    oc get openshiftapiserver -o=jsonpath='{range .items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}{"\n"}{.message}{"\n"}'
+
+    if [ "$status" == "EncryptionCompleted" ]; then
+        exit 0
+    fi
+
+    sleep 5
+done

--- a/applications/openshift/api-server/api_server_encryption_provider_config/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_config/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS 


### PR DESCRIPTION
this adds the ability to run manual remediations as part of the e2e
tests. These remediations cannot be currently done via the
compliance-operator, because either they only work on partial objects or
they require an opinionated decision about the deployment which the
operator cannot make.

These remediations will live in the ocp4 tests directory with the
filename `e2e-remediation.sh`. When this file is found, it'll get run.

The remediation is expected to wait for the status to converge.

There is a default timeout of 15 mins for the remediation script(s) to
finish.