### PR TITLE
disable_ctrlaltdel_burstaction: Take into account `.d/` directory too

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/oval/shared.xml
@@ -1,7 +1,8 @@
 <def-group>
   <definition class="compliance" id="disable_ctrlaltdel_burstaction" version="1">
     {{{ oval_metadata("Configure the CtrlAltDelBurstAction setting in /etc/systemd/system.conf
-      to none to prevent a reboot if Ctrl-Alt-Delete is pressed more than 7 times in 2 seconds.") }}}
+      or /etc/systemd/system.conf.d/* to none to prevent a reboot if Ctrl-Alt-Delete is
+      pressed more than 7 times in 2 seconds.") }}}
     <criteria>
       <criterion comment="check CtrlAltDelBurstAction is set to none"
       test_ref="test_disable_ctrlaltdel_burstaction" />
@@ -13,8 +14,9 @@
   id="test_disable_ctrlaltdel_burstaction" version="1">
     <ind:object object_ref="obj_disable_ctrlaltdel_burstaction" />
   </ind:textfilecontent54_test>
+
   <ind:textfilecontent54_object id="obj_disable_ctrlaltdel_burstaction" version="1">
-    <ind:filepath>/etc/systemd/system.conf</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/systemd/system.conf(\.d/.*\.conf)?$</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*CtrlAltDelBurstAction[\s]*=[\s]*none$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS


### PR DESCRIPTION
This rules used to check system.conf exclusively. This checks the `.d`
directory as well.

Co-Authored-By: Gabriel Becker <ggasparb@redhat.com>