### PR TITLE
mark some CIS rules as machine-only

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/rule.yml
@@ -79,3 +79,5 @@ ocil: |-
     To check if the system login banner is compliant,
     run the following command:
     <pre>$ cat /etc/issue</pre>
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
@@ -66,3 +66,5 @@ ocil: |-
     To check if the system login banner is compliant,
     run the following command:
     <pre>$ cat /etc/motd</pre>
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
@@ -51,3 +51,5 @@ ocil: |-
     run the following command:
     <pre>cat /etc/securetty</pre>
     If any output is returned, this is a finding.
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     <pre>$ sudo grep TMOUT /etc/profile</pre>
     The output should return the following:
     <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+
+platform: machine

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
@@ -34,3 +34,5 @@ template:
     name: package_installed
     vars:
         pkgname: sudo
+
+platform: machine


### PR DESCRIPTION
#### Description:

The following rules are marked with "machine" platform:

- banner_etc_motd
- banner_etc_issue
- no_direct_root_logins
- accounts_tmout
- package_sudo_installed

#### Rationale:

Mentioned rules are securing interactive login sessions. This is not use case for containers and therefore rules should not be applicable while scanning containers.