### PR TITLE
Remove requirement from rationale in ocp content

### DIFF
--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -10,8 +10,7 @@ description: |-
 rationale: |-
   The Controller Manager's kubeconfig contains information about how the
   component will access the API server. You should set its file ownership to
-  maintain the integrity of the file. The file should be owned by
-  <pre>root:root</pre>.
+  maintain the integrity of the file.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -10,8 +10,7 @@ description: |-
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
     persistent storage of all of its REST API objects. This data directory should
-    be protected from any unauthorized reads or writes. It should be owned by
-    <pre>root:root</pre>.
+    be protected from any unauthorized reads or writes.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -10,8 +10,7 @@ description: |-
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
     persistent storage of all of its REST API objects. This data directory should
-    be protected from any unauthorized reads or writes. It should be owned by
-    <pre>root:root</pre>.
+    be protected from any unauthorized reads or writes.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -10,8 +10,7 @@ description: |-
 rationale: |-
   The Controller Manager's kubeconfig contains information about how the
   component will access the API server. You should set its file ownership to
-  maintain the integrity of the file. The file should be owned by
-  <pre>root:root</pre>.
+  maintain the integrity of the file.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -10,8 +10,7 @@ description: |-
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
     persistent storage of all of its REST API objects. This data directory should
-    be protected from any unauthorized reads or writes. It should be owned by
-    <pre>root:root</pre>.
+    be protected from any unauthorized reads or writes.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
@@ -11,7 +11,6 @@ rationale: |-
   The kubeconfig for the Scheduler contains paramters for the scheduler
   to access the Kube API.
   You should set its file ownership to maintain the integrity of the file.
-  The file should be owned by <pre>root:root</pre>.
 
 severity: medium
 


### PR DESCRIPTION
Remove `The file should be owned by` statements in the rationale. They don't belong there, and in general, is an odd statement to make when the rules say what they should be.
