### PR TITLE
OCP4/CIS: 4.2.1 and 4.2.2 check updates

### DIFF
--- a/applications/openshift/kubelet/kubelet_anonymous_auth/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -30,4 +30,15 @@ ocil_clause: '<tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>'
 ocil: |-
     Run the following command on the master node(s):
     <pre>$ sudo grep -A1 authorization /etc/kubernetes/kubernetes.conf</pre>
-    Verify that the output is set to <tt>mode: Webhook</tt>.
+    Verify that the output is not set to <tt>mode: AlwaysAllow</tt>, or missing
+    (defaults to <tt>mode: Webhook</tt>).
+
+template:
+    name: yamlfile_value
+    vars:
+        filepath: /etc/kubernetes/kubelet.conf
+        yamlpath: ".authorization.mode"
+        check_existence: "none_exist"
+        values:
+         - value: "AlwaysAllow"
+           operation: "equals"

--- a/applications/openshift/kubelet/kubelet_authorization_mode/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -89,7 +89,7 @@ selections:
   # 4.2.1 Ensure that the --anonymous-auth argument is set to false
     - kubelet_anonymous_auth
   # 4.2.2 Ensure that the --authorization-mode argument is not set to AlwaysAllow
-    # - this seems to be the default in the code, so the rule should verify that authorization mode is NOT set to AlwaysAllow
+    - kubelet_authorization_mode
   # 4.2.3 Ensure that the --client-ca-file argument is set as appropriate
     - kubelet_configure_client_ca
   # 4.2.4 Ensure that the --read-only-port argument is set to 0


### PR DESCRIPTION
I think the template for kubelete_authorization_mode is correct - gotta check the test results.