### PR TITLE
OCP4/CIS 1.1.13 & 1.1.14: Add checks for kubeconfigs with admin privileges

### DIFF
--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Group Who Owns The OpenShift Admin Kubeconfig Files'
+
+description: |-
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", group="root") }}}
+
+rationale: |-
+  There are various kubeconfig files that can be used by the administrator,
+  defining various settings for the administration of the cluster. These files
+  contain credentials that can be used to control the cluster and are needed
+  for disaster recovery and each kubeconfig points to a different endpoint in
+  the cluster. You should restrict its file permissions to maintain the
+  integrity of the kubeconfig file as an attacker who gains access to these
+  files can take over the cluster.
+
+severity: medium
+
+references:
+  cis: 1.1.14
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", group="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", group="root") }}}
+
+template:
+  name: file_groupowner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig$
+    filegid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The OpenShift Admin Kubeconfig Files'
+
+description: |-
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", owner="root") }}}
+
+rationale: |-
+  There are various kubeconfig files that can be used by the administrator,
+  defining various settings for the administration of the cluster. These files
+  contain credentials that can be used to control the cluster and are needed
+  for disaster recovery and each kubeconfig points to a different endpoint in
+  the cluster. You should restrict its file permissions to maintain the
+  integrity of the kubeconfig file as an attacker who gains access to these
+  files can take over the cluster.
+
+severity: medium
+
+references:
+  cis: 1.1.14
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", owner="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", owner="root") }}}
+
+template:
+  name: file_owner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig$
+    fileuid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the OpenShift Admin Kubeconfig Files'
+
+description: |-
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", perms="0600") }}}
+
+rationale: |-
+  There are various kubeconfig files that can be used by the administrator,
+  defining various settings for the administration of the cluster. These files
+  contain credentials that can be used to control the cluster and are needed
+  for disaster recovery and each kubeconfig points to a different endpoint in
+  the cluster. You should restrict its file permissions to maintain the
+  integrity of the kubeconfig file as an attacker who gains access to these
+  files can take over the cluster.
+
+severity: medium
+
+references:
+  cis: 1.1.13
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", perms="-rw-------") }}}'
+
+ocil: |-
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", perms="-rw-------") }}}
+
+template:
+  name: file_permissions
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig$
+    filemode: '0600'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -80,7 +80,10 @@ selections:
     - file_owner_etcd_data_files
     - file_groupowner_etcd_data_files
   # 1.1.13 Ensure that the admin.conf file permissions are set to 644 or more restrictive
+    - file_permissions_master_admin_kubeconfigs
   # 1.1.14 Ensure that the admin.conf file ownership is set to root:root 
+    - file_owner_master_admin_kubeconfigs
+    - file_groupowner_master_admin_kubeconfigs
   # 1.1.15 Ensure that the scheduler.conf file permissions are set to 644 or more restrictive
     - file_permissions_scheduler_kubeconfig
   # 1.1.16 Ensure that the scheduler.conf file ownership is set to root:root


### PR DESCRIPTION
This checks that the kubeconfigs with admin privileges that exist in the
cluster have appropriate ownership and mode.