### PR TITLE
CIS 1.2.8: Minor fixups to the text and test stub

### DIFF
--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -1,6 +1,6 @@
 prodtype: ocp4
 
-title: Must have authorization-mode Node set
+title: Ensure authorization-mode Node is configured
 
 description: 'Restrict kubelet nodes to reading only objects associated with them.'
 
@@ -14,10 +14,10 @@ severity: medium
 references:
     cis: 1.2.8
 
-ocil_clause: 'The Node authorization-mode is configured and enabled on the master node'
+ocil_clause: 'The Node authorization-mode is configured and enabled'
 
 ocil: |-
-    Run the following command on the master node(s):
+    To verify that Node authorization mode is enabled, run the following command:
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | grep '"authorization-mode":\[[^]]*"Node"'</pre>
     The output should show that the "authorization-mode" list contains the "Node" authorizer.
 

--- a/applications/openshift/api-server/api_server_auth_mode_node/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
#### Description:

The text was instructing to run commands on the master nodes which is not
required nor it should be advised. A test stub was added as well.

#### Rationale:

Increases the profile coverage.