### PR TITLE
CIS Benchmark 4.2.13 (kubelet_configure_tls_cipher_suites)

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/ocp4/e2e-remediation.sh
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/ocp4/e2e-remediation.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cat << EOS | oc apply -f -
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: tls-ciphers
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      custom-kubelet: tls-ciphers
+  kubeletConfig:
+    tlsCipherSuites:
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+EOS
+
+overwrite_flag=''
+if [ "$(oc get machineconfigpool worker -o=jsonpath='{.metadata.labels.custom-kubelet}')" != "" ] ; then
+  overwrite_flag='--overwrite'
+fi
+
+oc label ${overwrite_flag} machineconfigpool worker custom-kubelet=tls-ciphers

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/ocp4/e2e.yml
@@ -1,0 +1,4 @@
+---
+default_result: FAIL
+result_after_remediation: PASS
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers"
+
+description: |-
+  Ensure that the Kubelet is configured to only use strong cryptographic ciphers.
+
+rationale: |-
+  TLS ciphers have had a number of known vulnerabilities and weaknesses,
+  which can reduce the protection provided by them. By default Kubernetes
+  supports a number of TLS ciphersuites including some that have security
+  concerns, weakening the protection provided.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+  cis@ocp4: 4.2.13
+
+ocil_clause: "TLS cipher suite configuration is not configured"
+
+ocil: |-
+  rule test.
+
+template:
+  name: yamlfile_value
+  vars:
+    filepath: /etc/kubernetes/kubelet.conf
+    yamlpath: ".tlsCipherSuites[:]"
+    values:
+    - value: '^(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)$'
+      operation: 'pattern match'
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_ingresscontroller/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_ingresscontroller/rule.yml
@@ -1,0 +1,42 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: "Ensure that the Ingress Controller only makes use of Strong Cryptographic Ciphers"
+
+description: |-
+  Ensure that the Ingress Controller is configured to only use strong cryptographic ciphers.
+
+rationale: |-
+  TLS ciphers have had a number of known vulnerabilities and weaknesses,
+  which can reduce the protection provided by them. By default Kubernetes
+  supports a number of TLS ciphersuites including some that have security
+  concerns, weakening the protection provided.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+  cis@ocp4: 4.2.13
+
+ocil_clause: "TLS cipher suite configuration is not configured"
+
+ocil: |-
+  Run the following comman on the kubelete nodes(s):
+  {{% raw %}}<pre>oc -n openshift-ingress-operator patch ingresscontroller/default --type merge -p '{"spec":{"tlsSecurityProfile":{"type":"Custom","custom":{"ciphers":["ECDHE-ECDSA-AES128-GCM-SHA256","ECDHE-RSA-AES128-GCM-SHA256","ECDHE-RSA-AES256-GCM-SHA384"],"minTLSVersion":"VersionTLS12"} } } }'</pre>{{% endraw %}}
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/apis/operator.openshift.io/v1/namespaces/openshift-ingress-operator/ingresscontrollers/default") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: '/apis/operator.openshift.io/v1/namespaces/openshift-ingress-operator/ingresscontrollers/default'
+    yamlpath: ".status.tlsProfile.ciphers[:]"
+    values:
+    - value: '^(ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-RSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305|ECDHE-RSA-AES256-GCM-SHA384|ECDHE-RSA-CHACHA20-POLY1305|ECDHE-ECDSA-AES256-GCM-SHA384|AES256-GCM-SHA384|AES128-GCM-SHA256)$'
+      operation: 'pattern match'

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_ingresscontroller/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_ingresscontroller/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+namespace=openshift-ingress-operator
+resource='ingresscontroller/default'
+before=$(oc -n ${namespace} get ${resource} -o jsonpath='{.status.tlsProfile.ciphers[*]}')
+oc -n ${namespace} patch ${resource} --type merge -p '{"spec":{"tlsSecurityProfile":{"type":"Custom","custom":{"ciphers":["ECDHE-ECDSA-AES128-GCM-SHA256","ECDHE-RSA-AES128-GCM-SHA256","ECDHE-RSA-AES256-GCM-SHA384"],"minTLSVersion":"VersionTLS12"}}}}'
+
+while true; do
+    after=$(oc -n ${namespace} get ${resource} -o jsonpath='{.status.tlsProfile.ciphers[*]}')
+    if [ "${before}" != "${after}" ] ; then
+        break
+    fi
+    sleep 5
+done

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_ingresscontroller/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_ingresscontroller/tests/ocp4/e2e.yml
@@ -1,0 +1,4 @@
+---
+default_result: FAIL
+result_after_remediation: PASS
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: "Ensure that the Kubernetes API Server only makes use of Strong Cryptographic Ciphers"
+title: "Ensure that the Kubernetes API Server Operator only makes use of Strong Cryptographic Ciphers"
 
 description: |-
-  Ensure that the Kubernetes API Server is configured to only use strong cryptographic ciphers.
+  Ensure that the Kubernetes API Server Operator is configured to only use strong cryptographic ciphers.
 
 rationale: |-
   TLS ciphers have had a number of known vulnerabilities and weaknesses,

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/rule.yml
@@ -1,0 +1,42 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: "Ensure that the Kubernetes API Server only makes use of Strong Cryptographic Ciphers"
+
+description: |-
+  Ensure that the Kubernetes API Server is configured to only use strong cryptographic ciphers.
+
+rationale: |-
+  TLS ciphers have had a number of known vulnerabilities and weaknesses,
+  which can reduce the protection provided by them. By default Kubernetes
+  supports a number of TLS ciphersuites including some that have security
+  concerns, weakening the protection provided.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+  cis@ocp4: 4.2.13
+
+ocil_clause: "TLS cipher suite configuration is not configured"
+
+ocil: |-
+  Run the following comman on the kubelete nodes(s):
+  {{% raw %}}<pre>oc patch kubeapiservers.operator.openshift.io cluster --type merge -p '{"spec":{"unsupportedConfigOverrides":{"servingInfo":{"cipherSuites":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_128_GCM_SHA256"]} } } }'</pre>{{% endraw %}}
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/apis/operator.openshift.io/v1/kubeapiservers/cluster") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: '/apis/operator.openshift.io/v1/kubeapiservers/cluster'
+    yamlpath: ".spec.unsupportedConfigOverrides.servingInfo.cipherSuites[:]"
+    values:
+    - value: '^(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_RSA_WITH_AES_256_GCM_SHA384|TLS_RSA_WITH_AES_128_GCM_SHA256)$'
+      operation: 'pattern match'

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+oc patch kubeapiservers.operator.openshift.io cluster --type merge -p '{"spec":{"unsupportedConfigOverrides":{"servingInfo":{"cipherSuites":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_128_GCM_SHA256"]}}}}'
+while true; do
+    after=$(oc get kubeapiservers.operator.openshift.io cluster -o=jsonpath='{.spec.unsupportedConfigOverrides}')
+    if [ "${after}" != "<nil>" ] ; then
+        break
+    fi
+    sleep 5
+done

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_kubeapiserver_operator/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/rule.yml
@@ -1,0 +1,42 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: "Ensure that the OpenShift API Server only makes use of Strong Cryptographic Ciphers"
+
+description: |-
+  Ensure that the OpenShift API Server is configured to only use strong cryptographic ciphers.
+
+rationale: |-
+  TLS ciphers have had a number of known vulnerabilities and weaknesses,
+  which can reduce the protection provided by them. By default Kubernetes
+  supports a number of TLS ciphersuites including some that have security
+  concerns, weakening the protection provided.
+
+severity: medium
+
+#identifiers:
+#    cce@ocp4:
+
+references:
+  cis@ocp4: 4.2.13
+
+ocil_clause: "TLS cipher suite configuration is not configured"
+
+ocil: |-
+  Run the following comman on the kubelete node(s):
+  {{% raw %}}<pre>oc patch openshiftapiservers.operator.openshift.io cluster --type merge -p '{"spec":{"unsupportedConfigOverrides":{"servingInfo":{"cipherSuites":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_128_GCM_SHA256"] } } } }'</pre>{{% endraw %}}
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/apis/operator.openshift.io/v1/openshiftapiservers/cluster") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: '/apis/operator.openshift.io/v1/openshiftapiservers/cluster'
+    yamlpath: ".spec.unsupportedConfigOverrides.servingInfo.cipherSuites[:]"
+    values:
+    - value: '^(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_RSA_WITH_AES_256_GCM_SHA384|TLS_RSA_WITH_AES_128_GCM_SHA256)$'
+      operation: 'pattern match'

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/rule.yml
@@ -2,10 +2,10 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: "Ensure that the OpenShift API Server only makes use of Strong Cryptographic Ciphers"
+title: "Ensure that the OpenShift API Server Operator only makes use of Strong Cryptographic Ciphers"
 
 description: |-
-  Ensure that the OpenShift API Server is configured to only use strong cryptographic ciphers.
+  Ensure that the OpenShift API Server Operator is configured to only use strong cryptographic ciphers.
 
 rationale: |-
   TLS ciphers have had a number of known vulnerabilities and weaknesses,

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+oc patch openshiftapiservers.operator.openshift.io cluster --type merge -p '{"spec":{"unsupportedConfigOverrides":{"servingInfo":{"cipherSuites":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_128_GCM_SHA256"]}}}}'
+while true; do
+    after=$(oc get openshiftapiservers.operator.openshift.io cluster -o=jsonpath='{.spec.unsupportedConfigOverrides}')
+    if [ "${after}" != "<nil>" ] ; then
+        break
+    fi
+    sleep 5
+done

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites_openshiftapiserver_operator/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -179,3 +179,5 @@ selections:
     - kubelet_enable_cert_rotation
   # 4.2.12 Verify that the RotateKubeletServerCertificate argument is set to true
     - kubelet_enable_server_cert_rotation
+  # 4.2.13 Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+    - kubelet_configure_tls_cipher_suites

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -174,7 +174,7 @@ selections:
     # Like kubelet_disable_readonly_port but check for .apiServerArguments["kubelet-client-certificate"]
     - kubelet_configure_tls_key
     # Like kubelet_disable_readonly_port but check for .apiServerArguments["kubelet-client-key"]
-  # 4.2.13 Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+
 
   ### 5 Policies
   ###


### PR DESCRIPTION
#### Description:

- implement a rule for [CIS Benchmark for OpenShift 4.2.13](https://workbench.cisecurity.org/sections/514741/recommendations/839648).

#### Rationale:

- (TBD)

#### discussion topic: check values in a list

Currently, this code fails with following error.  [yamlfile_value template](https://github.com/ComplianceAsCode/content/blob/master/shared/templates/yamlfile_value/oval.template) now supports checking value under a map, but (as far as I understand) it does not support checking value in a list.

```
$ oc logs -f platform-scan-api-checks-pod -c scanner
HOSTROOT not set, using normal oscap
Running oscap-chroot as oscap xccdf eval --fetch-remote-resources --profile xccdf_org.ssgproject.content_profile_cis --results-arf /tmp/report-arf.xml /content/ssg-ocp4-ds.xml
The scanner returned 1
OpenSCAP Error: File '/content/ssg-ocp4-ds.xml' line 8128: Element '{http://oval.mitre.org/XMLSchema/oval-definitions-5}field': Duplicate key-sequence ['#'] in unique identity-constraint '{http://oval.mitre.org/XMLSchema/oval-definitions-5#independent}UniqueYamlFileValueFieldName'.
 [/builddir/build/BUILD/openscap-1.3.4/src/XCCDF/xccdf_session.c:681]
File '/content/ssg-ocp4-ds.xml' line 8129: Element '{http://oval.mitre.org/XMLSchema/oval-definitions-5}field': Duplicate key-sequence ['#'] in unique identity-constraint '{http://oval.mitre.org/XMLSchema/oval-definitions-5#independent}UniqueYamlFileValueFieldName'.
 [/builddir/build/BUILD/openscap-1.3.4/src/XCCDF/xccdf_session.c:681]
...
Invalid SCAP Source Datastream (1.3) content in /content/ssg-ocp4-ds.xml. [/builddir/build/BUILD/openscap-1.3.4/src/source/oscap_source.c:353]
Invalid SCAP Source Datastream (1.3) content in /content/ssg-ocp4-ds.xml [/builddir/build/BUILD/openscap-1.3.4/src/XCCDF/xccdf_session.c:797]
OpenSCAP Error: Unable to open file: '/tmp/report-arf.xml' [/builddir/build/BUILD/openscap-1.3.4/src/source/oscap_source.c:288]
Could not create Result DataStream session: File is not Result DataStream. [/builddir/build/BUILD/openscap-1.3.4/src/DS/ds_rds_session.c:53]
Failed to split given result datastream '/tmp/report-arf.xml'.
The rds-split operation returned 1
```

