### PR TITLE
OCP: Add missing tests for two rules that are passing by default

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/api-server/api_server_api_priority_gate_enabled/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_api_priority_gate_enabled/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
#### Description:

- Two rules were missing tests

#### Rationale:

- Trying to get CIS to a nicer state