### PR TITLE
Set platform package mapping to None for not_s390x_arch CPE.

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -337,6 +337,7 @@ XCCDF_PLATFORM_TO_PACKAGE = {
   "sssd-ldap": None,  # Force package check wrapping skip
   "uefi": None,
   "non-uefi": None,
+  "not_s390x_arch": None,
 }
 
 # _version_name_map = {


### PR DESCRIPTION
#### Description:

- Set platform package mapping to None for not_s390x_arch CPE.

#### Rationale:

- Remediation that would check the rpm package condition always fail because `not_s390x_arch` does not translate to anything related to `rpm` database.
