### PR TITLE
Add ignition version to coreos_kernel_option template

### DIFF
--- a/shared/templates/coreos_kernel_option/kubernetes.template
+++ b/shared/templates/coreos_kernel_option/kubernetes.template
@@ -7,6 +7,9 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:
+  config:
+    ignition:
+      version: 3.1.0
   kernelArguments:
     - {{{ ARG_NAME }}}={{{ ARG_VALUE }}}
 


### PR DESCRIPTION
While not strictly necessary, it does show up in the kube object. So
let's add it for completeness.