### PR TITLE
Add cap_audit_write to be able to run sshd in containers

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -447,7 +447,10 @@ class PodmanTestEnv(ContainerTestEnv):
 
     def _new_container_from_image(self, image_name, container_name):
         long_name = "{0}_{1}".format(self._name_stem, container_name)
+        # Podman drops cap_audit_write which causes that it is not possible
+        # run sshd by default. Therefore, we need to add the capability.
         podman_cmd = ["podman", "run", "--name", long_name,
+                      "--cap-add=cap_audit_write",
                       "--publish", "{}".format(self.internal_ssh_port), "--detach", image_name,
                       "/usr/sbin/sshd", "-p", "{}".format(self.internal_ssh_port), "-D"]
         try:


### PR DESCRIPTION
Podman drops `cap_audit_write` which causes that it is not possible
run sshd by default. Therefore, we need to add the capability.

For more details see:
https://github.com/containers/podman/issues/3651