### PR TITLE
Drop remediation for sysctl_kernel_modules_disabled

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
@@ -26,6 +26,11 @@ references:
 
 platform: machine
 
+warnings:
+  - general:
+      This rule doesn't come with Bash remediation.
+      Remediating this rule during the installation process disrupts the install and boot process.
+
 template:
     name: sysctl
     vars:
@@ -33,5 +38,5 @@ template:
         sysctlval: '1'
         datatype: int
     backends:
-        # Automated remediation of this rule disrupts installs via kickstart
+        # Automated remediation of this rule during installations disrupts the first boot
         bash: 'off'

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
@@ -32,3 +32,6 @@ template:
         sysctlvar: kernel.modules_disabled
         sysctlval: '1'
         datatype: int
+    backends:
+        # Automated remediation of this rule disrupts installs via kickstart
+        bash: 'off'


### PR DESCRIPTION
#### Description:

- Remove Bash remediation for `sysctl_kernel_modules_disabled`.

#### Rationale:

- Remediating this during kickstart install time renders the machine unbootable.
- This makes it impossible to apply the fix during kickstart install. Unfortunately it also makes it impossible to fix it with Bash _force_.
  - There is no way to make a rule remediate with Bash during normal runs but not remediate during kickstart install. Thoughts on this?
- From what I tested, applying the fix after first boot is fine.
