### PR TITLE
Implement variable metadata for test scenarios

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# variables = var_accounts_tmout=600
 
 if grep -q "^TMOUT" /etc/profile; then
 	sed -i "s/^TMOUT.*/# TMOUT=600/" /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# variables = var_accounts_tmout=700
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=600/" /etc/profile
+	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile
 else
-	echo "TMOUT=600" >> /etc/profile
+	echo "TMOUT=700" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/line_not_there.fail.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^TMOUT.*/d" /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance.pass.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# variables = var_accounts_tmout=900
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=60/" /etc/profile
+	sed -i "s/.*TMOUT.*/TMOUT=800/" /etc/profile
 else
-	echo "TMOUT=60" >> /etc/profile
+	echo "TMOUT=800" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+
+# variables = var_accounts_tmout=200
 
 if grep -q "^TMOUT" /etc/profile; then
-	sed -i "s/^TMOUT.*/TMOUT=3600/" /etc/profile
+	sed -i "s/^TMOUT.*/TMOUT=250/" /etc/profile
 else
-	echo "TMOUT=3600" >> /etc/profile
+	echo "TMOUT=250" >> /etc/profile
 fi


### PR DESCRIPTION
- Modify datastreams, so XCCDF values have defaults that we want.
- Use XSLT transform to alter datastreams - OpenSCAP requires xsltproc, so the utility is installed.
- ~Datastreams are part of snapshots, so no worries with overwriting them.~ Datastreams have to be quasi-snapshotted on the host - there are no datastreams uploaded to the scanned guest, as `oscap-ssh` does the scan.

This PR requires #6322 to be merged in order to work.