### PR TITLE
Add SRG references for use_pam_wheel_for_su rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     ospp: FMT_SMF_EXT.1.1
+    srg: 'SRG-OS-000373-GPOS-00156,SRG-OS-000312-GPOS-00123'
 
 ocil_clause: 'the line is not in the file or it is commented'
 


### PR DESCRIPTION
#### Description:
Add missing SRGs for `use_pam_wheel_for_su` rule.
https://vaulted.io/library/disa-stigs-srgs/general_purpose_operating_system_srg/V-56837
https://vaulted.io/library/disa-stigs-srgs/general_purpose_operating_system_srg/V-57227

#### Rationale:
The `use_pam_wheel_for_su` rule is used in RHEL8 OSPP profile - https://github.com/ComplianceAsCode/content/blob/master/rhel8/profiles/ospp.profile#L225 - and the profile is extended by RHEL8 STIG profile.
