### PR TITLE
Add bootloader password to RHEL8 ANSSI kickstart file.

### DIFF
--- a/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -85,10 +85,11 @@ selinux --enforcing
 timezone --utc America/New_York
 
 # Specify how the bootloader should be installed (required)
+# Plaintext password is: password
 # Refer to e.g.
 #   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
 # to see how to create encrypted password form for different plaintext password
-bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none"
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
 
 # Initialize (format) all disks (optional)
 zerombr


### PR DESCRIPTION
#### Description:

- Add bootloader password to RHEL8 ANSSI kickstart file.

#### Rationale:

- Makes [grub2_password](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml) green
