### PR TITLE
fix oval of grub2_kernel_trust_cpu_rng

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="kernel_trust_cpu_rng" version="1">
+  <definition class="compliance" id="grub2_kernel_trust_cpu_rng" version="1">
     {{{ oval_metadata("Ensure the kernel is configured to trust the CPU hardware random number generator.") }}}
     <criteria operator="OR" >
       <criteria operator="AND">

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
     If the command does not return any output, then the boot parameter is
     missing.
 
-platform: grub2
+platform: machine
 
 template:
     name: grub2_bootloader_argument


### PR DESCRIPTION
#### Description:

- an old name was left as oval ID

- also changed platform to machine, as grub2 platform is inherited from the group

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
