### PR TITLE
Remove useless build-time noise

### DIFF
--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -80,8 +80,6 @@ def main():
     remediation.write_fixes_to_dir(fixes, args.remediation_type,
                                    args.output_dir)
 
-    sys.stderr.write("Collected %d %s remediations.\n" % (len(fixes), args.remediation_type))
-
     sys.exit(0)
 
 

--- a/build-scripts/generate_fixes_xml.py
+++ b/build-scripts/generate_fixes_xml.py
@@ -46,8 +46,6 @@ def main():
     remediation.write_fixes_to_xml(args.remediation_type, args.build_dir,
                                    args.output, fixes)
 
-    sys.stderr.write("Merged %d %s remediations.\n" % (len(fixes), args.remediation_type))
-
     sys.exit(0)
 
 

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -171,10 +171,6 @@ def main():
                     sys.exit(1)
 
     if len(unused_rules) > 0:
-        logging.warning(
-            "%i rules don't reference PCI-DSS!" % (len(unused_rules))
-        )
-
         group = ElementTree.Element("{%s}Group" % (XCCDF_NAMESPACE))
         group.set("id", ssg.constants.OSCAP_GROUP_NON_PCI)
         group.set("selected", "true")

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -327,6 +327,5 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
                     body.append(xml_content)
                     included_checks_count += 1
                     already_loaded[filename] = oval_version
-    sys.stderr.write("Merged %d OVAL checks.\n" % (included_checks_count))
 
     return "".join(body)

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -249,9 +249,6 @@ class OVALFileLinker(FileLinker):
                 # in the case:
                 # * OVAL definition is referenced from XCCDF file,
                 # * But not defined in OVAL file
-                print("WARNING: OVAL check '{0}' was not found, removing "
-                      "<check-content> element from the XCCDF rule."
-                      .format(xccdfid), file=sys.stderr)
                 rule.remove(check)
 
 


### PR DESCRIPTION
Make the build experience clean - remove useless warnings or announcements.

- Don't warn that a rule doesn't have an OVAL - there are many rules like that, some of them are like that on purpose, and ones that shouldn't be OVAL-less probably get lost in the noise.
- Don't print messages about how many remediations/OVALs were merged / collected.
- Don't warn about rules that don't reference PCI-DSS.

What remains is `oscap` warning about remote resources. It looks like that we could use an opt-out switch that would silence those warnings, as we don't want to download anything during the content build. Or, in a more extreme note, we aim to avoid to use the scanner in order to produce guides. Anyway, I don't think that those warnings could be removed without introducing drastic measures to the content build.