### PR TITLE
Extend list of rules of unselected rules for testing

### DIFF
--- a/tests/unselect_rules_list
+++ b/tests/unselect_rules_list
@@ -13,3 +13,4 @@ xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords
 xccdf_org.ssgproject.content_rule_disable_host_auth
 xccdf_org.ssgproject.content_rule_harden_sshd_crypto_policy
 xccdf_org.ssgproject.content_rule_configure_etc_hosts_deny
+xccdf_org.ssgproject.content_rule_sudo_add_noexec


### PR DESCRIPTION
#### Description:
Add `sudo_add_noexec` to the list because it prevents from running oscap scan on machine.