### PR TITLE
sshd_set_keepalive PCI DSS requirement reference

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -37,6 +37,7 @@ references:
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
     nist: AC-2(5),AC-12,AC-17(a),SC-10,CM-6(a)
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-2
+    pcidss: Req-8.1.8
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
     vmmsrg: SRG-OS-000480-VMM-002000
     stigid@rhel7: RHEL-07-040340


### PR DESCRIPTION
#### Description:
Add `sshd_set_keepalive` same PCI DSS requirement reference as [sshd_set_idle_timeout](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml#L44) has.
8.1.8 requirement:
> If  a session has been idle for more than 15 minutes, require the user to re-authenticate to re-activate the terminal or session

Because the `sshd_set_keepalive` rule already was in the PCI DSS profile, the missing reference caused that the rule was not properly categorized, see

Before
![wrong-pcidss](https://user-images.githubusercontent.com/18598137/104445355-50ddc300-5599-11eb-8214-4e8c838b48e2.png)

After
![correct-pcidss](https://user-images.githubusercontent.com/18598137/104443004-20e0f080-5596-11eb-821b-0778f2fe8d4e.png)


Side effect - both rules start to pass during profile remediation because this corrects their ordering - first remediate `sshd_set_keepalive`, then `sshd_set_idle_timeout`.

#### Rationale:
As [sshd_set_idle_timeout description](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml#L68) mentions, the rule does not have desired effect without configuring `ClientAliveCountMax` (configured by `sshd_set_keepalive`). Thus, if `sshd_set_idle_timeout` belongs to the requirement, `sshd_set_keepalive` also has to. 
