### PR TITLE
ocp4: openvswitch's conf.db and lock are now owned by a different group

### DIFF
--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database'
 
 description: |-
-    {{{ describe_file_group_owner(file="/etc/openvswitch/conf.db", group="openvswitch") }}}
+    {{{ describe_file_group_owner(file="/etc/openvswitch/conf.db", group="hugetlbfs") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,13 +21,13 @@ identifiers:
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="openvswitch") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="hugetlbfs") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/openvswitch/conf.db", group="openvswitch") }}}
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/conf.db", group="hugetlbfs") }}}
 
 template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/conf.db
-        filegid: '800'
+        filegid: '801'

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
-    {{{ describe_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="openvswitch") }}}
+    {{{ describe_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="hugetlbfs") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,13 +21,13 @@ identifiers:
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="openvswitch") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="hugetlbfs") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="openvswitch") }}}
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="hugetlbfs") }}}
 
 template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/.conf.db.~lock~
-        filegid: '800'
+        filegid: '801'

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 
 description: |-
-    {{{ describe_file_group_owner(file="/etc/openvswitch/system-id.conf", group="openvswitch") }}}
+    {{{ describe_file_group_owner(file="/etc/openvswitch/system-id.conf", group="hugetlbfs") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,13 +21,13 @@ identifiers:
 references:
     cis: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="openvswitch") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="hugetlbfs") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/openvswitch/system-id.conf", group="openvswitch") }}}
+    {{{ ocil_file_group_owner(file="/etc/openvswitch/system-id.conf", group="hugetlbfs") }}}
 
 template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/system-id.conf
-        filegid: '800'
+        filegid: '801'


### PR DESCRIPTION
This updates the appropriate rules to reflect a recent change in
openvswitch that changes the group ownership of the aforementioned
files. This was hitting CI.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>