### PR TITLE
ocp4/CIS 1.1.20: Fix references in rules

### DIFF
--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.1.21
+  cis: 1.1.20
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.1.21
+  cis: 1.1.20
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="-rw-------") }}}'
 


### PR DESCRIPTION
The appropriate rules were pointing to the wrong CIS reference.