### PR TITLE
Fix an omission when removing template parameter MASK_SERVICE.

### DIFF
--- a/shared/templates/template_BASH_service_disabled
+++ b/shared/templates/template_BASH_service_disabled
@@ -9,9 +9,7 @@
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
-{{%- if MASK_SERVICE %}}
 "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
-{{%- endif %}}
 # Disable socket activation if we have a unit file for it
 if "$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'; then
     "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'


### PR DESCRIPTION
#### Description:

- Fix an omission when removing template parameter MASK_SERVICE.

#### Rationale:

- The `mask` line would never be included into the final datastream
