### PR TITLE
ocp4/CIS 1.2.13: Fix SecurityContextDeny check

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -6,36 +6,20 @@ title: 'Ensure that the admission control plugin SecurityContextDeny is set if P
 
 description: |-
     Instead of using a customized SecurityContext for pods, a Pod Security
-    Policy (PSP) should be used. PSP is a cluster-level resource that controls
-    the actions that a pod can perform and what resource the pod may access.
-    The <tt>SecurityContextDeny</tt> admission control policy enables PSP.
-{{%- if product == "ocp4" %}}
-    Ensure that the list of admission controllers does not include SecurityContextDeny:
+    Policy (PSP) or a SecurityContextConstraint should be used. These are
+    cluster-level resources that control the actions that a pod can perform
+    and what resource the pod may access. The <tt>SecurityContextDeny</tt>
+    disallows folks from setting a pod's <tt>securityContext</tt> fields.
+    Ensure that the list of admission controllers does not include
+    SecurityContextDeny:
     <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data."config.yaml"' | jq '.apiServerArguments."enable-admission-plugins"' </pre>
-{{% else %}}
-    To configure OpenShift to use PSP, edit the API Server pod specification file
-    <tt>/etc/origin/master/master-config.yaml</tt> on the master node(s) and
-    set the <tt>admissionConfig</tt> to include <tt>SecurityContextDeny</tt>:
-    <pre>admissionConfig:
-      pluginConfig:
-        SecurityContextDeny:
-          configuration:
-          kind: DefaultAdmissionConfig
-          apiVersion: v1
-          disable: false</pre>
-{{%- endif %}}
 
 rationale: |-
-{{%- if product == "ocp4" %}}
-    SecurityContextDeny can be used to provide a layer of security for clusters 
-    which do not have PodSecurityPolicies enabled.
-{{% else %}}
-    Setting admission control policy to <tt>SecurityContextDeny</tt> denies the
-    pod level SecurityContext customization. Any attempts to customize the
-    SecurityContext that are not explicitly defined in the Pod Security Policy
-    (PSP) are blocked. This ensures that all pods adhere to the PSP defined
-    by your organization and you have a uniform pod level security posture.
-{{%- endif %}}
+    The <tt>SecurityContextDeny</tt> admission control plugin disallows
+    setting any security options for your pods. <tt>SecurityContextConstraints</tt>
+    allow you to enforce RBAC rules on who can set these options on the pods, and
+    what they're allowed to set. Thus, using the <tt>SecurityContextDeny</tt>
+    will deter you from enforcing granular permissions on your pods.
 
 severity: medium
 
@@ -43,36 +27,24 @@ references:
     cis: 1.2.13
 
 ocil_clause: |-
-{{%- if product == "ocp4" %}}
     '<tt>enable-admission-plugins</tt>does not contain <tt>SecurityContextDeny</tt>'
-{{% else %}}
-    '<tt>admissionConfig</tt> does not contain <tt>SecurityContextDeny</tt>'
-{{%- endif %}}
 
 ocil: |-
-{{%- if product == "ocp4" %}}
     The SecurityContextDeny plugin should not be enabled in the list of enabled plugins in the apiserver configuration:
     <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data."config.yaml"' | jq '.apiServerArguments."enable-admission-plugins"' </pre>
-{{% else %}}
-    Run the following command on the master node(s):
-    <pre>$ sudo grep -A4 SecurityContextDeny /etc/origin/master/master-config.yaml</pre>
-    The output should return <pre>disable: false</pre>.
-{{%- endif %}}
 
-{{%- if product == "ocp4" %}}
 warnings:
 - general: |-
     {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
-{{%- endif %}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "none satisfy"
     filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"enable-admission-plugins":\[[^]]*"SecurityContextDeny"'
       operation: "pattern match"
       type: "string"
+      entity_check: "none satisfy"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -49,7 +49,7 @@ selections:
     - api_server_admission_control_plugin_AlwaysAdmit
   # 1.2.12 Ensure that the admission control plugin AlwaysPullImages is set
     - api_server_admission_control_plugin_AlwaysPullImages
-  # 1.2.13 Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used
+  # 1.2.13 Ensure that the admission control plugin SecurityContextDeny is not set
     - api_server_admission_control_plugin_SecurityContextDeny
   # 1.2.14 Ensure that the admission control plugin ServiceAccount is set
     - api_server_admission_control_plugin_ServiceAccount


### PR DESCRIPTION
This also removes the templates differentiating between ocp versions, as we no longer need them.