### PR TITLE
ocp4: Add missing e2e tests for the 1.2 section

### DIFF
--- a/applications/openshift/api-server/api_server_insecure_bind_address/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/tests/ocp4/e2e.yml
+++ b/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
Specifically for these rules:

* `openshift_api_server_audit_log_path`
* `api_server_insecure_bind_address`