### PR TITLE
Update testing kickstart file partitions

### DIFF
--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -79,18 +79,24 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="noauto,nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup --pesize=4096 pv.01
 
 # Create particular logical volumes (optional)
-logvol / --fstype=xfs --name=root --vgname=VolGroup --size=11264 --grow
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=8192 --grow
 # Ensure /home Located On Separate Partition
 logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /usr Located On Separate Partition
+logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=2048 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /opt Located On Separate Partition
+logvol /opt --fstype=xfs --name=opt --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
+# Ensure /srv Located On Separate Partition
+logvol /srv --fstype=xfs --name=srv --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /var/tmp Located On Separate Partition
 logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /var Located On Separate Partition


### PR DESCRIPTION
#### Description:
Update ks file partitions to be also aligned with ANSSI profiles.

#### Rationale:
This ks is used for preparation of testing machines where profiles are tested. ANSSI profiles require to have `/srv`, `/opt`, and `/usr` as separate partitions thus they need to be specified as separate partitions or the rules will fail.