### PR TITLE
Add platform_package_overrides to OL7 and OL8

### DIFF
--- a/ol7/product.yml
+++ b/ol7/product.yml
@@ -17,3 +17,7 @@ cpes:
       name: "cpe:/o:oracle:linux:7"
       title: "Oracle Linux 7"
       check_id: installed_OS_is_ol7_family
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"

--- a/ol8/product.yml
+++ b/ol8/product.yml
@@ -17,3 +17,7 @@ cpes:
       name: "cpe:/o:oracle:linux:8"
       title: "Oracle Linux 8"
       check_id: installed_OS_is_ol8_family
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"


### PR DESCRIPTION
#### Description:

- Added platform CPE to package overrides for OL7 and OL8

#### Rationale:

- In OL installations, package `shadow-utils` is used instead of `login`. This causes remediation scripts to fail
