### PR TITLE
Abort the build if an OVAL is not included due to extend_definition

### DIFF
--- a/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: debian10,debian9,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu1604,ubuntu1804,ubuntu2004,wrlinux1019,wrlinux8
-
 title: 'Install the OpenSSH Server Package'
 
 description: |-

--- a/linux_os/guide/services/ssh/package_openssh-server_removed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_removed/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: debian10,debian9,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu1604,ubuntu1804,ubuntu2004,wrlinux1019,wrlinux8
-
 title: 'Remove the OpenSSH Server Package'
 
 description: |-

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
 
 title: 'Enable SSH Server firewalld Firewall Exception'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+
 title: 'Ensure auditd Collects File Deletion Events by User'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+
 title: 'Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful)'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - creat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - ftruncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - open'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - open_by_handle_at'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - openat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - truncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+
 title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Unloading - delete_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading - init_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+
 title: 'Record Attempts to Alter Logon and Logout Events'
 
 description: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - faillock'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - lastlog'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - tallylog'
 

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
-
 title: 'Disable IPv6 Networking Support Automatic Loading'
 
 description: |-

--- a/linux_os/guide/system/selinux/selinux_state/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_state/rule.yml
@@ -1,6 +1,7 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+# This rule is applicable even to non-selinux platforms, as the selinux_state is leveraged
+# by rules that deal with technologies that conflict with SELinux
 
 title: 'Ensure SELinux State is Enforcing'
 

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux8,wrlinux1019
 
 title: 'The Installed Operating System Is FIPS 140-2 Certified'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,sle12,sle15,rhv4
+
 title: 'Harden SSHD Crypto Policy'
 
 description: |-

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
@@ -1,7 +1,5 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15
-
 title: 'Install the Host Intrusion Prevention System (HIPS) Module'
 
 description: |-

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,rhel7
+prodtype: rhcos4,ol7,rhel7,wrlinux1019
 
 title: 'Install the dracut-fips-aesni Package'
 

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,rhel7
+prodtype: rhcos4,ol7,rhel7,wrlinux1019
 
 title: 'Install the dracut-fips Package'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+
 title: 'Build and Test AIDE Database'
 
 description: |-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Install AIDE'
 

--- a/shared/checks/oval/sysctl_kernel_ipv6_disable.xml
+++ b/shared/checks/oval/sysctl_kernel_ipv6_disable.xml
@@ -4,6 +4,7 @@
       <title>Kernel Runtime Parameter IPv6 Check</title>
       <affected family="unix">
 	<platform>multi_platform_debian</platform>
+	<platform>multi_platform_example</platform>
 	<platform>multi_platform_fedora</platform>
 	<platform>multi_platform_opensuse</platform>
 	<platform>multi_platform_ol</platform>

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -114,7 +114,6 @@ class OVALFileLinker(FileLinker):
 
     def __init__(self, translator, xccdftree, checks):
         super(OVALFileLinker, self).__init__(translator, xccdftree, checks)
-        self.tolerate_missing_extending_defs = False
         self.oval_groups = None
 
     def _get_checkid_string(self):
@@ -143,20 +142,12 @@ class OVALFileLinker(FileLinker):
 
         defs_miss = get_oval_checks_extending_non_existing_checks(self.tree, indexed_oval_defs)
         if defs_miss:
-            if self.tolerate_missing_extending_defs:
-                drop_oval_definitions(self.tree, defs_miss.keys(), self.oval_groups, indexed_oval_defs)
-                for broken, missed in defs_miss.items():
-                    print("WARNING: OVAL definition '{0}' extended by non-existing {1}, "
-                          "removing it from OVAL definitions."
-                          .format(broken.get("id"), list(missed)),
-                          file=sys.stderr)
-            else:
-                msg = ["Following extending definitions are missing:"]
-                for missing, broken in transpose_dict_with_sets(defs_miss).items():
-                    broken = [b.get("id") for b in broken]
-                    msg.append("\t'{missing}' needed by: {broken}"
-                               .format(missing=missing, broken=broken))
-                raise RuntimeError("\n".join(msg))
+            msg = ["Following extending definitions are missing:"]
+            for missing, broken in transpose_dict_with_sets(defs_miss).items():
+                broken = [b.get("id") for b in broken]
+                msg.append("\t'{missing}' needed by: {broken}"
+                           .format(missing=missing, broken=broken))
+            raise RuntimeError("\n".join(msg))
 
         self._add_cce_id_refs_to_oval_checks(xccdf_to_cce_id_mapping)
 

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import sys
+import collections
 
 
 from .constants import oval_namespace, XCCDF11_NS, cce_uri, ocil_cs, ocil_namespace
@@ -113,6 +114,7 @@ class OVALFileLinker(FileLinker):
 
     def __init__(self, translator, xccdftree, checks):
         super(OVALFileLinker, self).__init__(translator, xccdftree, checks)
+        self.tolerate_missing_extending_defs = False
         self.oval_groups = None
 
     def _get_checkid_string(self):
@@ -139,8 +141,22 @@ class OVALFileLinker(FileLinker):
         indexed_oval_defs = map_elements_to_their_ids(
             self.tree, ".//{0}".format(self._get_checkid_string()))
 
-        drop_oval_checks_extending_non_existing_checks(
-            self.tree, self.oval_groups, indexed_oval_defs)
+        defs_miss = get_oval_checks_extending_non_existing_checks(self.tree, indexed_oval_defs)
+        if defs_miss:
+            if self.tolerate_missing_extending_defs:
+                drop_oval_definitions(self.tree, defs_miss.keys(), self.oval_groups, indexed_oval_defs)
+                for broken, missed in defs_miss.items():
+                    print("WARNING: OVAL definition '{0}' extended by non-existing {1}, "
+                          "removing it from OVAL definitions."
+                          .format(broken.get("id"), list(missed)),
+                          file=sys.stderr)
+            else:
+                msg = ["Following extending definitions are missing:"]
+                for missing, broken in transpose_dict_with_sets(defs_miss).items():
+                    broken = [b.get("id") for b in broken]
+                    msg.append("\t'{missing}' needed by: {broken}"
+                               .format(missing=missing, broken=broken))
+                raise RuntimeError("\n".join(msg))
 
         self._add_cce_id_refs_to_oval_checks(xccdf_to_cce_id_mapping)
 
@@ -316,20 +332,33 @@ def get_nonexisting_check_definition_extends(definition, indexed_oval_defs):
     return None
 
 
-def drop_oval_checks_extending_non_existing_checks(ovaltree, oval_groups, indexed_oval_defs):
+def get_oval_checks_extending_non_existing_checks(ovaltree, indexed_oval_defs):
     # Incomplete OVAL checks are as useful as non existing checks
     # Here we check if all extend_definition refs from a definition exists in local OVAL file
     definitions = ovaltree.find(".//{%s}definitions" % oval_ns)
-    defstoremove = set()
+    definitions_misses = collections.defaultdict(set)
     for definition in definitions:
         nonexisting_ref = get_nonexisting_check_definition_extends(definition, indexed_oval_defs)
         if nonexisting_ref is not None:
-            print("WARNING: OVAL definition '{0}' extends non-existing '{1}', "
-                  "removing it from OVAL definitions."
-                  .format(definition.get("id"), nonexisting_ref),
-                  file=sys.stderr)
-            defstoremove.add(definition)
+            definitions_misses[definition].add(nonexisting_ref)
 
+    return definitions_misses
+
+
+def transpose_dict_with_sets(dict_in):
+    """
+    Given a mapping X: key -> set of values, produce a mapping Y of the same type, where
+        for every combination of a, b for which a in X[b], the following holds: b in Y[a].
+    """
+    result = collections.defaultdict(set)
+    for key, values in dict_in.items():
+        for val in values:
+            result[val].add(key)
+    return result
+
+
+def drop_oval_definitions(ovaltree, defstoremove, oval_groups, indexed_oval_defs):
+    definitions = ovaltree.find(".//{%s}definitions" % oval_ns)
     for definition in defstoremove:
         del oval_groups["definitions"][definition.get("id")]
         del indexed_oval_defs[definition.get("id")]

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -365,7 +365,7 @@ MAKEFILE_ID_TO_PRODUCT_MAP = {
     'sle': 'SUSE Linux Enterprise',
     'vsel': 'McAfee VirusScan Enterprise for Linux',
     'wrlinux': 'WRLinux',
-    'example': 'Example Linux Content',
+    'example': 'Example',
     'ol': 'Oracle Linux',
     'ocp': 'Red Hat OpenShift Container Platform',
     'rhcos': 'Red Hat Enterprise Linux CoreOS',


### PR DESCRIPTION
If an extending definition is missing, then the OVAL won't be there as well.
This indicates an incorrect setup of applicability - either extending definitions are not applicable as they should, or the compound definition should not be applicable.

Fixes: #6185 