### PR TITLE
Make rsyslog_remote_tls regex case insensitive for rsyslogs parameters.

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/oval/shared.xml
@@ -16,11 +16,11 @@
   <ind:textfilecontent54_object id="obj_rsyslog_remote_tls" version="1">
     <ind:behaviors singleline="true" />
     <ind:filepath operation="pattern match">^/etc/rsyslog\.(conf|d/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*action\(type="omfwd"(.+?)\)</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*action\((?i)type(?-i)="omfwd"(.+?)\)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">0</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_rsyslog_remote_tls" comment="value of omfwd action" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">(?=[\S\s]*\sprotocol="tcp")(?=[\S\s]*\sTarget="[^"]+?")(?=[\S\s]*\sport="6514")(?=[\S\s]*\sStreamDriver="gtls")(?=[\S\s]*\sStreamDriverMode="1")(?=[\S\s]*\sStreamDriverAuthMode="x509/name")(?=[\S\s]*\sstreamdriver\.CheckExtendedKeyPurpose="on")</ind:subexpression>
+    <ind:subexpression datatype="string" operation="pattern match">(?=[\S\s]*\s(?i)protocol(?-i)="tcp")(?=[\S\s]*\s(?i)Target(?-i)="[^"]+?")(?=[\S\s]*\s(?i)port(?-i)="6514")(?=[\S\s]*\s(?i)StreamDriver(?-i)="gtls")(?=[\S\s]*\s(?i)StreamDriverMode(?-i)="1")(?=[\S\s]*\s(?i)StreamDriverAuthMode(?-i)="x509/name")(?=[\S\s]*\s(?i)StreamDriver\.CheckExtendedKeyPurpose(?-i)="on")</ind:subexpression>
   </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_mixed_cases.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_mixed_cases.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat >> /etc/rsyslog.conf <<EOF
+action(tYpe="omfwd" protocol="tcp" TarGet="remote.system.com" port="6514" StreaMDrIver="gtls" StrEamDriverMode="1" StreamDrivErAuthMode="x509/name" stReamDriver.CheckExteNdedKeyPurpose="on")
+EOF


### PR DESCRIPTION
#### Description:

- Make rsyslog_remote_tls regex case insensitive for rsyslogs parameters.

#### Rationale:

- rsyslog parameters are case-insensitive

Reference: https://www.rsyslog.com/doc/master/configuration/modules/index.html

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1899032