### PR TITLE
OCP4: Add e2e tests for rules in section 1.3 of the CIS benchmark

### DIFF
--- a/applications/openshift/controller/controller_insecure_port_disabled/tests/ocp4/e2e.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/tests/ocp4/e2e.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/controller/controller_secure_port/tests/ocp4/e2e.yml
+++ b/applications/openshift/controller/controller_secure_port/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/controller/controller_service_account_ca/tests/ocp4/e2e.yml
+++ b/applications/openshift/controller/controller_service_account_ca/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/controller/controller_service_account_private_key/tests/ocp4/e2e.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
+++ b/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
@@ -26,6 +26,15 @@ references:
 
 severity: medium
 
+ocil_clause: |-
+    The <tt>cluster-debugger</tt> role isn't protecting <tt>/debug/pprof</tt>
+
+ocil: |-
+    To verify that the <tt>cluster-debugger</tt> role is configured correctly,
+    run the following command:
+    <pre>$ oc get clusterroles cluster-debugger -o jsonpath='{.rules[0].nonResourceURLs}'</pre>
+    and verify that the <tt>/debug/pprof</tt> path is included there.
+
 warnings:
 - general: |-
     {{{ openshift_cluster_setting("/apis/rbac.authorization.k8s.io/v1/clusterroles/cluster-debugger") | indent(4) }}}
@@ -40,3 +49,4 @@ template:
     values:
     - value: '\/debug\/pprof'
       operation: 'pattern match'
+      entity_check: 'at least one'

--- a/applications/openshift/rbac/rbac_debug_role_protects_pprof/tests/ocp4/e2e.yml
+++ b/applications/openshift/rbac/rbac_debug_role_protects_pprof/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
These rules had been verified and this merely adds the expected defaults
to test for.