### PR TITLE
E8 ocp revisions

### DIFF
--- a/ocp4/profiles/e8.profile
+++ b/ocp4/profiles/e8.profile
@@ -30,5 +30,5 @@ selections:
     - rbac_pod_creation_access
     - rbac_wildcard_use
     - rbac_limit_cluster_admin
-    - api_server_tls_cipher_suitres
+    - api_server_tls_cipher_suites
     - api_server_encryption_provider_cipher

--- a/ocp4/profiles/e8.profile
+++ b/ocp4/profiles/e8.profile
@@ -23,3 +23,12 @@ selections:
     - ocp_idp_no_htpasswd
     - ocp_allowed_registries_for_import
     - ocp_allowed_registries
+    - scc_limit_privileged_containers
+    - scc_limit_privilege_escalation
+    - scc_limit_root_containers
+    - scc_limit_container_allowed_capabilities
+    - rbac_pod_creation_access
+    - rbac_wildcard_use
+    - rbac_limit_cluster_admin
+    - api_server_tls_cipher_suitres
+    - api_server_encryption_provider_cipher

--- a/rhcos4/profiles/e8.profile
+++ b/rhcos4/profiles/e8.profile
@@ -82,6 +82,6 @@ selections:
   - sshd_enable_strictmodes
 
   # See also: https://www.cyber.gov.au/ism/guidelines-using-cryptography
-  - var_system_crypto_policy=default
+  - var_system_crypto_policy=default_nosha1
   - configure_crypto_policy
   - configure_ssh_crypto_policy

--- a/rhcos4/profiles/e8.profile
+++ b/rhcos4/profiles/e8.profile
@@ -81,7 +81,7 @@ selections:
   - sshd_disable_user_known_hosts
   - sshd_enable_strictmodes
 
-  # See also: https://www.cyber.gov.au/ism/guidelines-using-cryptography
+  # See also: https://www.cyber.gov.au/acsc/view-all-content/guidance/asd-approved-cryptographic-algorithms
   - var_system_crypto_policy=default_nosha1
   - configure_crypto_policy
   - configure_ssh_crypto_policy

--- a/rhcos4/profiles/e8.profile
+++ b/rhcos4/profiles/e8.profile
@@ -19,37 +19,10 @@ description: |-
 
 selections:
 
-  ### Remove obsolete packages
-  #- package_talk_removed
-  #- package_talk-server_removed
-  #- package_xinetd_removed
-  #- service_xinetd_disabled
-  #- package_ypbind_removed
-  #- package_telnet_removed
-  #- service_telnet_disabled
-  #- package_telnet-server_removed
-  #- package_rsh_removed
-  #- package_rsh-server_removed
-  #- service_zebra_disabled
-  #- package_quagga_removed
-  #- service_avahi-daemon_disabled
-  #- package_squid_removed
-  #- service_squid_disabled
-
-  ### Software update
-  #- ensure_redhat_gpgkey_installed
-  #- ensure_gpgcheck_never_disabled
-  #- ensure_gpgcheck_local_packages
-  #- ensure_gpgcheck_globally_activated
-  #- security_patches_up_to_date
-  #- dnf-automatic_security_updates_only
-
   ### System security settings
   - sysctl_kernel_randomize_va_space
-#  - sysctl_kernel_exec_shield
   - sysctl_kernel_kptr_restrict
   - sysctl_kernel_dmesg_restrict
-  - sysctl_kernel_kexec_load_disabled
   - sysctl_kernel_yama_ptrace_scope
   - sysctl_kernel_unprivileged_bpf_disabled
   - sysctl_net_core_bpf_jit_harden
@@ -60,41 +33,13 @@ selections:
   - var_selinux_policy_name=targeted
   - selinux_policytype
 
-  ### Filesystem integrity
-  #- rpm_verify_hashes
-  #- rpm_verify_permissions
-  #- rpm_verify_ownership
-  #- file_permissions_unauthorized_sgid
-  #- file_permissions_unauthorized_suid
-  #- file_permissions_unauthorized_world_writable
-  #- dir_perms_world_writable_sticky_bits
-  #- file_permissions_library_dirs
-  #- file_ownership_binary_dirs
-  #- file_permissions_binary_dirs
-  #- file_ownership_library_dirs
-
   ### Passwords
   - no_empty_passwords
 
-  ### Partitioning
-  #- mount_option_dev_shm_nodev
-  #- mount_option_dev_shm_nosuid
-  #- mount_option_dev_shm_noexec
-
-  ### Network
-  #- package_firewalld_installed
-  #- service_firewalld_enabled
-  #- network_sniffer_disabled
-
   ### Admin privileges
   - accounts_no_uid_except_zero
-  #- sudo_remove_nopasswd
-  #- sudo_remove_no_authenticate
-  #- sudo_require_authentication
-
+  
   ### Audit
-  #- package_rsyslog_installed
-  #- service_rsyslog_enabled
   - service_auditd_enabled
   - var_auditd_flush=incremental_async
   - auditd_data_retention_flush
@@ -137,10 +82,6 @@ selections:
   - sshd_enable_strictmodes
 
   # See also: https://www.cyber.gov.au/ism/guidelines-using-cryptography
-  - var_system_crypto_policy=future
+  - var_system_crypto_policy=default
   - configure_crypto_policy
   - configure_ssh_crypto_policy
-
-  ### Application whitelisting
-  #- package_fapolicyd_installed
-  #- service_fapolicyd_enabled

--- a/rhel8/profiles/e8.profile
+++ b/rhel8/profiles/e8.profile
@@ -136,7 +136,7 @@ selections:
   - sshd_disable_user_known_hosts
   - sshd_enable_strictmodes
 
-  # See also: https://www.cyber.gov.au/ism/guidelines-using-cryptography
+  # See also: https://www.cyber.gov.au/acsc/view-all-content/guidance/asd-approved-cryptographic-algorithms
   - var_system_crypto_policy=default_nosha1
   - configure_crypto_policy
   - configure_ssh_crypto_policy


### PR DESCRIPTION
This PR improves the RHCOS/OCP profile alignment with the Australian Cyber Security Centre (ACSC) Essential Eight guidance and RHCOS controlled immutability/platform management:

- Add additional controls for SCC/RBAC configuration
- Remove controls for packages not supported with RHCOS
- Remove file system integrity controls (handled by the File Integrity Operator)
- Remove RHCOS software update controls (handled by the Cluster Version Operator)
- Remove rsyslog packages from RHCOS configuration (handled by the `ClusterLogForwarder` CR)
- Remove firewalld configuration from RHCOS nodes (not included)
- Use NOSHA1 crypto policy to better align with ASD crypto guidelines
