### PR TITLE
OCP: Cleanup rules in section 1.1 of CIS profile

### DIFF
--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/.*", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,9 +20,9 @@ identifiers:
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/.*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/.*", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The OpenShift Controller Manager Kubeconfig File'
 
 description: |-
-  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
 
 rationale: |-
   The Controller Manager's kubeconfig contains information about how the
@@ -21,15 +21,16 @@ severity: medium
 references:
   cis: 1.1.18
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
     filegid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -25,9 +25,10 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/", gro
 ocil: |-
     {{{ ocil_file_group_owner(file="/var/lib/etcd/member/", group="root") }}}
 
+platform: ocp4-master-node
+
 template:
     name: file_groupowner
     vars:
         filepath: /var/lib/etcd/member/
         filegid: '0'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Etcd Write-Ahead-Log Files'
 
 description: |-
-    {{{ describe_file_group_owner(file="/var/lib/etcd/member/wal/.*", group="root") }}}
+    {{{ describe_file_group_owner(file="/var/lib/etcd/member/wal/*", group="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -20,15 +20,16 @@ identifiers:
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/wal/.*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/wal/*", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/lib/etcd/member/wal/.*", group="root") }}}
+    {{{ ocil_file_group_owner(file="/var/lib/etcd/member/wal/*", group="root") }}}
+
+platform: ocp4-master-node
 
 template:
     name: file_groupowner
     vars:
         filepath: ^/var/lib/etcd/member/wal/.*$
         filegid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -7,10 +7,12 @@ title: 'Verify Group Who Owns The etcd Member Pod Specification File'
 description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 
 rationale: |-
-    If the etcd specification file contains the configuration of
-    the etcd highly-available key-value store which Kubernetes uses for
-    persistent storage of all of its REST API object. Protection of this
-    file is critical for OpenShift security.
+    The etcd pod specification file controls various parameters that
+    set the behavior of the etcd service in the master node. etcd is a
+    highly-available key-value store which Kubernetes uses for persistent
+    storage of all of its REST API object. You should restrict its file
+    permissions to maintain the integrity of the file. The file should be
+    writable by only the administrators on the system.
 
 severity: medium
 

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -2,14 +2,15 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Group Who Owns The ETCD Member Pod Specification File'
+title: 'Verify Group Who Owns The etcd Member Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 
 rationale: |-
-    The Kube Specification file contains information about the configuration of the
-    OpenShift scheduler that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    If the etcd specification file contains the configuration of
+    the etcd highly-available key-value store which Kubernetes uses for
+    persistent storage of all of its REST API object. Protection of this
+    file is critical for OpenShift security.
 
 severity: medium
 
@@ -19,14 +20,15 @@ identifiers:
 references:
     cis: 1.1.8
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_groupowner
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
         filegid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Etcd PKI Certificate Files'
 
 description: |-
-  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", group="root") }}}
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", group="root") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificates as part of its operation.
@@ -22,10 +22,12 @@ severity: medium
 references:
   cis: 1.1.19
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", group="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", group="root") }}}
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", group="root") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -43,7 +45,6 @@ ocil: |-
 template:
   name: file_groupowner
   vars:
-    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt$
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.crt$
     filegid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -30,5 +30,4 @@ template:
     vars:
         filepath: ^/var/lib/cni/networks/openshift-sdn/.*$
         filegid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Group Who Owns The Kube API Server Pod Specification File'
+title: 'Verify Group Who Owns The Kubernetes API Server Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 
 rationale: |-
-    The Kube specification file contains information about the configuration of the
-    OpenShift API Server that is configured on the system. Protection of this file is
+    The Kubernetes specification file contains information about the configuration of the
+    Kubernetes API Server that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -19,14 +19,15 @@ identifiers:
 references:
     cis: 1.1.2
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_groupowner
     vars:
         filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
         filepath_is_regex: "true"
-        missing_file_pass: "true"
         filegid: '0'

--- a/applications/openshift/master/file_groupowner_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Group Who Owns The Kube Controller Manager Pod Specification File'
+title: 'Verify Group Who Owns The Kubernetes Controller Manager Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 
 rationale: |-
-    The Kube specification file contains information about the configuration of the
-    OpenShift Controller Manager Server that is configured on the system. Protection of this file is
+    The Kubernetes specification file contains information about the configuration of the
+    Kubernetes Controller Manager Server that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -19,14 +19,15 @@ identifiers:
 references:
     cis: 1.1.4
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_groupowner
     vars:
         filepath: '^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml$'
         filepath_is_regex: 'true'
-        missing_file_pass: 'true'
         filegid: '0'

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Group Who Owns The Kube Scheduler Pod Specification File'
+title: 'Verify Group Who Owns The Kubernetes Scheduler Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 
 rationale: |-
-    The Kube Specification file contains information about the configuration of the
-    OpenShift scheduler that is configured on the system. Protection of this file is
+    The Kubernetes Specification file contains information about the configuration of the
+    Kubernetes scheduler that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -19,14 +19,15 @@ identifiers:
 references:
     cis: 1.1.6
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_groupowner
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml$
         filegid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_kube_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The OpenShift Admin Kubeconfig Files'
 
 description: |-
-  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", group="root") }}}
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", group="root") }}}
 
 rationale: |-
   There are various kubeconfig files that can be used by the administrator,
@@ -25,15 +25,16 @@ severity: medium
 references:
   cis: 1.1.14
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", group="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", group="root") }}}
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", group="root") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig$
     filegid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The OpenShift Multus Container Network Interface Plugin Files'
 
-description: '{{{ describe_file_group_owner(file="/var/run/multus/cni/net.d/.*", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,14 +20,13 @@ identifiers:
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/.*", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/var/run/multus/cni/net.d/.*", group="root") }}}'
+ocil: '{{{ ocil_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 
 template:
     name: file_groupowner
     vars:
         filepath: ^/var/run/multus/cni/net.d/.*$
         filegid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The OpenShift PKI Certificate Files'
 
 description: |-
-  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", group="root") }}}
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", group="root") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificates as part of its operation.
@@ -22,10 +22,12 @@ severity: medium
 references:
   cis: 1.1.19
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", group="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", group="root") }}}
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls.crt", group="root") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -45,5 +47,4 @@ template:
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt$
     filegid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The OpenShift PKI Private Key Files'
 
 description: |-
-  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", group="root") }}}
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", group="root") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificates as part of its operation.
@@ -22,10 +22,12 @@ severity: medium
 references:
   cis: 1.1.19
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", group="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", group="root") }}}
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", group="root") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -45,5 +47,4 @@ template:
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key$
     filegid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /var/run/openshift-sdn/cniserver/config.json
         filegid: '0'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/conf.db
         filegid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/.conf.db.~lock~
         filegid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /var/run/openvswitch/ovs-vswitchd.pid
         filegid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/system-id.conf
         filegid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /run/openvswitch/ovs-vswitchd.pid
         filegid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /run/openvswitch/ovsdb-server.pid
         filegid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Kubernetes Scheduler Kubeconfig File'
 
 description: |-
-  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}
+  {{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}
 
 rationale: |-
   The kubeconfig for the Scheduler contains paramters for the scheduler
@@ -21,15 +21,16 @@ severity: medium
 references:
   cis: 1.1.16
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}
+  {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
     filegid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_owner(file="/etc/cni/net.d/.*", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,9 +20,9 @@ identifiers:
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/.*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cni/net.d/.*", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The OpenShift Controller Manager Kubeconfig File'
 
 description: |-
-  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
 
 rationale: |-
   The Controller Manager's kubeconfig contains information about how the
@@ -21,15 +21,16 @@ severity: medium
 references:
   cis: 1.1.18
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_owner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
     fileuid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -25,9 +25,10 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/", owner="ro
 ocil: |-
     {{{ ocil_file_owner(file="/var/lib/etcd/member/", owner="root") }}}
 
+platform: ocp4-master-node
+
 template:
     name: file_owner
     vars:
         filepath: /var/lib/etcd/member/
         fileuid: '0'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_etcd_data_dir/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Etcd Write-Ahead-Log Files'
 
 description: |-
-    {{{ describe_file_owner(file="/var/lib/etcd/member/wal/.*", owner="root") }}}
+    {{{ describe_file_owner(file="/var/lib/etcd/member/wal/*", owner="root") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for
@@ -20,15 +20,16 @@ identifiers:
 references:
     cis: 1.1.12
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/wal/.*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/wal/*", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/lib/etcd/member/wal/.*", owner="root") }}}
+    {{{ ocil_file_owner(file="/var/lib/etcd/member/wal/*", owner="root") }}}
+
+platform: ocp4-master-node
 
 template:
     name: file_owner
     vars:
         filepath: ^/var/lib/etcd/member/wal/.*$
         fileuid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_data_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -7,10 +7,12 @@ title: 'Verify User Who Owns The etcd Member Pod Specification File'
 description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
 rationale: |-
-    If the etcd specification file contains the configuration of
-    the etcd highly-available key-value store which Kubernetes uses for
-    persistent storage of all of its REST API object. Protection of this
-    file is critical for OpenShift security.
+    The etcd pod specification file controls various parameters that
+    set the behavior of the etcd service in the master node. etcd is a
+    highly-available key-value store which Kubernetes uses for persistent
+    storage of all of its REST API object. You should restrict its file
+    permissions to maintain the integrity of the file. The file should be
+    writable by only the administrators on the system.
 
 severity: medium
 

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -2,14 +2,15 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify User Who Owns The ETCD Member Pod Specification File'
+title: 'Verify User Who Owns The etcd Member Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
 rationale: |-
-    The ETCD specification file contains information about the configuration of the
-    OpenShift scheduler that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    If the etcd specification file contains the configuration of
+    the etcd highly-available key-value store which Kubernetes uses for
+    persistent storage of all of its REST API object. Protection of this
+    file is critical for OpenShift security.
 
 severity: medium
 
@@ -19,14 +20,15 @@ identifiers:
 references:
     cis: 1.1.8
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_owner
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
         fileuid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_member/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Etcd PKI Certificate Files'
 
 description: |-
-  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", owner="root") }}}
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", owner="root") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificates as part of its operation.
@@ -22,10 +22,12 @@ severity: medium
 references:
   cis: 1.1.19
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", owner="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", owner="root") }}}
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", owner="root") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -43,7 +45,6 @@ ocil: |-
 template:
   name: file_owner
   vars:
-    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt$
+    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.crt$
     fileuid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -29,5 +29,4 @@ template:
     vars:
         filepath: ^/var/lib/cni/networks/openshift-sdn/.*$
         fileuid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify User Who Owns The Kube API Server Pod Specification File'
+title: 'Verify User Who Owns The Kubernetes API Server Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 
 rationale: |-
-    The Kube specification file contains information about the configuration of the
-    OpenShift API Server that is configured on the system. Protection of this file is
+    The Kubernetes specification file contains information about the configuration of the
+    Kubernetes API Server that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -19,14 +19,15 @@ identifiers:
 references:
     cis: 1.1.2
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_owner
     vars:
         filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
         filepath_is_regex: "true"
-        missing_file_pass: "true"
         fileuid: '0'

--- a/applications/openshift/master/file_owner_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify User Who Owns The Kube Controller Manager Pod Specificiation File'
+title: 'Verify User Who Owns The Kubernetes Controller Manager Pod Specificiation File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
 rationale: |-
-    The Kube specification file contains information about the configuration of the
-    OpenShift Controller Manager Server that is configured on the system. Protection of this file is
+    The Kubernetes specification file contains information about the configuration of the
+    Kubernetes Controller Manager Server that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -19,14 +19,15 @@ identifiers:
 references:
     cis: 1.1.4
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_owner
     vars:
         filepath: '^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml$'
         filepath_is_regex: 'true'
-        missing_file_pass: 'true'
         fileuid: '0'

--- a/applications/openshift/master/file_owner_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify User Who Owns The Kube Scheduler Pod Specification File'
+title: 'Verify User Who Owns The Kubernetes Scheduler Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 
 rationale: |-
-    The Kube specification file contains information about the configuration of the
-    OpenShift scheduler that is configured on the system. Protection of this file is
+    The Kubernetes specification file contains information about the configuration of the
+    Kubernetes scheduler that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -19,14 +19,15 @@ identifiers:
 references:
     cis: 1.1.6
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
+
+platform: ocp4-master-node
 
 template:
     name: file_owner
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml$
         fileuid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_kube_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The OpenShift Admin Kubeconfig Files'
 
 description: |-
-  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", owner="root") }}}
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", owner="root") }}}
 
 rationale: |-
   There are various kubeconfig files that can be used by the administrator,
@@ -25,15 +25,16 @@ severity: medium
 references:
   cis: 1.1.14
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", owner="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", owner="root") }}}
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", owner="root") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_owner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig$
     fileuid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The OpenShift Multus Container Network Interface Plugin Files'
 
-description: '{{{ describe_file_owner(file="/var/run/multus/cni/net.d/.*", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -20,14 +20,13 @@ identifiers:
 references:
     cis: 1.1.10
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/.*", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/var/run/multus/cni/net.d/.*", owner="root") }}}'
+ocil: '{{{ ocil_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
 
 template:
     name: file_owner
     vars:
         filepath: ^/var/run/multus/cni/net.d/.*$
         fileuid: '0'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The OpenShift PKI Certificate Files'
 
 description: |-
-  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", owner="root") }}}
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", owner="root") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificates as part of its operation.
@@ -21,10 +21,12 @@ severity: medium
 references:
   cis: 1.1.19
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", owner="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", owner="root") }}}
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", owner="root") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -44,5 +46,4 @@ template:
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt$
     fileuid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The OpenShift PKI Private Key Files'
 
 description: |-
-  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", owner="root") }}}
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", owner="root") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificates as part of its operation.
@@ -22,10 +22,12 @@ severity: medium
 references:
   cis: 1.1.19
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", owner="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", owner="root") }}}
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", owner="root") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -45,5 +47,4 @@ template:
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key$
     fileuid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /var/run/openshift-sdn/cniserver/config.json
         fileuid: '0'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/conf.db
         fileuid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /var/run/openvswitch/ovs-vswitchd.pid
         fileuid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/system-id.conf
         fileuid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /run/openvswitch/ovs-vswitchd.pid
         fileuid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /run/openvswitch/ovsdb-server.pid
         fileuid: '800'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify User Who Owns The Kubernetes Scheduler Kubeconfig File'
 
 description: |-
-  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}
+  {{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}
 
 rationale: |-
   The kubeconfig for the Scheduler contains paramters for the scheduler
@@ -20,15 +20,16 @@ identifiers:
 references:
   cis: 1.1.16
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
 
 ocil: |-
-  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}
+  {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_owner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
     fileuid: '0'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/cni/net.d/.*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0644") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,10 +21,10 @@ identifiers:
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/.*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/cni/net.d/.*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Controller Manager Kubeconfig File'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="0644") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="0644") }}}
 
 rationale: |-
   The Controller Manager's kubeconfig contains information about how the
@@ -22,15 +22,16 @@ severity: medium
 references:
   cis: 1.1.17
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_permissions
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
     filemode: '0644'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -26,9 +26,10 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd", perms="drwx
 ocil: |-
     {{{ ocil_file_permissions(file="/var/lib/etcd", perms="drwx------") }}}
 
+platform: ocp4-master-node
+
 template:
     name: file_permissions
     vars:
         filepath: /var/lib/etcd/member/
         filemode: '0700'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_etcd_data_dir/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Etcd Write-Ahead-Log Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/var/lib/etcd/member/wal/.*", perms="0600") }}}
+    {{{ describe_file_permissions(file="/var/lib/etcd/member/wal/*", perms="0600") }}}
 
 rationale: |-
     etcd is a highly-available key-value store used by Kubernetes deployments for persistent
@@ -21,15 +21,16 @@ identifiers:
 references:
     cis: 1.1.11
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/member/wal/.*", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/member/wal/*", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/lib/etcd/member/wal/.*", perms="-rw-------") }}}
+    {{{ ocil_file_permissions(file="/var/lib/etcd/member/wal/*", perms="-rw-------") }}}
+
+platform: ocp4-master-node
 
 template:
     name: file_permissions
     vars:
         filepath: ^/var/lib/etcd/member/wal/.*$
         filemode: '0600'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_data_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -8,11 +8,12 @@ description: |-
     {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0644") }}}
 
 rationale: |-
-    If the etcd specification file is writable by a group-owner or the
-    world the risk of its compromise is increased. The file contains the configuration of
-    the etcd highly-available key-value store which Kubernetes uses for
-    persistent storage of all of its REST API object. Protection of this
-    file is critical for OpenShift security.
+    The etcd pod specification file controls various parameters that
+    set the behavior of the etcd service in the master node. etcd is a
+    highly-available key-value store which Kubernetes uses for persistent
+    storage of all of its REST API object. You should restrict its file
+    permissions to maintain the integrity of the file. The file should be
+    writable by only the administrators on the system.
 
 severity: medium
 

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -2,16 +2,17 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Permissions on the ETCD Member Pod Specification File'
+title: 'Verify Permissions on the etcd Member Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0644") }}}
 
 rationale: |-
-    If the ETCD specification file is writable by a group-owner or the
+    If the etcd specification file is writable by a group-owner or the
     world the risk of its compromise is increased. The file contains the configuration of
-    an OpenShift scheduler that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    the etcd highly-available key-value store which Kubernetes uses for
+    persistent storage of all of its REST API object. Protection of this
+    file is critical for OpenShift security.
 
 severity: medium
 
@@ -21,15 +22,16 @@ identifiers:
 references:
     cis: 1.1.7
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}
+
+platform: ocp4-master-node
 
 template:
     name: file_permissions
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
         filemode: '0644'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Etcd PKI Certificate Files'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="0600") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-*/secrets/*/*.crt", perms="0600") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificate files as part of the operation
@@ -21,10 +21,12 @@ severity: medium
 references:
   cis: 1.1.20
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-*/secrets/*/*.crt", perms="-rw-------") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt", perms="-rw-------") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-*/secrets/*/*.crt", perms="-rw-------") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -42,7 +44,6 @@ ocil: |-
 template:
   name: file_permissions
   vars:
-    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.internal\.crt$
+    filepath: ^/etc/kubernetes/static-pod-resources/etcd-.*/secrets/.*/.*\.crt$
     filemode: '0600'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift SDN Container Network Interface Plugin IP Address Allocations'
 
 description: |-
-    {{{ describe_file_permissions(file="/var/lib/cni/networks/openshift-sdn/.*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="0644") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,15 +21,14 @@ identifiers:
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/cni/networks/openshift-sdn/.*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/lib/cni/networks/openshift-sdn/.*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions
     vars:
         filepath: ^/var/lib/cni/networks/openshift-sdn/.*$
         filemode: '0644'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -2,15 +2,15 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Permissions on the Kube API Server Pod Specification File'
+title: 'Verify Permissions on the Kubernetes API Server Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="0644") }}}
 
 rationale: |-
-    If the Kube specification file is writable by a group-owner or the
+    If the Kubernetes specification file is writable by a group-owner or the
     world the risk of its compromise is increased. The file contains the configuration of
-    an OpenShift API server that is configured on the system. Protection of this file is
+    the Kubernetes API server that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -21,15 +21,16 @@ identifiers:
 references:
     cis: 1.1.1
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_permissions
   vars:
     filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
     filepath_is_regex: "true"
-    missing_file_pass: "true"
     filemode: '0644'

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -2,15 +2,15 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Permissions on the Kube Controller Manager Pod Specificiation File'
+title: 'Verify Permissions on the Kubernetes Controller Manager Pod Specificiation File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="0644") }}}
 
 rationale: |-
-    If the Kube specification file is writable by a group-owner or the
+    If the Kubernetes specification file is writable by a group-owner or the
     world the risk of its compromise is increased. The file contains the configuration of
-    an OpenShift Controller Manager server that is configured on the system. Protection of this file is
+    an Kubernetes Controller Manager server that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -21,10 +21,12 @@ identifiers:
 references:
     cis: 1.1.3
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}
+
+platform: ocp4-master-node
 
 template:
     name: file_permissions
@@ -32,4 +34,3 @@ template:
         filepath: '^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml$'
         filepath_is_regex: 'true'
         filemode: '0644'
-        missing_file_pass: 'true'

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Admin Kubeconfig Files'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", perms="0600") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", perms="0600") }}}
 
 rationale: |-
   There are various kubeconfig files that can be used by the administrator,
@@ -25,15 +25,16 @@ severity: medium
 references:
   cis: 1.1.13
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", perms="-rw-------") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig", perms="-rw-------") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", perms="-rw-------") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_permissions
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig$
     filemode: '0600'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Multus Container Network Interface Plugin Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/var/run/multus/cni/net.d/.*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/var/run/multus/cni/net.d/*", perms="0644") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,16 +21,15 @@ identifiers:
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/multus/cni/net.d/.*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/run/multus/cni/net.d/.*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions
     vars:
         filepath: ^/var/run/multus/cni/net.d/.*$
         filemode: '0644'
-        missing_file_pass: "true"
         filepath_is_regex: "true"
         allow_stricter_permissions: "true"

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift PKI Certificate Files'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="0600") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-*/secrets/*/tls.crt", perms="0600") }}}
 
 rationale: |-
   OpenShift makes use of a number of certificate files as part of the operation
@@ -21,10 +21,12 @@ severity: medium
 references:
   cis: 1.1.20
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-*/secrets/*/tls.crt", perms="-rw-------") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt", perms="-rw-------") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-*/secrets/*/tls.crt", perms="-rw-------") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -42,7 +44,6 @@ ocil: |-
 template:
   name: file_permissions
   vars:
-    filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt$
+    filepath: ^/etc/kubernetes/static-pod-resources/kube-.*/secrets/.*/tls\.crt$
     filemode: '0600'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift PKI Private Key Files'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", perms="0600") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", perms="0600") }}}
 
 rationale: |-
   OpenShift makes use of a number of key files as part of the operation of its
@@ -21,10 +21,12 @@ severity: medium
 references:
   cis: 1.1.21
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", perms="-rw-------") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key", perms="-rw-------") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", perms="-rw-------") }}}
+
+platform: ocp4-master-node
 
 # Note that this recursively checks for files, and the form is as follows:
 #
@@ -44,5 +46,4 @@ template:
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key$
     filemode: '0600'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/conf.db
         filemode: '0640'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/.conf.db.~lock~
         filemode: '0600'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /var/run/openvswitch/ovs-vswitchd.pid
         filemode: '0644'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /etc/openvswitch/system-id.conf
         filemode: '0644'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /run/openvswitch/ovs-vswitchd.pid
         filemode: '0644'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /run/openvswitch/ovsdb-server.pid
         filemode: '0644'
-        missing_file_pass: "true"

--- a/applications/openshift/master/file_permissions_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler/rule.yml
@@ -2,15 +2,15 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Permissions on the Kube Scheduler Pod Specification File'
+title: 'Verify Permissions on the Kubernetes Scheduler Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="0644") }}}
 
 rationale: |-
-    If the Kube specification file is writable by a group-owner or the
+    If the Kubernetes specification file is writable by a group-owner or the
     world the risk of its compromise is increased. The file contains the configuration of
-    an OpenShift Scheduler service that is configured on the system. Protection of this file is
+    an Kubernetes Scheduler service that is configured on the system. Protection of this file is
     critical for OpenShift security.
 
 severity: medium
@@ -21,15 +21,16 @@ identifiers:
 references:
     cis: 1.1.5
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}
+
+platform: ocp4-master-node
 
 template:
     name: file_permissions
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml$
         filemode: '0644'
-        missing_file_pass: "true"
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_scheduler/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kubernetes Scheduler Kubeconfig File'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", perms="0644") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="0644") }}}
 
 rationale: |-
   The kubeconfig for the Scheduler contains paramters for the scheduler
@@ -22,15 +22,16 @@ severity: medium
 references:
   cis: 1.1.15
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
+
+platform: ocp4-master-node
 
 template:
   name: file_permissions
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
     filemode: '0644'
-    missing_file_pass: "true"
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,4 @@
 ---
-default_result: PASS
+default_result:
+  master: PASS
+  worker: SKIP

--- a/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
@@ -31,4 +31,3 @@ template:
     vars:
         filepath: /var/run/openshift-sdn/cniserver/config.json
         filemode: '0444'
-        missing_file_pass: "true"

--- a/tests/ocp4e2e/helpers.go
+++ b/tests/ocp4e2e/helpers.go
@@ -741,7 +741,7 @@ func matchFoundResultToExpectation(foundResult cmpv1alpha1.ComplianceCheckResult
 			}
 			// NOTE(jaosorior): Normally, the results will have a reference
 			// to the role they apply to in the name. This is hacky...
-			if strings.Contains(foundResult.GetName(), role) {
+			if strings.Contains(foundResult.GetLabels()[cmpv1alpha1.ComplianceScanLabel], role) {
 				return strings.ToLower(string(foundResult.Status)) == strings.ToLower(roleResult), nil
 			}
 		}


### PR DESCRIPTION
NOTE: Please pay special attention to the last commit about cert and keys.
This is the only one that actually changed the probe, the rest is more or less
just cosmetic changes and making sure the rules run on master nodes only without
ignoring missing files.

#### Description:

- Hardens the rules in section 1.1 of the CIS standard by running the rules on
  master nodes only and dropping the `missing_file_pass: true` attribute except
  for several files under /var or /run like pidfiles which might be ephemeral
- Adjusts tests accordingly
- Uses wildcards instead of regexes in OCILs and description to make sure them
  usable better for copy-paste

#### Rationale:

- Let's make the CIS profile production-ready