### PR TITLE
fix bogus messages and failing ansible remediations

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 
 - name: Search for privileged commands
-  shell: find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null
+  shell: find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null
   args:
     warn: False
     executable: /bin/bash

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -4,57 +4,15 @@
 # complexity = low
 # disruption = low
 
-- name: "Configure excluded (non local) file systems"
-  set_fact:
-    excluded_fstypes:
-      - afs
-      - ceph
-      - cifs
-      - smb3
-      - smbfs
-      - sshfs
-      - ncpfs
-      - ncp
-      - nfs
-      - nfs4
-      - gfs
-      - gfs2
-      - glusterfs
-      - gpfs
-      - pvfs2
-      - ocfs2
-      - lustre
-      - davfs
-      - fuse.sshfs
-
-- name: "Create empty list of excluded paths"
-  set_fact:
-    excluded_paths: []
-
-- name: "Create empty list of suid / sgid binaries"
-  set_fact:
-    suid_sgid_binaries: []
-
-- name: "Detect nonlocal file systems and add them to excluded paths"
-  set_fact: 
-    excluded_paths: "{{ excluded_paths | union([item.mount]) }}"
-  loop: "{{ ansible_mounts }}"
-  when: item.fstype in excluded_fstypes
-
-- name: "Find all files excluding non-local partitions"
-  find:
-    paths: "/"
-    excludes: excluded_paths
-    file_type: file
-    hidden: yes
-    recurse: yes
-  register: found_files
-
-- name: "construct list of suid or sgid binaries"
-  set_fact:
-    suid_sgid_binaries: "{{ suid_sgid_binaries | union([item.path]) }}"
-  when: item.mode is match("2.*") or item.mode is match("4.*")
-  loop: '{{ found_files.files }}'
+- name: Search for privileged commands
+  shell: find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null
+  args:
+    warn: False
+    executable: /bin/bash
+  check_mode: no
+  register: find_result
+  changed_when: false
+  failed_when: false
 
 # Inserts/replaces the rule in /etc/audit/rules.d
 
@@ -64,7 +22,8 @@
     recurse: no
     contains: "^.*path={{ item }} .*$"
     patterns: "*.rules"
-  loop: "{{ suid_sgid_binaries }}"
+  with_items:
+    - "{{ find_result.stdout_lines }}"
   register: files_result
 
 - name: Overwrites the rule in rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -3,6 +3,6 @@
 AUID=$1
 KEY=$2
 RULEPATH=$3
-for file in $(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null); do
+for file in $(find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null); do
      echo "-a always,exit -F path=$file -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
 done

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -51,10 +51,6 @@
   set_fact:
     world_writable_dirs: "{{ found_dirs.files | selectattr('woth') | list }}"
 
-- name: "debug"
-  debug:
-    msg: "{{ world_writable_dirs }}"
-
 - name: "Change owner to root on directories which are world writable"
   file:
     path: '{{ item.path }}'

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -47,9 +47,17 @@
     recurse: yes
   register: found_dirs
 
+- name: "Create list of world writable directories"
+  set_fact:
+    world_writable_dirs: "{{ found_dirs.files | selectattr('woth') | list }}"
+
+- name: "debug"
+  debug:
+    msg: "{{ world_writable_dirs }}"
+
 - name: "Change owner to root on directories which are world writable"
   file:
     path: '{{ item.path }}'
     owner: root
-  loop:  '{{ found_dirs.files }}'
-  when: item.woth
+  loop:  '{{ world_writable_dirs }}'
+  ignore_errors: yes

--- a/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
+++ b/shared/bash_remediation_functions/perform_audit_rules_privileged_commands_remediation.sh
@@ -57,7 +57,7 @@ fi
 # Obtain the list of SUID/SGID binaries on the particular system (split by newline)
 # into privileged_binaries array
 privileged_binaries=()
-readarray -t privileged_binaries < <(find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type f -perm -4000 -o -type f -perm -2000 2>/dev/null)
+readarray -t privileged_binaries < <(find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null)
 
 # Keep list of SUID/SGID binaries that have been already handled within some previous iteration
 declare -a sbinaries_to_skip=()


### PR DESCRIPTION
#### Description:

- audit_rules_privileged_commands
  - go back to shell command, ensure that the task does not fail
- dir_perms_world_writable_root_owned
  - remove bogus messages about skipped files
  - ensure that the file being changed did not get deleted in mean time

#### Rationale:

solving problems found during productization:
- excessive error messages
- dead ansible worker jobs
- possible race condition where a file got deleted before ansible tried to change its owner