### PR TITLE
add rule sshd_set_keepalive as a dependency

### DIFF
--- a/fedora/profiles/pci-dss.profile
+++ b/fedora/profiles/pci-dss.profile
@@ -100,6 +100,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - accounts_password_pam_minlen
     - accounts_password_pam_dcredit
     - accounts_password_pam_ucredit

--- a/ol7/profiles/pci-dss.profile
+++ b/ol7/profiles/pci-dss.profile
@@ -99,6 +99,7 @@ selections:
     - ensure_logrotate_activated
     - sshd_idle_timeout_value=15_minutes
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - disable_prelink
     - display_login_attempts
     - gid_passwd_group_same

--- a/ol8/profiles/pci-dss.profile
+++ b/ol8/profiles/pci-dss.profile
@@ -105,6 +105,7 @@ selections:
     - ensure_logrotate_activated
     - sshd_idle_timeout_value=15_minutes
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - display_login_attempts
     - gid_passwd_group_same
     - grub2_audit_argument

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -82,6 +82,7 @@ selections:
     - accounts_tmout
     - sshd_set_idle_timeout
     - sshd_idle_timeout_value=5_minutes
+    - sshd_set_keepalive
 
     # ==============================================
     # R35 - umask value

--- a/rhel7/profiles/pci-dss.profile
+++ b/rhel7/profiles/pci-dss.profile
@@ -85,6 +85,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - accounts_password_pam_minlen
     - accounts_password_pam_dcredit
     - accounts_password_pam_ucredit

--- a/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -39,6 +39,7 @@ selections:
     - accounts_tmout
     - sshd_set_idle_timeout
     - sshd_idle_timeout_value=5_minutes
+    - sshd_set_keepalive
 
     # umask value
     - var_accounts_user_umask=077

--- a/rhel8/profiles/pci-dss.profile
+++ b/rhel8/profiles/pci-dss.profile
@@ -106,6 +106,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
     - sshd_set_idle_timeout
+    - sshd_set_keepalive
     - accounts_password_pam_minlen
     - accounts_password_pam_dcredit
     - accounts_password_pam_ucredit

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -1,5 +1,6 @@
 description: Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 documentation_complete: true
+reference: https://www.hhs.gov/hipaa/for-professionals/index.html
 selections:
 - account_disable_post_pw_expiration
 - account_unique_name
@@ -121,6 +122,7 @@ selections:
 - set_password_hashing_algorithm_logindefs
 - set_password_hashing_algorithm_systemauth
 - sshd_set_idle_timeout
+- sshd_set_keepalive
 - sssd_enable_smartcards
 - var_password_pam_unix_remember=4
 - var_account_disable_post_pw_expiration=90


### PR DESCRIPTION
#### Description:

- add rule sshd_set_keepalive to a profile in case it contains sshd_set_idle_timeout rule

#### Rationale:

The check of rule sshd_set_idle_timeout references rule sshd_set_keepalive. In case the whole profile is remediated and this rule is not present, the status of rule sshd_set_idle_timeout will be alway fail, because there does not exist any rule which would remediate the dependency.