### PR TITLE
configure_crypto_policy test scenario - ensure that both files have same timestamp

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
@@ -2,9 +2,11 @@
 # platform = Red Hat Enterprise Linux 8
 
 # IMPORTANT: This is a false negative scenario.
-# File /etc/crypto-policies/config can be newer than /etc/crypto-policies/state/current
-# but the difference can be in milliseconds and after rounding to seconds timestamps of
-# those files can be same, thus incompliant.
+# File /etc/crypto-policies/config can be newer than /etc/crypto-policies/state/current,
+# which should always be a finding.
+# But the difference can be in a couple of milliseconds, and timestamps of
+# those files rounded to seconds can be same, thus making the OVAL test pass, although the system is incompliant.
+# The scenario equalizes those timestamps, so the corresponding test always passes.
 # With a precision of seconds in OVAL, there is not really much we can do to detect this.
 update-crypto-policies --set "DEFAULT"
 touch -r /etc/crypto-policies/state/current /etc/crypto-policies/config

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
@@ -2,8 +2,9 @@
 # platform = Red Hat Enterprise Linux 8
 
 # IMPORTANT: This is a false negative scenario.
-# File /etc/crypto-policies/config is newer than /etc/crypto-policies/state/current, thus incompliant,
-# but the OVAL evaluation restuls in pass.
+# File /etc/crypto-policies/config can be newer than /etc/crypto-policies/state/current
+# but the difference can be in milliseconds and after rounding to seconds timestamps of
+# those files can be same, thus incompliant.
 # With a precision of seconds in OVAL, there is not really much we can do to detect this.
 update-crypto-policies --set "DEFAULT"
-touch /etc/crypto-policies/config
+touch -r /etc/crypto-policies/state/current /etc/crypto-policies/config


### PR DESCRIPTION
#### Description:
Improve the test scenario because in the past it was occasionally causing failures when the `/etc/crypto-policies/config` timestamp got rounded to second greater than the `/etc/crypto-policies/state/current` timestamp.
