### PR TITLE
fix wrong description of sshd_limit_user_access

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
@@ -7,7 +7,7 @@ description: |-
     to access the system. In order to specify the users that are allowed to login
     via SSH and deny all other users, add or correct the following line in the
     <tt>/etc/ssh/sshd_config</tt> file:
-    <pre>DenyUsers USER1 USER2</pre>
+    <pre>AllowUsers USER1 USER2</pre>
     Where <tt>USER1</tt> and <tt>USER2</tt> are valid user names.
 
 rationale: |-


### PR DESCRIPTION
#### Description:

- correct the description - replace DenyUsers with AllowUsers

#### Rationale:

- https://bugzilla.redhat.com/show_bug.cgi?id=1859551
- using DenyUsers did not make sense with the rest of description, AllowUsers should be used instead