### PR TITLE
compliance-operator: Prepare rules and profiles for productization

### DIFF
--- a/applications/openshift/scc/scc_drop_container_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_drop_container_capabilities/rule.yml
@@ -32,20 +32,16 @@ ocil: |-
     completely disabled as a list entry under <tt>requiredDropCapabilities</tt>,
     or that all the un-required capabilities are dropped for containers and SCCs.
 
-warnings:
-    - general: |-
-        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
-
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['requiredDropCapabilities','#'][:]"
-        check_existence: "at_least_one_exists"
-        entity_check: "at least one"
-        values:
-          - key: "requiredDropCapabilities"
-            value: "^ALL$"
-            entity_check: "at least one"
-            operation: "pattern match"
+#template:
+#    name: yamlfile_value
+#    vars:
+#        ocp_data: "true"
+#        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+#        yamlpath: ".items[:]['requiredDropCapabilities','#'][:]"
+#        check_existence: "at_least_one_exists"
+#        entity_check: "at least one"
+#        values:
+#          - key: "requiredDropCapabilities"
+#            value: "^ALL$"
+#            entity_check: "at least one"
+#            operation: "pattern match"

--- a/applications/openshift/scc/scc_drop_container_capabilities/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_drop_container_capabilities/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/applications/openshift/scc/scc_limit_ipc_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_ipc_namespace/rule.yml
@@ -33,18 +33,14 @@ ocil: |-
     completely disabled, or that <tt>allowHostIPC</tt> is only enabled to
     a small set of containers and SCCs.
 
-warnings:
-    - general: |-
-        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
-
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['allowHostIPC']"
-        check_existence: "at_least_one_exists"
-        entity_check: "at least one"
-        values:
-          - type: "boolean"
-            value: "false"
+#template:
+#    name: yamlfile_value
+#    vars:
+#        ocp_data: "true"
+#        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+#        yamlpath: ".items[:]['allowHostIPC']"
+#        check_existence: "at_least_one_exists"
+#        entity_check: "at least one"
+#        values:
+#          - type: "boolean"
+#            value: "false"

--- a/applications/openshift/scc/scc_limit_ipc_namespace/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_ipc_namespace/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
+++ b/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
@@ -32,20 +32,16 @@ ocil: |-
     or that either <tt>NET_RAW</tt> or <tt>ALL</tt> is only enabled to a small set of
     containers and SCCs.
 
-warnings:
-    - general: |-
-        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
-
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['requiredDropCapabilities','#'][:]"
-        check_existence: "at_least_one_exists"
-        entity_check: "at least one"
-        values:
-          - key: "requiredDropCapabilities"
-            value: "^NET_RAW|ALL$"
-            entity_check: "at least one"
-            operation: "pattern match"
+#template:
+#    name: yamlfile_value
+#    vars:
+#        ocp_data: "true"
+#        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+#        yamlpath: ".items[:]['requiredDropCapabilities','#'][:]"
+#        check_existence: "at_least_one_exists"
+#        entity_check: "at least one"
+#        values:
+#          - key: "requiredDropCapabilities"
+#            value: "^NET_RAW|ALL$"
+#            entity_check: "at least one"
+#            operation: "pattern match"

--- a/applications/openshift/scc/scc_limit_net_raw_capability/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_net_raw_capability/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/applications/openshift/scc/scc_limit_network_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_network_namespace/rule.yml
@@ -33,18 +33,14 @@ ocil: |-
     completely disabled, or that <tt>allowHostNetwork</tt> is only enabled to
     a small set of containers and SCCs.
 
-warnings:
-    - general: |-
-        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
-
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['allowHostNetwork']"
-        check_existence: "at_least_one_exists"
-        entity_check: "at least one"
-        values:
-          - type: "boolean"
-            value: "false"
+#template:
+#    name: yamlfile_value
+#    vars:
+#        ocp_data: "true"
+#        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+#        yamlpath: ".items[:]['allowHostNetwork']"
+#        check_existence: "at_least_one_exists"
+#        entity_check: "at least one"
+#        values:
+#          - type: "boolean"
+#            value: "false"

--- a/applications/openshift/scc/scc_limit_network_namespace/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_network_namespace/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/applications/openshift/scc/scc_limit_privilege_escalation/rule.yml
+++ b/applications/openshift/scc/scc_limit_privilege_escalation/rule.yml
@@ -34,18 +34,14 @@ ocil: |-
     completely disabled, or that <tt>allowPrivilegeEscalation</tt> is only enabled to
     a small set of containers and SCCs.
 
-warnings:
-    - general: |-
-        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
-
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['allowPrivilegeEscalation']"
-        check_existence: "at_least_one_exists"
-        entity_check: "at least one"
-        values:
-          - type: "boolean"
-            value: "false"
+#template:
+#    name: yamlfile_value
+#    vars:
+#        ocp_data: "true"
+#        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+#        yamlpath: ".items[:]['allowPrivilegeEscalation']"
+#        check_existence: "at_least_one_exists"
+#        entity_check: "at least one"
+#        values:
+#          - type: "boolean"
+#            value: "false"

--- a/applications/openshift/scc/scc_limit_privilege_escalation/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_privilege_escalation/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
@@ -31,18 +31,14 @@ ocil: |-
     a small set of containers and SCCs.
 
 
-warnings:
-    - general: |-
-        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
-
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['allowPrivilegedContainer']"
-        check_existence: "at_least_one_exists"
-        entity_check: "at least one"
-        values:
-          - type: "boolean"
-            value: "false"
+#template:
+#    name: yamlfile_value
+#    vars:
+#        ocp_data: "true"
+#        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+#        yamlpath: ".items[:]['allowPrivilegedContainer']"
+#        check_existence: "at_least_one_exists"
+#        entity_check: "at least one"
+#        values:
+#          - type: "boolean"
+#            value: "false"

--- a/applications/openshift/scc/scc_limit_privileged_containers/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
@@ -29,18 +29,14 @@ ocil: |-
     completely disabled, or that <tt>allowHostPID</tt> is only enabled to
     a small set of containers and SCCs.
 
-warnings:
-    - general: |-
-        {{{ openshift_cluster_setting("/apis/security.openshift.io/v1/securitycontextconstraints") | indent(8) }}}
-
-template:
-    name: yamlfile_value
-    vars:
-        ocp_data: "true"
-        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
-        yamlpath: ".items[:]['allowHostPID']"
-        check_existence: "at_least_one_exists"
-        entity_check: "at least one"
-        values:
-          - type: "boolean"
-            value: "false"
+#template:
+#    name: yamlfile_value
+#    vars:
+#        ocp_data: "true"
+#        filepath: /apis/security.openshift.io/v1/securitycontextconstraints
+#        yamlpath: ".items[:]['allowHostPID']"
+#        check_existence: "at_least_one_exists"
+#        entity_check: "at least one"
+#        values:
+#          - type: "boolean"
+#            value: "false"

--- a/applications/openshift/scc/scc_limit_process_id_namespace/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_process_id_namespace/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/applications/openshift/scc/scc_limit_root_containers/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_root_containers/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: INFO

--- a/ocp4/profiles/cis-node.profile
+++ b/ocp4/profiles/cis-node.profile
@@ -4,6 +4,12 @@ title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4-node
 
+metadata:
+    SMEs:
+        - JAORMX
+        - mrogers950
+        - jhrozek
+
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
     Red Hat OpenShift Container Platform 4 Benchmark™, V0.3, currently unreleased.
@@ -149,7 +155,7 @@ selections:
   # 4.2.5 Ensure that the --streaming-connection-idle-timeout argument is not set to 0
     - kubelet_enable_streaming_connections
   # 4.2.6 Ensure that the --protect-kernel-defaults argument is set to true
-    - kubelet_enable_protect_kernel_defaults
+    #- kubelet_enable_protect_kernel_defaults
   # 4.2.7 Ensure that the --make-iptables-util-chains argument is set to true
     - kubelet_enable_iptables_util_chains
   # 4.2.8 Ensure that the --hostname-override argument is not set

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -4,6 +4,12 @@ title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4
 
+metadata:
+    SMEs:
+        - JAORMX
+        - mrogers950
+        - jhrozek
+
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
     Red Hat OpenShift Container Platform 4 Benchmark™, V0.3, currently unreleased.


### PR DESCRIPTION
The rules that are not working in the CIS benchmark have their checks
removed to only be informational. We'll re-take them once we start
working on the next release.

The profiles that are not gonna be part of this release are being
commented out and will be re-enabled in a subsequent PR.