### PR TITLE
Add stricter permissions option to file permissions template

### DIFF
--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -33,3 +33,4 @@ template:
         filemode: '0644'
         missing_file_pass: "true"
         filepath_is_regex: "true"
+        allow_stricter_permissions: "true"

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1339,6 +1339,10 @@ the following to `rule.yml`:
     -   **filemode** - File permissions in a hexadecimal format, eg.
         `'0640'`.
 
+    -   **allow_stricter_permissions** - If set to `"true"` the OVAL
+        will also consider permissions stricter than **filemode** as compliant.
+        Default value is `"false"`.
+
 -   Languages: Ansible, Bash, OVAL
 
 #### grub2_bootloader_argument

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -4,33 +4,40 @@
       If the target file or directory has an extended ACL, then it will fail the mode check.
       ") }}}
     <criteria>
-      <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_file_permissions{{{ FILEID }}}" />
+      <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_file_permissions{{{ FILEID }}}"{{{ ' negate="true"' if ALLOW_STRICTER_PERMISSIONS }}}/>
     </criteria>
   </definition>
-  {{%- if MISSING_FILE_PASS -%}}
-    {{# Any number of files can exist, from zero to any #}}
-    {{% set FILE_EXISTENCE = "any_exist" %}}
+  {{%- if ALLOW_STRICTER_PERMISSIONS %}}
+    {{% set FILE_EXISTENCE = "at_least_one_exists" %}}
   {{%- else -%}}
-    {{# All defined files must exist. When using regex, at least one file must match #}}
-    {{% set FILE_EXISTENCE = "all_exist" %}}
-  {{%- endif -%}}
-    <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing mode of {{{ FILEPATH }}}" id="test_file_permissions{{{ FILEID }}}" version="1">
-    <unix:object object_ref="object_file_permissions{{{ FILEID }}}" />
-    <unix:state state_ref="state_file_permissions{{{ FILEID }}}_mode_{{{ FILEMODE }}}" />
-  </unix:file_test>
-  <unix:file_state id="state_file_permissions{{{ FILEID }}}_mode_{{{ FILEMODE }}}" version="1">
-    {{{ STATEMODE }}}
-  </unix:file_state>
-  <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_permissions{{{ FILEID }}}" version="1">
-    {{%- if IS_DIRECTORY -%}}
-      <unix:path>{{{ FILEPATH }}}</unix:path>
-      {{%- if FILE_REGEX -%}}
-        <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
-      {{%- else -%}}
-        <unix:filename xsi:nil="true" />
-      {{%- endif -%}}
+    {{%- if MISSING_FILE_PASS -%}}
+      {{# Any number of files can exist, from zero to any #}}
+      {{% set FILE_EXISTENCE = "any_exist" %}}
     {{%- else -%}}
-      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
+      {{# All defined files must exist. When using regex, at least one file must match #}}
+      {{% set FILE_EXISTENCE = "all_exist" %}}
     {{%- endif -%}}
-  </unix:file_object>
+  {{%- endif -%}}
+      <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing mode of {{{ FILEPATH }}}" id="test_file_permissions{{{ FILEID }}}" version="2">
+      <unix:object object_ref="object_file_permissions{{{ FILEID }}}" />
+      <unix:state state_ref="state_file_permissions{{{ FILEID }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}" />
+    </unix:file_test>
+    <unix:file_state id="state_file_permissions{{{ FILEID }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}"{{{ ' operator="OR"' if ALLOW_STRICTER_PERMISSIONS }}} version="2">
+      {{{ STATEMODE | indent(6) }}}
+    </unix:file_state>
+    <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_permissions{{{ FILEID }}}" version="1">
+    {{%- if IS_DIRECTORY %}}
+      <unix:path>{{{ FILEPATH }}}</unix:path>
+      {{%- if FILE_REGEX %}}
+        <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else %}}
+        <unix:filename xsi:nil="true" />
+      {{%- endif %}}
+    {{%- else %}}
+      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
+      {{%- if ALLOW_STRICTER_PERMISSIONS %}}
+      <filter action="include">state_file_permissions{{{ FILEID }}}_mode_not_{{{ FILEMODE }}}</filter>
+      {{%- endif %}}
+    {{%- endif %}}
+    </unix:file_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- Add stricter permissions option to file permissions template

#### Rationale:

- OVAL check will pass even if the permissions are more restrictive.

- Fixes #6431
