### PR TITLE
Add noauto option to /boot in ANSSI kickstart files.

### DIFF
--- a/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
@@ -103,7 +103,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="noauto"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)

--- a/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -102,7 +102,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="noauto"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)


### PR DESCRIPTION
#### Description:

- Add noauto option to /boot in ANSSI kickstart files.

#### Rationale:

- ANSSI requires that this partition contains this property
