### PR TITLE
adjust the OVAL data urls for SLE12 and SLE15 to current locations

### DIFF
--- a/sle12/product.yml
+++ b/sle12/product.yml
@@ -10,7 +10,7 @@ init_system: "systemd"
 
 pkg_manager: "zypper"
 pkg_manager_config_file: "/etc/zypp/zypp.conf"
-oval_feed_url: "https://support.novell.com/security/oval/suse.linux.enterprise.12.xml"
+oval_feed_url: "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.12.xml"
 
 cpes_root: "../shared/applicability"
 cpes:

--- a/sle15/product.yml
+++ b/sle15/product.yml
@@ -9,7 +9,7 @@ profiles_root: "./profiles"
 pkg_manager: "zypper"
 
 init_system: "systemd"
-oval_feed_url: "https://support.novell.com/security/oval/suse.linux.enterprise.15.xml"
+oval_feed_url: "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml"
 
 cpes_root: "../shared/applicability"
 cpes:


### PR DESCRIPTION
#### Description:

The novell.com URLs were no longer valid for some months, content is now available via ftp.suse.com over https.

#### Rationale:

- old URLS were not updated anymore

