### PR TITLE
Support SLES-12-010380, SLES-12-010110, and SLES-12-030150

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
@@ -21,6 +21,7 @@ severity: high
 identifiers:
     cce@rhel7: CCE-27471-2
     cce@rhel8: CCE-80896-4
+    cce@sle12: CCE-83014-1
 
 references:
     stigid@ol7: OL07-00-010300

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
@@ -17,6 +17,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-27363-1
     cce@rhel8: CCE-80903-8
+    cce@sle12: CCE-83015-8
 
 references:
     stigid@ol7: OL07-00-010460

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12
 
 title: 'Disable GDM Automatic Login'
 
@@ -22,6 +22,7 @@ severity: high
 identifiers:
     cce@rhel7: CCE-80104-3
     cce@rhel8: CCE-80823-8
+    cce@sle12: CCE-83016-6
 
 references:
     stigid@ol7: OL07-00-010440
@@ -32,6 +33,7 @@ references:
     ospp: FIA_UAU.1
     srg: SRG-OS-000480-GPOS-00229
     stigid@rhel7: RHEL-07-010440
+    stigid@sle12: SLES-12-010380
     isa-62443-2013: 'SR 7.6'
     isa-62443-2009: 4.3.4.3.2,4.3.4.3.3
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80350-2
     cce@rhel8: CCE-82202-3
+    cce@sle12: CCE-83013-3
 
 references:
     anssi: BP28(R5),BP28(R59)
@@ -29,6 +30,7 @@ references:
     srg: SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158
     vsrg: SRG-OS-000373-VMM-001470,SRG-OS-000373-VMM-001480,SRG-OS-000373-VMM-001490
     stigid@rhel7: RHEL-07-010350
+    stigid@sle12: SLES-12-010110
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.5.1,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
     cobit5: DSS05.04,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80351-0
     cce@rhel8: CCE-82197-5
+    cce@sle12: CCE-83012-5
 
 references:
     stigid@ol7: OL07-00-010340
@@ -31,6 +32,7 @@ references:
     srg: SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158
     vsrg: SRG-OS-000373-VMM-001470,SRG-OS-000373-VMM-001480,SRG-OS-000373-VMM-001490
     stigid@rhel7: RHEL-07-010340
+    stigid@sle12: SLES-12-010110
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.5.1,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
     cobit5: DSS05.04,DSS05.10,DSS06.03,DSS06.10

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -9,3 +9,8 @@ description: |-
 selections:
     - installed_OS_is_vendor_supported
     - security_patches_up_to_date
+    - sudo_remove_nopasswd
+    - sudo_remove_no_authenticate
+    - sshd_disable_empty_passwords
+    - sshd_do_not_permit_user_env
+    - gnome_gdm_disable_automatic_login


### PR DESCRIPTION
Leveraging existing rules to support SUSE Enterprose Linux 12 STIGs: SLES-12-010380, SLES-12-010110, and SLES-12-030150.

#### Description:

- Leveraging existing rules to support SUSE Enterprose Linux 12 STIGs: SLES-12-010380, SLES-12-010110, and SLES-12-030150.

#### Rationale:

- To properly remediate SUSE Enterprose Linux 12 STIGs: SLES-12-010380, SLES-12-010110, and SLES-12-030150.