### PR TITLE
Update Ubuntu support in kernel_module_disabled

### DIFF
--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
 # reboot = true
 # strategy = disable
 # complexity = low

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
 # reboot = true
 # strategy = disable
 # complexity = low

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -4,19 +4,14 @@
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.d" />
-
-{{% if product != "ubuntu1804" %}}
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
-{{% endif %}}
-
-{{% if (product != "ubuntu1804") %}}
-
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_etcmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modules-load.d" />
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modules-load.d" />
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodules-load" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modules-load.d" />
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_runmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /run/modprobe.d" />
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_libmodprobed" comment="kernel module {{{ KERNMODULE }}} disabled in /usr/lib/modprobe.d" />
 
+{{% if "ubuntu" not in product %}}
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
 {{% endif %}}
 
     </criteria>


### PR DESCRIPTION
#### Description:

All the now supported versions of Ubuntu use systemd so the oval unnecessarily excluded kernel module loading config files and did not include Ubuntu families for the remediation templates.

#### Rationale:

Ubuntu 14.04 support was recently removed due to it being quasi-EOL (there is paid extended support available) which did not use systemd.  As such, all current and presumably future Ubuntu releases now use systemd. The `kernel_module_disabled` OVAL template unnecessarily excluded systemd-flavored files under 16.04 and will cause issues for my eventual Ubuntu 20.04 merge.
