### PR TITLE
Add xwindows_runlevel_target to RHEL7 STIG profile.

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -287,6 +287,7 @@ selections:
     - sshd_enable_x11_forwarding
     - tftpd_uses_secure_mode
     - package_xorg-x11-server-common_removed
+    - xwindows_runlevel_target
     - sysctl_net_ipv4_ip_forward
     - mount_option_krb_sec_remote_filesystems
     - snmpd_not_default_password


### PR DESCRIPTION
#### Description:

- Add xwindows_runlevel_target to RHEL7 STIG profile.

#### Rationale:

- This rule is now part of the check/fix text from RHEL7 STIG v3: https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-09-03/finding/V-204624

- It doesn't have a new STIG ID assigned though and it's treated in the same item configuration for removal of `xorg-x11-server-common` package
