### PR TITLE
Fix accounts tmout regex and remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -2,8 +2,8 @@
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("var_accounts_tmout") }}}
 
-if grep --silent ^TMOUT /etc/profile ; then
-        sed -i "s/^TMOUT.*/TMOUT=$var_accounts_tmout/g" /etc/profile
+if grep --silent '^\s*TMOUT' /etc/profile ; then
+        sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/\1TMOUT=$var_accounts_tmout\3/g" /etc/profile
 else
         echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile
         echo "TMOUT=$var_accounts_tmout" >> /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -15,7 +15,7 @@
   {{% endmacro %}}
 
   {{% macro object_tmout(test_stem, path, filename, filepath) %}}
-  <ind:textfilecontent54_object id="object_{{{ test_stem }}}" version="2">
+  <ind:textfilecontent54_object id="object_{{{ test_stem }}}" version="3">
     {{% if path %}}
     <ind:path>{{{ path }}}</ind:path>
     {{% endif %}}
@@ -25,7 +25,7 @@
     {{% if filepath %}}
     <ind:filepath>{{{ filepath }}}</ind:filepath>
     {{% endif %}}
-    <ind:pattern operation="pattern match">^[\s]*TMOUT[\s]*=[\s]*(.*)[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+).*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endmacro %}}


### PR DESCRIPTION
#### Description:

- Modified regex pattern on oval definition to capture only value of interest. Also to not match white-space arround "="
- Modified remediation script so it does not replace whole line with TMOUT variable assignment

#### Rationale:

- Regex pattern on oval definition caused oscap tool to fail when more statements followed the variable assignment (e.g. `TMOUT=600; readonly TMOUT; export TMOUT`)
- Replacing the whole line where the TMOUT var assignment is found could remove statements after the assignment
