### PR TITLE
ocp4: Add automatic remediation for etcd encryption provider

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_config/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_config/kubernetes/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_ocp
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  encryption:
+    type: aescbc

--- a/applications/openshift/api-server/api_server_encryption_provider_config/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/api-server/api_server_encryption_provider_config/tests/ocp4/e2e-remediation.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 #
-# This applies the remediation needed for this rule. Which enables etcd encryption
-# This rule wasn't able to be done via a standard remediation since we only need to
-# apply a partial part of the Kubernetes object. PATCH support for the
-# compliance-operator would be needed to make this work
+# This waits for etcd encryption to be enabled. The operator can apply the
+# remediation, but waiting for this to get applied is still something that
+# needs to be done outside of the operator.
 #
 # This patch sets the encryption setting and waits for it to be applied
-
-oc patch apiservers cluster -p '{"spec":{"encryption":{"type":"aescbc"}}}' --type=merge
 
 while true; do
     status=$(oc get openshiftapiserver -o=jsonpath='{range .items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}')


### PR DESCRIPTION
Instead of this relying on a manual remediation, we should instead
create an automated one that the compliance-operator can deploy.

Depends on: https://github.com/openshift/compliance-operator/pull/487