### PR TITLE
Fix 'when' clause issue in sudo_defaults_option when using older Ansible

### DIFF
--- a/shared/templates/sudo_defaults_option/ansible.template
+++ b/shared/templates/sudo_defaults_option/ansible.template
@@ -19,7 +19,7 @@
     path: /etc/sudoers
     line: 'Defaults {{{ OPTION }}}={{ {{{ VARIABLE_NAME }}} }}'
     validate: /usr/sbin/visudo -cf %s
-  when: edit_sudoers_{{{ OPTION }}}_option.changed is false
+  when: not edit_sudoers_{{{ OPTION }}}_option.changed
 {{% else %}}
 - name: Ensure {{{ OPTION }}} is enabled in /etc/sudoers
   lineinfile:

--- a/shared/templates/sudo_defaults_option/ansible.template
+++ b/shared/templates/sudo_defaults_option/ansible.template
@@ -19,7 +19,7 @@
     path: /etc/sudoers
     line: 'Defaults {{{ OPTION }}}={{ {{{ VARIABLE_NAME }}} }}'
     validate: /usr/sbin/visudo -cf %s
-  when: not edit_sudoers_{{{ OPTION }}}_option.changed
+  when: edit_sudoers_{{{ OPTION }}}_option is defined and not edit_sudoers_{{{ OPTION }}}_option.changed
 {{% else %}}
 - name: Ensure {{{ OPTION }}} is enabled in /etc/sudoers
   lineinfile:


### PR DESCRIPTION
#### Description:

- Fix syntax in `when` clause in template `sudo_defaults_option`

#### Rationale:

- It worked fine for Ansible 2.10, but Ansible 2.9 had issues with the `when` clause.
`
TASK [Enable umask option with appropriate value in /etc/sudoers] ************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'edit_sudoers_umask_option.changed is defined and edit_sudoers_umask_option.changed is false' failed. The error was: template error while templating string: no test named 'false'. String: {% if edit_sudoers_umask_option.changed is defined and edit_sudoers_umask_option.changed is false %} True {% else %} False {% endif %}\n\nThe error appears to be in '/usr/share/scap-security-guide/ansible/rhel7-playbook-anssi_nt28_enhanced.yml': line 176, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Enable umask option with appropriate value in /etc/sudoers\n      ^ here\n"}
`
