### PR TITLE
remove accounts_passwords_pam_faillock_enforce_local from rhel8 stig

### DIFF
--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -45,7 +45,6 @@ selections:
     - package_audispd-plugins_installed
     - package_libcap-ng-utils_installed
     - auditd_audispd_syslog_plugin_activated
-    - accounts_passwords_pam_faillock_enforce_local
     - accounts_password_pam_enforce_local
     - accounts_password_pam_enforce_root
 

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -41,7 +41,6 @@ selections:
 - accounts_password_set_max_life_existing
 - accounts_password_set_min_life_existing
 - accounts_passwords_pam_faillock_deny
-- accounts_passwords_pam_faillock_enforce_local
 - accounts_passwords_pam_faillock_interval
 - accounts_passwords_pam_faillock_unlock_time
 - accounts_umask_etc_bashrc


### PR DESCRIPTION
#### Description:

- remove the rule from profile and from data for stable profile test

#### Rationale:

- The rhel8 STIG does not include such requirement