### PR TITLE
ocp: Add missing reference to idp_is_configured

### DIFF
--- a/applications/openshift/authentication/idp_is_configured/rule.yml
+++ b/applications/openshift/authentication/idp_is_configured/rule.yml
@@ -54,6 +54,10 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-84088-4
 
+
+references:
+  cis: 3.1.1
+
 severity: medium
 
 warnings:


### PR DESCRIPTION
This was tripping up the stats script