### PR TITLE
Render policy to HTML

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -995,6 +995,7 @@ class Rule(object):
         "platform": lambda: None,
         "inherited_platforms": lambda: list(),
         "template": lambda: None,
+        "definition_location": lambda: None,
     }
 
     def __init__(self, id_):
@@ -1002,6 +1003,7 @@ class Rule(object):
         self.prodtype = "all"
         self.title = ""
         self.description = ""
+        self.definition_location = ""
         self.rationale = ""
         self.severity = "unknown"
         self.references = {}
@@ -1044,6 +1046,9 @@ class Rule(object):
         if yaml_contents:
             raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
                                % (yaml_file, yaml_contents))
+
+        if not rule.definition_location:
+            rule.definition_location = yaml_file
 
         rule.validate_prodtype(yaml_file)
         rule.validate_identifiers(yaml_file)

--- a/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
@@ -1,4 +1,5 @@
 policy: ABCD Benchmark for securing Linux systems with levels
+title: ABCD Benchmark for securing Linux systems with levels
 id: abcd-levels
 version: 1.2.3
 source: https://www.abcd.com/linux.pdf

--- a/tests/unit/ssg-module/data/controls_dir/abcd.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd.yml
@@ -1,4 +1,5 @@
 policy: ABCD Benchmark for securing Linux systems
+title: ABCD Benchmark for securing Linux systems
 id: abcd
 version: 1.2.3
 source: https://www.abcd.com/linux.pdf

--- a/utils/controls-template.html
+++ b/utils/controls-template.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-<style type="text/css">
+  <meta charset="UTF-8">
+  <title>Definition of {{{ policy.title }}} for {{{ full_name }}}</title>
+<style>
 </style>
 </head>
 <body>
@@ -19,7 +21,6 @@ based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
   <p>Description: {{{ control.description | safe }}}</p>
   <p>Level: {{{ control.level }}}</p>
   <p>Automated: {{{ control.automated }}}</p>
-  <p>
   {{% if control.rules -%}}
   Selections:
   <ul>
@@ -32,9 +33,10 @@ based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
     {{%- endfor %}}
   </ul>
   {{% else -%}}
+  <p>
   <strong>No rules selected</strong>
-  {{%- endif %}}
   </p>
+  {{%- endif %}}
 </div>  
 {{% endfor -%}}
 </div>  

--- a/utils/controls-template.html
+++ b/utils/controls-template.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style type="text/css">
+</style>
+</head>
+<body>
+
+<h1>Definition of {{{ policy.title }}} for {{{ full_name }}}</h1>
+
+{{% if policy.source %}}
+based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
+{{% endif %}}
+
+<div class="all_controls">
+{{% for control in policy.controls -%}}
+<div class="one_control">
+  <h2>{{{ control.id }}}: {{{ control.title }}}</h2>
+  <p>Description: {{{ control.description | safe }}}</p>
+  <p>Level: {{{ control.level }}}</p>
+  <p>Automated: {{{ control.automated }}}</p>
+  <p>
+  {{% if control.rules %}}
+  Selections:
+  <ul>
+    {{% for rulid in control.rules -%}}
+    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[rulid].relative_definition_location }}}">{{{ rulid }}}</a>: {{{ rules[rulid].title }}}</li>
+    {{% endfor -%}}
+  </ul>
+  {{% else %}}
+  <strong>No rules selected</strong>
+  {{% endif %}}
+  </p>
+</div>  
+{{% endfor -%}}
+</div>  
+
+</body>
+</html>

--- a/utils/controls-template.html
+++ b/utils/controls-template.html
@@ -20,16 +20,20 @@ based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
   <p>Level: {{{ control.level }}}</p>
   <p>Automated: {{{ control.automated }}}</p>
   <p>
-  {{% if control.rules %}}
+  {{% if control.rules -%}}
   Selections:
   <ul>
-    {{% for rulid in control.rules -%}}
-    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[rulid].relative_definition_location }}}">{{{ rulid }}}</a>: {{{ rules[rulid].title }}}</li>
-    {{% endfor -%}}
+    {{%- for rule_id in control.rules -%}}
+    {{%- if rule_id in rules %}}
+    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[rule_id].relative_definition_location }}}">{{{ rule_id }}}</a>: {{{ rules[rule_id].title }}}</li>
+    {{%- else %}}
+    <li>{{{ rule_id }}} - not available for this product</li>
+    {{%- endif -%}}
+    {{%- endfor %}}
   </ul>
-  {{% else %}}
+  {{% else -%}}
   <strong>No rules selected</strong>
-  {{% endif %}}
+  {{%- endif %}}
   </p>
 </div>  
 {{% endfor -%}}

--- a/utils/gen_tables.py
+++ b/utils/gen_tables.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 from glob import glob
 import collections
 import os

--- a/utils/render-policy.py
+++ b/utils/render-policy.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+
+from glob import glob
+import collections
+import os
+import pathlib
+
+import argparse
+
+import ssg.build_yaml
+import ssg.controls
+import ssg.yaml
+import ssg.jinja
+
+
+class HtmlOutput(object):
+    def __init__(self, product, build_dir, policy_file):
+        self.project_directory = pathlib.Path(os.path.dirname(__file__)).parent
+
+        self.env_yaml = self.get_env_yaml(product, build_dir)
+
+        policy = ssg.controls.Policy(policy_file, self.env_yaml)
+        policy.load()
+        self.policy = policy
+
+        self.product = product
+        self.rules_dict = self.get_rules_with_metadata(product, build_dir)
+
+    def get_rules_with_metadata(self, product, build_dir):
+        compiled_rules = "{build_dir}/{product}/rules".format(build_dir=build_dir, product=product)
+        rule_files = glob("{compiled_rules}/*".format(compiled_rules=compiled_rules))
+        if not rule_files:
+            msg = (
+                "No files found in '{compiled_rules}', please make sure that "
+                "you select the build dir correctly and that the appropriate product is built."
+                .format(compiled_rules=compiled_rules)
+            )
+            raise ValueError(msg)
+        rules_dict = dict()
+
+        for r_file in rule_files:
+            rule = ssg.build_yaml.Rule.from_yaml(r_file, self.env_yaml)
+            rule.relative_definition_location = (
+                pathlib.PurePath(rule.definition_location)
+                .relative_to(self.project_directory))
+            rules_dict[rule.id_] = rule
+        return rules_dict
+
+    def get_env_yaml(self, product, build_dir):
+        product_yaml = self.project_directory / product / "product.yml"
+        build_config_yaml = pathlib.Path(build_dir) / "build_config.yml"
+        if not (product_yaml.exists() and build_config_yaml.exists()):
+            msg = (
+                "No product yaml and/or build config found in "
+                "'{product_yaml}' and/or '{build_config_yaml}', respectively, please make sure "
+                "that you got the product right, and that it is built."
+                .format(product_yaml=product_yaml, build_config_yaml=build_config_yaml)
+            )
+            raise ValueError(msg)
+        env_yaml = ssg.yaml.open_environment(build_config_yaml, product_yaml)
+        return env_yaml
+
+    def get_result(self):
+        subst_dict = dict(rules=self.rules_dict, product=self.product, policy=self.policy)
+        subst_dict.update(self.env_yaml)
+        html_jinja_template = os.path.join(os.path.dirname(__file__), "controls-template.html")
+        return ssg.jinja.process_file(html_jinja_template, subst_dict)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate reference-rule mapping.")
+    parser.add_argument("policy", help="The policy YAML")
+    parser.add_argument("product", help="What product to consider")
+    parser.add_argument("--build-dir", default="build", help="Path to the build directory")
+    parser.add_argument("--output", help="The filename to generate")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    result = HtmlOutput(args.product, args.build_dir, args.policy).get_result()
+    if not args.output:
+        print(result)
+    else:
+        with open(args.output, "w") as outfile:
+            outfile.write(result)

--- a/utils/render-policy.py
+++ b/utils/render-policy.py
@@ -71,7 +71,7 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Render a policy file typically located in 'controls' directory "
         "of the project to HTML in a context of a product. "
-        "The product must be built")
+        "The product must be built.")
     parser.add_argument(
         "policy", metavar="FILENAME", help="The policy YAML file")
     parser.add_argument(

--- a/utils/render-policy.py
+++ b/utils/render-policy.py
@@ -15,7 +15,7 @@ import ssg.jinja
 
 class HtmlOutput(object):
     def __init__(self, product, build_dir, policy_file):
-        self.project_directory = pathlib.Path(os.path.dirname(__file__)).parent
+        self.project_directory = pathlib.Path(os.path.dirname(__file__)).parent.resolve()
 
         self.env_yaml = self.get_env_yaml(product, build_dir)
 
@@ -68,9 +68,15 @@ class HtmlOutput(object):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Generate reference-rule mapping.")
-    parser.add_argument("policy", help="The policy YAML")
-    parser.add_argument("product", help="What product to consider")
+    parser = argparse.ArgumentParser(
+        description="Render a policy file typically located in 'controls' directory "
+        "of the project to HTML in a context of a product. "
+        "The product must be built")
+    parser.add_argument(
+        "policy", metavar="FILENAME", help="The policy YAML file")
+    parser.add_argument(
+        "product", metavar="PRODTYPE",
+        help="Product that provides context to the policy. It must already be built")
     parser.add_argument("--build-dir", default="build", help="Path to the build directory")
     parser.add_argument("--output", help="The filename to generate")
     return parser.parse_args()


### PR DESCRIPTION
This PR adds a capability to render a policy definition into HTML in a context of some product.

In order to accomplish this, the build system needed to be extended a bit:

- Rule records definition_location, which points to the actual rule file in the source tree - this is used to be able to deduce a Github URL from a compiled rule file.
- Security Policy now records `title` and `source`.
- Security Policy now records a list of controls under `controls`.
  Formerly, that attribute recorded mapping of control ID to controls, and has been moved to `controls_by_id`.
- Security Control constructor initializes `title`, `description`, and `automated`.