### PR TITLE
Add docs/.gitignore file to ignore temporary files.

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,7 @@
+# Ignore Sphinx _build directory
+_build
+
+# these folders are created by conf.py so it can properly Markdown files that are symbolic links from their original
+# local, since it's not possible to render Markdown files that are from outside of this directory.
+tests
+release_tools


### PR DESCRIPTION
#### Description:

- Add docs/.gitignore file to ignore temporary files.

#### Rationale:

- These files are generated when building the documentation locally and we don't need them to show up in the git workspace.
- It was an omission when integrating with readthedocs.org
