### PR TITLE
Remove comments that trick readthedocs jinja doc parser.

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1,5 +1,3 @@
-{{# ##### High level macros ##### #}}
-
 {{#
 Pass strings that correspond to XCCDF value names as arguments to this macro:
 bash_instantiate_variables("varname1", "varname2")
@@ -409,9 +407,6 @@ do
     {{{ bash_set_faillock_option_account("$pam_file") | indent(4) }}}
 done
 {{%- endmacro -%}}
-
-
-{{# ##### Low level macros ##### #}}
 
 {{#
 # Print a message to stderr and exit the shell


### PR DESCRIPTION
#### Description:

- Remove comments that trick readthedocs jinja doc parser.

#### Rationale:

- It causes the readthedocs page to miss some documentation.

For example: `bash_instantiate_variables` now shows up in the documentation page, preview: https://ggbecker-content.readthedocs.io/en/readthedocs-support/jinja_macros/bash.html
