### PR TITLE
CIS: Add two missing OCILs 

### DIFF
--- a/applications/openshift/rbac/rbac_limit_secrets_access/rule.yml
+++ b/applications/openshift/rbac/rbac_limit_secrets_access/rule.yml
@@ -24,10 +24,19 @@ severity: medium
 references:
     cis: 5.1.2
 
-#ocil_clause: 'cluster-admin role is in use by more personnel than necessary'
-#
-#ocil: |-
-#    To review the <tt>cluster-admin</tt> role, run the following command:
-#    <pre>$ oc get clusterrolebinding -o json | jq '.items[] | select(.metadata.name |  startswith("cluster-admin"))'</pre>
-#    Review the output and ensure that authorized users have
-#    the <tt>cluster-admin</tt> role.
+ocil_clause: 'Access to Kubernetes clusters is too wide'
+
+ocil: |-
+    To review the policy rules assigned to roles in all namespaces, run
+    the following command:
+    <pre>$ for ns in $(oc get projects -ojsonpath='{.items[*].metadata.name}'); do oc describe roles -n$ns; done</pre>
+    To review the policy rules assigned to cluster roles, run the following
+    command:
+    <pre>$ for i in $(oc get clusterroles -o jsonpath='{.items[*].metadata.name}'); do oc describe clusterrole ${i}; done</pre>
+    Review the output and ensure that only authorized roles have access to the
+    secrets resource or all resources using a wildcard.
+    To filter clusterroles that have assigned access to the secrets resources for clustrroles, run:
+    <pre>$ oc get clusterroles -ojson | jq -r '.items[] | {name: .metadata.name, rules: .rules} | select(.rules[]?.resources | try contains(["secrets"])) | .name' | sort | uniq</pre>
+    and similarly to filter namespace/role pairs:
+    <pre>$ for ns in $(oc get projects -ojsonpath='{.items[*].metadata.name}'); do oc get roles -n$ns -ojson | jq -r '.items[] | {name: .metadata.name, namespace: .metadata.namespace, rules: .rules} | select(.rules[]?.resources | try contains(["secrets"])) | "\(.namespace)/\(.name)"' | sort | uniq; done</pre>
+    note that the two commands above do not show roles and/or clusterroles with wildcard access to any resources.

--- a/applications/openshift/secrets/secrets_no_environment_variables/rule.yml
+++ b/applications/openshift/secrets/secrets_no_environment_variables/rule.yml
@@ -18,10 +18,10 @@ severity: medium
 references:
     cis: 5.4.1
 
-#ocil_clause: 'environment variables are in use for secrets'
-#
-#ocil: |-
-#    To review the <tt>cluster-admin</tt> role, run the following command:
-#    <pre>$ oc get clusterrolebinding -o json | jq '.items[] | select(.metadata.name |  startswith("cluster-admin"))'</pre>
-#    Review the output and ensure that authorized users have
-#    the <tt>cluster-admin</tt> role.
+ocil_clause: 'environment variables are in use for secrets'
+
+ocil: |-
+    To find workloads that use environment variables for secrets, run the following:
+    <pre>$ oc get all -o jsonpath='{range .items[?(@..secretKeyRef)]} {.kind} {.metadata.namespace} {.metadata.name} {"\n"}{end}' -A</pre>
+    Review the output and ensure that workloads that can mount secrets as data
+    volumes use that instead of environment variables.


### PR DESCRIPTION
Adds OCILs to a rule that checks for secrets access. The OCIL is a little longer than usual because I find the review of all roles tedious, so I tried also to add two (long!) one-liners that find all roles and clusterroles with direct access to secrets. I think for custom workloads, this is quite useful.

The other one is for a rule that checks if secrets are used as
environment variables. Here I wonder if we should file bugs against the
OCP components that do that? I'm not sure myself and would be leaning
towards "no, this sounds like busywork", but I wonder if we would get
support tickets from people who would prefer the rule check to be clean.