### PR TITLE
fix ansible remediation of dir_perms_world_writable_root_owned

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -30,7 +30,7 @@
 
 - name: "Create empty list of excluded paths"
   set_fact:
-    excluded_paths: "[]"
+    excluded_paths: []
 
 - name: "Detect nonlocal file systems and add them to excluded paths"
   set_fact: 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/world_writable_dir_on_nonlocal_fs.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/world_writable_dir_on_nonlocal_fs.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = nfs-utils
+
+mkdir -p /tmp/testdir/testdir2
+mkdir /tmp/testmount
+chown 2 /tmp/testdir/testdir2
+chmod 777 /tmp/testdir/testdir2
+
+echo '/tmp/testdir localhost(rw)' > /etc/exports
+systemctl restart nfs-server
+mount.nfs localhost:/tmp/testdir /tmp/testmount


### PR DESCRIPTION
#### Description:

- fix wrong list declaration in remediation
- add test which uses nfs4 as a nonlocal file system

#### Rationale:

