### PR TITLE
make usbguard rules not applicable on s390x

### DIFF
--- a/linux_os/guide/services/usbguard/group.yml
+++ b/linux_os/guide/services/usbguard/group.yml
@@ -5,3 +5,4 @@ title: 'USBGuard daemon'
 description: |-
     The USBGuard daemon enforces the USB device authorization policy for all USB devices.
 
+platform: not_s390x_arch

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -24,6 +24,12 @@ cpes:
       title: "Package net-snmp is installed"
       check_id: installed_env_has_net-snmp_package
 
+  - not_s390x_arch:
+      name: "cpe:/a:not_s390x_arch"
+      title: "System architecture is not S390X"
+      check_id: system_info_architecture_not_s390x
+
+
   - nss-pam-ldapd:
       name: "cpe:/a:nss-pam-ldapd"
       title: "Package nss-pam-ldapd is installed"

--- a/shared/checks/oval/system_info_architecture_not_s390x.xml
+++ b/shared/checks/oval/system_info_architecture_not_s390x.xml
@@ -1,8 +1,6 @@
 <def-group>
-  <definition class="compliance" id="system_info_architecture_not_s390x"
+  <definition class="inventory" id="system_info_architecture_not_s390x"
   version="1">
-    <!-- Note that this does not meet requirements for class=inventory as
-         that only tests for patches per 5.10.1 Revision 1 -->
     <metadata>
       <title>Test for different architecture than S390X</title>
       <affected family="unix">

--- a/shared/checks/oval/system_info_architecture_not_s390x.xml
+++ b/shared/checks/oval/system_info_architecture_not_s390x.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="system_info_architecture_not_s390x"
+  version="1">
+    <!-- Note that this does not meet requirements for class=inventory as
+         that only tests for patches per 5.10.1 Revision 1 -->
+    <metadata>
+      <title>Test for different architecture than S390X</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Generic test checking if the architecture is not S390X to be used by other tests</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Architecture is not S390X"
+      test_ref="test_system_info_architecture_s390x" negate="true"/>
+    </criteria>
+  </definition>
+  <unix:uname_test check="all" comment="s390x architecture"
+  id="test_system_info_architecture_s390x" version="1">
+    <unix:object object_ref="object_system_info_architecture_s390x" />
+    <unix:state state_ref="state_system_info_architecture_s390x" />
+  </unix:uname_test>
+  <unix:uname_object comment="s390x architecture"
+  id="object_system_info_architecture_s390x" version="1" />
+  <unix:uname_state comment="s390x architecture"
+  id="state_system_info_architecture_s390x" version="1">
+    <unix:machine_class operation="equals">s390x</unix:machine_class>
+  </unix:uname_state>
+</def-group>


### PR DESCRIPTION
#### Description:

- create new platform not_s390x_arch

- apply this platform to usbguard group

#### Rationale:

- S390X has no USB and rules do not make sense there.