### PR TITLE
OCP4/CIS 4.2.6: add kubelet_enable_protect_kernel_defaults

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
@@ -1,0 +1,40 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'kubelet - Enable Protect Kernel Defaults'
+
+description: |-
+  Protect tuned kernel parameters from being overwritten by the kubelet.
+
+rationale: |-
+  Kernel parameters are usually tuned and hardened by the system administrators
+  before putting the systems into production. These parameters protect the
+  kernel and the system. Your kubelet kernel defaults that rely on such
+  parameters should be appropriately set to match the desired secured system
+  state. Ignoring this could potentially lead to running pods with undesired
+  kernel behavior.
+
+severity: medium
+
+ocil_clause: 'the kubelet can modify kernel parameters'
+
+ocil: |-
+    Run the following command on the kubelet node(s):
+    <pre>$ sudo grep protectKernelDefaults /etc/kubernetes/kubernetes.conf</pre>
+    The output should return <tt>true</tt>.
+
+#identifiers:
+#   cce@ocp4: 
+
+references:
+    cis: 4.2.6
+
+template:
+    name: yamlfile_value
+    vars:
+        filepath: /etc/kubernetes/kubelet.conf
+        yamlpath: ".protectKernelDefaults"
+        values:
+         - value: "true"
+           operation: "equals"

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e-remediation.sh
@@ -2,7 +2,7 @@
 set -xe
 
 echo "applying kernel tuning for kubelet"
-cat << EOF | oc apply -f -
+cat << EOF | oc apply --server-side -f -
 ---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
@@ -65,7 +65,7 @@ done
 sleep 20
 
 echo "applying protectKernelDefaults"
-cat << EOF | oc apply -f -
+cat << EOF | oc apply --server-side -f -
 ---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -xe
+
+echo "applying kernel tuning for kubelet"
+cat << EOF | oc apply -f -
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 75-master-kubelet-sysctls
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+      - contents:
+          source: data:,vm.overcommit_memory%3D1%0Avm.panic_on_oom%3D0%0Akernel.panic%3D10%0Akernel.panic_on_oops%3D1%0Akernel.keys.root_maxkeys%3D1000000%0Akernel.keys.root_maxbytes%3D25000000
+        mode: 0644
+        path: /etc/sysctl.d/90-kubelet.conf
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 75-worker-kubelet-sysctls
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      files:
+      - contents:
+          source: data:,vm.overcommit_memory%3D1%0Avm.panic_on_oom%3D0%0Akernel.panic%3D10%0Akernel.panic_on_oops%3D1%0Akernel.keys.root_maxkeys%3D1000000%0Akernel.keys.root_maxbytes%3D25000000
+        mode: 0644
+        path: /etc/sysctl.d/90-kubelet.conf
+
+EOF
+
+sleep 20
+
+echo "waiting for workers to update"
+while true; do
+		status=$(oc get mcp/worker | grep worker | awk '{ print $3 $4 }')
+		if [ "$status" == "TrueFalse" ]; then
+			echo "workers have been updated"
+			break
+		fi
+		sleep 1
+done
+
+echo "waiting for masters to update"
+while true; do
+		status=$(oc get mcp/master | grep master | awk '{ print $3 $4 }')
+		if [ "$status" == "TrueFalse" ]; then
+			echo "masters have been updated"
+			break
+		fi
+		sleep 1
+done
+
+sleep 20
+
+echo "applying protectKernelDefaults"
+cat << EOF | oc apply -f -
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: master-protect-kernel-defaults
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+  kubeletConfig:
+    protectKernelDefaults: true
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: worker-protect-kernel-defaults
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+  kubeletConfig:
+    protectKernelDefaults: true
+EOF
+
+sleep 30
+
+echo "waiting for workers to update"
+while true; do
+		status=$(oc get mcp/worker | grep worker | awk '{ print $3 $4 }')
+		if [ "$status" == "TrueFalse" ]; then
+			break
+		fi
+		sleep 1
+done
+
+echo "waiting for masters to update"
+while true; do
+		status=$(oc get mcp/master | grep master | awk '{ print $3 $4 }')
+		if [ "$status" == "TrueFalse" ]; then
+			echo "masters have been updated"
+			break
+		fi
+		sleep 1
+done
+
+exit 0

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: FAIL

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
 default_result: FAIL
+result_after_remediation: PASS

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -154,9 +154,7 @@ selections:
   # 4.2.5 Ensure that the --streaming-connection-idle-timeout argument is not set to 0
     - kubelet_enable_streaming_connections
   # 4.2.6 Ensure that the --protect-kernel-defaults argument is set to true
-    # - like kubelet_anonymous_auth_disabled but check that protectKernelDefaults is set to true
-    # FIXME(jhrozek): This does not seem to be set in OCP explicitly and the code seems to suggest
-    # that the default is false? Need to confirm
+    - kubelet_enable_protect_kernel_defaults
   # 4.2.7 Ensure that the --make-iptables-util-chains argument is set to true
     - kubelet_enable_iptables_util_chains
   # 4.2.8 Ensure that the --hostname-override argument is not set

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -52,7 +52,7 @@ const (
 	apiPollInterval           = 5 * time.Second
 	testProfilebundleName     = "e2e"
 	autoApplySettingsName     = "auto-apply-debug"
-	manualRemediationsTimeout = 15 * time.Minute
+	manualRemediationsTimeout = 20 * time.Minute
 )
 
 // This is the definition of the structure rule-specific e2e tests should have

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -622,7 +622,7 @@ func (ctx *e2econtext) getInvalidResultsFromSuite(s string) int {
 }
 
 func (ctx *e2econtext) verifyCheckResultsForSuite(s string, afterRemediations bool) (int, []string) {
-	manualRemediations := []string{}
+	manualRemediationSet := map[string]bool{}
 	resList := &cmpv1alpha1.ComplianceCheckResultList{}
 	matchLabels := dynclient.MatchingLabels{
 		cmpv1alpha1.SuiteLabel: s,
@@ -643,8 +643,13 @@ func (ctx *e2econtext) verifyCheckResultsForSuite(s string, afterRemediations bo
 			ctx.t.Error(err)
 		}
 		if manualRem != "" {
-			manualRemediations = append(manualRemediations, manualRem)
+			manualRemediationSet[manualRem] = true
 		}
+	}
+
+	manualRemediations := []string{}
+	for key := range manualRemediationSet {
+		manualRemediations = append(manualRemediations, key)
 	}
 
 	return len(resList.Items), manualRemediations


### PR DESCRIPTION
@JAORMX @redhatrises here's the corrected rule to check _for_ protectKernelDefaults: true. Currently should be a default fail.