### PR TITLE
Implement a rule for sudoers - ANSSI R 60

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/oval/shared.xml
@@ -1,0 +1,47 @@
+<def-group>
+     <definition class="compliance" id="{{{ rule_id }}}" version="1">
+     {{{ oval_metadata("Check that sudoers doesn't allow users to run commands as root") }}}
+     <criteria operator="AND">
+        <criterion comment="Make sure that no user spec in sudoers has a runas spec that includes root or ALL" test_ref="test_no_root_or_ALL_in_runas_spec" />
+        <criterion comment="Make sure that all user specs in sudoers feature a runas spec" test_ref="test_no_user_spec_rules" />
+     </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="Make sure that no user spec in sudoers has a runas spec that includes root or ALL"
+  id="test_no_root_or_ALL_in_runas_spec" version="1">
+    <ind:object object_ref="root_or_ALL_in_runas_spec" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="root_or_ALL_in_runas_spec" version="1">
+    <ind:filepath operation="pattern match">^/etc/sudoers(\.d/.*)?$</ind:filepath>
+    <!-- The regex matches:
+      - The username or group. If root, ignore everything, root can be allowed to do anything.
+      - User specs are present in brackets, and if there are no brackets root user is assumed.
+      - \1: The username or group.
+      - \2: target hostname or ALL
+      - later: word ALL or root inside brackets
+    -->
+    <ind:pattern operation="pattern match">^\s*((?!root\b)[\w]+)\s*(\w+)\s*=\s*(.*,)?\s*\([\w\s]*\b(root|ALL)\b[\w\s]*\)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="make sure that all user specs in sudoers feature a runas spec"
+  id="test_no_user_spec_rules" version="1">
+    <ind:object object_ref="object_no_runas_spec" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_no_runas_spec" version="1">
+    <ind:filepath operation="pattern match">^/etc/sudoers(\.d/.*)?$</ind:filepath>
+    <!-- The regex matches:
+      - The username or group. If root, ignore everything, root can be allowed to do anything.
+      - User specs are present in brackets, and if there are no brackets root user is assumed.
+      - \1: The username
+      - \2: target hostname or ALL
+      - later: No bracket either right after "hosts =", or no bracket after the "previous command"
+    -->
+    <ind:pattern operation="pattern match">^\s*((?!root\b)[\w]+)\s*(\w+)\s*=\s*(.*,)?\s*[^\(\s]</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/rule.yml
@@ -1,0 +1,38 @@
+documentation_complete: true
+
+# Set prodtypes if needed, otherwise let the rule to be applicable for all products by omitting the prodtype declaration
+# prodtype: fedora
+
+title: "Don't target root user in the sudoers file"
+
+description: |-
+    The targeted users of a user specification should be, as much as possible, non privileged users (i.e.: non-root).
+
+    User specifications have to explicitly list the runas spec (i.e. the list of target users that can be impersonated), and <tt>ALL</tt> or <tt>root</tt> should not be used.
+
+rationale: |-
+    It is common that the command to be executed does not require superuser rights (editing a file
+    whose the owner is not root, sending a signal to an unprivileged process,etc.). In order to limit
+    any attempt of privilege escalation through a command, it is better to apply normal user rights.
+
+severity: medium
+
+references:
+    anssi: BP28(R60) 
+
+# The second part of the sentence explaining what got wrong.
+# ... Is it the case that <YOUR ocil_clause>
+ocil_clause: '/etc/sudoers file contains rules that allow non-root users to run commands as root'
+
+# A setp-by-step guide how to modify the configuration to achieve compliance
+ocil: |-
+    To determine if the users are allowed to run commands as root, run the following commands:
+    <pre>$ sudo grep -PR '^\s*((?!root\b)[\w]+)\s*(\w+)\s*=\s*(.*,)?\s*[^\(\s]' /etc/sudoers /etc/sudoers.d/</pre>
+    and
+    <pre>$ sudo grep -PR '^\s*((?!root\b)[\w]+)\s*(\w+)\s*=\s*(.*,)?\s*\([\w\s]*\b(root|ALL)\b[\w\s]*\)' /etc/sudoers /etc/sudoers.d/</pre>
+    Both commands should return no output.
+
+platform: sudo
+
+warnings:
+  - general: This rule doesn't come with a remediation, as the exact requirement allows exceptions, and removing lines from the sudoers file can make the system non-administrable.

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/absent-complex.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/absent-complex.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'user ALL= (admin) /bin/sh, (foo bar) /baz, /bin/git' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/absent-complex2.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/absent-complex2.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'user ALL= (admin) /bin/sh, /baz, (foo bar) /bin/git' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/absent.fail.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+# No spec of users that user can impersonate
+echo 'user ALL= ALL' > /etc/sudoers
+

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allmighty.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allmighty.pass.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# packages = sudo
+
+# Allow root to execute commands on behalf of anybody
+echo ' root ALL=(ALL) ALL' > /etc/sudoers
+echo 'root ALL= ALL' >> /etc/sudoers
+echo '# user ALL= ALL' >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allowed_later.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allowed_later.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'user ALL= (admin) /bin/sh, (foo bar) /baz, (baz root bzz) /bin/git' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allowed_later2.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allowed_later2.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'user ALL= (admin) /bin/sh, (foo bar) /baz, (baz bzz) /bin/git, (nobody ALL somebody)  /bin/touch' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allowed_right_away.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/root_allowed_right_away.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'user ALL= (root) /bin/sh, (foo bar) /baz, (baz bzz) /bin/git' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/simple.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/simple.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'user ALL=(ALL) ALL' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/simple.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/simple.pass.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+
+echo '%wheel ALL=(admin) ALL' > /etc/sudoers
+echo 'user ALL=(admin) ALL' > /etc/sudoers.d/foo

--- a/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/sudoers_d.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_root_target/tests/sudoers_d.fail.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo '%wheel ALL=(admin) ALL' > /etc/sudoers
+echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/foo

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -59,6 +59,11 @@ cpes:
       title: "SSSD is configured to use LDAP"
       check_id: sssd_conf_uses_ldap
 
+  - sudo:
+      name: "cpe:/a:sudo"
+      title: "Package sudo is installed"
+      check_id: installed_env_has_sudo_package
+
   - systemd:
       name: "cpe:/a:systemd"
       title: "Package systemd is installed"

--- a/shared/checks/oval/installed_env_has_sudo_package.xml
+++ b/shared/checks/oval/installed_env_has_sudo_package.xml
@@ -1,0 +1,38 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_sudo_package" version="1">
+    <metadata>
+      <title>Package sudo is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package sudo is installed.</description>
+      <reference ref_id="cpe:/a:sudo" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package sudo is installed" test_ref="test_env_has_sudo_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_sudo_installed" version="1"
+  comment="system has package sudo installed">
+    <linux:object object_ref="obj_env_has_sudo_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_sudo_installed" version="1">
+    <linux:name>sudo</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_sudo_installed" version="1"
+  comment="system has package sudo installed">
+    <linux:object object_ref="obj_env_has_sudo_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_sudo_installed" version="1">
+    <linux:name>sudo</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>
+


### PR DESCRIPTION
The ANSSI R60 requirement states that users should not be allowed impersonate as `root`.

The rule analyzes the "user specifications" in sudoers files, and if there is no "runas spec", or `root` or `ALL` are part of it, the rule will fail. I would recommend to check out test scenarios.
So far there is no remediation for the rule, as:

1. ANSSI doesn't say that no user should be allowed to run as root, so exceptions apply, and this can't be determined automatically.
2. Removing user specs from sudoers could lock all admins out of the system.