### PR TITLE
Add test to grub2_enable_fips_mode to check if /etc/system-fips exists.

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8,rhv4
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
 
 title: Ensure '/etc/system-fips' exists
 

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
@@ -6,6 +6,7 @@
       <extend_definition comment="prelink disabled" definition_ref="disable_prelink" />
       <extend_definition comment="package dracut-fips installed" definition_ref="package_dracut-fips_installed" />
       <extend_definition comment="package dracut-fips-aesni installed" definition_ref="package_dracut-fips-aesni_installed" />
+      <extend_definition comment="check /etc/system-fips exists" definition_ref="etc_system_fips_exists" />
       <criteria operator="OR">
         <criterion test_ref="test_grub2_enable_fips_mode" comment="check for fips=1 in /etc/default/grub via GRUB_CMDLINE_LINUX" />
         <criteria operator="AND">


### PR DESCRIPTION
#### Description:

- Add test to grub2_enable_fips_mode to check if /etc/system-fips exists.

#### Rationale:

- Reference: https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-09-03/finding/V-204497