### PR TITLE
Fix FIPS checks for RHCOS

### DIFF
--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
@@ -6,6 +6,7 @@
     <criteria comment="Installed operating system is a certified operating system" operator="OR">
       <extend_definition comment="Installed OS is RHEL7" definition_ref="installed_OS_is_rhel7" />
       <extend_definition comment="Installed OS is RHEL8" definition_ref="installed_OS_is_rhel8" />
+      <extend_definition comment="Installed OS is RHCOS4" definition_ref="installed_OS_is_rhcos4" />
       <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7_family" />
       <!-- DO NOT add operating systems here unless they adhere to government certifications
            and the vendor provides professional security updates and support -->

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/rhcos4.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/rhcos4.xml
@@ -1,0 +1,23 @@
+<def-group oval_version="5.10">
+  <definition class="compliance" id="enable_fips_mode" version="1">
+    {{{ oval_metadata("Check if FIPS mode is enabled on the system") }}}
+    <criteria operator="AND">
+      <extend_definition comment="check /etc/system-fips exists" definition_ref="etc_system_fips_exists" />
+      <extend_definition comment="check sysctl crypto.fips_enabled = 1" definition_ref="proc_sys_crypto_fips_enabled" />
+      <extend_definition comment="system cryptography policy is configured" definition_ref="configure_crypto_policy" />
+      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
+      <criterion comment="check if system crypto policy selection in var_system_crypto_policy in the profile is set to FIPS" test_ref="test_system_crypto_policy_value" />
+    </criteria>
+  </definition>
+  <ind:variable_test check="at least one" comment="tests if var_system_crypto_policy is set to FIPS" id="test_system_crypto_policy_value" version="1">
+    <ind:object object_ref="obj_system_crypto_policy_value" />
+    <ind:state state_ref="ste_system_crypto_policy_value" />
+  </ind:variable_test>
+  <ind:variable_object id="obj_system_crypto_policy_value" version="1">
+    <ind:var_ref>var_system_crypto_policy</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state comment="variable value is set to 'FIPS' or 'FIPS:modifier', where the modifier corresponds to a crypto policy module that further restricts the modified crypto policy." id="ste_system_crypto_policy_value" version="2">
+    <ind:value operation="pattern match" datatype="string">^FIPS(:(OSPP|NO-SHA1|NO-CAMELLIA))?$</ind:value>
+  </ind:variable_state>
+  <external_variable comment="defined crypto policy" datatype="string" id="var_system_crypto_policy" version="1" />
+</def-group>

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/tests/ocp4/e2e.yml
@@ -1,0 +1,4 @@
+---
+# This has to pass by default as in the moderate e2e test we enable
+# FIPS in the job itself.
+default_result: PASS

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/oval/rhcos4.xml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/oval/rhcos4.xml
@@ -1,0 +1,21 @@
+<def-group>
+  <definition class="compliance" id="proc_sys_crypto_fips_enabled" version="1">
+    {{{ oval_metadata("The kernel 'crypto.fips_enabled' parameter should be set to '1' in system runtime.") }}}
+    <criteria operator="AND">
+      <criterion comment="kernel runtime parameter crypto.fips_enabled set to 1" test_ref="test_proc_sys_crypto_fips_enabled" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+   comment="kernel runtime parameter crypto.fips_enabled set to 1"
+   id="test_proc_sys_crypto_fips_enabled" version="1">
+    <ind:object object_ref="obj_proc_sys_crypto_fips_enabled" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_proc_sys_crypto_fips_enabled" version="1">
+    <ind:filepath>/proc/sys/crypto/fips_enabled</ind:filepath>
+    <ind:pattern operation="pattern match">^1$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -249,7 +249,6 @@ selections:
     - harden_ssh_client_crypto_policy
     - configure_openssl_crypto_policy
     - configure_kerberos_crypto_policy
-    - enable_dracut_fips_module
 
     #######################################################
     ### CONFIGURATION ANNEX TO THE PROTECTION PROFILE

--- a/rhcos4/profiles/ncp.profile
+++ b/rhcos4/profiles/ncp.profile
@@ -259,7 +259,6 @@ selections:
     - harden_ssh_client_crypto_policy
     - configure_openssl_crypto_policy
     - configure_kerberos_crypto_policy
-    - enable_dracut_fips_module
 
     #######################################################
     ### CONFIGURATION ANNEX TO THE PROTECTION PROFILE

--- a/rhcos4/profiles/ospp.profile
+++ b/rhcos4/profiles/ospp.profile
@@ -189,7 +189,6 @@ selections:
     - configure_openssl_crypto_policy
     - configure_libreswan_crypto_policy
     - configure_kerberos_crypto_policy
-    - enable_dracut_fips_module
 
     ## Enable Screen Lock
     ## FMT_MOF_EXT.1


### PR DESCRIPTION
This adds RHCOS as a FIPS certified OS (it inherits that from RHEL) and
it enables OVAL that's specific to checking RHCOS.

The relevant changes are:

modify sysctl check
-------------------

Given that in the Compliance Operator the OpenSCAP command runs in
offline mode, we can't use the sysctl probe directly. So, instead I
modified that check to use the value from
`/proc/sys/crypto/fips_enabled` directly.

Remove dracut checks
--------------------

Initramfs is managed by ostree, which in turn wraps dracut. It doesn't
use the dracut-fips module directly as that part is handled by ignition
itself. So, these checks have been removed.