### PR TITLE
Moved OVAL CVE Feed metadata from the rule to individual products.

### DIFF
--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -74,5 +74,5 @@ warnings:
 {{% else %}}
 {{# The rule will be "notchecked" #}}
 warnings:
-    - general: "{{{ full_name }}} doesn't have a OVAL CVE Feed associated, so this rule doesn't have a corresponding check."
+    - general: '{{{ full_name }}} does not have a corresponding OVAL CVE Feed. Therefore, this will result in a "not checked" result during a scan.'
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -64,9 +64,6 @@ references:
 # SCAP 1.3 content should reference flat non compressed xml files
 {{% if oval_feed_url %}}
 oval_external_content: {{{ oval_feed_url }}}
-  {{% if not oval_feed_url.startswith("https") %}}
-  {{{ raise("OVAL feed of product '" + product + "' is not available through an encrypted channel: " + oval_feed_url) }}}
-  {{% endif %}}
   {{% if not oval_feed_url.endswith(".xml") %}}
 warnings:
     - general: "The OVAL feed of {{{ full_name }}} is not a XML file, which may not be understood by all scanners."

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -60,21 +60,19 @@ references:
     cis-csc: 18,20,4
     anssi: BP28(R08)
 
-{{# Make sure all the external OVAL content links are secured via TLS! #}}
 
 # SCAP 1.3 content should reference flat non compressed xml files
-{{% if product == "rhel7" %}}
-oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml"
-{{% elif product == "rhel8" %}}
-oval_external_content: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml"
-{{% elif product == "ubuntu1604" %}}
-oval_external_content: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml"
-{{% elif product in ["ol7", "ol8"] %}}
-oval_external_content: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
-{{% elif product == "sle12" %}}
-oval_external_content: "https://support.novell.com/security/oval/suse.linux.enterprise.12.xml"
-{{% elif product == "sle15" %}}
-oval_external_content: "https://support.novell.com/security/oval/suse.linux.enterprise.15.xml"
+{{% if oval_feed_url %}}
+oval_external_content: {{{ oval_feed_url }}}
+  {{% if not oval_feed_url.startswith("https") %}}
+  {{{ raise("OVAL feed of product '" + product + "' is not available through an encrypted channel: " + oval_feed_url) }}}
+  {{% endif %}}
+  {{% if not oval_feed_url.endswith(".xml") %}}
+warnings:
+    - general: "The OVAL feed of {{{ full_name }}} is not a XML file, which may not be understood by all scanners."
+  {{% endif %}}
 {{% else %}}
 {{# The rule will be "notchecked" #}}
+warnings:
+    - general: "{{{ full_name }}} doesn't have a OVAL CVE Feed associated, so this rule doesn't have a corresponding check."
 {{% endif %}}

--- a/ol7/product.yml
+++ b/ol7/product.yml
@@ -9,6 +9,7 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
 cpes_root: "../shared/applicability"
 cpes:

--- a/ol8/product.yml
+++ b/ol8/product.yml
@@ -9,6 +9,7 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
 cpes_root: "../shared/applicability"
 cpes:

--- a/rhel7/product.yml
+++ b/rhel7/product.yml
@@ -18,6 +18,7 @@ aux_pkg_version: "2fa658e0"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
+oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml"
 
 cpes_root: "../shared/applicability"
 cpes:

--- a/rhel8/product.yml
+++ b/rhel8/product.yml
@@ -18,6 +18,7 @@ aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
+oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml"
 
 cpes_root: "../shared/applicability"
 cpes:

--- a/sle12/product.yml
+++ b/sle12/product.yml
@@ -9,6 +9,7 @@ profiles_root: "./profiles"
 init_system: "systemd"
 
 pkg_manager: "zypper"
+oval_feed_url: "https://support.novell.com/security/oval/suse.linux.enterprise.12.xml"
 
 cpes_root: "../shared/applicability"
 cpes:

--- a/sle15/product.yml
+++ b/sle15/product.yml
@@ -9,6 +9,7 @@ profiles_root: "./profiles"
 pkg_manager: "zypper"
 
 init_system: "systemd"
+oval_feed_url: "https://support.novell.com/security/oval/suse.linux.enterprise.15.xml"
 
 cpes_root: "../shared/applicability"
 cpes:

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -138,9 +138,22 @@ def open_raw(yaml_file):
     return yaml_contents
 
 
+def _validate_product_oval_feed_url(contents):
+    if "oval_feed_url" not in contents:
+        return
+    url = contents["oval_feed_url"]
+    if not url.startswith("https"):
+        msg = (
+            "OVAL feed of product '{product}' is not available through an encrypted channel: {url}"
+            .format(product=contents["product"], url=url)
+        )
+        raise ValueError(msg)
+
+
 def open_environment(build_config_yaml, product_yaml):
     contents = open_raw(build_config_yaml)
     contents.update(open_raw(product_yaml))
+    _validate_product_oval_feed_url(contents)
     platform_package_overrides = contents.get("platform_package_overrides", {})
     # Merge common platform package mappings, while keeping product specific mappings
     contents["platform_package_overrides"] = merge_dicts(XCCDF_PLATFORM_TO_PACKAGE,

--- a/ubuntu1604/product.yml
+++ b/ubuntu1604/product.yml
@@ -9,6 +9,7 @@ profiles_root: "./profiles"
 pkg_manager: "apt_get"
 
 init_system: "systemd"
+oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml"
 
 cpes_root: "../shared/applicability"
 cpes:


### PR DESCRIPTION
This change brings following benefits:

- Changes of feeds don't require to touch the rule file.
- The build aborts if a feed doesn't start with https.
- Rule gets XCCDF warnings if there is no feed, or if the feed doesn't end with `.xml`.