### PR TITLE
Select sshd_set_keepalive where sshd_set_idle_timeout is selected.

### DIFF
--- a/example/profiles/example.profile
+++ b/example/profiles/example.profile
@@ -24,3 +24,4 @@ selections:
     - sshd_disable_empty_passwords
     - sshd_idle_timeout_value=5_minutes
     - sshd_set_idle_timeout
+    - sshd_set_keepalive

--- a/fedora/profiles/pci-dss.profile
+++ b/fedora/profiles/pci-dss.profile
@@ -100,6 +100,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - accounts_password_pam_minlen
     - accounts_password_pam_dcredit
     - accounts_password_pam_ucredit

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -45,6 +45,9 @@ references:
     iso27001-2013: A.12.4.1,A.12.4.3,A.14.1.1,A.14.2.1,A.14.2.5,A.18.1.4,A.6.1.2,A.6.1.5,A.7.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
 
+requires:
+    - sshd_set_idle_timeout
+
 ocil_clause: 'it is commented out or not configured properly'
 
 ocil: |-

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -99,6 +99,7 @@ selections:
     - ensure_logrotate_activated
     - sshd_idle_timeout_value=15_minutes
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - disable_prelink
     - display_login_attempts
     - gid_passwd_group_same

--- a/ol8/profiles/pci-dss.profile
+++ b/ol8/profiles/pci-dss.profile
@@ -105,6 +105,7 @@ selections:
     - ensure_logrotate_activated
     - sshd_idle_timeout_value=15_minutes
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - display_login_attempts
     - gid_passwd_group_same
     - grub2_audit_argument

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -82,6 +82,7 @@ selections:
     - accounts_tmout
     - sshd_set_idle_timeout
     - sshd_idle_timeout_value=5_minutes
+    - sshd_set_keepalive
 
     # ==============================================
     # R35 - umask value

--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -85,6 +85,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - accounts_password_pam_minlen
     - accounts_password_pam_dcredit
     - accounts_password_pam_ucredit

--- a/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -39,6 +39,7 @@ selections:
     - accounts_tmout
     - sshd_set_idle_timeout
     - sshd_idle_timeout_value=5_minutes
+    - sshd_set_keepalive
 
     # umask value
     - var_accounts_user_umask=077

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -106,6 +106,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - accounts_password_pam_minlen
     - accounts_password_pam_dcredit
     - accounts_password_pam_ucredit

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -4,7 +4,7 @@ metadata:
     SMEs:
         - redhatrises
 
-reference: https://www.hhs.gov/hipaa/for-professionals/index.html
+reference: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
 
 title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 8'
 

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -121,6 +121,7 @@ selections:
 - set_password_hashing_algorithm_logindefs
 - set_password_hashing_algorithm_systemauth
 - sshd_set_idle_timeout
+- sshd_set_keepalive
 - sssd_enable_smartcards
 - var_password_pam_unix_remember=4
 - var_account_disable_post_pw_expiration=90

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -1,5 +1,6 @@
 description: Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 documentation_complete: true
+reference: https://www.hhs.gov/hipaa/for-professionals/index.html
 selections:
 - account_disable_post_pw_expiration
 - account_unique_name

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -1,6 +1,6 @@
 description: Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 documentation_complete: true
-reference: https://www.hhs.gov/hipaa/for-professionals/index.html
+reference: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
 selections:
 - account_disable_post_pw_expiration
 - account_unique_name


### PR DESCRIPTION
#### Description:

- Select sshd_set_keepalive where sshd_set_idle_timeout is selected. Update document reference for `rhel8/pci-dss` profile

#### Rationale:

- sshd_set_keepalive is required to be selected in order to
sshd_set_idle_timeout to work properly.

Relates to: https://bugzilla.redhat.com/show_bug.cgi?id=1873547
