### PR TITLE
Dconf fixes

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/login-screen/banner-message-enable'
     line: '/org/gnome/login-screen/banner-message-enable'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
@@ -43,3 +43,6 @@
     line: '/org/gnome/login-screen/banner-message-text'
     create: yes
     state: present
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/login-screen/disable-restart-buttons'
     line: '/org/gnome/login-screen/disable-restart-buttons'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/login-screen/disable-user-list'
     line: '/org/gnome/login-screen/disable-user-list'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
@@ -9,6 +9,7 @@
     section: org/gnome/login-screen
     option: disable-user-list
     value: "true"
+    no_extra_spaces: yes
     create: yes
 
 - name: "Prevent user modification of GNOME3 disablement of Login User List"

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/login-screen/enable-smartcard-authentication'
     line: '/org/gnome/login-screen/enable-smartcard-authentication'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/login-screen/allowed-failures'
     line: '/org/gnome/login-screen/allowed-failures'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/media-handling/automount'
     line: '/org/gnome/desktop/media-handling/automount'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/media-handling/automount-open'
     line: '/org/gnome/desktop/media-handling/automount-open'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
@@ -19,3 +19,5 @@
     line: '/org/gnome/desktop/media-handling/autorun-never'
     create: yes
 
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/thumbnailers/disable-all'
     line: '/org/gnome/desktop/thumbnailers/disable-all'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/nm-applet/disable-wifi-create'
     line: '/org/gnome/nm-applet/disable-wifi-create'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/nm-applet/suppress-wireless-networks-available'
     line: '/org/gnome/nm-applet/suppress-wireless-networks-available'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/Vino/authentication-methods'
     line: '/org/gnome/Vino/authentication-methods'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/Vino/require-encryption'
     line: '/org/gnome/Vino/require-encryption'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
@@ -9,3 +9,6 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -20,3 +20,6 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-delay'
     line: '/org/gnome/desktop/screensaver/idle-delay'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-delay'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
@@ -9,3 +9,6 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/screensaver/picture-uri'
     line: '/org/gnome/desktop/screensaver/picture-uri'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     line: '/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
@@ -9,3 +9,6 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-delay'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
@@ -10,3 +10,6 @@
     regexp: '^/org/gnome/desktop/session/idle-delay'
     line: '/org/gnome/desktop/session/idle-delay'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/settings-daemon/plugins/media-keys/logout'
     line: '/org/gnome/settings-daemon/plugins/media-keys/logout'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
@@ -33,3 +33,6 @@
     regexp: '^/org/gnome/clocks/geolocation'
     line: '/org/gnome/clocks/geolocation'
     create: yes
+
+- name: Dconf Update
+  command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/ansible/shared.yml
@@ -18,3 +18,6 @@
     regexp: '^/org/gnome/desktop/lockdown/user-administration-disabled'
     line: '/org/gnome/desktop/lockdown/user-administration-disabled'
     create: yes
+
+- name: Dconf Update
+  command: dconf update


### PR DESCRIPTION
#### Description:

- ac49ea6 fixes the problem with spaces in remediation because the OVAL as the way it is doesn't support spaces between `=`
- Also add `dconf update` to ansible remediation similarly to what `bash` remediation does.

#### Additional information

These gdm configurations should really become a template. There is a draft PR #6118 to implement the template, I should get back to it soon.
