### PR TITLE
Fix CentOS 8 CPE

### DIFF
--- a/shared/checks/oval/installed_OS_is_centos8.xml
+++ b/shared/checks/oval/installed_OS_is_centos8.xml
@@ -14,20 +14,34 @@
     <criteria operator="AND">
       <extend_definition comment="Installed OS is part of the Unix family"
       definition_ref="installed_OS_is_part_of_Unix_family" />
-      <criterion comment="CentOS8 is installed"
-      test_ref="test_centos8" />
+      <criterion comment="OS is CentOS" test_ref="test_centos8_name" />
+      <criterion comment="OS version is 8" test_ref="test_centos8_version" />
     </criteria>
   </definition>
 
-  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="centos-release is version 8" id="test_centos8" version="1">
-    <linux:object object_ref="obj_centos8" />
-    <linux:state state_ref="state_centos8" />
-  </linux:rpminfo_test>
-  <linux:rpminfo_state id="state_centos8" version="1">
-    <linux:version operation="pattern match">^8.*$</linux:version>
-  </linux:rpminfo_state>
-  <linux:rpminfo_object id="obj_centos8" version="1">
-    <linux:name>centos-release</linux:name>
-  </linux:rpminfo_object>
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check os-release ID" id="test_centos8_name" version="1">
+    <ind:object object_ref="obj_name_centos8" />
+    <ind:state state_ref="state_name_centos8" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_name_centos8" version="1" comment="Check os-release ID">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^ID=&quot;(\w+)&quot;$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_name_centos8" version="1">
+    <ind:subexpression>centos</ind:subexpression>
+  </ind:textfilecontent54_state>
 
+  <ind:textfilecontent54_test check="all" comment="Check os-release VERSION_ID" id="test_centos8_version" version="1">
+    <ind:object object_ref="obj_version_centos8" />
+    <ind:state state_ref="state_version_centos8" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_version_centos8" version="1" comment="Check os-release VERSION_ID">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=&quot;(\d)&quot;$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_version_centos8" version="1">
+    <ind:subexpression>8</ind:subexpression>
+  </ind:textfilecontent54_state>
 </def-group>


### PR DESCRIPTION
With the CentOS stream effort, the centos-relase RPM package is no
longer available. While CentOS 8.2.2004 features centos-release RPM
package, the CentOS 8.3.2011 features centos-linux-release RPM and
CentOS Stream features centos-stream-release RPM package.  We have
decided to parse /etc/os-release file instead which is often present and
doesn't require librpm to be present.
Fixes: https://github.com/OpenSCAP/openscap/issues/1661

