### PR TITLE
Fix release tooling

### DIFF
--- a/release_tools/content_gh.py
+++ b/release_tools/content_gh.py
@@ -82,7 +82,8 @@ def close_milestone(milestone):
 def get_closed_prs(repo, milestone):
     closed_issues = repo.get_issues(milestone=milestone, state="closed", sort="updated")
     issues_with_prs = [i for i in closed_issues if i.pull_request is not None]
-    merged_prs = [i.as_pull_request() for i in issues_with_prs if i.as_pull_request().merged == True]
+    merged_prs =
+    [i.as_pull_request() for i in issues_with_prs if i.as_pull_request().merged is True]
     return merged_prs
 
 

--- a/release_tools/content_gh.py
+++ b/release_tools/content_gh.py
@@ -80,9 +80,10 @@ def close_milestone(milestone):
 
 
 def get_closed_prs(repo, milestone):
-    issues_and_prs = repo.get_issues(milestone=milestone, state="closed", sort="updated")
-    prs_only = [i for i in issues_and_prs if i.pull_request is not None]
-    return prs_only
+    closed_issues = repo.get_issues(milestone=milestone, state="closed", sort="updated")
+    issues_with_prs = [i for i in closed_issues if i.pull_request is not None]
+    merged_prs = [i.as_pull_request() for i in issues_with_prs if i.as_pull_request().merged == True]
+    return merged_prs
 
 
 def generate_release_notes(repo, args):
@@ -94,16 +95,15 @@ def generate_release_notes(repo, args):
     for pr in get_closed_prs(repo, milestone):
         pr_title = pr.title
         pr_number = str(pr.number)
-        pr_info = repo.get_pull(pr.number)
         section = "nosection"
 
-        changed_files = pr_info.get_files()
+        changed_files = pr.get_files()
         for changed_file in changed_files:
             changed_filename = changed_file.filename
 
-            # do not include files from profile_stability folder
+            # do not include files from tests folder
             # they are part of testing mechanisms
-            if ".profile" in changed_filename and "profile_stability" not in changed_filename:
+            if changed_filename.endswith(".profile") and "tests" not in changed_filename:
                 # Track changes to product:profile
                 profile_match = re.match(r"(\w+)/profiles/([\w-]+).profile", changed_filename)
                 product, profile = profile_match.groups()

--- a/release_tools/release_content.py
+++ b/release_tools/release_content.py
@@ -130,7 +130,9 @@ def prep_next_release(env, args):
     print(f"Creating commit for version bump")
     local_repo = git.Repo('../')
 
-    bump_branch = local_repo.create_head('bump_version_{0}'.format(args.next_version), local_repo.heads.master)
+    bump_branch = local_repo.create_head(
+        'bump_version_{0}'.format(args.next_version), local_repo.heads.master
+    )
     local_repo.head.reference = bump_branch
     # reset the index and working tree to match the pointed-to commit
     local_repo.head.reset(index=True, working_tree=True)

--- a/release_tools/release_content.py
+++ b/release_tools/release_content.py
@@ -130,7 +130,7 @@ def prep_next_release(env, args):
     print(f"Creating commit for version bump")
     local_repo = git.Repo('../')
 
-    bump_branch = local_repo.create_head('bump_version_0.1.48', local_repo.heads.master)
+    bump_branch = local_repo.create_head('bump_version_{0}'.format(args.next_version), local_repo.heads.master)
     local_repo.head.reference = bump_branch
     # reset the index and working tree to match the pointed-to commit
     local_repo.head.reset(index=True, working_tree=True)


### PR DESCRIPTION
#### Description:

- while creating release notes, ignore files ending in .profile if they contain "tests" in their filepath.

- the version used in the name of a new commit which bumps the version after release was hardcoded. Now it is dynamically detected.

- while generating release notes, take into account only merged pull requests.

#### Rationale:

- generation of release notes ended with an exception if there was a PR which introduced change to some file ending in .profile and that file was not part of a product.

- closed but not merged pull requests were part of release notes

- the branch name for bumping of version after release was hardcoded and had to be changed manually, annoying.