### PR TITLE
ocp4/CIS 1.1.(19-21): Add checks for Certificates and Keys

### DIFF
--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Group Who Owns The Etcd PKI Certificate Files'
+
+description: |-
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", group="root") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificates as part of its operation.
+  You should verify the ownership of the directory containing the PKI
+  information and all files in that directory to maintain their integrity.
+  The directory and files should be owned by the system administrator.
+
+severity: medium
+
+references:
+  cis: 1.1.19
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", group="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", group="root") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/etcd-pod-2/secrets/etcd-all-serving/etcd-serving-ip-10-0-136-27.ec2.internal.crt
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'etcd-pod-2' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'etcd-all-serving' the mount name
+# - 'etcd-serving-ip-10-0-136-27.ec2.internal.crt' the cert file
+template:
+  name: file_groupowner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt$
+    filegid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -23,7 +23,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", group="root") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
 #

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Group Who Owns The OpenShift PKI Certificate Files'
+
+description: |-
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", group="root") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificates as part of its operation.
+  You should verify the ownership of the directory containing the PKI
+  information and all files in that directory to maintain their integrity.
+  The directory and files should be owned by the system administrator.
+
+severity: medium
+
+references:
+  cis: 1.1.19
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", group="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", group="root") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-7/secrets/serving-cert/tls.crt
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'kube-controller-manager-pod-7' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'serving-cert' the mount name
+# - 'tls.crt' the cert file
+template:
+  name: file_groupowner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt$
+    filegid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -23,7 +23,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", group="root") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
 #

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Group Who Owns The OpenShift PKI Private Key Files'
+
+description: |-
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", group="root") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificates as part of its operation.
+  You should verify the ownership of the directory containing the PKI
+  information and all files in that directory to maintain their integrity.
+  The directory and files should be owned by root:root.
+
+severity: medium
+
+references:
+  cis: 1.1.19
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", group="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", group="root") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/kube-apiserver-pod-3/secrets/kubelet-client/tls.key
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'kube-apiserver-pod-3' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'kubelet-client' the mount name
+# - 'tls.key' the file
+template:
+  name: file_groupowner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key$
+    filegid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -23,7 +23,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", group="root") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key
 #

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
@@ -23,7 +23,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", owner="root") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
 #

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The Etcd PKI Certificate Files'
+
+description: |-
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", owner="root") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificates as part of its operation.
+  You should verify the ownership of the directory containing the PKI
+  information and all files in that directory to maintain their integrity.
+  The directory and files should be owned by the system administrator.
+
+severity: medium
+
+references:
+  cis: 1.1.19
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", owner="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", owner="root") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/etcd-pod-2/secrets/etcd-all-serving/etcd-serving-ip-10-0-136-27.ec2.internal.crt
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'etcd-pod-2' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'etcd-all-serving' the mount name
+# - 'etcd-serving-ip-10-0-136-27.ec2.internal.crt' the cert file
+template:
+  name: file_owner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt$
+    fileuid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -23,7 +23,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", owner="root") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
 #

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The OpenShift PKI Certificate Files'
+
+description: |-
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", owner="root") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificates as part of its operation.
+  You should verify the ownership of the directory containing the PKI
+  information and all files in that directory to maintain their integrity.
+  The directory and files should be owned by the system administrator.
+
+severity: medium
+
+references:
+  cis: 1.1.19
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", owner="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", owner="root") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-7/secrets/serving-cert/tls.crt
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'kube-controller-manager-pod-7' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'serving-cert' the mount name
+# - 'tls.crt' the cert file
+template:
+  name: file_owner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt$
+    fileuid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify User Who Owns The OpenShift PKI Private Key Files'
+
+description: |-
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", owner="root") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificates as part of its operation.
+  You should verify the ownership of the directory containing the PKI
+  information and all files in that directory to maintain their integrity.
+  The directory and files should be owned by root:root.
+
+severity: medium
+
+references:
+  cis: 1.1.19
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", owner="root") }}}'
+
+ocil: |-
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", owner="root") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/kube-apiserver-pod-3/secrets/kubelet-client/tls.key
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'kube-apiserver-pod-3' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'kubelet-client' the mount name
+# - 'tls.key' the file
+template:
+  name: file_owner
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key$
+    fileuid: '0'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
@@ -23,7 +23,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", owner="root") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key
 #

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -22,7 +22,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="-rw-------") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
 #

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the Etcd PKI Certificate Files'
+
+description: |-
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="0600") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificate files as part of the operation
+  of its components. The permissions on these files should be set to
+  <pre>600</pre> or more restrictive to protect their integrity.
+
+severity: medium
+
+references:
+  cis: 1.1.21
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="-rw-------") }}}'
+
+ocil: |-
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="-rw-------") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/etcd-pod-2/secrets/etcd-all-serving/etcd-serving-ip-10-0-136-27.ec2.internal.crt
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'etcd-pod-2' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'etcd-all-serving' the mount name
+# - 'etcd-serving-ip-10-0-136-27.ec2.internal.crt' the cert file
+template:
+  name: file_permissions
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt$
+    filemode: '0600'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the OpenShift PKI Certificate Files'
+
+description: |-
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="0600") }}}
+
+rationale: |-
+  OpenShift makes use of a number of certificate files as part of the operation
+  of its components. The permissions on these files should be set to
+  <pre>600</pre> or more restrictive to protect their integrity.
+
+severity: medium
+
+references:
+  cis: 1.1.21
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="-rw-------") }}}'
+
+ocil: |-
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="-rw-------") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/kube-controller-manager-pod-7/secrets/serving-cert/tls.crt
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'kube-controller-manager-pod-7' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'serving-cert' the mount name
+# - 'tls.crt' the cert file
+template:
+  name: file_permissions
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt$
+    filemode: '0600'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -22,7 +22,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="-rw-------") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key
 #

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Verify Permissions on the OpenShift PKI Private Key Files'
+
+description: |-
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", perms="0600") }}}
+
+rationale: |-
+  OpenShift makes use of a number of key files as part of the operation of its
+  components. The permissions on these files should be set to <pre>600</pre>
+  to protect their integrity and confidentiality.
+
+severity: medium
+
+references:
+  cis: 1.1.21
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", perms="-rw-------") }}}'
+
+ocil: |-
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", perms="-rw-------") }}}
+
+# Note that this recursively checks for files, and the formas is as follows:
+#
+#  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key
+#
+# Taking as an example:
+#
+#  /etc/kubernetes/static-pod-resources/kube-apiserver-pod-3/secrets/kubelet-client/tls.key
+#
+# - /etc/kubernetes/static-pod-resources/ is the base path
+# - 'kube-apiserver-pod-3' This initial versioned resourced directory (e.g. pod version)
+# - 'secrets' The type of resource (e.g. configmap or secret)
+# - 'kubelet-client' the mount name
+# - 'tls.key' the file
+template:
+  name: file_permissions
+  vars:
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key$
+    filemode: '0600'
+    missing_file_pass: "true"
+    filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -22,7 +22,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", perms="-rw-------") }}}
 
-# Note that this recursively checks for files, and the formas is as follows:
+# Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key
 #

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -96,8 +96,11 @@ selections:
     - file_groupowner_openshift_pki_key_files
     - file_owner_openshift_pki_cert_files
     - file_groupowner_openshift_pki_cert_files
+    - file_owner_etcd_pki_cert_files
+    - file_groupowner_etcd_pki_cert_files
   # 1.1.20 Ensure that the OpenShift PKI certificate file permissions are set to 644 or more restrictive
     - file_permissions_openshift_pki_cert_files
+    - file_permissions_etcd_pki_cert_files
   # 1.1.21 Ensure that the OpenShift PKI key file permissions are set to 600 
     - file_permissions_openshift_pki_key_files
 

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -92,8 +92,11 @@ selections:
     - file_owner_controller_manager_kubeconfig
     - file_groupowner_controller_manager_kubeconfig
   # 1.1.19 Ensure that the OpenShift PKI directory and file ownership is set to root:root
+    - file_owner_openshift_pki_key_files
+    - file_groupowner_openshift_pki_key_files
   # 1.1.20 Ensure that the OpenShift PKI certificate file permissions are set to 644 or more restrictive
   # 1.1.21 Ensure that the OpenShift PKI key file permissions are set to 600 
+    - file_permissions_openshift_pki_key_files
 
   ### 2 etcd
   # 2.1 Ensure that the --cert-file and --key-file arguments are set as appropriate

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -94,7 +94,10 @@ selections:
   # 1.1.19 Ensure that the OpenShift PKI directory and file ownership is set to root:root
     - file_owner_openshift_pki_key_files
     - file_groupowner_openshift_pki_key_files
+    - file_owner_openshift_pki_cert_files
+    - file_groupowner_openshift_pki_cert_files
   # 1.1.20 Ensure that the OpenShift PKI certificate file permissions are set to 644 or more restrictive
+    - file_permissions_openshift_pki_cert_files
   # 1.1.21 Ensure that the OpenShift PKI key file permissions are set to 600 
     - file_permissions_openshift_pki_key_files
 


### PR DESCRIPTION
This checks that the certificates and keys that lie on-disk and are used by the
kube control plane have the appropriate permissions and ownership.

Note that a regex is used to check for all certs and keys, so further additions
will get automatically picked up.

* OCP4/CIS 1.1.19 & 1.1.21: Add checks for OpenShift PKI keys
* OCP4/CIS 1.1.20 & 1.1.21: Add checks for OpenShift PKI cert files
* OCP4/CIS 1.1.20 & 1.1.21: Add checks for Etcd pki cert files