### PR TITLE
fix selinux_policytype oval regex

### DIFF
--- a/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_policytype/oval/shared.xml
@@ -23,7 +23,7 @@
 
   <ind:textfilecontent54_object id="obj_selinux_policy" version="1">
     <ind:filepath>/etc/selinux/config</ind:filepath>
-    <ind:pattern operation="pattern match">^SELINUXTYPE=(.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^SELINUXTYPE=([\w]*)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/selinux/selinux_policytype/tests/selinuxtype_targeted_additional_spaces.pass.sh
+++ b/linux_os/guide/system/selinux/selinux_policytype/tests/selinuxtype_targeted_additional_spaces.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_ospp
+
+SELINUX_FILE='/etc/selinux/config'
+
+if grep -s '^[[:space:]]*SELINUXTYPE' $SELINUX_FILE; then
+	sed -i 's/^\([[:space:]]*SELINUXTYPE[[:space:]]*=[[:space:]]*\).*/\1targeted   /' $SELINUX_FILE
+else
+	echo 'SELINUXTYPE=targeted   ' >> $SELINUX_FILE
+fi


### PR DESCRIPTION
#### Description:

- relax the oval to allow space characters after the policy name
- add test for this case

#### Rationale:

The rule was too strict.