### PR TITLE
add remediation for 1.2.25

### DIFF
--- a/applications/openshift/api-server/api_server_audit_log_maxsize/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/kubernetes/shared.yml
@@ -1,0 +1,7 @@
+# platform = multi_platform_ocp
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  maximumFileSizeMegabytes: 150

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -51,6 +51,6 @@ template:
     filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
     yamlpath: '.data["config.yaml"]'
     values:
-    - value: '"apiServerArguments":{.*"audit-log-maxsize":\["100"\]'
+    - value: '"apiServerArguments":{.*"audit-log-maxsize":\["90"\]'
       operation: "pattern match"
       type: "string"


### PR DESCRIPTION
#### Description:

- Remediation created for 1.2.25 Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate.

#### Rationale:

- Remediation currently not in place. Code written to fill this void.