### PR TITLE
SRG for ssh_client_rekey_limit

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/ssh_client_rekey_limit/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/ssh_client_rekey_limit/rule.yml
@@ -30,6 +30,7 @@ identifiers:
 
 references:
     ospp: FCS_SSHS_EXT.1
+    srg: SRG-OS-000423-GPOS-00187
 
 ocil_clause: 'it is commented out or is not set'
 


### PR DESCRIPTION
#### Description:
Add SRG identifier https://vaulted.io/library/disa-stigs-srgs/general_purpose_operating_system_srg/V-56861 to `ssh_client_rekey_limit` rule.

#### Rationale:
The rule is in the ospp profile and stig extends ospp.