### PR TITLE
Disable unique-stigids test.

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1265,12 +1265,14 @@ macro(ssg_define_guide_and_table_tests)
             NAME "unique-cces"
             COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/assert_reference_unique.sh" "cce"
         )
-        add_test(
-            NAME "unique-stigids"
-            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/assert_reference_unique.sh" "stigid"
-        )
+        # Disable unique-stigids temporarily since it breaks many jobs. There are multiple duplicates
+        # of STIG IDs and they should be fixed by DISA first.
+        # add_test(
+        #     NAME "unique-stigids"
+        #     COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/assert_reference_unique.sh" "stigid"
+        # )
         set_tests_properties("unique-cces" PROPERTIES LABELS quick)
-        set_tests_properties("unique-stigids" PROPERTIES LABELS quick)
+        # set_tests_properties("unique-stigids" PROPERTIES LABELS quick)
     endif()
 endmacro()
 


### PR DESCRIPTION
#### Description:

- Disable unique-stigids test.
  - The project contains multiple duplicates and they should be addressed
first before enabling the test. This test gets into many jobs and it's
not worth the effort to reconfigure all other jobs to skip it.

#### Additional Information

Relates: #6113
