### PR TITLE
OCP4/CIS 2.7: Check that etcd has its own CA

### DIFF
--- a/applications/openshift/etcd/etcd_unique_ca/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_unique_ca/oval/shared.xml
@@ -1,0 +1,52 @@
+<def-group>
+  <definition class="compliance" id="etcd_unique_ca" version="1">
+    {{{ oval_metadata("The etcd CA should be different from the Kubernetes CA.") }}}
+    <criteria>
+      <criterion test_ref="test_etcd_different_ca_than_k8s"
+      comment="Check that etcd uses a different CA than Kubernetes." />
+    </criteria>
+  </definition>
+
+  <!-- Start CA file check -->
+
+    <ind:variable_test check="all" check_existence="all_exist"
+    comment="Verify that the etcd CA is different than the Kubernetes CA"
+    id="test_etcd_different_ca_than_k8s" version="1">
+      <ind:object object_ref="obj_var_etcd_ca_file_hash" />
+      <ind:state state_ref="ste_cas_are_equal" />
+    </ind:variable_test>
+
+    <!--- etcd CA File -->
+
+    <ind:variable_object id="obj_var_etcd_ca_file_hash" version="1">
+      <ind:var_ref>var_etcd_ca_file_hash</ind:var_ref>
+    </ind:variable_object>
+
+    <local_variable id="var_etcd_ca_file_hash" datatype="string" version="1" comment="File hash for etcd CA">
+      <object_component item_field="hash" object_ref="obj_etcd_ca_file_hash" />
+    </local_variable>
+
+    <ind:filehash58_object id="obj_etcd_ca_file_hash" version="1">
+      <ind:filepath>/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-serving-ca/ca-bundle.crt</ind:filepath>
+      <ind:hash_type>SHA-256</ind:hash_type>
+    </ind:filehash58_object>
+
+    <!--- Kubernetes CA File -->
+
+    <local_variable id="var_k8s_ca_file_hash" datatype="string" version="1" comment="The hash for the Kubernetes CA file">
+      <object_component item_field="hash" object_ref="object_k8s_ca_file_hash" />
+    </local_variable>
+
+    <ind:filehash58_object id="object_k8s_ca_file_hash" version="1">
+      <ind:filepath>/etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/client-ca/ca-bundle.crt</ind:filepath>
+      <ind:hash_type>SHA-256</ind:hash_type>
+    </ind:filehash58_object>
+
+    <!--- State -->
+
+    <ind:variable_state comment="CA files" id="ste_cas_are_equal" version="1">
+      <ind:value operation="not equal" datatype="string" var_ref="var_k8s_ca_file_hash" var_check="all" />
+    </ind:variable_state>
+
+  <!-- End CA file check -->
+</def-group>

--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -5,17 +5,15 @@ prodtype: ocp4
 title: 'Configure A Unique CA Certificate for etcd'
 
 description: |-
-    A unique and different CA certificate should be created for <tt>etcd</tt>.
-    To ensure the <tt>etcd</tt> service is using a unique certificate,
-    set <tt>ETCD_TRUSTED_CA_FILE</tt> to <tt>/etc/etcd/ca.crt</tt>
-    in <tt>/etc/etcd/etcd.conf</tt> on the master node that does NOT match
-    the OpenShift CA certificate:
-    <pre>ETCD_TRUSTED_CA_FILE=/etc/ssl/etcd/ca.crt</pre>
+  A unique and different CA certificate should be created for <tt>etcd</tt>.
+  OpenShift by default creates different and separate PKIs for etcd and the
+  Kubernetes API server. The same is done for other points of communication
+  in the cluster.
 
 rationale: |-
-    A unique CA certificate that is utilized by etcd and is different from
-    OpenShift ensures that the etcd data is still protected in the event that
-    the OpenShift certificate is compromised.
+  A unique CA certificate that is utilized by etcd and is different from
+  OpenShift ensures that the etcd data is still protected in the event that
+  the OpenShift certificate is compromised.
 
 severity: medium
 
@@ -23,12 +21,15 @@ severity: medium
 #    cce@ocp4:
 
 references:
-    cis: '2.7'
+  cis: '2.7'
 
-ocil_clause: 'the etcd CA certificate is not unique'
+platform: ocp4-master-node
+
+ocil_clause: 'The etcd CA certificate is not unique'
 
 ocil: |-
-    Run the following command on the master node(s):
-    <pre>$ grep ETCD_TRUSTED_CA_FILE /etc/etcd/etcd.conf</pre>
-    Inspect the certificate file that is returned and verify that it
-    does not match the OpenShift CA certificate.
+  Run the following command:
+  <pre>oc debug node/$NODE -- diff /host/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-serving-ca/ca-bundle.crt /host/etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/client-ca/ca-bundle.crt</pre>
+  where <tt>$NODE</tt> is a master node. If you don't see diff output
+  the differences, you might have a compromise and should isolate the cluster.
+  OpenShift will use separate PKIs by default.

--- a/applications/openshift/etcd/etcd_unique_ca/tests/ocp4/e2e.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/tests/ocp4/e2e.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: SKIP

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1950,11 +1950,11 @@ In order to test that a rule is yielding expected results in the e2e
 tests, one must create a file called `e2e.yml` in a `tests/ocp4/`
 directory which will exist in the rule’s directory itself.
 
-The format looks as follows:
+The format may look as follows:
 
     ---
-    default_result: [PASS|FAIL]
-    result_after_remediation: [PASS|FAIL]
+    default_result: [PASS|FAIL|SKIP]
+    result_after_remediation: [PASS|FAIL|SKIP]
 
 Where:
 
@@ -1964,7 +1964,23 @@ Where:
     scan is run. The second scan takes place after remediations are
     applied.
 
+Note that this format applies if the result of a rule will be the same accross
+roles in the cluster.
+
+It is also possible to differentiate results between roles. For such a thing,
+the format would look as follows:
+
 Let’s look at an example:
+
+    ---
+    default_result:
+      worker: [PASS|FAIL|SKIP]
+      master: [PASS|FAIL|SKIP]
+    result_after_remediation:
+      worker: [PASS|FAIL|SKIP]
+      master: [PASS|FAIL|SKIP]
+
+Where "worker" and "master" are node roles.
 
 For the `controller_use_service_account` rule, which exists in the
 `applications/openshift/controller/` directory, the directory tree will

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -108,13 +108,8 @@ selections:
     - file_permissions_openshift_pki_key_files
 
   ### 2 etcd
-  # 2.1 Ensure that the --cert-file and --key-file arguments are set as appropriate
-  # 2.2 Ensure that the --client-cert-auth argument is set to true
-  # 2.3 Ensure that the --auto-tls argument is not set to true
-  # 2.4 Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate
-  # 2.5 Ensure that the --peer-client-cert-auth argument is set to true
-  # 2.6 Ensure that the --peer-auto-tls argument is not set to true
-  # 2.7 Ensure that a unique Certificate Authority is used for etcd (manual)
+  # 2.7 Ensure that a unique Certificate Authority is used for etcd
+    - etcd_unique_ca
 
   ### 3 Control Plane Configuration
   ###

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -137,8 +137,6 @@ selections:
     - etcd_peer_client_cert_auth
   # 2.6 Ensure that the --peer-auto-tls argument is not set to true
     - etcd_peer_auto_tls
-  # 2.7 Ensure that a unique Certificate Authority is used for etcd
-    - etcd_unique_ca
 
   ### 3 Control Plane Configuration
   ###

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -34,6 +34,11 @@ cpes:
       title: "Package ntp is installed"
       check_id: installed_env_has_ntp_package
 
+  - ocp4-master-node:
+      name: "cpe:/a:ocp4-master-node"
+      title: "Node is an OpenShift 4 master node"
+      check_id: node_is_ocp4_master_node
+
   - pam:
       name: "cpe:/a:pam"
       title: "Package pam is installed"

--- a/shared/checks/oval/node_is_ocp4_master_node.xml
+++ b/shared/checks/oval/node_is_ocp4_master_node.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="inventory" id="node_is_ocp4_master_node" version="1">
+    <metadata>
+      <title>Node is Red Hat OpenShift Container Platform 4 Master Node</title>
+      <affected family="unix">
+        <platform>Red Hat OpenShift Container Platform 4 Node</platform>
+      </affected>
+      <reference ref_id="cpe:/a:ocp4-master-node" source="CPE" />
+      <description>The current node is an OpenShift 4 master node.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="The Kube API pod is present" test_ref="test_kube_api_pod_exists" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing if /etc/kubernetes/static-pod-resources/kube-apiserver-certs exists" id="test_kube_api_pod_exists" version="1">
+    <unix:object object_ref="object_kube_api_pod_exists" />
+  </unix:file_test>
+
+  <unix:file_object comment="/etc/kubernetes/static-pod-resources/kube-apiserver-certs" id="object_kube_api_pod_exists" version="1">
+    <unix:path>/etc/kubernetes/static-pod-resources/kube-apiserver-certs</unix:path>
+    <unix:filename xsi:nil="true" />
+  </unix:file_object>
+
+</def-group>


### PR DESCRIPTION
This introduces a rule that checks that etcd is using its own CA which
is different from Kube's CA. It does this by using custom OVAL to check
that the two CA files are indeed different.

Since both components (etcd and the kube apiserver) only run on the
master nodes, this introduces a new cpe `ocp4-master-node`. This allows
us to differentiate between master nodes and other nodes. However, take
into account that it's on a node level and it isn't applicable to
"platform checks"