### PR TITLE
CIS 1.2.34: update api_server_encryption_provider_cipher

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/kubernetes/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_ocp
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  encryption:
+    type: aescbc

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -5,20 +5,13 @@ prodtype: ocp4
 title: 'Configure the Encryption Provider Cipher'
 
 description: |-
-    To configure OpenShift to use the <tt>aescbc</tt> encryption provider,
-    follow the OpenShift documentation to create or modify an
-    <tt>EncryptionConfig</tt> file.
-    In this file, choose <tt>aescbc</tt> as the encryption provider:
-    <pre>kind: EncryptionConfig
-    apiVersion: v1
-    resources:
-      - resources:
-        - secrets
-        providers:
-        - aescbc:
-            keys:
-            - name: key1
-              secret: <i>32-byte base64-encoded secret</i></pre>
+    To ensure the correct cipher, set the encryption type <tt>aescbc</tt> in the
+    <tt>apiserver</tt> object which configures the API server itself.
+    <pre>
+    spec:
+      encryption:
+        type: aescbc
+    </pre>
 
 rationale: |-
     <tt>aescbc</tt> is currently the strongest encryption provider, it should
@@ -33,7 +26,21 @@ ocil_clause: '<tt>aescbc</tt> is not configured as the encryption provider'
 
 ocil: |-
     Run the following command:
-    <pre>$ oc get secrets encryption-config -n openshift-kube-apiserver -o json | jq -r '.data["encryption-config"]' | base64 -d | jq -r '.resources'</pre>
-    Verify that the <tt>aescbc</tt> encryption provider is used for all the desired
-    <tt>resources</tt>.
+    <pre>$ oc get apiserver cluster -ojson | jq -r '.spec.encryption.type'</pre>
+    The output should return <tt>aescdc</tt> as the encryption type.
 
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/apis/config.openshift.io/v1/apiservers/cluster") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: '/apis/config.openshift.io/v1/apiservers/cluster'
+    yamlpath: '.spec.encryption.type'
+    values:
+    - value: 'aescbc'
+      type: "string"
+      operation: "pattern match"

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# This waits for etcd encryption to be enabled. The operator can apply the
+# remediation, but waiting for this to get applied is still something that
+# needs to be done outside of the operator.
+#
+# This patch sets the encryption setting and waits for it to be applied
+
+while true; do
+    status=$(oc get openshiftapiserver -o=jsonpath='{range .items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}')
+
+    echo "Current Encryption Status:"
+    oc get openshiftapiserver -o=jsonpath='{range .items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}{"\n"}{.message}{"\n"}'
+
+    if [ "$status" == "EncryptionCompleted" ]; then
+        exit 0
+    fi
+
+    sleep 5
+done

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS


### PR DESCRIPTION
The previous manual recommendation of checking the EncryptionConfig directly, as well as the Status of the encryption process would be too error prone to make for a reliable check. For one, the automatic check cannot reference a secret, and verifying based on status output would likely return true if the encryption was disabled after being previously enabled.

Instead, do the same check as api_server_encryption_provider_config, since selecting `aescbc` at the top level config is both the method to enable and start encryption of etcd as well as configure the strongest cipher.