### PR TITLE
remove kernel_module_vfat_disabled from CIS profiles

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -627,4 +627,3 @@ selections:
     - kernel_module_squashfs_disabled
     - kernel_module_udf_disabled
     - kernel_module_usb-storage_disabled
-    - kernel_module_vfat_disabled

--- a/rhel7/profiles/cis.profile
+++ b/rhel7/profiles/cis.profile
@@ -46,8 +46,7 @@ selections:
     #### 1.1.1.7 Ensure mounting of udf filesystems is disabled (Scored)
     - kernel_module_udf_disabled
 
-    #### 1.1.1.8 Ensure mounting of FAT filesystems is disabled (Scored)
-    - kernel_module_vfat_disabled
+    #### 1.1.1.8 Ensure mounting of FAT filesystems is disabled (Manual)
 
     ### 1.1.2 Ensure separate partition exists for /tmp (Scored)
     - partition_for_tmp

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -31,8 +31,8 @@ selections:
     #### 1.1.1.1 Ensure mounting cramfs filesystems is disabled (Scored)
     - kernel_module_cramfs_disabled
 
-    #### 1.1.1.2 Ensure mounting of vFAT flesystems is limited (Not Scored)
-    - kernel_module_vfat_disabled
+    #### 1.1.1.2 Ensure mounting of vFAT filesystems is limited (Not Scored)
+
 
     #### 1.1.1.3 Ensure mounting of squashfs filesystems is disabled (Scored)
     - kernel_module_squashfs_disabled

--- a/sle15/profiles/cis.profile
+++ b/sle15/profiles/cis.profile
@@ -25,7 +25,6 @@ selections:
     - kernel_module_udf_disabled
 
     #### 1.1.1.4 Ensure mounting of vFAT flesystems is limited (Not Scored)
-    - kernel_module_vfat_disabled
 
     ### 1.1.2 Ensure /tmp is configured (Scored)
     - partition_for_tmp


### PR DESCRIPTION
#### Description:

- remove the rule from all cis profiles

#### Rationale:

- the rule is marked as manual / unscored and additionally it prevents UEFI systems from booting