### PR TITLE
More precise modified time comparison in "configure_crypto_policy"

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -19,16 +19,12 @@
     <unix:filepath datatype="string">/etc/crypto-policies/config</unix:filepath>
   </unix:file_object>
 
-  <local_variable id="variable_crypto_policies_current_file_age" version="1" comment="Age of /etc/crypto-policies/state/current" datatype="int">
-      <time_difference format_2="seconds_since_epoch">
-        <object_component object_ref="crypto_policies_current_file" item_field="m_time"/>
-      </time_difference>
+  <local_variable id="variable_crypto_policies_current_file_timestamp" version="1" comment="Age of /etc/crypto-policies/state/current" datatype="int">
+    <object_component object_ref="crypto_policies_current_file" item_field="m_time"/>
   </local_variable>
 
-  <local_variable id="variable_crypto_policies_config_file_age" version="1" comment="Age of /etc/crypto-policies/config" datatype="int">
-    <time_difference format_2="seconds_since_epoch">
-      <object_component object_ref="crypto_policies_config_file" item_field="m_time"/>
-    </time_difference>
+  <local_variable id="variable_crypto_policies_config_file_timestamp" version="1" comment="Age of /etc/crypto-policies/config" datatype="int">
+    <object_component object_ref="crypto_policies_config_file" item_field="m_time"/>
   </local_variable>
 
   <ind:variable_test check="all" check_existence="all_exist" id="test_crypto_policies_updated" version="1" comment="Check if update-crypto-policies has been run">
@@ -36,14 +32,14 @@
     <ind:state state_ref="state_crypto_current_file_newer_than_config_file" />
   </ind:variable_test>
 
-  <ind:variable_object comment="Crypto policy current file age"
+  <ind:variable_object comment="Crypto policy current file timestamp"
 id="object_crypto_policies_config_file_modified_time" version="1">
-     <ind:var_ref>variable_crypto_policies_config_file_age</ind:var_ref>
+     <ind:var_ref>variable_crypto_policies_config_file_timestamp</ind:var_ref>
    </ind:variable_object>
 
   <ind:variable_state id="state_crypto_current_file_newer_than_config_file" version="1">
-    <ind:value datatype="int" operation="greater than or equal" var_check="all"
-    var_ref="variable_crypto_policies_current_file_age" />
+    <ind:value datatype="int" operation="less than or equal" var_check="all"
+    var_ref="variable_crypto_policies_current_file_timestamp" />
   </ind:variable_state>
 
   <ind:textfilecontent54_test id="test_configure_crypto_policy"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+# IMPORTANT: This is a false negative scenario.
+# File /etc/crypto-policies/config is newer than /etc/crypto-policies/state/current, thus incompliant,
+# but the OVAL evaluation restuls in pass.
+# With a precision of seconds in OVAL, there is not really much we can do to detect this.
+update-crypto-policies --set "DEFAULT"
+touch /etc/crypto-policies/config

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_newer_than_current.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_newer_than_current.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+update-crypto-policies --set "DEFAULT"
+sleep 1s
+touch /etc/crypto-policies/config


### PR DESCRIPTION
#### Description:

- Change the way we compare the timestamps of `/etc/crypto-policies/config` and `/etc/crypto-policies/state/current` to be a bit more precise.
  - Instead of comparing the difference between each file and current time, and ensuring that time difference to `config` file is greater (i.e. `config` file was changed before `current` file).
  - Let's directly compare their timestamp (in seconds since epoch), and ensure that `config` timestamp is less than `current` timestamp.

#### Rationale:

- There is no way to calculate the `time_difference` against the same moment in time.
