### PR TITLE
remove extended check from accounts_passwords_pam_faillock_enforce_local

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/oval/shared.xml
@@ -2,7 +2,6 @@
   <definition class="compliance" id="accounts_passwords_pam_faillock_enforce_local" version="1">
     {{{ oval_metadata("Failed password attempts are enforced for local users only.") }}}
     <criteria operator="AND" comment="conditions for accounts_passwords_pam_faillock_enforce_local are satisfied">
-      <extend_definition comment="faillock.so exists in system-auth" definition_ref="accounts_password_pam_faillock" />
       <criterion comment="faillock.conf" test_ref="test_accounts_passwords_pam_faillock_enforce_local" />
     </criteria>
   </definition>


### PR DESCRIPTION
#### Description:

- remove extending definition  checking for accounts_password_pam_faillock from oval check of accounts_passwords_pam_faillock_enforce_local

#### Rationale:

- the extending check is not directly connected with the rule description. Usage of faillock should be verified with extra rule.