### PR TITLE
Add custom OVAL check file_permissions_multus_conf to check stricter permissions

### DIFF
--- a/applications/openshift/master/file_permissions_multus_conf/oval/shared.xml
+++ b/applications/openshift/master/file_permissions_multus_conf/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+    <definition class="compliance" id="file_permissions_multus_conf" version="1">
+      {{{ oval_metadata(description="This test makes sure that ^/var/run/multus/cni/net.d/.*$ has mode 0644. If the target file or directory has an extended ACL, then it will fail the mode check.") }}}
+      <criteria>
+        <criterion comment="Check file mode of ^/var/run/multus/cni/net.d/.*$" test_ref="test_file_permissions_multus_conf" negate="true"/>
+      </criteria>
+    </definition>
+      <unix:file_test check="all" check_existence="at_least_one_exists" comment="Testing mode of ^/var/run/multus/cni/net.d/.*$" id="test_file_permissions_multus_conf" version="1">
+      <unix:object object_ref="object_file_permissions_multus_conf" />
+      <unix:state state_ref="state_file_permissions_multus_conf_mode_not_0644" />
+    </unix:file_test>
+    <unix:file_state id="state_file_permissions_multus_conf_mode_not_0644" version="1" operator="OR">
+        <!-- if any one of these is true then mode is NOT 0644 (hence the OR operator) -->
+        <unix:suid datatype="boolean">true</unix:suid>
+        <unix:sgid datatype="boolean">true</unix:sgid>
+        <unix:sticky datatype="boolean">true</unix:sticky>
+        <unix:uexec datatype="boolean">true</unix:uexec>
+        <unix:gwrite datatype="boolean">true</unix:gwrite>
+        <unix:gexec datatype="boolean">true</unix:gexec>
+        <unix:owrite datatype="boolean">true</unix:owrite>
+        <unix:oexec datatype="boolean">true</unix:oexec>
+    </unix:file_state>
+    <unix:file_object comment="^/var/run/multus/cni/net.d/.*$" id="object_file_permissions_multus_conf" version="1">
+        <unix:filepath operation="pattern match">^/var/run/multus/cni/net.d/.*$</unix:filepath>
+        <filter action="include">state_file_permissions_multus_conf_mode_not_0644</filter>
+    </unix:file_object>
+  </def-group>


### PR DESCRIPTION

#### Description:

- Add custom OVAL check file_permissions_multus_conf to check stricter permissions

#### Rationale:

- Some security requirements say that file must have a specific file permissions mode or stricter.
