### PR TITLE
Remove rule for /boot noauto from R13

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -229,8 +229,11 @@ controls:
     description: >-
       When possible, the /boot partition should not be mounted. In any case, access to
       the /boot directory must only be allowed to the root user.
-    rules:
-    - mount_option_boot_noauto
+    notes: >-
+      The rule disabling auto-mount for /boot is commented until the rules checking for other
+      /boot mount options are updated to handle this usecase.
+    #rules:
+    #- mount_option_boot_noauto
 
   - id: R14
     level: intermediary


### PR DESCRIPTION

#### Description:

- Disable the rule until mount options for `/boot` can be checked without the need for the partition to be mounted.

#### Rationale:

- This causes false positives in other rules for `/boot` mount options
