### PR TITLE
Improve yamlfile_value template

### DIFF
--- a/shared/templates/yamlfile_value/oval.template
+++ b/shared/templates/yamlfile_value/oval.template
@@ -32,7 +32,7 @@
     <ind:state state_ref="state_{{{ rule_id }}}"/>
   </ind:yamlfilecontent_test>
 {{% else %}}
-  <ind:variable_test id="test_{{{ rule_id }}}" check="all" check_existence="all_exist" comment="comment1" version="1">
+  <ind:variable_test id="test_{{{ rule_id }}}" check="all" check_existence="all_exist" comment="Variable test to check XCCDF variable" version="1">
     <ind:object object_ref="variable_object_{{{ rule_id }}}" />
     <ind:state state_ref="variable_state_{{{ rule_id }}}" />
   </ind:variable_test>
@@ -45,13 +45,11 @@
     <ind:value datatype="string" operation="equals" var_ref="{{{ XCCDF_VARIABLE }}}"/>
   </ind:variable_state>
 
-  {{% for val in VALUES %}}
-  <local_variable id="local_variable_{{{ rule_id }}}" datatype="string" comment="comment1" version="1">
-    <regex_capture pattern='{{{ val.value }}}'>
-       <object_component item_field="value" record_field="#" object_ref="object_{{{ rule_id }}}" />
+  <local_variable id="local_variable_{{{ rule_id }}}" datatype="string" comment="Captured value to be compared with XCCDF value" version="1">
+    <regex_capture pattern='{{{ (VALUES|first).value }}}'>
+       <object_component item_field="value" record_field="{{{ (VALUES|first).key|default('#') }}}" object_ref="object_{{{ rule_id }}}" />
     </regex_capture>
   </local_variable>
-  {{% endfor %}}
 
 {{% endif %}}
 

--- a/shared/templates/yamlfile_value/template.py
+++ b/shared/templates/yamlfile_value/template.py
@@ -1,10 +1,23 @@
 def preprocess(data, lang):
 
     if data.get("xccdf_variable") and data.get("embedded_data") == "true":
-        if not data.get("values"):
+        values = data.get("values", [{}])
+        if len(values) > 1:
+            raise ValueError(
+                "Only a single value can be checked when querying "
+                "for a 'xccdf_value' that returns an embedded value. "
+                "Rule ID: {}".format(data["_rule_id"]))
+        elif not values[0].get("value"):
             raise ValueError(
                 "You should specify a capture regex in the 'value' field "
                 "when querying for a 'xccdf_value' that returns an embedded value. "
+                "Rule ID: {}".format(data["_rule_id"]))
+
+    if data.get("xccdf_variable") and data.get("embedded_data") != "true":
+        if data.get("values"):
+            raise ValueError(
+                "You cannot specify the 'value' field when querying "
+                "for a 'xccdf_value' that doesn't return an embedded value. "
                 "Rule ID: {}".format(data["_rule_id"]))
 
     data["embedded_data"] = data.get("embedded_data", "false") == "true"


### PR DESCRIPTION
#### Description:

- Improve yamlfile_value template.
  - Remove option to use multiple value when using xccdf_variable option
which retrieves a not embedded value. Also improves error handling of
input data.

#### Rationale:

- Follow up from #6563 
  - Addresses the concern here: https://github.com/ComplianceAsCode/content/pull/6563/files/8757c19db8615aa0ce6c047ac95d3400386a641a#diff-c2a55cbd862ad7426d44721793dc155f03270f2a374c313ee034e652d1961621


@JAORMX FYI