### PR TITLE
ocp4/CIS: Remove file ownership sentences

### DIFF
--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -11,7 +11,6 @@ rationale: |-
   The kubeconfig for the Scheduler contains paramters for the scheduler
   to access the Kube API.
   You should set its file ownership to maintain the integrity of the file.
-  The file should be owned by <pre>root:root</pre>.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -10,8 +10,7 @@ description: |-
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
     persistent storage of all of its REST API objects. This data directory should
-    be protected from any unauthorized reads or writes. It should be owned by
-    <pre>root:root</pre>.
+    be protected from any unauthorized reads or writes.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -11,7 +11,6 @@ rationale: |-
   OpenShift makes use of a number of certificates as part of its operation.
   You should verify the ownership of the directory containing the PKI
   information and all files in that directory to maintain their integrity.
-  The directory and files should be owned by the system administrator.
 
 severity: medium
 


### PR DESCRIPTION
This enforces consistency in our rules and these sentences were not relevant for the rationale.