### PR TITLE
remove "noauto" option from boot partition in anssi kickstarts

### DIFF
--- a/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
@@ -103,7 +103,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512 --fsoptions="noauto"
+part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)

--- a/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -103,7 +103,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512 --fsoptions="noauto"
+part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)


### PR DESCRIPTION
#### Description:

- remove option from rhel7 and rhel8 kickstarts

#### Rationale:

- rule was removed from the profile and presence of this option causes errors when checking / remediating