### PR TITLE
Fix typos in CPE Applicability devel documentation.

### DIFF
--- a/docs/manual/developer_guide.adoc
+++ b/docs/manual/developer_guide.adoc
@@ -1914,9 +1914,9 @@ All profiles and rules included in a products' DataStream are applicable by defa
 For example, all profiles and rules included in a `rhel8` DS will apply and evaluate in a RHEL 8 host.
 
 But a content's applicability can be fine tuned to a specific environment in the product.
-The SCAP standard specifies two mechanisms to define aplicability:
+The SCAP standard specifies two mechanisms to define applicability:
 - link:https://nvd.nist.gov/products/cpe[CPE]: Allows a specific hardware or platform to be identified.
-- link:https://csrc.nist.gov/projects/security-content-automation-protocol/specifications/cpe/applicability-language[Applicability Language]: Allows the contruction of logical expressions involving CPEs.
+- link:https://csrc.nist.gov/projects/security-content-automation-protocol/specifications/cpe/applicability-language[Applicability Language]: Allows the construction of logical expressions involving CPEs.
 
 At the moment, only the CPE mechanism is supported.
 
@@ -1929,27 +1929,25 @@ Syntax is as follows (using examples of existing CPEs):
 [source,yml]
 ----
 cpes:
-
   - machine:                                  ## The id of the CPE
       name: "cpe:/a:machine"                  ## The CPE Name as defined by the CPE standard
-      title: "Bare-metal or Virtual Machine"  ## Human readable tile for the CPE
+      title: "Bare-metal or Virtual Machine"  ## Human readable title for the CPE
       check_id: installed_env_is_a_machine    ## ID of OVAL implementing the applicability check
-
   - gdm:
       name: "cpe:/a:gdm"
       title: "Package gdm is installed"
       check_id: installed_env_has_gdm_package
 ----
 
-The first entry above defines the a CPE whose id is `machine`, this CPE is used for rules not applicable to containers. +
+The first entry above defines a CPE whose id is `machine`, this CPE is used for rules not applicable to containers. +
 A rule or profile with `platform: machine` will be evaluated only if the targeted scan environment is either bare-metal or virtual machine.
 
-The second entry defines a cpe for GDM. +
+The second entry defines a CPE for GDM. +
 By setting the `platform` to `gdm`, the rule will have its applicability restricted to only environments which have `gdm` package installed. +
 
 The OVAL checks for the CPE need to be of `inventory` class, and must be under `shared/checks/oval/`.
 
-===== Setting a produt's default CPE
+===== Setting a product's default CPE
 The product's default applicability is set in its `product.yml` file, under the `cpes` key.
 For example:
 
@@ -1967,9 +1965,9 @@ Multiple CPEs can be set as default platforms for a product. +
 ===== Setting the product's CPE source directory
 
 The key `cpes_root` in `product.yml` file specifies the directory to source the CPES from. +
-By default, all products source their CPES from `shared/applicabilty/`. Any file with extension `.yml` will be sourced for CPE definitions.
+By default, all products source their CPES from `shared/applicability/`. Any file with extension `.yml` will be sourced for CPE definitions.
 
-Note: Only CPEs that are reference by a rule or profile will be included in the product's CPE Dictionary. +
+Note: Only CPEs that are referenced by a rule or profile will be included in the product's CPE Dictionary. +
 If no content requires the CPE it is deemed unnecessary and won't be included in the dictonary.
 
 === Tests (ctest)


### PR DESCRIPTION
#### Description:

- Fix typos in CPE Applicability devel documentation.

#### Additional Information

Identified when porting this newly introduced documentation to the readthedocs format here: https://github.com/ComplianceAsCode/content/pull/6382/commits/46ddd3bd5ab57c22234730cc7457b2e8b41f63ab