### PR TITLE
Add the sudoers_no_command_negation rule - ANSSI R62

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+     <definition class="compliance" id="{{{ rule_id }}}" version="1">
+     {{{ oval_metadata("Check that sudoers doesn't contain command negations") }}}
+     <criteria operator="AND">
+	     <criterion comment="Make sure that no command in user spec contains negation" test_ref="test_{{{ rule_id }}}" />
+     </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="Make sure that no user spec in sudoers has a runas spec that includes root or ALL"
+	  id="test_{{{ rule_id }}}" version="1">
+  <ind:object object_ref="object_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_{{{ rule_id }}}" version="1">
+    <ind:filepath operation="pattern match">^/etc/sudoers(\.d/.*)?$</ind:filepath>
+    <!-- The regex idea: <user list> <host list> = (<the whole command without negation>,)* <command with negation> <whatever>
+         where a command is <runas spec>?<anything except , or !>+,
+           - ',' is a command delimiter, while
+           - '!' outside of a runas spec is a command negation we are after,
+         The capturing group holds the offending command.
+    -->
+    <ind:pattern operation="pattern match">^(?:\s*[^#][^=]+)=(?:\s*(\([^\)]+\))?\s*(?!\s*\()[^,!\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()([^,\n]*!\S+).*</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
@@ -7,7 +7,7 @@
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
-  comment="Make sure that no user spec in sudoers has a runas spec that includes root or ALL"
+  comment="Make sure that no command in user spec contains negation"
 	  id="test_{{{ rule_id }}}" version="1">
   <ind:object object_ref="object_{{{ rule_id }}}" />
   </ind:textfilecontent54_test>
@@ -18,9 +18,9 @@
          where a command is <runas spec>?<anything except , or !>+,
            - ',' is a command delimiter, while
            - '!' outside of a runas spec is a command negation we are after,
-         The capturing group holds the offending command.
+         The last non-capturing group holds the offending command.
     -->
-    <ind:pattern operation="pattern match">^(?:\s*[^#][^=]+)=(?:\s*(\([^\)]+\))?\s*(?!\s*\()[^,!\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()([^,\n]*!\S+).*</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:\s*[^#=]+)=(?:\s*(\([^\)]+\))?\s*(?!\s*\()[^,!\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()(?:[^,\n]*!\S+).*</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
@@ -20,7 +20,7 @@
            - '!' outside of a runas spec is a command negation we are after,
          The last non-capturing group holds the offending command.
     -->
-    <ind:pattern operation="pattern match">^(?:\s*[^#=]+)=(?:\s*(\([^\)]+\))?\s*(?!\s*\()[^,!\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()(?:[^,\n]*!\S+).*</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:\s*[^#=]+)=(?:\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,!\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()([^,\n]*!\S+).*</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/rule.yml
@@ -1,0 +1,39 @@
+documentation_complete: true
+
+title: "Don't define allowed commands in sudoers by means of exclusion"
+
+description: |-
+    Policies applied by sudo through the sudoers file should not involve negation.
+
+    Each user specification in the <code>sudoers</code> file contains a comma-delimited list of command specifications.
+    The definition can make use glob patterns, as well as of negations.
+    Indirect definition of those commands by means of exclusion of a set of commands is trivial to bypass, so it is not allowed to use such constructs.
+
+rationale: |-
+    Specifying access right using negation is inefficient and can be easily circumvented.
+    For example, it is expected that a specification like <pre>
+    # To avoid absolutely , this rule can be easily circumvented!
+    user ALL = ALL ,!/ bin/sh
+    </pre> prevents the execution of the shell
+    but that’s not the case: just copy the binary <code>/bin/sh</code> to a different name to make it executable
+    again through the rule keyword <code>ALL</code>.
+
+severity: medium
+
+references:
+    anssi: BP28(R61)
+
+ocil_clause: '/etc/sudoers file contains rules that define the set of allowed commands using negation'
+
+# A setp-by-step guide how to modify the configuration to achieve compliance
+ocil: |-
+    To determine if negation is used to define commands users are allowed to execute using <tt>sudo</tt>, run the following command:
+    <pre>$ sudo grep -PR '^(?\s*[^#][^=]+)=(?\s*(\([^\)]+\))?\s*[^,!\n]+,)*\s*(?\([^\)]+\))?\s*([^,\n]*!\S+).*' /etc/sudoers /etc/sudoers.d/</pre>
+    The command should return no output.
+
+platform: sudo
+
+warnings:
+  - general:
+      This rule doesn't come with a remediation, as negations indicate design issues with the sudoers user specifications design.
+      Just removing negations doesn't increase the security - you typically have to rethink the definition of allowed commands to fix the issue.

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/commented.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/commented.pass.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+
+echo '#jen !fred		ALL, !SERVERS = !/bin/sh' > /etc/sudoers
+echo '# somebody ALL=/bin/ls, (!bob alice) !/bin/cat, /bin/dog' > /etc/sudoers.d/foo

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/complex-1.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/complex-1.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'somebody ALL=/bin/ls, (!bob alice) !/bin/cat, /bin/dog' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/complex-2.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/complex-2.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'nobody ALL=/bin/ls, (!bob alice) /bin/dog, !/bin/cat' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/simple.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/simple.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'jen !fred		ALL, !SERVERS = !/bin/sh' > /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/simple.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/simple.pass.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# packages = sudo
+
+echo 'nobody ALL=/bin/ls, (!bob alice) /bin/dog, /bin/cat' > /etc/sudoers
+echo 'jen		ALL, !SERVERS = ALL' >> /etc/sudoers
+echo 'jen !fred		ALL, !SERVERS = /bin/sh' >> /etc/sudoers
+echo 'nobody ALL=/bin/ls, (bob !alice) /bin/dog, /bin/cat' > /etc/sudoers.d/foo

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/sudoers_d.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/sudoers_d.fail.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_all
+# packages = sudo
+# remediation = none
+
+echo 'nobody ALL=/bin/ls, (!bob alice) /bin/dog, /bin/cat' > /etc/sudoers
+echo 'jen		ALL, !SERVERS = ALL' >> /etc/sudoers
+echo 'jen !fred		ALL, !SERVERS = /bin/sh' >> /etc/sudoers
+echo 'nobody ALL=/bin/ls, (bob !alice) /bin/dog, /bin/cat' > /etc/sudoers.d/foo
+# Example from ANSSI R62
+echo 'user ALL = ALL ,!/bin/sh' > /etc/sudoers.d/bar


### PR DESCRIPTION
The rule makes sure that sudoers user specifications don't define commands using negations, which creates a false sense of security.

Again, remediations are questionable here - removing offending negations wouldn't fix any security issues, as the job to do in those cases is to redesign the user specification, or even to modify the system group layout,