### PR TITLE
Add custom OVAL for partition_for_tmp to check for tmp.mount service.

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/oval/shared.xml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/oval/shared.xml
@@ -1,0 +1,32 @@
+<def-group>
+    <definition class="compliance" id="partition_for_tmp" version="1">
+      {{{ oval_metadata("If stored locally, create a separate partition for
+        /tmp. If /tmp will be mounted from another
+        system such as an NFS server, then creating a separate partition is not
+        necessary at this time, and the mountpoint can instead be configured
+        later.") }}}
+      <criteria operator="OR">
+        <criterion test_ref="test_tmp_partition" comment="/tmp on own partition" />
+        <criterion comment="tmp.mount is running" test_ref="test_service_running_tmp.mount" />
+      </criteria>
+    </definition>
+    <linux:partition_test check="all" check_existence="all_exist"
+    id="test_tmp_partition" version="1" comment="/tmp on own partition">
+      <linux:object object_ref="object_mount_tmp_own_partition" />
+    </linux:partition_test>
+    <linux:partition_object id="object_mount_tmp_own_partition" version="1">
+      <linux:mount_point>/tmp</linux:mount_point>
+    </linux:partition_object>
+
+    <linux:systemdunitproperty_test id="test_service_running_tmp.mount" check="at least one" check_existence="at_least_one_exists" comment="Test that the tmp.mount service is running" version="1">
+      <linux:object object_ref="obj_service_running_tmp.mount"/>
+      <linux:state state_ref="state_service_running_tmp.mount"/>
+    </linux:systemdunitproperty_test>
+    <linux:systemdunitproperty_object id="obj_service_running_tmp.mount" comment="Retrieve the ActiveState property of tmp.mount" version="1">
+      <linux:unit operation="pattern match">^tmp.mount$</linux:unit>
+      <linux:property>ActiveState</linux:property>
+    </linux:systemdunitproperty_object>
+    <linux:systemdunitproperty_state id="state_service_running_tmp.mount" version="1" comment="tmp.mount is running">
+        <linux:value>active</linux:value>
+    </linux:systemdunitproperty_state>
+  </def-group>

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
@@ -38,8 +38,3 @@ references:
 {{{ complete_ocil_entry_separate_partition(part="/tmp") }}}
 
 platform: machine
-
-template:
-    name: mount
-    vars:
-        mountpoint: /tmp

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/tests/tmp_mount_enabled.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/tests/tmp_mount_enabled.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl start tmp.mount


### PR DESCRIPTION
#### Description:

- Create custom OVAL check for `/tmp` partition. This enables the check to comply with checking of `tmp.mount` service status.

#### Rationale:

- Reference: https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-09-03/finding/V-204496

#### Questions:

- I'm not entirely sure if we need such check. I suspect that `partition_test` is enough which comes from the `mount` template. What do you think?
