### PR TITLE
Add sshd_set_keepalive rule to PCI DSS profile

### DIFF
--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -85,6 +85,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - accounts_password_pam_minlen
     - accounts_password_pam_dcredit
     - accounts_password_pam_ucredit


### PR DESCRIPTION
#### Description:
The PCI DSS profile contains the `sshd_set_idle_timeout` rule and `sshd_set_idle_timeout` relies on `sshd_set_keepalive` (not in PCI DSS).

https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml#L67:

>         SSH disconnecting idle clients will not have desired effect without also
>         configuring ClientAliveCountMax in the SSH service configuration.  


See also https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml#L30 - it performs `sshd_set_keepalive` check but the remediating it is matter of `sshd_set_keepalive`, not of the `sshd_set_idle_timeout` rule.
