### PR TITLE
kubernetes: Fix kernel argument template

### DIFF
--- a/linux_os/guide/system/auditing/coreos_audit_option/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/coreos_audit_option/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS

--- a/shared/templates/coreos_kernel_option/kubernetes.template
+++ b/shared/templates/coreos_kernel_option/kubernetes.template
@@ -8,5 +8,5 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:
   kernelArguments:
-    - {{ ARG_NAME }}={{ ARG_VALUE }}
+    - {{{ ARG_NAME }}}={{{ ARG_VALUE }}}
 


### PR DESCRIPTION
The jinja was missing braces.

This also adds an e2e test to one of the rules that uses this so we
don't regress.

We'll add the rest of the e2e tests in a subsequent commit.