### PR TITLE
OCP4/CIS 2: Fix OCIL and add tests

### DIFF
--- a/applications/openshift/etcd/etcd_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/rule.yml
@@ -30,8 +30,9 @@ ocil_clause: 'the etcd is using self-signed certificates'
 
 ocil: |-
     Run the following command on the master node(s):
-    <pre>$ grep ETCD_AUTO_TLS /etc/etcd/etcd.conf</pre>
-    The output should not return <tt>true</tt>.
+    <pre>$ oc get cm/etcd-pod -n openshift-etcd -o yaml</pre>
+    The etcd pod configuration contained in the configmap should not
+    contain the <tt>--auto-tls=true</tt> flag.
 
 warnings:
     - general: |-

--- a/applications/openshift/etcd/etcd_auto_tls/tests/ocp4/e2e.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -9,7 +9,7 @@ description: |-
     make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
     <tt>openshift-etcd</tt> namespace contain the following argument
     for the <tt>etcd</tt> binary in the <tt>etcd</tt> pod:
-    <pre>--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-<i>NODE_NAME</i>.crt</pre>
+    <pre>--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt</pre>
 
 rationale: |-
     Without cryptographic integrity protections, information can be
@@ -27,7 +27,7 @@ ocil_clause: 'the etcd client certificate is not configured'
 
 ocil: |-
     Run the following command:
-    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep --cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-<i>NODE_NAME</i>.crt</pre>
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt"</pre>
     Verify that there is a certificate configured.
 
 warnings:

--- a/applications/openshift/etcd/etcd_cert_file/tests/ocp4/e2e.yml
+++ b/applications/openshift/etcd/etcd_cert_file/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -6,10 +6,10 @@ title: 'Ensure That The etcd Key File Is Correctly Set'
 
 description: |-
     To ensure the <tt>etcd</tt> service is serving TLS to clients,
-    edit the <tt>etcd</tt> configuration file
-    <tt>/etc/etcd/etcd.conf</tt> on the master and
-    adding a key file to <tt>ETCD_KEY_FILE</tt>:
-    <pre>ETCD_CERT_FILE=/etc/ssl/etcd/system:etcd-server:<i>etcd_dns_name</i>.key</pre>
+    make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
+    <tt>openshift-etcd</tt> namespace contain the following argument
+    for the <tt>etcd</tt> binary in the <tt>etcd</tt> pod:
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key"</pre>
 
 rationale: |-
     Without cryptographic integrity protections, information can be
@@ -26,6 +26,20 @@ references:
 ocil_clause: 'the etcd client key file is not configured'
 
 ocil: |-
-    Run the following command on the master node(s):
-    <pre>$ grep ETCD_KEY_FILE=/etc/etcd/etcd.conf</pre>
-    Verify that there is a key file configured.
+    Run the following command:
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key"</pre>
+    Verify that there is a certificate configured.
+
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+
+template:
+    name: yamlfile_value
+    vars:
+        ocp_data: "true"
+        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
+        yamlpath: ".data['pod.yaml']"
+        values:
+          - value: ".*--key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key \\.*"
+            operation: "pattern match"

--- a/applications/openshift/etcd/etcd_key_file/tests/ocp4/e2e.yml
+++ b/applications/openshift/etcd/etcd_key_file/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
For rules that were covered during the hackfest, this does some minor fixes and
adds tests.

Note that some rules were left untouched because they need actual checks
entirely.