### PR TITLE
Evaluate Role default added variable conditionals first

### DIFF
--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -188,7 +188,7 @@ class PlaybookToRoleConverter():
                 task["when"] = [task["when"]]
 
             variables_to_add = {tag for tag in task["tags"] if self._tag_is_valid_variable(tag)}
-            task["when"] += ["{varname} | bool".format(varname=v) for v in variables_to_add]
+            task["when"] = ["{varname} | bool".format(varname=v) for v in variables_to_add] + task["when"]
             variables.update(variables_to_add)
 
             if not task["when"]:


### PR DESCRIPTION

#### Description:

- Add "added variables" to beginning of "when" list, so they are evaluated before any conditional that is task specific.

#### Notes: 
The Task goes from:
```yaml
3002 - name: Import RedHat GPG key
3003   rpm_key:
3004     state: present
3005     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
3006   when:
3007   - gpg_key_directory_permission.stat.mode <= '0755'
3008   - (gpg_installed_fingerprints | difference(gpg_valid_fingerprints)) | length == 0
3009   - gpg_installed_fingerprints | length > 0
3010   - ansible_distribution == "RedHat"
3011   - no_reboot_needed | bool
3012   - medium_disruption | bool
3013   - restrict_strategy | bool
3014   - high_severity | bool
3015   - medium_complexity | bool
3016   - ensure_redhat_gpgkey_installed | bool
```
to 
```yaml
3002 - name: Import RedHat GPG key
3003   rpm_key:
3004     state: present
3005     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
3006   when:
3007   - no_reboot_needed | bool
3008   - medium_complexity | bool
3009   - restrict_strategy | bool
3010   - medium_disruption | bool
3011   - ensure_redhat_gpgkey_installed | bool
3012   - high_severity | bool
3013   - gpg_key_directory_permission.stat.mode <= '0755'
3014   - (gpg_installed_fingerprints | difference(gpg_valid_fingerprints)) | length == 0
3015   - gpg_installed_fingerprints | length > 0
3016   - ansible_distribution == "RedHat"
```

#### Rationale:

- Fixes #6307 