### PR TITLE
Improved regex and tests

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/oval/shared.xml
@@ -17,10 +17,10 @@
     <!-- The regex idea: <user list> <host list> = (<the whole command without negation>,)* <command with negation> <whatever>
          where a command is <runas spec>?<anything except , or !>+,
            - ',' is a command delimiter, while
-           - '!' outside of a runas spec is a command negation we are after,
+           - '!' as the leading character outside of a runas spec is a command negation we are after,
          The last non-capturing group holds the offending command.
     -->
-    <ind:pattern operation="pattern match">^(?:\s*[^#=]+)=(?:\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,!\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()([^,\n]*!\S+).*</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:\s*[^#=]+)=(?:\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,!\n][^,\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()(!\S+).*</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/rule.yml
@@ -32,7 +32,7 @@ ocil_clause: '/etc/sudoers file contains rules that define the set of allowed co
 # A setp-by-step guide how to modify the configuration to achieve compliance
 ocil: |-
     To determine if negation is used to define commands users are allowed to execute using <tt>sudo</tt>, run the following command:
-    <pre>$ sudo grep -PR '^(?\s*[^#][^=]+)=(?\s*(\([^\)]+\))?\s*[^,!\n]+,)*\s*(?\([^\)]+\))?\s*([^,\n]*!\S+).*' /etc/sudoers /etc/sudoers.d/</pre>
+    <pre>$ sudo grep -PR '^(?:\s*[^#=]+)=(?:\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,!\n][^,\n]+,)*\s*(?:\([^\)]+\))?\s*(?!\s*\()(!\S+).*' /etc/sudoers /etc/sudoers.d/</pre>
     The command should return no output.
 
 platform: sudo

--- a/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/simple.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_no_command_negation/tests/simple.pass.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_all
 # packages = sudo
 
-echo 'nobody ALL=/bin/ls, (!bob alice) /bin/dog, /bin/cat' > /etc/sudoers
+echo 'nobody ALL=/bin/ls, (!bob alice) /bin/dog !arg, /bin/cat' > /etc/sudoers
 echo 'jen		ALL, !SERVERS = ALL' >> /etc/sudoers
 echo 'jen !fred		ALL, !SERVERS = /bin/sh' >> /etc/sudoers
-echo 'nobody ALL=/bin/ls, (bob !alice) /bin/dog, /bin/cat' > /etc/sudoers.d/foo
+echo 'nobody ALL=/bin/ls, (bob !alice) /bin/dog, /bin/cat !arg' > /etc/sudoers.d/foo


### PR DESCRIPTION
Negated commands start with an exclamation mark. As `!` may be present in the command's allowed argument, the regexp has to reflect that.

The exclamation mark in command argument doesn't lead to false positives any more - without the change, the modified test scenario would end up as a positive finding.

Complements #6498 