### PR TITLE
Enable checks and remediations for the following SLES-12 STIGs:

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_user_known_hosts/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80372-6
     cce@rhel8: CCE-80902-0
+    cce@sle12: CCE-83056-2 
 
 references:
     stigid@ol7: OL07-00-040380

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -28,6 +28,7 @@ identifiers:
     cce@rhel7: CCE-27433-2
     cce@rhel8: CCE-80906-1
     cce@rhcos4: CCE-82549-7
+    cce@sle12: CCE-83027-3
 
 references:
     stigid@ol7: OL07-00-040320

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -24,6 +24,7 @@ identifiers:
     cce@rhel7: CCE-27082-7
     cce@rhel8: CCE-80907-9
     cce@rhcos4: CCE-82464-9
+    cce@sle12: CCE-83034-9
 
 references:
     stigid@ol7: OL07-00-040340

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12
 
 title: 'Set Password Hashing Algorithm in /etc/login.defs'
 
@@ -21,6 +21,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-82050-6
     cce@rhel8: CCE-80892-3
+    cce@sle12: CCE-83029-9
 
 references:
     stigid@ol7: OL07-00-010210
@@ -33,6 +34,7 @@ references:
     pcidss: Req-8.2.1
     srg: SRG-OS-000073-GPOS-00041
     stigid@rhel7: RHEL-07-010210
+    stigid@sle12: SLES-12-010210
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.4
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12
 
 title: 'Set Account Expiration Following Inactivity'
 
@@ -28,6 +28,7 @@ identifiers:
     cce@rhel7: CCE-27355-7
     cce@rhel8: CCE-80954-1
     cce@rhcos4: CCE-82695-8
+    cce@sle12: CCE-83051-3
 
 references:
     stigid@ol7: OL07-00-010310
@@ -40,6 +41,7 @@ references:
     srg: SRG-OS-000118-GPOS-00060
     vmmsrg: SRG-OS-000003-VMM-000030,SRG-OS-000118-VMM-000590
     stigid@rhel7: RHEL-07-010310
+    stigid@sle12: SLES-12-010340
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 6.2'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4
     cobit5: DSS01.03,DSS03.05,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhv4
+prodtype: fedora,rhel7,rhel8,rhv4,sle12
 
 title: 'Assign Expiration Date to Temporary Accounts'
 
@@ -30,6 +30,7 @@ severity: unknown
 identifiers:
     cce@rhel7: CCE-81000-2
     cce@rhel8: CCE-82474-8
+    cce@sle12: CCE-83043-0
 
 references:
     disa: CCI-000016,CCI-001682
@@ -42,6 +43,7 @@ references:
     cobit5: DSS01.03,DSS03.05,DSS05.04,DSS05.05,DSS05.07,DSS06.03
     iso27001-2013: A.12.4.1,A.12.4.3,A.6.1.2,A.7.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
+    stigid@sle12: SLES-12-010360
 
 ocil_clause: 'any temporary or emergency accounts have no expiration date set or do not expire within a documented time frame'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
@@ -27,6 +27,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-27051-2
     cce@rhel8: CCE-80647-1
+    cce@sle12: CCE-83050-5
 
 references:
     stigid@ol7: OL07-00-010250
@@ -39,6 +40,7 @@ references:
     pcidss: Req-8.2.4
     srg: SRG-OS-000076-GPOS-00044
     stigid@rhel7: RHEL-07-010250
+    stigid@sle12: SLES-12-010280
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.4
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
@@ -26,6 +26,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-82036-5
     cce@rhel8: CCE-80648-9
+    cce@sle12: CCE-83049-7
 
 references:
     stigid@ol7: OL07-00-010230
@@ -36,6 +37,7 @@ references:
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     srg: SRG-OS-000075-GPOS-00043
     stigid@rhel7: RHEL-07-010230
+    stigid@sle12: SLES-12-010270
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.4
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12
 
 title: 'Set Existing Passwords Maximum Age'
 
@@ -21,6 +21,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80522-6
     cce@rhel8: CCE-82473-0
+    cce@sle12: CCE-83041-4
 
 references:
     stigid@ol7: OL07-00-010260
@@ -29,6 +30,7 @@ references:
     srg: SRG-OS-000076-GPOS-00044
     vmmsrg: SRG-OS-000076-VMM-000430
     stigid@rhel7: RHEL-07-010260
+    stigid@sle12: SLES-12-010290
 
 ocil_clause: 'existing passwords are not configured correctly'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12
 
 title: 'Set Existing Passwords Minimum Age'
 
@@ -21,6 +21,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80521-8
     cce@rhel8: CCE-82472-2
+    cce@sle12: CCE-83042-2
 
 references:
     stigid@ol7: OL07-00-010240
@@ -29,6 +30,7 @@ references:
     srg: SRG-OS-000075-GPOS-00043
     vmmsrg: SRG-OS-000075-VMM000420
     stigid@rhel7: RHEL-07-010240
+    stigid@sle12: SLES-12-010260
 
 ocil_clause: 'existing passwords are not configured correctly'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/sle12.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/sle12.yml
@@ -1,0 +1,17 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+- name: Find files in /etc/pam.d/ with password auth
+  find:
+    paths: /etc/pam.d
+    contains: ".*pam_unix\\.so.*nullok.*"
+    recurse: yes
+  register: find_pam_conf_files_result
+
+- name: Prevent Log In to Accounts with Empty Password
+  replace:
+    dest: "{{ item.path }}"
+    regexp: nullok
+  with_items: "{{ find_pam_conf_files_result.files }}"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -9,7 +9,11 @@
     <ind:object object_ref="object_no_empty_passwords" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_empty_passwords" version="1">
+{{% if product == "sle12" %}}
+    <ind:filepath operation="pattern match">^/etc/pam.d/.*$</ind:filepath>
+{{% else %}}
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+{{% endif %}}
     <ind:pattern operation="pattern match">^[^#]*\bnullok\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -5,9 +5,14 @@ title: 'Prevent Login to Accounts With Empty Password'
 description: |-
     If an account is configured for password authentication
     but does not have an assigned password, it may be possible to log
-    into the account without authentication. Remove any instances of the <tt>nullok</tt>
-    option in <tt>/etc/pam.d/system-auth</tt> to
-    prevent logins with empty passwords.
+    into the account without authentication. Remove any instances of the
+    <tt>nullok</tt> in
+    {{% if product == 'sle12' %}}
+    password authentication configurations in <tt>/etc/pam.d/</tt>
+    {{% else %}}
+    <tt>/etc/pam.d/system-auth</tt>
+    {{% endif %}}
+    to prevent logins with empty passwords.
 
 rationale: |-
     If an account has an empty password, anyone could log in and
@@ -20,6 +25,7 @@ identifiers:
     cce@rhel7: CCE-27286-4
     cce@rhel8: CCE-80841-0
     cce@rhcos4: CCE-82553-9
+    cce@sle12: CCE-83039-8
 
 references:
     stigid@ol7: OL07-00-010290
@@ -33,6 +39,7 @@ references:
     pcidss: Req-8.2.3
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: RHEL-07-010290
+    stigid@sle12: SLES-12-010231
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 5.2'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4
     cobit5: APO01.06,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.02,DSS06.03,DSS06.10
@@ -43,7 +50,11 @@ ocil_clause: 'NULL passwords can be used'
 
 ocil: |-
     To verify that null passwords cannot be used, run the following command:
+    {{% if product == 'sle12' %}}
+    <pre>$ grep pam_unix.so /etc/pam.d/* | grep nullok</pre>
+    {{% else %}}
     <pre>$ grep nullok /etc/pam.d/system-auth</pre>
+    {{% endif %}}
     If this produces any output, it may be possible to log into accounts
     with empty passwords. Remove any instances of the <tt>nullok</tt> option to
     prevent logins with empty passwords.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,fedora
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019,fedora
 
 title: 'Ensure Home Directories are Created for New Users'
 
@@ -21,12 +21,14 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80434-4
     cce@rhel8: CCE-83789-8
+    cce@sle12: CCE-83053-9
 
 references:
     stigid@ol7: OL07-00-020610
     disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel7: RHEL-07-020610
+    stigid@sle12: SLES-12-010720
 
 ocil_clause: 'the value of CREATE_HOME is not set to yes, is missing, or the line is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/rule.yml
@@ -17,6 +17,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80205-8
     cce@rhel8: CCE-82888-9
+    cce@sle12: CCE-83052-1
 
 references:
     stigid@ol7: OL07-00-020240
@@ -25,6 +26,7 @@ references:
     nist-csf: PR.IP-1,PR.IP-2
     srg: SRG-OS-000480-GPOS-00228
     stigid@rhel7: RHEL-07-020240
+    stigid@sle12: SLES-12-010620
     isa-62443-2013: 'SR 7.6'
     isa-62443-2009: 4.3.4.3.2,4.3.4.3.3
     cobit5: APO13.01,BAI03.01,BAI03.02,BAI03.03,BAI10.01,BAI10.02,BAI10.03,BAI10.05

--- a/linux_os/guide/system/auditing/package_audit-audispd-plugins_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audit-audispd-plugins_installed/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+title: 'Ensure the default plugins for the audit dispatcher are Installed'
+
+description: 'The audit-audispd-plugins package should be installed.'
+
+rationale: 'Information stored in one location is vulnerable to accidental or incidental deletion or alteration. Off-loading is a common process in information systems with limited audit storage capacity.'
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83033-1
+
+ocil_clause: 'the package is not installed'
+
+references:
+    stigid@sle12: SLES-12-020070
+    srg@sle12: SRG-OS-000342-GPOS-00133
+    disa@sle12: CCI-001851
+    nist@sle12: AU-4(1)
+
+template:
+    name: package_installed
+    vars:
+        pkgname: audit-audispd-plugins

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
 
 title: 'Set Boot Loader Password in grub2'
 
@@ -10,8 +10,22 @@ description: |-
     <br /><br />
     Since plaintext passwords are a security risk, generate a hash for the password
     by running the following command:
+    {{% if product == "sle12" %}}
+    <pre>$ grub2-mkpasswd-pbkdf2</pre>
+    {{% else %}}
     <pre>$ grub2-setpassword</pre>
+    {{% endif %}}
     When prompted, enter the password that was selected.
+    <br /><br />
+    {{% if product == "sle12" %}}
+    Using the hash from the output, modify the <tt>/etc/grub.d/40_custom</tt>
+    file with the following content:
+    <pre>set superusers="boot"
+    password_pbkdf2 boot grub.pbkdf2.sha512.VeryLongString
+    </pre>
+    NOTE: the bootloader superuser account and password MUST differ from the
+    root account and password.
+    {{% endif %}}
     <br /><br />
     Once the superuser password has been added,
     update the
@@ -29,6 +43,7 @@ severity: high
 identifiers:
     cce@rhel7: CCE-27309-4
     cce@rhel8: CCE-80828-7
+    cce@sle12: CCE-83044-8
 
 references:
     cis@rhel8: 1.5.2
@@ -41,6 +56,7 @@ references:
     ospp: FIA_UAU.1
     srg: SRG-OS-000080-GPOS-00048
     stigid@rhel7: RHEL-07-010482
+    stigid@sle12: SLES-12-010430
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4
     cobit5: DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.06,DSS06.10
@@ -53,17 +69,28 @@ ocil_clause: 'it does not'
 ocil: |-
     To verify the boot loader superuser password has been set, run the following
     command:
+    {{% if product == "sle12" %}}
+    <pre>sudo grep "boot" /boot/grub2/grub.cfg</pre>
+    {{% else %}} 
     <pre>sudo grep "superusers" /etc/grub2.cfg</pre>
+    {{% endif %}}
     The output should show the following:
     <pre>password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
     To verify the boot loader superuser account password has been set,
     and the password encrypted, run the following command:
+    {{% if product == "sle12" %}}
+    <pre>sudo cat /etc/grub.d/40_custom</pre>
+    The output should be similar to:
+    <pre>set superusers="boot"
+    password_pbkdf2 boot grub.pbkdf2.sha512.10000.5DE5DF6E01A52E17A8C2FEDF585A3916B345F654C9D19C9ECD0BC958DF8C8A5E1AB15862D9C0B6DCE1F3209D8E8B46101DB3AE7146BB9D7D6C1D379E1854AF9E.CD75F981FE5223C583FB7887544C3A4C96431B5C089801D26855B93A1CB0BC0A508D189F1799A1CC40036B069C36EAD51DAE6A2EE6C0732353B2B5B4F5C49088</pre>
+    {{% else %}}
     <pre>sudo cat /boot/grub2/user.cfg</pre>
     The output should be similar to:
     <pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
     2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
     916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
     0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828</pre>
+    {{% endif %}}
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12
 
 title: 'Set the UEFI Boot Loader Password'
 
@@ -10,13 +10,30 @@ description: |-
     <br /><br />
     Since plaintext passwords are a security risk, generate a hash for the password
     by running the following command:
+    {{% if product == "sle12" %}}
+    <pre>$ grub2-mkpasswd-pbkdf2</pre>
+    {{% else %}}
     <pre>$ grub2-setpassword</pre>
+    {{% endif %}}
     When prompted, enter the password that was selected.
     <br /><br />
+    {{% if product == "sle12" %}}
+    Using the hash from the output, modify the <tt>/etc/grub.d/40_custom</tt>
+    file with the following content:
+    <pre>set superusers="boot"
+    password_pbkdf2 boot grub.pbkdf2.sha512.VeryLongString
+    </pre>
+    NOTE: the bootloader superuser account and password MUST differ from the
+    root account and password.
+    {{% endif %}}
     Once the superuser password has been added,
     update the
     <tt>grub.cfg</tt> file by running:
+    {{% if product == "sle12" %}}
+    <pre>grub2-mkconfig -o /boot/efi/EFI/sles/grub.cfg</pre>
+    {{% else %}}
     <pre>grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre>
+    {{% endif %}}
 
 rationale: |-
     Password protection on the boot loader configuration ensures
@@ -30,6 +47,7 @@ identifiers:
     cce@rhel7: CCE-80354-4
     cce@rhel8: CCE-80829-5
     cce@rhcos4: CCE-82552-1
+    cce@sle12: CCE-83045-5
 
 references:
     stigid@ol7: OL07-00-010490
@@ -42,6 +60,7 @@ references:
     ospp: FIA_UAU.1
     srg: SRG-OS-000080-GPOS-00048
     stigid@rhel7: RHEL-07-010491
+    stigid@sle12: SLES-12-010440
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4
     cobit5: DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.03,DSS06.06
@@ -54,17 +73,30 @@ ocil_clause: 'it does not'
 ocil: |-
     To verify the boot loader superuser password has been set, run the following
     command:
+    {{% if product == "sle12" %}}
+    <pre>sudo grep -A1 "superusers\|password" /etc/grub.d/40_custom</pre>
+    {{% else %}}
     <pre>sudo grep "password" /etc/grub2-efi.cfg</pre>
+    {{% endif %}}
     The output should show the following:
     <pre>password_pbkdf2 <b>superusers-account</b> <b>${GRUB2_PASSWORD}</b></pre>
     To verify the boot loader superuser account password has been set,
     and the password encrypted, run the following command:
+    {{% if product == "sle12" %}}
+    <pre>sudo cat /boot/efi/EFI/sles/grub.cfg</pre>
+    The output should be similar to:
+    <pre>password_pbkdf2 superuser grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
+    2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
+    916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
+    0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828</pre>
+    {{% else %}}
     <pre>sudo cat /boot/efi/EFI/redhat/user.cfg</pre>
     The output should be similar to:
     <pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
     2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
     916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
     0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828</pre>
+    {{% endif %}}
 
 warnings:
     - general: |-

--- a/shared/checks/oval/installed_env_has_grub2_package.xml
+++ b/shared/checks/oval/installed_env_has_grub2_package.xml
@@ -31,7 +31,7 @@
     <linux:object object_ref="obj_env_has_grub2_installed" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_env_has_grub2_installed" version="1">
-    <linux:name>grub2-common</linux:name>
+    <linux:name>{{% if product == "sle12" %}}grub2{{% else %}}grub2-common{{% endif %}}</linux:name>
   </linux:rpminfo_object>
 {{% elif pkg_system == "dpkg" %}}
   <linux:dpkginfo_test check="all" check_existence="all_exist"

--- a/sle12/product.yml
+++ b/sle12/product.yml
@@ -25,3 +25,4 @@ cpes:
 
 platform_package_overrides:
   login_defs: "shadow"
+  grub2: "grub2"

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -8,24 +8,38 @@ description: |-
 
 selections:
     - var_accounts_fail_delay=4
-    - installed_OS_is_vendor_supported
-    - security_patches_up_to_date
-    - sudo_remove_nopasswd
-    - sudo_remove_no_authenticate
-    - sshd_disable_empty_passwords
-    - sshd_do_not_permit_user_env
-    - gnome_gdm_disable_automatic_login
-    - disable_ctrlaltdel_reboot
-    - sshd_enable_x11_forwarding
-    - no_user_host_based_files
-    - auditd_data_disk_full_action
-    - postfix_client_configure_mail_alias
-    - accounts_logon_fail_delay 
-    - no_host_based_files
-    - banner_etc_motd
+    - account_disable_post_pw_expiration
+    - account_temp_expire_date
+    - accounts_have_homedir_login_defs
+    - accounts_logon_fail_delay
+    - accounts_maximum_age_login_defs
     - accounts_no_uid_except_zero
-    - no_user_host_based_files
-    - no_user_host_based_files
-    - package_audit_installed
-    - service_auditd_enabled
+    - accounts_password_set_max_life_existing
+    - accounts_password_set_min_life_existing
+    - accounts_umask_etc_login_defs
+    - auditd_data_disk_full_action
+    - auditd_data_retention_action_mail_acct
     - auditd_data_retention_space_left
+    - banner_etc_motd
+    - disable_ctrlaltdel_reboot
+    - gnome_gdm_disable_automatic_login
+    - grub2_password
+    - grub2_uefi_password
+    - installed_OS_is_vendor_supported
+    - no_empty_passwords
+    - no_host_based_files
+    - no_user_host_based_files
+    - package_audit-audispd-plugins_installed
+    - package_audit_installed
+    - postfix_client_configure_mail_alias
+    - security_patches_up_to_date
+    - service_auditd_enabled
+    - set_password_hashing_algorithm_logindefs
+    - sshd_disable_empty_passwords
+    - sshd_disable_user_known_hosts
+    - sshd_do_not_permit_user_env
+    - sshd_enable_x11_forwarding
+    - sshd_set_idle_timeout
+    - sshd_set_keepalive
+    - sudo_remove_no_authenticate
+    - sudo_remove_nopasswd


### PR DESCRIPTION
- SLES-12-010210 'set_password_hashing_algorithm_logindefs'
- SLES-12-010231 'no_empty_passwords'
- SLES-12-010260 'accounts_password_set_min_life_existing'
- SLES-12-010270 'accounts_minimum_age_login_defs'
- SLES-12-010280 'accounts_maximum_age_login_defs'
- SLES-12-010290 'accounts_password_set_max_life_existing'
- SLES-12-010340 'account_disable_post_pw_expiration'
- SLES-12-010360 'account_temp_expire_date'
- SLES-12-010430 'grub2_password'
- SLES-12-010440 'grub2_uefi_password'
- SLES-12-010620 'accounts_umask_etc_login_defs'
- SLES-12-010720 'accounts_have_homedir_login_defs'
- SLES-12-020070 'package_audit-audispd-plugins_installed'
- SLES-12-030190 'ssh_server/sshd_set_idle_timeout'
- SLES-12-030191 'sshd_set_keepalive'
- SLES-12-030200 'sshd_disable_user_known_hosts'
