### PR TITLE
RHEL-07-040710 now configures X11Forwarding to disable

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/rule.yml
@@ -19,22 +19,23 @@ rationale: |-
     other users on the X11 server. Note that even if X11 forwarding is disabled,
     users can always install their own forwarders.
 
-severity: low
+severity: medium
 
-ocil_clause: "that the X11Forwarding option exists and is enabled"
-
-ocil: |-
-    {{{ ocil_sshd_option(default="no", option="X11Forwarding", value="no") }}}
+{{{ complete_ocil_entry_sshd_option(default="yes", option="X11Forwarding", value="no") }}}
 
 identifiers:
     cce@rhel7: CCE-83359-0
     cce@rhel8: CCE-83360-8
 
 references:
-  cis@rhel7: 5.2.4
-  cis@rhel8: 5.2.6
-  cis@sle12: 5.2.4
-  cis@sle15: 5.2.6
+    cis@rhel7: 5.2.4
+    cis@rhel8: 5.2.6
+    cis@sle12: 5.2.4
+    cis@sle15: 5.2.6
+    stigid@rhel7: RHEL-07-040710
+    srg: SRG-OS-000480-GPOS-00227
+    disa: CCI-000366
+    nist: CM-6(b)
 
 template:
     name: sshd_lineinfile

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_x11_forwarding/rule.yml
@@ -29,7 +29,6 @@ references:
     nist: CM-6(a),AC-17(a),AC-17(2)
     nist-csf: DE.AE-1,PR.DS-7,PR.IP-1
     srg: SRG-OS-000480-GPOS-00227
-    stigid@rhel7: RHEL-07-040710
     stigid@sle12: SLES-12-030260
     isa-62443-2013: 'SR 7.6'
     isa-62443-2009: 4.3.4.3.2,4.3.4.3.3,4.4.3.3

--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -285,7 +285,7 @@ selections:
     - postfix_prevent_unrestricted_relay
     - package_vsftpd_removed
     - package_tftp-server_removed
-    - sshd_enable_x11_forwarding
+    - sshd_disable_x11_forwarding
     - sshd_x11_use_localhost
     - tftpd_uses_secure_mode
     - package_xorg-x11-server-common_removed


### PR DESCRIPTION
#### Description:

- RHEL-07-040710 now configures X11Forwarding to disable.

#### Rationale:

- Change from the upcoming version of RHEL7 STIG
- Severity has been changed to `medium`. Previously when the setting was to enable it was `high`
