### PR TITLE
add the ocp4 test profile to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ release_tools/.jenkins_builds
 release_tools/*.log
 release_tools/release_notes.txt
 release_tools/artifacts
+
+# Ignore the test profile that utils/add_platform_rule.py creates
+ocp4/profiles/test.profile


### PR DESCRIPTION
#### Description:

- Amends gitignore with a file that is frankly a build artifact

#### Rationale:

This should prevent accidentally adding the file to a PR.