### PR TITLE
Fix STIG id reference for sshd_x11_use_localhost.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_x11_use_localhost/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_x11_use_localhost/rule.yml
@@ -26,8 +26,8 @@ identifiers:
 
 references:
     srg: SRG-OS-000480-GPOS-00227
-    stig@rhel7: RHEL-07-040711
-    stig@ol7: OL07-00-040711
+    stigid@rhel7: RHEL-07-040711
+    stigid@ol7: OL07-00-040711
     disa: CCI-000366
     nist: CM-6(b)
     stigid@rhel8: RHEL-08-040341


### PR DESCRIPTION
#### Description:

- Fix STIG id reference for sshd_x11_use_localhost.

#### Rationale:

- The format for STIG id references is `stigid`