### PR TITLE
OCP4/CIS 4.2.9: Update kubelet_configure_event_creation rule

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -2,32 +2,46 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'kubelet - Do Not Limit Event Creation'
+title: 'Kubelet - Ensure Event Creation Is Configured'
 
 description: |-
-    All events should be captured and not restricted as this helps in
-    reconstucting the chain-of-events.
-
-    To prevent log creation limiting, edit the kubelet configuration
-    file <tt>/etc/kubernetes/kubernetes.conf</tt>
-    on the kubelet node(s) and set the below parameter:
-    <pre>eventRecordQPS: 0</pre>
+    Security relevant information should be captured. The eventRecordQPS
+    Kubelet option can be used to limit the rate at which events are gathered.
+    Setting this too low could result in relevant events not being logged,
+    however the unlimited setting of 0 could result in a denial of service on
+    the kubelet. Processing and storage systems should be scaled to handle the
+    expected event load.
 
 rationale: |-
-    All events should be captured and not restricted as this helps in
-    reconstucting the chain-of-events.
+    It is important to capture all events and not restrict event creation.
+    Events are an important source of security information and analytics that
+    ensure that your environment is consistently monitored using the event
+    data.
 
 severity: medium
 
-ocil_clause: 'events are limited'
+ocil_clause: 'event creation limits are not configured'
 
 ocil: |-
     Run the following command on the kubelet node(s):
     <pre>$ sudo grep eventRecordQPS /etc/kubernetes/kubernetes.conf</pre>
-    The output should return <tt>0</tt>.
+    The output should return <tt>{{{ xccdf_value("var_event_record_qps") }}}</tt>.
 
 #identifiers:
 #    cce@ocp4:
 
 references:
     cis: 4.2.9
+
+# This check ensures that the option is not left defaulted in the config.  The
+# default of 5 might be sufficient for a deployment; here the point is to check
+# that at least _some_ value has been considered.
+template:
+    name: yamlfile_value
+    vars:
+        filepath: /etc/kubernetes/kubelet.conf
+        yamlpath: ".eventRecordQPS"
+        values:
+         - value: 0
+           type: int
+           operation: "greater than or equal"

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: FAIL

--- a/applications/openshift/kubelet/var_event_record_qps.var
+++ b/applications/openshift/kubelet/var_event_record_qps.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Configure Kubelet Event Limit'
+
+description: 'Maximum event creations per second.'
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    default: 5

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -162,7 +162,7 @@ selections:
   # 4.2.8 Ensure that the --hostname-override argument is not set
     - kubelet_disable_hostname_override
   # 4.2.9 Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture
-    # - like kubelet_anonymous_auth_disabled but check for kubeAPIQPS set to 50
+    - kubelet_configure_event_creation
   # 4.2.11 Ensure that the --rotate-certificates argument is not set to false
     - kubelet_enable_client_cert_rotation
     - kubelet_enable_cert_rotation


### PR DESCRIPTION
The benchmark does not recommend a setting of 0, but to a value that is appropriate for the scale of the deployment. This means any value would be appropriate (including the default of 5 when eventRecordQPS is omitted as per the cluster default). So here we check that there has at least been a configured value. The OCP4 kubelet default excludes eventRecordQPS, so the default compliance state for this item is a fail.