### PR TITLE
ocp4/CIS: Address 1.2.24 and 1.2.25

### DIFF
--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -2,17 +2,17 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Configure the Maximum Retained Audit Logs'
+title: 'Configure the Kubernetes API Server Maximum Retained Audit Logs'
 
 description: |-
     To configure how many rotations of audit logs are retained,
     edit the <tt>openshift-kube-apiserver</tt> configmap
-    on the master node(s) and set the <tt>maximumRetainedFiles</tt> parameter to
+    on the master node(s) and set the <tt>audit-log-maxbackup</tt> parameter to
     <tt>10</tt> or to an organizationally appropriate value:
     <pre>
-    "auditConfig":{
+    "apiServerArguments":{
       ...
-      "maximumRetainedFiles": 10,
+      "audit-log-maxbackup": [10],
       ...
     </pre>
 
@@ -28,9 +28,21 @@ severity: low
 references:
     cis: 1.2.24
 
-ocil_clause: '<tt>maximumRetainedFiles</tt> is set to <tt>10</tt> or as appropriate'
+ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
 
 ocil: |-
     Run the following command on the master node(s):
-    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.auditConfig["maximumRetainedFiles"]'</pre>
+    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxbackup"][0]'</pre>
     The output should return a value of <pre>10</pre> or as appropriate.
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"apiServerArguments":{.*"audit-log-maxbackup":\["10"\]'
+      operation: "pattern match"
+      type: "string"

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -35,6 +35,10 @@ ocil: |-
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxbackup"][0]'</pre>
     The output should return a value of <pre>10</pre> or as appropriate.
 
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+
 template:
   name: yamlfile_value
   vars:

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -2,17 +2,17 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Configure Maximum Audit Log Size'
+title: 'Configure Kubernetes API Server Maximum Audit Log Size'
 
 description: |-
     To rotate audit logs upon reaching a maximum size,
     edit the <tt>openshift-kube-apiserver</tt> configmap on
-    the master node(s) and set the <tt>maximumFileSizeMegabytes</tt> parameter to
+    the master node(s) and set the <tt>audit-log-maxsize</tt> parameter to
     an appropriate size in MB. For example, to set it to 100 MB:
     <pre>
-    "auditConfig":{
+    "apiServerArguments":{
       ...
-      "maximumFileSizeMegabytes": 100,
+      "audit-log-maxsize": ["100"],
       ...
     </pre>
 
@@ -28,9 +28,21 @@ severity: medium
 references:
     cis: 1.2.25
 
-ocil_clause: '<tt>maximumFileSizeMegabytes</tt> is set to <tt>100</tt> or as appropriate'
+ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
 
 ocil: |-
     Run the following command on the master node(s):
-    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["maximumFileSizeMegabytes"]'</pre>
-    The output should return a value of <pre>100</pre> or as appropriate.
+    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxsize"]'</pre>
+    The output should return a value of <pre>["100"]</pre> or as appropriate.
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"apiServerArguments":{.*"audit-log-maxsize":\["100"\]'
+      operation: "pattern match"
+      type: "string"

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -35,6 +35,10 @@ ocil: |-
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxsize"]'</pre>
     The output should return a value of <pre>["100"]</pre> or as appropriate.
 
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+
 template:
   name: yamlfile_value
   vars:

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
@@ -1,0 +1,48 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Configure the OpenShift API Server Maximum Retained Audit Logs'
+
+description: |-
+    To configure how many rotations of audit logs are retained,
+    edit the <tt>openshift-apiserver</tt> configmap
+    on the master node(s) and set the <tt>audit-log-maxbackup</tt> parameter to
+    <tt>10</tt> or to an organizationally appropriate value:
+    <pre>
+    "apiServerArguments":{
+      ...
+      "audit-log-maxbackup": [10],
+      ...
+    </pre>
+
+rationale: |-
+    OpenShift automatically rotates the log files. Retaining old log files ensures
+    OpenShift Operators will have sufficient log data available for carrying out
+    any investigation or correlation. For example, if the audit log size is set to
+    100 MB and the number of retained log files is set to 10, OpenShift Operators
+    would have approximately 1 GB of log data to use during analysis.
+
+severity: low
+
+references:
+    cis: 1.2.24
+
+ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
+
+ocil: |-
+    Run the following command on the master node(s):
+    <pre>$ oc get configmap config -n openshift-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxbackup"][0]'</pre>
+    The output should return a value of <pre>10</pre> or as appropriate.
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"apiServerArguments":{.*"audit-log-maxbackup":\["10"\]'
+      operation: "pattern match"
+      type: "string"

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
@@ -35,6 +35,10 @@ ocil: |-
     <pre>$ oc get configmap config -n openshift-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxbackup"][0]'</pre>
     The output should return a value of <pre>10</pre> or as appropriate.
 
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-apiserver/configmaps/config") | indent(4) }}}
+
 template:
   name: yamlfile_value
   vars:

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -35,6 +35,10 @@ ocil: |-
     <pre>$ oc get configmap config -n openshift-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxsize"]'</pre>
     The output should return a value of <pre>["100"]</pre> or as appropriate.
 
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-apiserver/configmaps/config") | indent(4) }}}
+
 template:
   name: yamlfile_value
   vars:

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -1,0 +1,48 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Configure OpenShift API Server Maximum Audit Log Size'
+
+description: |-
+    To rotate audit logs upon reaching a maximum size,
+    edit the <tt>openshift-apiserver</tt> configmap on
+    the master node(s) and set the <tt>audit-log-maxsize</tt> parameter to
+    an appropriate size in MB. For example, to set it to 100 MB:
+    <pre>
+    "apiServerArguments":{
+      ...
+      "audit-log-maxsize": ["100"],
+      ...
+    </pre>
+
+rationale: |-
+    OpenShift automatically rotates log files. Retaining old log files ensures that
+    OpenShift Operators have sufficient log data available for carrying out any
+    investigation or correlation. If you have set file size of 100 MB and the number of
+    old log files to keep as 10, there would be approximately 1 GB of log data
+    available for use in analysis.
+
+severity: medium
+
+references:
+    cis: 1.2.25
+
+ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
+
+ocil: |-
+    Run the following command on the master node(s):
+    <pre>$ oc get configmap config -n openshift-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["audit-log-maxsize"]'</pre>
+    The output should return a value of <pre>["100"]</pre> or as appropriate.
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"apiServerArguments":{.*"audit-log-maxsize":\["100"\]'
+      operation: "pattern match"
+      type: "string"

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -70,6 +70,7 @@ selections:
     - api_server_audit_log_maxage
   # 1.2.24 Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate
     - api_server_audit_log_maxbackup
+    - ocp_api_server_audit_log_maxbackup
   # 1.2.25 Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate
     - api_server_audit_log_maxsize
   # 1.2.26 Ensure that the --request-timeout argument is set as appropriate

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -73,6 +73,7 @@ selections:
     - ocp_api_server_audit_log_maxbackup
   # 1.2.25 Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate
     - api_server_audit_log_maxsize
+    - ocp_api_server_audit_log_maxsize
   # 1.2.26 Ensure that the --request-timeout argument is set as appropriate
     - api_server_request_timeout
   # 1.2.27 Ensure that the --service-account-lookup argument is set to true


### PR DESCRIPTION
This addresses the aforementioned controls by checking the configMap for both
the kube apiserver and the openshift apiserver.

* ocp4/CIS 1.2.25: Add check for OpenShift APIServer audit-log-maxsize
* ocp4/CIS 1.2.25: Fix description and add check for audit-log-maxsize setting
* ocp4/CIS 1.2.24: Add check for OpenShift APIServer audit-log-maxbackup
* ocp4/CIS 1.2.24: Fix description and add rule for audit-log-maxbackup