### PR TITLE
Fix jinja expansion on installed_OS_is_vendor_supported

### DIFF
--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
@@ -9,7 +9,7 @@ description: |-
 {{% if product in ["ol7", "ol8"] %}}
     Oracle Linux is supported by Oracle Corporation. As the Oracle
     Linux vendor, Oracle Corporation is responsible for providing security patches.
-{{% elif product == "sle12", "sle15" %}}
+{{% elif product in ["sle12", "sle15"] %}}
     SUSE Linux Enterprise is supported by SUSE. As the SUSE Linux Enterprise
     vendor, SUSE is responsible for providing security patches.
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Fix Jinja Expansion.

#### Rationale:

- Condition was always returning true and `SUSE` was getting into every product than `ol7` and `ol8` in this case.
