### PR TITLE
Remove noauto for boot partition from test kickstart and ANSSI profiles

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -181,7 +181,9 @@ controls:
     - partition_for_boot
     - mount_option_boot_nosuid
     - mount_option_boot_noexec
-    - mount_option_boot_noauto
+    # The noauto option rule breaks checking of the other mount options
+    # Commented until rules for /boot mount_option handles this use case
+    # - mount_option_boot_noauto
 
     # /opt nosuid, nodev (optional ro) Additional packages to the system.  Read-only editing if not used
     - partition_for_opt

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -79,7 +79,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512 --fsoptions="noauto,nosuid,noexec"
+part /boot --fstype=xfs --size=512 --fsoptions="nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)


### PR DESCRIPTION
#### Description:

- remove "noauto" option from definition of /boot partition in test suite kickstart

#### Rationale:

This causes many problems during testing because /boot partition has to be manually mounted.