### PR TITLE
Fix bash_dconf_settings to grep whole keyword alike.

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/tests/wrong_value.fail.sh
@@ -5,3 +5,6 @@
 
 install_dconf_and_gdm_if_needed
 clean_dconf_settings
+
+add_dconf_setting "org/gnome/desktop/media-handling" "automount-open" "false" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/media-handling" "automount-open" "local.d" "00-security-settings"

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -181,7 +181,7 @@ then
     printf '%s=%s\n' "{{{ key }}}" "{{{ value }}}" >> ${DCONFFILE}
 else
     escaped_value="$(sed -e 's/\\/\\\\/g' <<< "{{{ value }}}")"
-    if grep -q "^\\s*{{{ key }}}" "${SETTINGSFILES[@]}"
+    if grep -q "^\\s*{{{ key }}}\\s*=" "${SETTINGSFILES[@]}"
     then
         sed -i "s/\\s*{{{ key }}}\\s*=\\s*.*/{{{ key }}}=${escaped_value}/g" "${SETTINGSFILES[@]}"
     else


### PR DESCRIPTION
#### Description:

- Fix `bash_dconf_settings` to grep whole keyword alike.

#### Rationale:

- Avoid cases where `automount-open` could be misinterpreted as a match for `automount` thus no applying correctly the fix.
