### PR TITLE
Add /boot options to ANSSI kickstarts and remediation for mount_option_nodev_nonroot_local_partitions

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
@@ -1,0 +1,18 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = high
+
+- name: Ensure non-root local partitions are mounted with nodev option
+  mount:
+    path: "{{ item.mount }}"
+    src: "{{ item.device}}"
+    opts: "{{ item.options }},nodev"
+    state: "mounted"
+    fstype: "{{ item.fstype }}"
+  when:
+    - "item.mount is match('/\\w')"
+    - "item.options is not search('nodev')"
+  with_items:
+    - "{{ ansible_facts.mounts }}"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
@@ -7,7 +7,7 @@
 - name: Ensure non-root local partitions are mounted with nodev option
   mount:
     path: "{{ item.mount }}"
-    src: "{{ item.device}}"
+    src: "{{ item.device }}"
     opts: "{{ item.options }},nodev"
     state: "mounted"
     fstype: "{{ item.fstype }}"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
@@ -1,0 +1,18 @@
+# platform = multi_platform_all
+. /usr/share/scap-security-guide/remediation_functions
+
+include_mount_options_functions
+
+MOUNT_OPTION="nodev"
+# Create array of local non-root partitions
+readarray -t partitions_records < <(findmnt --mtab --raw --evaluate | grep "^/\w" | grep "\s/dev/\w")
+
+for partition_record in "${partitions_records[@]}"; do
+    # Get all important information for fstab
+    mount_point="$(echo ${partition_record} | cut -d " " -f1)"
+    device="$(echo ${partition_record} | cut -d " " -f2)"
+    device_type="$(echo ${partition_record} | cut -d " " -f3)"
+    # device and device_type will be used only in case when the device doesn't have fstab record
+    ensure_mount_option_in_fstab "$mount_point" "$MOUNT_OPTION" "$device" "$device_type"
+    ensure_partition_is_mounted "$mount_point"
+done

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/correct.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/correct.pass.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+# Add nodev option to all records in fstab to ensure that test will
+# run on environment where everything is set correctly for rule check.
+cp /etc/fstab /etc/fstab.backup
+sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
+awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+# Remount all partitions. (--all option can't be used because it doesn't
+# mount e.g. /boot partition
+declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
+for partition in ${partitions[@]}; do
+    mount -o remount "$partition"
+done
+
+PARTITION="/dev/new_partition1"; create_partition
+make_fstab_given_partition_line "/tmp/partition1" ext2 nodev
+mount_partition "/tmp/partition1"
+
+PARTITION="/dev/new_partition2"; create_partition
+make_fstab_given_partition_line "/tmp/partition2" ext2 nodev
+mount_partition "/tmp/partition2"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/local_mounted_during_runtime.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/local_mounted_during_runtime.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+# Add nodev option to all records in fstab to ensure that test will
+# run on environment where everything is set correctly for rule check.
+cp /etc/fstab /etc/fstab.backup
+sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
+awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+# Remount all partitions. (--all option can't be used because it doesn't
+# mount e.g. /boot partition
+declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
+for partition in ${partitions[@]}; do
+    mount -o remount "$partition"
+done
+
+PARTITION="/dev/new_partition1"; create_partition
+mkdir /tmp/test_dir
+mount $PARTITION /tmp/test_dir

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_multiple_nodev.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_multiple_nodev.fail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+# Add nodev option to all records in fstab to ensure that test will
+# run on environment where everything is set correctly for rule check.
+cp /etc/fstab /etc/fstab.backup
+sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
+awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+# Remount all partitions. (--all option can't be used because it doesn't
+# mount e.g. /boot partition
+declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
+for partition in ${partitions[@]}; do
+    mount -o remount "$partition"
+done
+
+PARTITION="/dev/new_partition1"; create_partition
+make_fstab_given_partition_line "/tmp/partition1" ext2
+mount_partition "/tmp/partition1"
+
+PARTITION="/dev/new_partition2"; create_partition
+make_fstab_given_partition_line "/tmp/partition2" ext2
+mount_partition "/tmp/partition2"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_one_nodev.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_one_nodev.fail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+# Add nodev option to all records in fstab to ensure that test will
+# run on environment where everything is set correctly for rule check.
+cp /etc/fstab /etc/fstab.backup
+sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
+awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+# Remount all partitions. (--all option can't be used because it doesn't
+# mount e.g. /boot partition
+declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
+for partition in ${partitions[@]}; do
+    mount -o remount "$partition"
+done
+
+PARTITION="/dev/new_partition1"; create_partition
+make_fstab_given_partition_line "/tmp/partition1" ext2 nodev
+mount_partition "/tmp/partition1"
+
+PARTITION="/dev/new_partition2"; create_partition
+make_fstab_given_partition_line "/tmp/partition2" ext2
+mount_partition "/tmp/partition2"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/remote_without_nodev.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/remote_without_nodev.pass.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# packages = nfs-utils
+
+. $SHARED/partition.sh
+
+# Add nodev option to all records in fstab to ensure that test will
+# run on environment where everything is set correctly for rule check.
+cp /etc/fstab /etc/fstab.backup
+sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
+awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+# Remount all partitions. (--all option can't be used because it doesn't
+# mount e.g. /boot partition
+declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
+for partition in ${partitions[@]}; do
+    mount -o remount "$partition"
+done
+
+mkdir /tmp/testdir
+mkdir /tmp/testmount
+chown 2 /tmp/testdir
+chmod 777 /tmp/testdir
+
+echo '/tmp/testdir localhost(rw)' > /etc/exports
+systemctl restart nfs-server
+mount.nfs localhost:/tmp/testdir /tmp/testmount

--- a/rhel7/kickstart/ssg-rhel7-anssi_nt28_enhanced-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-anssi_nt28_enhanced-ks.cfg
@@ -99,7 +99,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)

--- a/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
@@ -103,7 +103,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)

--- a/rhel7/kickstart/ssg-rhel7-anssi_nt28_intermediary-ks.cfg
+++ b/rhel7/kickstart/ssg-rhel7-anssi_nt28_intermediary-ks.cfg
@@ -99,7 +99,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)

--- a/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
@@ -90,7 +90,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)

--- a/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -94,7 +94,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)

--- a/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
@@ -90,7 +90,7 @@ zerombr
 clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
-part /boot --fstype=xfs --size=512
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)


### PR DESCRIPTION
#### Description:
Add `nodev` option to `/boot` partition for ANSSI kickstarts with intermediary level or higher.

#### Rationale:
ANSSI profiles have [rule](https://github.com/ComplianceAsCode/content/blob/master/controls/anssi.yml#L177) that requires `nodev` option on all non-root partitions. The `/boot` partition doesn't have the option and because of that the rules fails after installation.