### PR TITLE
OCP4: Add checks for CIS 1.1 section

### DIFF
--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -18,7 +18,7 @@ severity: medium
 #    cce@ocp4:
 
 references:
-    cis: 1.4.10
+    cis: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 
@@ -27,6 +27,7 @@ ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 template:
     name: file_groupowner
     vars:
-        filepath: /etc/cni/net.d/
-        file_regex: ^.*$
+        filepath: ^/etc/cni/net.d/.*$
         filegid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/.*", group="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,9 +20,9 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/.*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/.*", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -29,5 +29,4 @@ template:
     vars:
         filepath: ^/etc/cni/net.d/.*$
         filegid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_cni_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -4,27 +4,29 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The OpenShift Controller Manager Kubeconfig File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
+description: |-
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
 
 rationale: |-
-    The Controller Manager Kubeconfig file contains information about the configuration of the
-    OpenShift Controller Manager Server that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+  The Controller Manager's kubeconfig contains information abot how the
+  component will access the API server. You should set its file ownership to
+  maintain the integrity of the file. The file should be owned by
+  <pre>root:root</pre>.
 
 severity: medium
 
-#identifiers:
-#    cce@ocp4: 80612-5
-
 references:
-    cis: 1.1.18
+  cis: 1.1.18
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
+ocil: |-
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
 
 template:
-    name: file_groupowner
-    vars:
-        filepath: /etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-        filegid: '0'
+  name: file_groupowner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
+    filegid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -8,7 +8,7 @@ description: |-
   {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
 
 rationale: |-
-  The Controller Manager's kubeconfig contains information abot how the
+  The Controller Manager's kubeconfig contains information about how the
   component will access the API server. You should set its file ownership to
   maintain the integrity of the file. The file should be owned by
   <pre>root:root</pre>.

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Etcd Database Directory'
+
+description: |-
+    {{{ describe_file_group_owner(file="/var/lib/etcd", group="root") }}}
+
+rationale: |-
+    etcd is a highly-available key-value store used by Kubernetes deployments for
+    persistent storage of all of its REST API objects. This data directory should
+    be protected from any unauthorized reads or writes. It should be owned by
+    <pre>root:root</pre>.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.12
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/lib/etcd", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /var/lib/etcd
+        filegid: '0'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Etcd Database Directory'
+title: 'Verify Group Who Owns The Etcd Database Directory'
 
 description: |-
     {{{ describe_file_group_owner(file="/var/lib/etcd", group="root") }}}

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Etcd Database Directory'
 
 description: |-
-    {{{ describe_file_group_owner(file="/var/lib/etcd", group="root") }}}
+    {{{ describe_file_group_owner(file="/var/lib/etcd/member/", group="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -21,14 +21,14 @@ severity: medium
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/lib/etcd", group="root") }}}
+    {{{ ocil_file_group_owner(file="/var/lib/etcd/member/", group="root") }}}
 
 template:
     name: file_groupowner
     vars:
-        filepath: /var/lib/etcd
+        filepath: /var/lib/etcd/member/
         filegid: '0'
         missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -24,7 +24,7 @@ references:
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/lib/etcd", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/var/lib/etcd", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Etcd Database Files'
+
+description: |-
+    {{{ describe_file_group_owner(file="/var/lib/etcd/*", group="root") }}}
+
+rationale: |-
+    etcd is a highly-available key-value store used by Kubernetes deployments for
+    persistent storage of all of its REST API objects. This data directory should
+    be protected from any unauthorized reads or writes. It should be owned by
+    <pre>root:root</pre>.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.12
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/*", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/lib/etcd/*", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: ^/var/lib/etcd/*$
+        filegid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Group Who Owns The Etcd Database Files'
+title: 'Verify Group Who Owns The Etcd Write-Ahead-Log Files'
 
 description: |-
-    {{{ describe_file_group_owner(file="/var/lib/etcd/.*", group="root") }}}
+    {{{ describe_file_group_owner(file="/var/lib/etcd/member/wal/.*", group="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/.*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/wal/.*", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/lib/etcd/.*", group="root") }}}
+    {{{ ocil_file_group_owner(file="/var/lib/etcd/member/wal/.*", group="root") }}}
 
 template:
     name: file_groupowner
     vars:
-        filepath: ^/var/lib/etcd/.*$
+        filepath: ^/var/lib/etcd/member/wal/.*$
         filegid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Etcd Database Files'
 
 description: |-
-    {{{ describe_file_group_owner(file="/var/lib/etcd/*", group="root") }}}
+    {{{ describe_file_group_owner(file="/var/lib/etcd/.*", group="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/.*", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/lib/etcd/*", group="root") }}}
+    {{{ ocil_file_group_owner(file="/var/lib/etcd/.*", group="root") }}}
 
 template:
     name: file_groupowner
     vars:
-        filepath: ^/var/lib/etcd/*$
+        filepath: ^/var/lib/etcd/.*$
         filegid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -24,7 +24,7 @@ references:
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/*", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/lib/etcd/*", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/var/lib/etcd/*", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Etcd Database Files'
+title: 'Verify Group Who Owns The Etcd Database Files'
 
 description: |-
     {{{ describe_file_group_owner(file="/var/lib/etcd/*", group="root") }}}

--- a/applications/openshift/master/file_groupowner_etcd_data_files/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The ETCD Member Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube Specification file contains information about the configuration of the
@@ -19,14 +19,14 @@ severity: medium
 references:
     cis: 1.1.8
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", group="root") }}}'
 
 template:
     name: file_groupowner
     vars:
-        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml$
+        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
         filegid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The ETCD Member Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/manifests/etcd-member.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube Specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.8
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/manifests/etcd-member.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/manifests/etcd-member.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 
-#template:
-#    name: file_groupowner
-#    vars:
-#        filepath: /etc/kubernetes/manifests/etcd-member.yaml
-#        filegid: '0'
+template:
+    name: file_groupowner
+    vars:
+        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml$
+        filegid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -4,7 +4,8 @@ prodtype: ocp4
 
 
 title: 'Verify Group Who Owns The OpenShift SDN Container Network Interface Plugin IP Address Allocations'
-description: '{{{ describe_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/*", group="root") }}}'
+
+description: '{{{ describe_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,14 +21,14 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/*", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}'
 
 template:
     name: file_groupowner
     vars:
-        filepath: ^/var/lib/cni/networks/openshift-sdn/*$
+        filepath: ^/var/lib/cni/networks/openshift-sdn/.*$
         filegid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+
+title: 'Verify Group Who Owns The OpenShift SDN Container Network Interface Plugin IP Address Allocations'
+description: '{{{ describe_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/*", group="root") }}}'
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.10
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/*", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/*", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: ^/var/lib/cni/networks/openshift-sdn/*$
+        filegid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_ip_allocations/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The Kube API Server Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,9 +19,9 @@ severity: medium
 references:
     cis: 1.1.2
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The Kube Controller Manager Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,9 +19,9 @@ severity: medium
 references:
     cis: 1.1.4
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The Kube Scheduler Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube Specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.6
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 
-#template:
-#    name: file_groupowner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml
-#        filegid: '0'
+template:
+    name: file_groupowner
+    vars:
+        filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml$
+        filegid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The Kube Scheduler Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", group="root") }}}'
 
 rationale: |-
     The Kube Specification file contains information about the configuration of the
@@ -19,9 +19,9 @@ severity: medium
 references:
     cis: 1.1.6
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_kube_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
+
+description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.10
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+
+ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: ^/etc/cni/net.d/.*$
+        filegid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -2,9 +2,9 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
+title: 'Verify Group Who Owns The OpenShift Multus Container Network Interface Plugin Files'
 
-description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,14 +20,14 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 
 template:
     name: file_groupowner
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/var/run/multus/cni/net.d/*$
         filegid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The OpenShift Multus Container Network Interface Plugin Files'
 
-description: '{{{ describe_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/var/run/multus/cni/net.d/.*", group="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,14 +20,14 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/.*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/var/run/multus/cni/net.d/.*", group="root") }}}'
 
 template:
     name: file_groupowner
     vars:
-        filepath: ^/var/run/multus/cni/net.d/*$
+        filepath: ^/var/run/multus/cni/net.d/.*$
         filegid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_multus_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The OpenShift SDN CNI Server Config'
+
+description: |-
+    {{{ describe_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="root") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /var/run/openshift-sdn/cniserver/config.json
+        filegid: '0'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -24,7 +24,7 @@ references:
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The OpenShift SDN CNI Server Config'
+title: 'Verify Group Who Owns The OpenShift SDN CNI Server Config'
 
 description: |-
     {{{ describe_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="root") }}}

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_groupowner_openvswitch/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The OpenShift Open vSwitch Files'
 
-description: '{{{ describe_file_group_owner(file="/etc/openvswitch/*", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/openvswitch/.*", group="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,9 +20,9 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/origin/openvswitch/*", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/origin/openvswitch/.*", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_groupowner_openvswitch/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Open vSwitch Configuration Database'
+title: 'Verify Group Who Owns The Open vSwitch Configuration Database'
 
 description: |-
     {{{ describe_file_group_owner(file="/etc/openvswitch/conf.db", group="800") }}}

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Open vSwitch Configuration Database'
+
+description: |-
+    {{{ describe_file_group_owner(file="/etc/openvswitch/conf.db", group="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/conf.db", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/openvswitch/conf.db
+        filegid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database'
 
 description: |-
-    {{{ describe_file_group_owner(file="/etc/openvswitch/conf.db", group="800") }}}
+    {{{ describe_file_group_owner(file="/etc/openvswitch/conf.db", group="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/openvswitch/conf.db", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/conf.db", group="openvswitch") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
-    {{{ describe_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="800") }}}
+    {{{ describe_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="openvswitch") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Open vSwitch Configuration Database Lock'
+title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
     {{{ describe_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="800") }}}

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Open vSwitch Configuration Database Lock'
+
+description: |-
+    {{{ describe_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/openvswitch/.conf.db.~lock~
+        filegid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Open vSwitch Process ID File'
+
+description: |-
+    {{{ describe_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /var/run/openvswitch/ovs-vswitchd.pid
+        filegid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Open vSwitch Process ID File'
+title: 'Verify Group Who Owns The Open vSwitch Process ID File'
 
 description: |-
     {{{ describe_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="800") }}}

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Process ID File'
 
 description: |-
-    {{{ describe_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="800") }}}
+    {{{ describe_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_ovs_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Open vSwitch Persistent System ID'
+title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 
 description: |-
     {{{ describe_file_group_owner(file="/etc/openvswitch/system-id.conf", group="800") }}}

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Open vSwitch Persistent System ID'
+
+description: |-
+    {{{ describe_file_group_owner(file="/etc/openvswitch/system-id.conf", group="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/system-id.conf", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/openvswitch/system-id.conf
+        filegid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 
 description: |-
-    {{{ describe_file_group_owner(file="/etc/openvswitch/system-id.conf", group="800") }}}
+    {{{ describe_file_group_owner(file="/etc/openvswitch/system-id.conf", group="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/openvswitch/system-id.conf", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/system-id.conf", group="openvswitch") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Open vSwitch Daemon PID File'
+title: 'Verify Group Who Owns The Open vSwitch Daemon PID File'
 
 description: |-
     {{{ describe_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="800") }}}

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Daemon PID File'
 
 description: |-
-    {{{ describe_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="800") }}}
+    {{{ describe_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Open vSwitch Daemon PID File'
+
+description: |-
+    {{{ describe_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /run/openvswitch/ovs-vswitchd.pid
+        filegid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Grop Who Owns The Open vSwitch Database Server PID'
+
+description: |-
+    {{{ describe_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="owner") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /run/openvswitch/ovsdb-server.pid
+        filegid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Database Server PID'
 
 description: |-
-    {{{ describe_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="800") }}}
+    {{{ describe_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="owner") }}}
+    {{{ ocil_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="openvswitch") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Grop Who Owns The Open vSwitch Database Server PID'
+title: 'Verify Group Who Owns The Open vSwitch Database Server PID'
 
 description: |-
     {{{ describe_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="800") }}}

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -2,29 +2,31 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Group Who Owns The OpenShift Scheduler Kubeconfig File'
+title: 'Verify Group Who Owns The Kubernetes Scheduler Kubeconfig File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
+description: |-
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}
 
 rationale: |-
-    The Scheduler Kubeconfig file contains information about the configuration of the
-    OpenShift scheduler that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+  The kubeconfig for the Scheduler contains paramters for the scheduler
+  to access the Kube API.
+  You should set its file ownership to maintain the integrity of the file.
+  The file should be owned by <pre>root:root</pre>.
 
 severity: medium
 
-#identifiers:
-#    cce@ocp4: 80639-8
-
 references:
-    cis: 1.1.16
+  cis: 1.1.16
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
+ocil: |-
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}
 
-#template:
-#    name: file_groupowner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
-#        filegid: '0'
+template:
+  name: file_groupowner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
+    filegid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/cni/net.d/.*", owner="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,9 +20,9 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/.*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/cni/net.d/.*", owner="root") }}}'
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -29,5 +29,4 @@ template:
     vars:
         filepath: ^/etc/cni/net.d/.*$
         fileuid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -18,7 +18,7 @@ severity: medium
 #    cce@ocp4:
 
 references:
-    cis: 1.4.10
+    cis: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 
@@ -27,6 +27,7 @@ ocil: '{{{ ocil_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 template:
     name: file_owner
     vars:
-        filepath: /etc/cni/net.d/
-        file_regex: ^.*$
+        filepath: ^/etc/cni/net.d/.*$
         fileuid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_cni_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_cni_conf/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -4,27 +4,29 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift Controller Manager Kubeconfig File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
+description: |-
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
 
 rationale: |-
-    The Controller Manager Kubeconfig file contains information about the configuration of the
-    OpenShift Controller Manager Server that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+  The Controller Manager's kubeconfig contains information abot how the
+  component will access the API server. You should set its file ownership to
+  maintain the integrity of the file. The file should be owned by
+  <pre>root:root</pre>.
 
 severity: medium
 
-#identifiers:
-#    cce@ocp4: 80612-5
-
 references:
-    cis: 1.1.18
+  cis: 1.1.18
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
+ocil: |-
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
 
 template:
-    name: file_owner
-    vars:
-        filepath: /etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-        fileuid: '0'
+  name: file_owner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
+    fileuid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -8,7 +8,7 @@ description: |-
   {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
 
 rationale: |-
-  The Controller Manager's kubeconfig contains information abot how the
+  The Controller Manager's kubeconfig contains information about how the
   component will access the API server. You should set its file ownership to
   maintain the integrity of the file. The file should be owned by
   <pre>root:root</pre>.

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -24,7 +24,7 @@ references:
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/lib/etcd", owner="owner") }}}
+    {{{ ocil_file_owner(file="/var/lib/etcd", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Etcd Database Directory'
+
+description: |-
+    {{{ describe_file_owner(file="/var/lib/etcd", owner="root") }}}
+
+rationale: |-
+    etcd is a highly-available key-value store used by Kubernetes deployments for
+    persistent storage of all of its REST API objects. This data directory should
+    be protected from any unauthorized reads or writes. It should be owned by
+    <pre>root:root</pre>.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.12
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/lib/etcd", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/lib/etcd
+        fileuid: '0'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Etcd Database Directory'
 
 description: |-
-    {{{ describe_file_owner(file="/var/lib/etcd", owner="root") }}}
+    {{{ describe_file_owner(file="/var/lib/etcd/member/", owner="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -21,14 +21,14 @@ severity: medium
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/lib/etcd", owner="root") }}}
+    {{{ ocil_file_owner(file="/var/lib/etcd/member/", owner="root") }}}
 
 template:
     name: file_owner
     vars:
-        filepath: /var/lib/etcd
+        filepath: /var/lib/etcd/member/
         fileuid: '0'
         missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_etcd_data_dir/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Etcd Database Files'
 
 description: |-
-    {{{ describe_file_owner(file="/var/lib/etcd/*", owner="root") }}}
+    {{{ describe_file_owner(file="/var/lib/etcd/.*", owner="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/.*", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/lib/etcd/*", owner="root") }}}
+    {{{ ocil_file_owner(file="/var/lib/etcd/.*", owner="root") }}}
 
 template:
     name: file_owner
     vars:
-        filepath: ^/var/lib/etcd/*$
+        filepath: ^/var/lib/etcd/.*$
         fileuid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Etcd Database Files'
+
+description: |-
+    {{{ describe_file_owner(file="/var/lib/etcd/*", owner="root") }}}
+
+rationale: |-
+    etcd is a highly-available key-value store used by Kubernetes deployments for
+    persistent storage of all of its REST API objects. This data directory should
+    be protected from any unauthorized reads or writes. It should be owned by
+    <pre>root:root</pre>.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.12
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/*", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/lib/etcd/*", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: ^/var/lib/etcd/*$
+        fileuid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify User Who Owns The Etcd Database Files'
+title: 'Verify User Who Owns The Etcd Write-Ahead-Log Files'
 
 description: |-
-    {{{ describe_file_owner(file="/var/lib/etcd/.*", owner="root") }}}
+    {{{ describe_file_owner(file="/var/lib/etcd/member/wal/.*", owner="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/.*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/wal/.*", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/lib/etcd/.*", owner="root") }}}
+    {{{ ocil_file_owner(file="/var/lib/etcd/member/wal/.*", owner="root") }}}
 
 template:
     name: file_owner
     vars:
-        filepath: ^/var/lib/etcd/.*$
+        filepath: ^/var/lib/etcd/member/wal/.*$
         fileuid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -24,7 +24,7 @@ references:
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/*", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/lib/etcd/*", owner="owner") }}}
+    {{{ ocil_file_owner(file="/var/lib/etcd/*", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_etcd_data_files/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The ETCD Member Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The ETCD specification file contains information about the configuration of the
@@ -19,14 +19,14 @@ severity: medium
 references:
     cis: 1.1.8
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", owner="root") }}}'
 
 template:
     name: file_owner
     vars:
-        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml$
+        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
         fileuid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The ETCD Member Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/manifests/etcd-member.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The ETCD specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.8
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/manifests/etcd-member.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/manifests/etcd-member.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
-#template:
-#    name: file_owner
-#    vars:
-#        filepath: /etc/kubernetes/manifests/etcd-member.yaml
-#        fileuid: '0'
+template:
+    name: file_owner
+    vars:
+        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml$
+        fileuid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_member/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift SDN Container Network Interface Plugin IP Address Allocations'
 
-description: '{{{ describe_file_owner(file="/var/lib/cni/networks/openshift-sdn/*", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,14 +20,14 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/cni/networks/openshift-sdn/*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/var/lib/cni/networks/openshift-sdn/*", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'
 
 template:
     name: file_owner
     vars:
-        filepath: ^/var/lib/cni/networks/openshift-sdn/*$
+        filepath: ^/var/lib/cni/networks/openshift-sdn/.*$
         fileuid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The OpenShift SDN Container Network Interface Plugin IP Address Allocations'
+
+description: '{{{ describe_file_owner(file="/var/lib/cni/networks/openshift-sdn/*", owner="root") }}}'
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.10
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/cni/networks/openshift-sdn/*", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/var/lib/cni/networks/openshift-sdn/*", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: ^/var/lib/cni/networks/openshift-sdn/*$
+        fileuid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ip_allocations/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Kube API Server Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,9 +19,9 @@ severity: medium
 references:
     cis: 1.1.2
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", owner="root") }}}'
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Kube Controller Manager Pod Specificiation File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,9 +19,9 @@ severity: medium
 references:
     cis: 1.1.4
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -26,7 +26,7 @@ ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-sched
 template:
     name: file_owner
     vars:
-        filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml$
+        filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml$
         fileuid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Kube Scheduler Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,9 +19,9 @@ severity: medium
 references:
     cis: 1.1.6
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", owner="root") }}}'
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Kube Scheduler Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The Kube specification file contains information about the configuration of the
@@ -19,12 +19,14 @@ severity: medium
 references:
     cis: 1.1.6
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 
-#template:
-#    name: file_owner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml
-#        fileuid: '0'
+template:
+    name: file_owner
+    vars:
+        filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml$
+        fileuid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_kube_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift Multus Container Network Interface Plugin Files'
 
-description: '{{{ describe_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/var/run/multus/cni/net.d/.*", owner="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,14 +20,14 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/.*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/var/run/multus/cni/net.d/.*", owner="root") }}}'
 
 template:
     name: file_owner
     vars:
-        filepath: ^/var/run/multus/cni/net.d/*$
+        filepath: ^/var/run/multus/cni/net.d/.*$
         fileuid: '0'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The OpenShift Multus Container Network Interface Plugin Files'
+
+description: '{{{ describe_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.10
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: ^/var/run/multus/cni/net.d/*$
+        fileuid: '0'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_multus_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_multus_conf/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
@@ -24,7 +24,7 @@ references:
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="owner") }}}
+    {{{ ocil_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The OpenShift SDN CNI Server Config'
+
+description: |-
+    {{{ describe_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="root") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/run/openshift-sdn/cniserver/config.json
+        fileuid: '0'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_owner_openvswitch/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift Open vSwitch Files'
 
-description: '{{{ describe_file_owner(file="/etc/openvswitch/*", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/openvswitch/.*", owner="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,9 +20,9 @@ severity: medium
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/openvswitch/*", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/openvswitch/.*", owner="root") }}}'
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_owner_openvswitch/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Open vSwitch Configuration Database'
 
 description: |-
-    {{{ describe_file_owner(file="/etc/openvswitch/conf.db", owner="800") }}}
+    {{{ describe_file_owner(file="/etc/openvswitch/conf.db", owner="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/conf.db", owner="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/conf.db", owner="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/etc/openvswitch/conf.db", owner="owner") }}}
+    {{{ ocil_file_owner(file="/etc/openvswitch/conf.db", owner="openvswitch") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Open vSwitch Configuration Database'
+
+description: |-
+    {{{ describe_file_owner(file="/etc/openvswitch/conf.db", owner="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/conf.db", owner="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/openvswitch/conf.db", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/openvswitch/conf.db
+        fileuid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_conf_db/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
-    {{{ describe_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="800") }}}
+    {{{ describe_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="owner") }}}
+    {{{ ocil_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="openvswitch") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Open vSwitch Configuration Database Lock'
+
+description: |-
+    {{{ describe_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/openvswitch/.conf.db.~lock~
+        fileuid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Open vSwitch Process ID File'
 
 description: |-
-    {{{ describe_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}
+    {{{ describe_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="owner") }}}
+    {{{ ocil_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Open vSwitch Process ID File'
+
+description: |-
+    {{{ describe_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/run/openvswitch/ovs-vswitchd.pid
+        fileuid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Open vSwitch Persistent System ID'
 
 description: |-
-    {{{ describe_file_owner(file="/etc/openvswitch/system-id.conf", owner="800") }}}
+    {{{ describe_file_owner(file="/etc/openvswitch/system-id.conf", owner="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/system-id.conf", owner="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/system-id.conf", owner="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/etc/openvswitch/system-id.conf", owner="owner") }}}
+    {{{ ocil_file_owner(file="/etc/openvswitch/system-id.conf", owner="openvswitch") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Open vSwitch Persistent System ID'
+
+description: |-
+    {{{ describe_file_owner(file="/etc/openvswitch/system-id.conf", owner="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/system-id.conf", owner="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/openvswitch/system-id.conf", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/openvswitch/system-id.conf
+        fileuid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Open vSwitch Daemon PID File'
+
+description: |-
+    {{{ describe_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /run/openvswitch/ovs-vswitchd.pid
+        fileuid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Open vSwitch Daemon PID File'
 
 description: |-
-    {{{ describe_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}
+    {{{ describe_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="owner") }}}
+    {{{ ocil_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Open vSwitch Database Server PID'
+
+description: |-
+    {{{ describe_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="800") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="800") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="owner") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /run/openvswitch/ovsdb-server.pid
+        fileuid: '800'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Open vSwitch Database Server PID'
 
 description: |-
-    {{{ describe_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="800") }}}
+    {{{ describe_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="openvswitch") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="800") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="openvswitch") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="owner") }}}
+    {{{ ocil_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="openvswitch") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
@@ -2,29 +2,34 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify User Who Owns The OpenShift Scheduler Kubeconfig File'
+title: 'Verify User Who Owns The Kubernetes Scheduler Kubeconfig File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
+description: |-
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}
 
 rationale: |-
-    The Scheduler Kubeconfig file contains information about the configuration of the
-    OpenShift scheduler that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+  The kubeconfig for the Scheduler contains paramters for the scheduler
+  to access the Kube API.
+  You should set its file ownership to maintain the integrity of the file.
+  The file should be owned by <pre>root:root</pre>.
 
 severity: medium
 
 #identifiers:
-#    cce@ocp4: 80639-8
+#    cce@ocp4:
 
 references:
-    cis: 1.1.16
+  cis: 1.1.16
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
+ocil: |-
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}
 
-#template:
-#    name: file_owner
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
-#        fileuid: '0'
+template:
+  name: file_owner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
+    fileuid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -19,7 +19,7 @@ severity: medium
 #    cce@ocp4:
 
 references:
-    cis: 1.4.9
+    cis: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}'
 
@@ -29,6 +29,7 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: /etc/cni/net.d/
-        file_regex: ^.*$
+        filepath: ^/etc/cni/net.d/.*$
         filemode: '0644'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -31,5 +31,4 @@ template:
     vars:
         filepath: ^/etc/cni/net.d/.*$
         filemode: '0644'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/cni/net.d/.*", perms="0644") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/.*", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/cni/net.d/.*", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/applications/openshift/master/file_permissions_cni_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -5,29 +5,28 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Controller Manager Kubeconfig File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", perms="0600") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="0644") }}}
 
 rationale: |-
-    If the Controller Manager Kubeconfig file is writable by a group-owner or the
-    world the risk of its compromise is increased. The file contains the configuration of
-    an OpenShift Controller Manager server that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+  The Controller Manager's kubeconfig contains information abot how the
+  component will access the API server. You should restrict its file
+  permissions to maintain the integrity of the file. The file should be
+  writable by only the administrators on the system.
 
 severity: medium
 
-#identifiers:
-#    cce@ocp4: 80612-5
-
 references:
-    cis: 1.1.17
+  cis: 1.1.17
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-------") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
 
 template:
-    name: file_permissions
-    vars:
-        filepath: /etc/kubernetes/static-pod-resources/configmaps/controller-manager-kubeconfig/kubeconfig
-        filemode: '0600'
+  name: file_permissions
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
+    filemode: '0644'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -8,7 +8,7 @@ description: |-
   {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="0644") }}}
 
 rationale: |-
-  The Controller Manager's kubeconfig contains information abot how the
+  The Controller Manager's kubeconfig contains information about how the
   component will access the API server. You should restrict its file
   permissions to maintain the integrity of the file. The file should be
   writable by only the administrators on the system.

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Etcd Database Directory'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/lib/etcd", perms="0700") }}}
+
+rationale: |-
+    etcd is a highly-available key-value store used by Kubernetes deployments for persistent
+    storage of all of its REST API objects. This data directory should be protected from any
+    unauthorized reads or writes. It should not be readable or writable by any group members
+    or the world.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.11
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd", perms="drwx------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/lib/etcd", perms="drwx------") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/lib/etcd
+        filemode: '0700'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -29,6 +29,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: /var/lib/etcd
+        filepath: /var/lib/etcd/member/
         filemode: '0700'
         missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_etcd_data_dir/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Etcd Database Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/var/lib/etcd/*", perms="0600") }}}
+    {{{ describe_file_permissions(file="/var/lib/etcd/.*", perms="0600") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for persistent
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.11
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/*", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/.*", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/lib/etcd/*", perms="-rw-------") }}}
+    {{{ ocil_file_permissions(file="/var/lib/etcd/.*", perms="-rw-------") }}}
 
 template:
     name: file_permissions
     vars:
-        filepath: ^/var/lib/etcd/*$
+        filepath: ^/var/lib/etcd/.*$
         filemode: '0600'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Permissions on the Etcd Database Files'
+title: 'Verify Permissions on the Etcd Write-Ahead-Log Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/var/lib/etcd/.*", perms="0600") }}}
+    {{{ describe_file_permissions(file="/var/lib/etcd/member/wal/.*", perms="0600") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for persistent
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.11
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/.*", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/member/wal/.*", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/lib/etcd/.*", perms="-rw-------") }}}
+    {{{ ocil_file_permissions(file="/var/lib/etcd/member/wal/.*", perms="-rw-------") }}}
 
 template:
     name: file_permissions
     vars:
-        filepath: ^/var/lib/etcd/.*$
+        filepath: ^/var/lib/etcd/member/wal/.*$
         filemode: '0600'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Etcd Database Files'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/lib/etcd/*", perms="0600") }}}
+
+rationale: |-
+    etcd is a highly-available key-value store used by Kubernetes deployments for persistent
+    storage of all of its REST API objects. This data directory should be protected from any
+    unauthorized reads or writes. It should not be readable or writable by any group members
+    or the world.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.11
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/*", perms="-rw-------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/lib/etcd/*", perms="-rw-------") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: ^/var/lib/etcd/*$
+        filemode: '0600'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_data_files/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the ETCD Member Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", perms="0644") }}}
 
 rationale: |-
     If the ETCD specification file is writable by a group-owner or the
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.7
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -29,7 +29,7 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml$
+        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
         filemode: '0644'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the ETCD Member Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/manifests/etcd-member.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0644") }}}
 
 rationale: |-
     If the ETCD specification file is writable by a group-owner or the
@@ -21,13 +21,15 @@ severity: medium
 references:
     cis: 1.1.7
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/manifests/etcd-member.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/manifests/etcd-member.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}
 
-#template:
-#    name: file_permissions
-#    vars:
-#        filepath: /etc/kubernetes/manifests/etcd-member.yaml
-#        filemode: '0644'
+template:
+    name: file_permissions
+    vars:
+        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml$
+        filemode: '0644'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the OpenShift SDN Container Network Interface Plugin IP Address Allocations'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="0644") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: ^/var/lib/cni/networks/openshift-sdn/*$
+        filemode: '0644'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift SDN Container Network Interface Plugin IP Address Allocations'
 
 description: |-
-    {{{ describe_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/var/lib/cni/networks/openshift-sdn/.*", perms="0644") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/cni/networks/openshift-sdn/.*", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/var/lib/cni/networks/openshift-sdn/.*", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions
     vars:
-        filepath: ^/var/lib/cni/networks/openshift-sdn/*$
+        filepath: ^/var/lib/cni/networks/openshift-sdn/.*$
         filemode: '0644'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_ip_allocations/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kube API Server Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", perms="0644") }}}
 
 rationale: |-
     If the Kube specification file is writable by a group-owner or the
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.1
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
 
 template:
   name: file_permissions

--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the OpenShift Multus Container Network Interface Plugin Files'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/run/multus/cni/net.d/*", perms="0644") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: ^/var/run/multus/cni/net.d/*$
+        filemode: '0644'
+        missing_file_pass: "true"
+        filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Multus Container Network Interface Plugin Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/var/run/multus/cni/net.d/*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/var/run/multus/cni/net.d/.*", perms="0644") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,15 +21,15 @@ severity: medium
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/multus/cni/net.d/.*", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/var/run/multus/cni/net.d/.*", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions
     vars:
-        filepath: ^/var/run/multus/cni/net.d/*$
+        filepath: ^/var/run/multus/cni/net.d/.*$
         filemode: '0644'
         missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_multus_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_openvswitch/rule.yml
+++ b/applications/openshift/master/file_permissions_openvswitch/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_openvswitch/rule.yml
+++ b/applications/openshift/master/file_permissions_openvswitch/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Open vSwitch Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/openvswitch/*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/openvswitch/.*", perms="0644") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.4.9
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/.*", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/openvswitch/*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/openvswitch/.*", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Open vSwitch Configuration Database'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/openvswitch/conf.db", perms="0644") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/conf.db", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/openvswitch/conf.db", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/openvswitch/conf.db
+        filemode: '0644'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_conf_db/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Open vSwitch Configuration Database Lock'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/openvswitch/.conf.db.~lock~", perms="0600") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/.conf.db.~lock~", perms="-rw-------") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/openvswitch/.conf.db.~lock~", perms="-rw-------") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/openvswitch/.conf.db.~lock~
+        filemode: '0600'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Open vSwitch Process ID File'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/run/openvswitch/ovs-vswitchd.pid", perms="0644") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/run/openvswitch/ovs-vswitchd.pid
+        filemode: '0644'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Open vSwitch Persistent System ID'
+
+description: |-
+    {{{ describe_file_permissions(file="/etc/openvswitch/system-id.conf", perms="0644") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/system-id.conf", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/openvswitch/system-id.conf", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/openvswitch/system-id.conf
+        filemode: '0644'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Open vSwitch Daemon PID File'
+
+description: |-
+    {{{ describe_file_permissions(file="/run/openvswitch/ovs-vswitchd.pid", perms="0644") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /run/openvswitch/ovs-vswitchd.pid
+        filemode: '0644'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Open vSwitch Database Server PID'
+
+description: |-
+    {{{ describe_file_permissions(file="/run/openvswitch/ovsdb-server.pid", perms="0644") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovsdb-server.pid", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/run/openvswitch/ovsdb-server.pid", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /run/openvswitch/ovsdb-server.pid
+        filemode: '0644'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kube Scheduler Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", perms="0644") }}}
 
 rationale: |-
     If the Kube specification file is writable by a group-owner or the
@@ -21,10 +21,10 @@ severity: medium
 references:
     cis: 1.1.5
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
@@ -2,32 +2,31 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Permissions on the OpenShift Scheduler Kubeconfig File'
+title: 'Verify Permissions on the Kubernetes Scheduler Kubeconfig File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", perms="0600") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", perms="0644") }}}
 
 rationale: |-
-    If the Scheduler Kubeconfig file is writable by a group-owner or the
-    world the risk of its compromise is increased. The file contains the configuration of
-    an OpenShift scheduler that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+  The kubeconfig for the Scheduler contains paramters for the scheduler
+  to access the Kube API. You should restrict its file permissions to maintain
+  the integrity of the file. The file should be writable by only the
+  administrators on the system.
 
 severity: medium
 
-#identifiers:
-#    cce@ocp4:
-
 references:
-    cis: 1.1.15
+  cis: 1.1.15
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-------") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
 
-#template:
-#    name: file_permissions
-#    vars:
-#        filepath: /etc/kubernetes/static-pod-resources/configmaps/scheduler-kubeconfig/kubeconfig
-#        filemode: '0600'
+template:
+  name: file_permissions
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
+    filemode: '0644'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/e2e/e2e.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/e2e/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
     writing plugins to configure network interfaces in Linux containers, along with a number
     of supported plugins. Allowing writeable access to the files could allow an attacker to modify
-    the networking configuration potentially adding a rouge network connection.
+    the networking configuration potentially adding a rogue network connection.
 
 severity: medium
 

--- a/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the OpenShift SDN CNI Server Config'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/run/openshift-sdn/cniserver/config.json", perms="0444") }}}
+
+rationale: |-
+    CNI (Container Network Interface) files consist of a specification and libraries for
+    writing plugins to configure network interfaces in Linux containers, along with a number
+    of supported plugins. Allowing writeable access to the files could allow an attacker to modify
+    the networking configuration potentially adding a rouge network connection.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+    cis: 1.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/openshift-sdn/cniserver/config.json", perms="-r--r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/run/openshift-sdn/cniserver/config.json", perms="-r--r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/run/openshift-sdn/cniserver/config.json
+        filemode: '0444'
+        missing_file_pass: "true"

--- a/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -43,6 +43,7 @@ selections:
     - file_permissions_cni_conf
     - file_permissions_multus_conf
     - file_permissions_ip_allocations
+    - file_perms_openshift_sdn_cniserver_config
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
@@ -50,6 +51,8 @@ selections:
     - file_groupowner_multus_conf
     - file_owner_ip_allocations
     - file_groupowner_ip_allocations
+    - file_owner_openshift_sdn_cniserver_config
+    - file_groupowner_openshift_sdn_cniserver_config
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -87,7 +87,10 @@ selections:
     - file_owner_scheduler_kubeconfig
     - file_groupowner_scheduler_kubeconfig
   # 1.1.17 Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive
+    - file_permissions_controller_manager_kubeconfig
   # 1.1.18 Ensure that the controller-manager.conf file ownership is set to root:root 
+    - file_owner_controller_manager_kubeconfig
+    - file_groupowner_controller_manager_kubeconfig
   # 1.1.19 Ensure that the OpenShift PKI directory and file ownership is set to root:root
   # 1.1.20 Ensure that the OpenShift PKI certificate file permissions are set to 644 or more restrictive
   # 1.1.21 Ensure that the OpenShift PKI key file permissions are set to 600 

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -72,7 +72,13 @@ selections:
     - file_owner_ovsdb_server_pid
     - file_groupowner_ovsdb_server_pid
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
+    - file_permissions_etcd_data_dir
+    - file_permissions_etcd_data_files
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
+    - file_owner_etcd_data_dir
+    - file_groupowner_etcd_data_dir
+    - file_owner_etcd_data_files
+    - file_groupowner_etcd_data_files
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive
   # 1.1.14 Ensure that the admin.conf file ownership is set to root:root 
   # 1.1.15 Ensure that the scheduler.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -48,6 +48,7 @@ selections:
     - file_permissions_ovs_conf_db
     - file_permissions_ovs_sys_id_conf
     - file_permissions_ovs_conf_db_lock
+    - file_permissions_ovs_vswitchd_pid
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
@@ -65,6 +66,8 @@ selections:
     - file_groupowner_ovs_sys_id_conf
     - file_owner_ovs_conf_db_lock
     - file_groupowner_ovs_conf_db_lock
+    - file_owner_ovs_vswitchd_pid
+    - file_groupowner_ovs_vswitchd_pid
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -49,6 +49,7 @@ selections:
     - file_permissions_ovs_sys_id_conf
     - file_permissions_ovs_conf_db_lock
     - file_permissions_ovs_vswitchd_pid
+    - file_permissions_ovsdb_server_pid
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
@@ -68,6 +69,8 @@ selections:
     - file_groupowner_ovs_conf_db_lock
     - file_owner_ovs_vswitchd_pid
     - file_groupowner_ovs_vswitchd_pid
+    - file_owner_ovsdb_server_pid
+    - file_groupowner_ovsdb_server_pid
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -47,6 +47,7 @@ selections:
     - file_permissions_ovs_pid
     - file_permissions_ovs_conf_db
     - file_permissions_ovs_sys_id_conf
+    - file_permissions_ovs_conf_db_lock
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
@@ -62,6 +63,8 @@ selections:
     - file_groupowner_ovs_conf_db
     - file_owner_ovs_sys_id_conf
     - file_groupowner_ovs_sys_id_conf
+    - file_owner_ovs_conf_db_lock
+    - file_groupowner_ovs_conf_db_lock
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -42,11 +42,14 @@ selections:
   # 1.1.9 Ensure that the Container Network Interface file permissions are set to 644 or more restrictive
     - file_permissions_cni_conf
     - file_permissions_multus_conf
+    - file_permissions_ip_allocations
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
     - file_owner_multus_conf
     - file_groupowner_multus_conf
+    - file_owner_ip_allocations
+    - file_groupowner_ip_allocations
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -32,6 +32,8 @@ selections:
   # 1.1.5 Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive
     - file_permissions_scheduler
   # 1.1.6 Ensure that the scheduler pod specification file ownership is set to root:root
+    - file_owner_kube_scheduler
+    - file_groupowner_kube_scheduler
   # 1.1.7 Ensure that the etcd pod specification file permissions are set to 644 or more restrictive
   # 1.1.8 Ensure that the etcd pod specification file ownership is set to root:root (Automated)
   # 1.1.9 Ensure that the Container Network Interface file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -40,6 +40,7 @@ selections:
     - file_owner_etcd_member
     - file_groupowner_etcd_member
   # 1.1.9 Ensure that the Container Network Interface file permissions are set to 644 or more restrictive
+    - file_permissions_cni_conf
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -44,6 +44,7 @@ selections:
     - file_permissions_multus_conf
     - file_permissions_ip_allocations
     - file_perms_openshift_sdn_cniserver_config
+    - file_permissions_ovs_pid
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
@@ -53,6 +54,8 @@ selections:
     - file_groupowner_ip_allocations
     - file_owner_openshift_sdn_cniserver_config
     - file_groupowner_openshift_sdn_cniserver_config
+    - file_owner_ovs_pid
+    - file_groupowner_ovs_pid
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -41,9 +41,12 @@ selections:
     - file_groupowner_etcd_member
   # 1.1.9 Ensure that the Container Network Interface file permissions are set to 644 or more restrictive
     - file_permissions_cni_conf
+    - file_permissions_multus_conf
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
+    - file_owner_multus_conf
+    - file_groupowner_multus_conf
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -45,6 +45,7 @@ selections:
     - file_permissions_ip_allocations
     - file_perms_openshift_sdn_cniserver_config
     - file_permissions_ovs_pid
+    - file_permissions_ovs_conf_db
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
@@ -56,6 +57,8 @@ selections:
     - file_groupowner_openshift_sdn_cniserver_config
     - file_owner_ovs_pid
     - file_groupowner_ovs_pid
+    - file_owner_ovs_conf_db
+    - file_groupowner_ovs_conf_db
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -46,6 +46,7 @@ selections:
     - file_perms_openshift_sdn_cniserver_config
     - file_permissions_ovs_pid
     - file_permissions_ovs_conf_db
+    - file_permissions_ovs_sys_id_conf
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
     - file_owner_cni_conf
     - file_groupowner_cni_conf
@@ -59,6 +60,8 @@ selections:
     - file_groupowner_ovs_pid
     - file_owner_ovs_conf_db
     - file_groupowner_ovs_conf_db
+    - file_owner_ovs_sys_id_conf
+    - file_groupowner_ovs_sys_id_conf
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -35,7 +35,10 @@ selections:
     - file_owner_kube_scheduler
     - file_groupowner_kube_scheduler
   # 1.1.7 Ensure that the etcd pod specification file permissions are set to 644 or more restrictive
+    - file_permissions_etcd_member
   # 1.1.8 Ensure that the etcd pod specification file ownership is set to root:root (Automated)
+    - file_owner_etcd_member
+    - file_groupowner_etcd_member
   # 1.1.9 Ensure that the Container Network Interface file permissions are set to 644 or more restrictive
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -82,7 +82,10 @@ selections:
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive
   # 1.1.14 Ensure that the admin.conf file ownership is set to root:root 
   # 1.1.15 Ensure that the scheduler.conf file permissions are set to 644 or more restrictive
+    - file_permissions_scheduler_kubeconfig
   # 1.1.16 Ensure that the scheduler.conf file ownership is set to root:root
+    - file_owner_scheduler_kubeconfig
+    - file_groupowner_scheduler_kubeconfig
   # 1.1.17 Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive
   # 1.1.18 Ensure that the controller-manager.conf file ownership is set to root:root 
   # 1.1.19 Ensure that the OpenShift PKI directory and file ownership is set to root:root

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -42,6 +42,8 @@ selections:
   # 1.1.9 Ensure that the Container Network Interface file permissions are set to 644 or more restrictive
     - file_permissions_cni_conf
   # 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
+    - file_owner_cni_conf
+    - file_groupowner_cni_conf
   # 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
   # 1.1.12 Ensure that the etcd data directory ownership is set to root:root
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive

--- a/ocp4/profiles/test.profile
+++ b/ocp4/profiles/test.profile
@@ -1,0 +1,9 @@
+documentation_complete: true
+
+title: 'Test Profile for etcd_peer_auto_tls'
+
+platform: ocp4
+
+description: Test Profile
+selections:
+- etcd_peer_auto_tls

--- a/ocp4/profiles/test.profile
+++ b/ocp4/profiles/test.profile
@@ -1,9 +1,0 @@
-documentation_complete: true
-
-title: 'Test Profile for etcd_peer_auto_tls'
-
-platform: ocp4
-
-description: Test Profile
-selections:
-- etcd_peer_auto_tls


### PR DESCRIPTION
ocp4/CIS 1.1.11 & 1.1.12: Add checks for etcd database files
ocp4/CIS 1.1.9 & 1.1.10: Add checks for OVSDB server PID File
ocp4/CIS 1.1.9 & 1.1.10: Add check for vswitchd PID File
ocp4/CIS 1.1.9 & 1.1.10: Check OVS conf.db lock file
ocp4/CIS 1.1.9 & 1.1.10: Add checks for OVS system-id.conf
ocp4/CIS 1.1.9 & 1.1.10 Check for OVS conf.db File
ocp4/CIS 1.1.9 & 1.1.10: Add check for Open vSwitch PID file
ocp4/CIS 1.1.9 & 1.1.10: Add checks for ocp cniserver config files
ocp4/CIS 1.1.9 and 1.1.10: Add checks for ip allocation files
ocp4/CIS 1.1.9 & 1.1.10: Add checks for multus plugin files
ocp4/CIS 1.1.10: Fix references, add OVAL and add checks to profile
ocp4/CIS 1.1.9: Fix reference, check and add it to cis-node profile
ocp4/CIS 1.1.7 & 1.1.8: Fix descriptions and add missing OVAL checks
ocp4/CIS 1.1.6 add mising OVAL checks and fix descriptions