### PR TITLE
Remove capture_output option from subprocess.run in SSGTS

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -198,7 +198,8 @@ def matches_platform(scenario_platforms, benchmark_cpes):
 def run_with_stdout_logging(command, args, log_file):
     log_file.write("{0} {1}\n".format(command, " ".join(args)))
     result = subprocess.run(
-            (command,) + args, encoding="utf-8", capture_output=True, check=True)
+            (command,) + args, encoding="utf-8", stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=True)
     if result.stdout:
         log_file.write("STDOUT: ")
         log_file.write(result.stdout)


### PR DESCRIPTION
#### Description:
The `capture_output` option was added in Python 3.7 - https://docs.python.org/3/library/subprocess.html

> Changed in version 3.7: Added the text parameter, as a more understandable alias of universal_newlines. Added the capture_output parameter.

However, RHEL 7 has Python 3.6 thus SSGTS does not work there at all.

This PR changes the `capture_output` option to `stdout=PIPE` + `stderr=PIPE` that has the same effect as `capture_output=True`.