### PR TITLE
Update ANSSI profile descriptions

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -1,5 +1,5 @@
 policy: 'ANSSI-BP-028'
-title: 'ANSSI-BP-028'
+title: 'Configuration Recommendations of a GNU/Linux System'
 id: anssi
 version: '1.2'
 source: https://www.ssi.gouv.fr/uploads/2019/03/linux_configuration-en-v1.2.pdf

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -1,9 +1,15 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI DAT-BP28 (enhanced)'
+title: 'ANSSI BP-028 (enhanced)'
 
-description: 'Draft profile for ANSSI compliance at the enhanced level. ANSSI stands for Agence nationale de la sécurité des
-    systèmes d''information. Based on https://www.ssi.gouv.fr/.'
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the enhanced hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
     - anssi:all:enhanced

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -5,7 +5,7 @@ title: 'ANSSI-BP-028 (enhanced)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-title: 'ANSSI BP-028 (enhanced)'
+title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:

--- a/rhel7/profiles/anssi_nt28_high.profile
+++ b/rhel7/profiles/anssi_nt28_high.profile
@@ -5,7 +5,7 @@ title: 'DRAFT - ANSSI-BP-028 (high)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel7/profiles/anssi_nt28_high.profile
+++ b/rhel7/profiles/anssi_nt28_high.profile
@@ -1,9 +1,15 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI DAT-BP28 (high)'
+title: 'DRAFT - ANSSI BP-028 (high)'
 
-description: 'Draft profile for ANSSI compliance at the high level. ANSSI stands for Agence nationale de la sécurité des systèmes
-    d''information. Based on https://www.ssi.gouv.fr/.'
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the high hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
     - anssi:all:high

--- a/rhel7/profiles/anssi_nt28_high.profile
+++ b/rhel7/profiles/anssi_nt28_high.profile
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI BP-028 (high)'
+title: 'DRAFT - ANSSI-BP-028 (high)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:

--- a/rhel7/profiles/anssi_nt28_high.profile
+++ b/rhel7/profiles/anssi_nt28_high.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'DRAFT - ANSSI-BP-028 (high)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -1,10 +1,16 @@
 # Don't forget to enable build of tables in rhel7CMakeLists.txt when setting to true
 documentation_complete: true
 
-title: 'DRAFT - ANSSI DAT-BP28 (intermediary)'
+title: 'ANSSI BP-028 (intermediary)'
 
-description: 'Draft profile for ANSSI compliance at the intermediary level. ANSSI stands for Agence nationale de la sécurité
-    des systèmes d''information. Based on https://www.ssi.gouv.fr/.'
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the intermediary hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
-  - anssi:all:intermediary
+    - anssi:all:intermediary

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -6,7 +6,7 @@ title: 'ANSSI-BP-028 (intermediary)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -1,15 +1,15 @@
 # Don't forget to enable build of tables in rhel7CMakeLists.txt when setting to true
 documentation_complete: true
 
-title: 'ANSSI BP-028 (intermediary)'
+title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:

--- a/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/rhel7/profiles/anssi_nt28_minimal.profile
@@ -1,9 +1,15 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI DAT-BP28 (minimal)'
+title: 'ANSSI BP-028 (minimal)'
 
-description: 'Draft profile for ANSSI compliance at the minimal level. ANSSI stands for Agence nationale de la sécurité des
-    systèmes d''information. Based on https://www.ssi.gouv.fr/.'
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the minimal hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
-  - anssi:all:minimal
+    - anssi:all:minimal

--- a/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/rhel7/profiles/anssi_nt28_minimal.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/rhel7/profiles/anssi_nt28_minimal.profile
@@ -5,7 +5,7 @@ title: 'ANSSI-BP-028 (minimal)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/rhel7/profiles/anssi_nt28_minimal.profile
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-title: 'ANSSI BP-028 (minimal)'
+title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:

--- a/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -2,10 +2,14 @@ documentation_complete: true
 
 title: 'ANSSI BP-028 (enhanced)'
 
-description: 
-    ANSSI BP-028 compliance at the enhanced level. ANSSI stands for
-    Agence nationale de la sécurité des systèmes d'information. Based on
-    https://www.ssi.gouv.fr/.
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the enhanced hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
     - anssi:all:enhanced

--- a/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -5,7 +5,7 @@ title: 'ANSSI-BP-028 (enhanced)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-title: 'ANSSI BP-028 (enhanced)'
+title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:

--- a/rhel8/profiles/anssi_bp28_high.profile
+++ b/rhel8/profiles/anssi_bp28_high.profile
@@ -5,7 +5,7 @@ title: 'DRAFT - ANSSI-BP-028 (high)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel8/profiles/anssi_bp28_high.profile
+++ b/rhel8/profiles/anssi_bp28_high.profile
@@ -1,11 +1,15 @@
 documentation_complete: true
 
-title: 'ANSSI BP-028 (high)'
+title: 'DRAFT - ANSSI BP-028 (high)'
 
-description: 
-    ANSSI BP-028 compliance at the high level. ANSSI stands for
-    Agence nationale de la sécurité des systèmes d'information. Based on
-    https://www.ssi.gouv.fr/.
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the high hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
     - anssi:all:high

--- a/rhel8/profiles/anssi_bp28_high.profile
+++ b/rhel8/profiles/anssi_bp28_high.profile
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI BP-028 (high)'
+title: 'DRAFT - ANSSI-BP-028 (high)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:

--- a/rhel8/profiles/anssi_bp28_high.profile
+++ b/rhel8/profiles/anssi_bp28_high.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'DRAFT - ANSSI-BP-028 (high)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -7,7 +7,6 @@ description:
     Agence nationale de la sécurité des systèmes d''information. Based on
     https://www.ssi.gouv.fr/.
 
-extends: anssi_bp28_minimal
 
 selections:
   - anssi:all:intermediary

--- a/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -5,7 +5,7 @@ title: 'ANSSI-BP-028 (intermediary)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-title: 'ANSSI BP-028 (intermediary)'
+title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:

--- a/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -2,11 +2,14 @@ documentation_complete: true
 
 title: 'ANSSI BP-028 (intermediary)'
 
-description: 
-    ANSSI BP-028 compliance at the intermediary level. ANSSI stands for
-    Agence nationale de la sécurité des systèmes d''information. Based on
-    https://www.ssi.gouv.fr/.
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the intermediary hardening level.
 
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
   - anssi:all:intermediary

--- a/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/rhel8/profiles/anssi_bp28_minimal.profile
@@ -2,10 +2,14 @@ documentation_complete: true
 
 title: 'ANSSI BP-028 (minimal)'
 
-description: 
-    ANSSI BP-028 compliance at the minimal level. ANSSI stands for
-    Agence nationale de la sécurité des systèmes d'information. Based on
-    https://www.ssi.gouv.fr/.
+description: |-
+    This profile contains configurations that align to ANSSI BP-28 at the minimal hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:
   - anssi:all:minimal

--- a/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/rhel8/profiles/anssi_bp28_minimal.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-28 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/rhel8/profiles/anssi_bp28_minimal.profile
@@ -5,7 +5,7 @@ title: 'ANSSI-BP-028 (minimal)'
 description: |-
     This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
 
-    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:

--- a/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/rhel8/profiles/anssi_bp28_minimal.profile
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-title: 'ANSSI BP-028 (minimal)'
+title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This profile contains configurations that align to ANSSI BP-28 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-28 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d''information.
-    ANSSI BP-028 is a configuration recommendation for GNU/Linux systems.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
 
-    A copy of the ANSSI BP-028 can be found at the ANSSI website:
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
 selections:


### PR DESCRIPTION
#### Description:

- Update title of RHEL7 ANSSI profiles to `BP-028`
  - For compatibility reasons their IDs will remain `nt28`.
- Update descriptions of RHEL ANSSI profiles.
- Update title of `controls/anssi.yml` file.
- The High Hardening levels are still in DRAFT state.

#### Rationale:

- The RHEL profiles are moving to alignment with ANSSI BP-028
