### PR TITLE
Add s390x (IBM Z) as a 64bit architecture

### DIFF
--- a/shared/checks/oval/system_info_architecture_64bit.xml
+++ b/shared/checks/oval/system_info_architecture_64bit.xml
@@ -17,6 +17,8 @@
       definition_ref="system_info_architecture_ppc_64" />
       <extend_definition comment="Generic test for aarch64 architecture"
       definition_ref="system_info_architecture_aarch_64" />
+      <extend_definition comment="Generic test for s390x architecture"
+      definition_ref="system_info_architecture_s390_64" />
     </criteria>
   </definition>
 

--- a/shared/checks/oval/system_info_architecture_s390_64.xml
+++ b/shared/checks/oval/system_info_architecture_s390_64.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="system_info_architecture_s390_64"
+  version="1">
+    <!-- Note that this does not meet requirements for class=inventory as
+         that only tests for patches per 5.10.1 Revision 1 -->
+    <metadata>
+      <title>Test for s390_64 Architecture</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Generic test for s390_64 architecture to be used by other tests</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Generic test for s390_64 architecture"
+      test_ref="test_system_info_architecture_s390_64" />
+    </criteria>
+  </definition>
+  <unix:uname_test check="all" comment="64 bit architecture"
+  id="test_system_info_architecture_s390_64" version="1">
+    <unix:object object_ref="object_system_info_architecture_s390_64" />
+    <unix:state state_ref="state_system_info_architecture_s390_64" />
+  </unix:uname_test>
+  <unix:uname_object comment="64 bit architecture"
+  id="object_system_info_architecture_s390_64" version="1" />
+  <unix:uname_state comment="64 bit architecture"
+  id="state_system_info_architecture_s390_64" version="1">
+    <unix:processor_type operation="equals">s390x</unix:processor_type>
+  </unix:uname_state>
+</def-group>


### PR DESCRIPTION
#### Description:

- s390x (IBM Z) is not recognized as a 64bit architecture, causing some rules to fail.

Without this patch:
~~~
Title   Record Attempts to Alter Time Through stime
Rule    xccdf_org.ssgproject.content_rule_audit_rules_time_stime
Ident   CCE-27299-7
Result  fail
~~~

With this patch:
~~~
Title   Record Attempts to Alter Time Through stime
Rule    xccdf_org.ssgproject.content_rule_audit_rules_time_stime
Ident   CCE-27299-7
Result  pass
~~~
There are likely other rules impacted by not having IBM Z systems detected as 64bit systems.
