### PR TITLE
SLES-12 add checks and remediations.

### DIFF
--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
@@ -1,0 +1,23 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Service facts
+  service_facts:
+
+- name: Configure banner_file setting
+  lineinfile:
+    dest: /etc/vsftpd.conf
+    line: banner_file=/etc/issue
+    regexp: '^\s*banner_file\s*=\s*.*$'
+    state: present
+  register: banner_file_update_result
+  when: ansible_facts.services["vsftpd.service"] is defined
+
+- name: Restart vsftpd
+  systemd:
+    name: vsftpd.service
+    state: restarted
+  when: banner_file_update_result.changed and ansible_facts.services["vsftpd.service"].state == "running"

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -8,20 +8,19 @@
       shell: df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
       register: local_mount_points
 
-    - name: "Detect the .shosts files on the system"
+    - name: "Detect the shosts.equiv files on the system"
       find:
           paths: "{{ item }}"
           recurse: yes
-          patterns: [".shosts"]
-          hidden: yes
+          patterns: ["shosts.equiv"]
           file_type: "file"
       check_mode: no
       with_items: "{{ local_mount_points.stdout_lines }}"
-      register: shosts_locations
+      register: shosts_equiv_locations
 
-    - name: "Remove .shosts Files"
+    - name: "Remove shosts.equiv Files"
       file:
           path: "{{ item.path }}"
           state: absent
-      with_items: "{{ shosts_locations.results | map(attribute='files') | list }}"
-      when: shosts_locations is success
+      with_items: "{{ shosts_equiv_locations.results | map(attribute='files') | list }}"
+      when: shosts_equiv_locations is success

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,wrlinux1019,wrlinux8
+prodtype: ol7,ol8,rhel7,rhel8,wrlinux1019,wrlinux8,sle12
 
 title: 'Use Only FIPS 140-2 Validated Ciphers'
 
@@ -49,6 +49,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-27295-5
     cce@rhel8: CCE-81032-5
+    cce@sle12: CCE-83181-8
 
 references:
     cis: 5.2.10
@@ -60,6 +61,7 @@ references:
     nist-csf: PR.AC-1,PR.AC-3,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-1,PR.PT-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000033-GPOS-00014,SRG-OS-000120-GPOS-00061,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
     vmmsrg: SRG-OS-000033-VMM-000140,SRG-OS-000120-VMM-000600,SRG-OS-000478-VMM-001980,SRG-OS-000396-VMM-001590
+    stigid@sle12: SLES-12-030170
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.10,SR 2.11,SR 2.12,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7,SR 2.8,SR 2.9,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 7.1,SR 7.6'
     isa-62443-2009: 4.3.3.2.2,4.3.3.3.9,4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.3.2,4.3.4.3.3,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4
     cobit5: APO11.04,APO13.01,BAI03.05,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.06,DSS06.10,MEA02.01

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_all,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12
 
 title: 'Configure SSSD''s Memory Cache to Expire'
 
@@ -27,12 +27,14 @@ platform: machine  # The check uses service_... extended definition, which doesn
 identifiers:
     cce@rhel7: CCE-80364-3
     cce@rhel8: CCE-80910-3
+    cce@sle12: CCE-83040-6
 
 references:
     disa: CCI-002007
     nist: CM-6(a),IA-5(13)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     srg: SRG-OS-000383-GPOS-00166
+    stigid@sle12: SLES-12-010670
     vmmsrg: SRG-OS-000383-VMM-001570
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1'
     isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.4

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,rhcos4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,rhcos4,sle12
 
 title: 'Configure SSSD to Expire Offline Credentials'
 
@@ -24,6 +24,7 @@ platform: machine  # The check uses service_... extended definition, which doesn
 identifiers:
     cce@rhel7: CCE-80365-0
     cce@rhel8: CCE-82460-7
+    cce@sle12: CCE-83206-3
 
 references:
     disa: CCI-002007
@@ -36,6 +37,7 @@ references:
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
+    stigid@sle12: SLES-12-010680
     stigid@rhel8: RHEL-08-020290
 
 ocil_clause: 'it does not exist or is not configured properly'

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
 
 title: 'Modify the System Message of the Day Banner'
 
@@ -51,14 +51,9 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-83394-7
     cce@rhel8: CCE-83496-0
-    cce@sle12: CCE-83025-7
 
 references:
     cis@rhel8: 1.8.1.1
-    stigid@sle12: SLES-12-010030
-    srg@sle12: SRG-OS-000023-GPOS-00006
-    disa@sle12: CCI-000048
-    nist@sle12: AC-8(a),AC-8.1(ii)
 
 ocil_clause: 'it does not display the required banner'
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/ansible/shared.yml
@@ -1,0 +1,12 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+{{{ ansible_instantiate_variables("login_banner_text") }}}
+
+- name: "{{{ rule_title }}}"
+  lineinfile:
+    dest: /etc/gdm/banner
+    line: '{{{ ansible_deregexify_banner_dconf_gnome("login_banner_text") }}}'
+    create: yes

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/bash/shared.sh
@@ -1,0 +1,14 @@
+# platform = multi_platform_sle
+. /usr/share/scap-security-guide/remediation_functions
+populate login_banner_text
+
+# There was a regular-expression matching various banners, needs to be expanded
+expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/\^(\(.*\)|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/[^-]- /\n\n-/g;s/(n)\**//g')
+formatted=$(echo "$expanded" | fold -sw 80)
+
+cat <<EOF >/etc/gdm/banner
+$formatted
+
+EOF
+
+chmod 0644 /etc/gdm/banner

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/oval/shared.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="compliance" id="banner_etc_gdm_banner" version="2">
+    {{{ oval_metadata("The system login banner text should be set correctly.") }}}
+    <criteria operator="OR">
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
+      <criteria operator="AND">
+        <criterion comment="/etc/gdm/banner is set appropriately" test_ref="test_banner_etc_gdm_banner" />
+        <criterion comment="/etc/gdm/banner is world-readable" test_ref="test_banner_etc_gdm_banner_readable" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="correct banner in /etc/gdm/banner" id="test_banner_etc_gdm_banner" version="1">
+    <ind:object object_ref="object_banner_etc_gdm_banner" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_banner_etc_gdm_banner" version="1">
+    <ind:filepath>/etc/gdm/banner</ind:filepath>
+    <ind:pattern var_ref="login_banner_text" operation="pattern match" />
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <external_variable comment="warning banner text variable" datatype="string" id="login_banner_text" version="1" />
+
+  <unix:file_test check="all" check_existence="all_exist" comment="/etc/gdm/banner read permissions" id="test_banner_etc_gdm_banner_readable" version="1">
+    <unix:object object_ref="object_banner_etc_gdm_banner_readable" />
+    <unix:state state_ref="state_banner_etc_gdm_banner_readable" />
+  </unix:file_test>
+  <unix:file_object comment="/etc/gdm/banner" id="object_banner_etc_gdm_banner_readable" version="1">
+    <unix:filepath>/etc/gdm/banner</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_banner_etc_gdm_banner_readable" version="1">
+      <unix:uread datatype="boolean">true</unix:uread>
+      <unix:gread datatype="boolean">true</unix:gread>
+      <unix:oread datatype="boolean">true</unix:oread>
+  </unix:file_state>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/rule.yml
@@ -1,13 +1,13 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: sle12
 
-title: 'Modify the System Login Banner'
+title: 'Modify the System GUI Login Banner'
 
 description: |-
-    To configure the system login banner edit <tt>/etc/issue</tt>. Replace the
-    default text with a message compliant with the local site policy or a legal
-    disclaimer.
+    To configure the GUI system login banner edit <tt>/etc/gdm/banner</tt>.
+    Replace the default text with a message compliant with the local site
+    policy or a legal disclaimer.
 
     The DoD required text is either:
     <br /><br />
@@ -49,36 +49,16 @@ rationale: |-
 severity: medium
 
 identifiers:
-    cce@rhel7: CCE-27303-7
-    cce@rhel8: CCE-80763-6
-    cce@rhcos4: CCE-82555-4
-    cce@sle12: CCE-83054-7
+    cce@sle12: CCE-83183-4
 
 references:
-    stigid@ol7: OL07-00-010050
-    cis@rhel8: 1.8.1.2
-    cui: 3.1.9
-    disa: CCI-000048,CCI-000050
-    nist: AC-8(a),AC-8(c)
-    nist@sle12: AC-8(a),AC-8.1(ii)
-    nist-csf: PR.AC-7
-    ospp: FMT_MOF_EXT.1
-    srg: SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007
-    vmmsrg: SRG-OS-000023-VMM-000060,SRG-OS-000024-VMM-000070
-    stigid@rhel7: RHEL-07-010050
-    stigid@sle12: SLES-12-010030
-    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
-    isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
-    cobit5: DSS05.04,DSS05.10,DSS06.10
-    iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
-    cis-csc: 1,12,15,16
-    stigid@rhel8: RHEL-08-010060
+    disa: CCI-000050
+    nist: AC-8(b)
+    stigid@sle12: SLES-12-030020
 
 ocil_clause: 'it does not display the required banner'
 
 ocil: |-
     To check if the system login banner is compliant,
     run the following command:
-    <pre>$ cat /etc/issue</pre>
-
-platform: machine
+    <pre>$ cat /etc/gdm/banner</pre>

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
 
 {{{ bash_dconf_settings("org/gnome/login-screen", "banner-message-enable", "true", "gdm.d", "00-security-settings") }}}

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12,sle15
 
 title: 'Enable GNOME3 Login Warning Banner'
 
@@ -33,6 +33,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-26970-4
     cce@rhel8: CCE-80768-5
+    cce@sle12: CCE-83005-9
 
 references:
     cis@rhel8: 1.8.2
@@ -44,6 +45,7 @@ references:
     ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088
     stigid@rhel7: RHEL-07-010030
+    stigid@sle12: SLES-12-010040
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
     cobit5: DSS05.04,DSS05.10,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("login_banner_text") }}}
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12,sle15
 
 title: 'Set the GNOME3 Login Warning Banner Text'
 
@@ -31,6 +31,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-26892-0
     cce@rhel8: CCE-80770-1
+    cce@sle12: CCE-83007-5
 
 references:
     cis@rhel8: 1.8.2
@@ -42,6 +43,7 @@ references:
     ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088
     stigid@rhel7: RHEL-07-010040
+    stigid@sle12: SLES-12-010050
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
     cobit5: DSS05.04,DSS05.10,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/ansible/shared.yml
@@ -1,0 +1,33 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+
+- name: Validate /etc/gdm/Xsession is executable
+  stat:
+    path: /etc/gdm/Xsession
+  register: file_stat
+
+- name: Validate /etc/gdm/Xsession is a shell script
+  lineinfile:
+    dest: /etc/gdm/Xsession
+    line: "#!/bin/sh"
+  check_mode: yes
+  register: presence
+
+- name: Update file /etc/gdm/Xsession
+  blockinfile:
+    path: /etc/gdm/Xsession
+    block: |
+      if ! zenity --text-info \
+       --title "Consent" \
+       --filename=/etc/gdm/banner \
+       --no-markup \
+       --checkbox="Accept." 10 10; then
+        sleep 1;
+        exit 1;
+      fi
+    insertafter: "#!/bin/sh"
+    state: present
+  when: presence.changed == false and file_stat.stat.executable == true

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/bash/shared.sh
@@ -1,0 +1,32 @@
+# platform = multi_platform_sle
+
+if ! [ -x /etc/gdm/Xsession ] ; then
+    echo "can only remediate if /etc/gdm/Xsession is an executable shell script" >&2
+    exit 1
+fi
+
+if ! awk 'NR==1 && $0 == "#!/bin/sh" { exit 0 } ; { exit 1 }' /etc/gdm/Xsession ; then
+    echo "can only remediate if /etc/gdm/Xsession is a shell script" >&2
+    exit 1
+fi
+
+f=$(mktemp)
+
+echo '#!/bin/sh
+
+if ! zenity --text-info \
+ --title "Consent" \
+ --filename=/etc/gdm/banner \
+ --no-markup \
+ --checkbox="Accept." 10 10; then
+  sleep 1;
+  exit 1;
+fi
+' > "$f"
+
+# copy original contents of /etc/gdm/Xsession - but skip the shebang
+tail -n +2 /etc/gdm/Xsession >> "$f"
+
+chown --reference=/etc/gdm/Xsession "$f"
+chmod --reference=/etc/gdm/Xsession "$f"
+mv "$f" /etc/gdm/Xsession

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/oval/shared.xml
@@ -1,0 +1,43 @@
+<def-group>
+  <definition class="compliance" id="gui_login_dod_acknowledgement" version="1">
+    {{{ oval_metadata("Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.") }}}
+    <criteria operator="OR">
+      <extend_definition comment="gdm installed" definition_ref="package_gdm_installed" negate="true" />
+      <criteria comment="GUI Banner acknowledgement" operator="AND">
+        <criterion comment="GUI Banner acknowledgement is active" test_ref="test_banner_gui_acknowledgement" />
+        <criterion comment="/etc/gdm/Xsession world executable and owned by root" test_ref="test_banner_gui_acknowledgement_exec" />
+      </criteria>
+    </criteria>
+  </definition>
+  <unix:file_test check="all" check_existence="all_exist" comment="/etc/gdm/Xsession world executable and owned by root" id="test_banner_gui_acknowledgement_exec" version="1">
+    <unix:object object_ref="object_banner_gui_acknowledgement_file" />
+    <unix:state state_ref="state_banner_gui_acknowledgement_file" />
+  </unix:file_test>
+
+  <unix:file_object comment="/etc/gdm/Xsession" id="object_banner_gui_acknowledgement_file" version="1">
+      <unix:filepath>/etc/gdm/Xsession</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_state id="state_banner_gui_acknowledgement_file" version="1">
+    <unix:uread datatype="boolean">true</unix:uread>
+    <!-- don't care about uwrite-->
+    <unix:uexec datatype="boolean">true</unix:uexec>
+    <unix:gread datatype="boolean">true</unix:gread>
+    <unix:gwrite datatype="boolean">false</unix:gwrite>
+    <unix:gexec datatype="boolean">true</unix:gexec>
+    <unix:oread datatype="boolean">true</unix:oread>
+    <unix:owrite datatype="boolean">false</unix:owrite>
+    <unix:oexec datatype="boolean">true</unix:oexec>
+  </unix:file_state>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="GUI Banner acknowledgement is active"
+  id="test_banner_gui_acknowledgement" version="1">
+    <ind:object object_ref="obj_banner_gui_acknowledgement" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_banner_gui_acknowledgement" version="1">
+    <ind:filepath>/etc/gdm/Xsession</ind:filepath>
+    <ind:pattern operation="pattern match">\A#!/bin/sh\n(# BEGIN ANSIBLE MANAGED BLOCK\n)?\s*if ! zenity --text-info(\\\n|(?!\n)\s)+--title "Consent"(\\\n|(?!\n)\s)+--filename=/etc/gdm/banner(\\\n|(?!\n)\s)+--no-markup(\\\n|(?!\n)\s)+--checkbox="Accept." 10 10; then\s+sleep 1[;\n]\s*exit 1[;\n]\s*fi(# END ANSIBLE MANAGED BLOCK\n)?\s</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/rule.yml
@@ -1,0 +1,84 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Display the Standard Mandatory DoD Notice and Consent Banner until Explicit Acknowledgement'
+
+description: |-
+    Display of a standardized and approved use notification before granting access to the SUSE operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.<br/><br/>
+
+    The banner must be acknowledged by the user prior to allowing the user access to the SUSE operating system. This provides assurance that the user has seen the message and accepted the conditions for access. If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.<br/><br/>
+
+    System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.<br/><br/>
+
+    The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for the SUSE operating system:
+
+    <pre>You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+    By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+    -The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+    -At any time, the USG may inspect and seize data stored on this IS.
+
+    -Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+    -This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+    -Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.</pre>
+
+    Check the configuration by running the following command:
+
+    <pre># more /etc/gdm/Xsession</pre>
+
+    The beginning of the file must contain the following text immediately after <tt>#!/bin/sh</tt>:
+
+    <pre>if ! zenity --text-info \
+    --title "Consent" \
+    --filename=/etc/gdm/banner \
+    --no-markup \
+    --checkbox="Accept." 10 10; then
+    sleep 1;
+    exit 1;
+    fi</pre>
+
+rationale: |-
+    Display of a standardized and approved use notification before granting access to the operating system
+    ensures privacy and security notification verbiage used is consistent with applicable federal laws,
+    Executive Orders, directives, policies, regulations, standards, and guidance.
+    <br /><br />
+    For U.S. Government systems, system use notifications are required only for access via login interfaces
+    with human users and are not required when such human interfaces do not exist.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83003-4
+
+references:
+    stigid@sle12: SLES-12-010020
+    disa@sle12: CCI-000048,CCI-000050
+
+ocil_clause: 'the GNOME environment does not display the standard mandatory DoD notice and consent banner'
+
+ocil: |-
+    Verify the SUSE operating system displays the Standard Mandatory DoD Notice and Consent Banner until users acknowledge the usage conditions and take explicit actions to log on via the local GUI.
+
+    Note: If GNOME is not installed, this requirement is Not Applicable.
+
+    Check the configuration by running the following command:
+
+    <pre># more /etc/gdm/Xsession</pre>
+
+    The beginning of the file must contain the following text immediately after <tt>#!/bin/sh</tt>:
+
+    <pre>if ! zenity --text-info \
+    --title "Consent" \
+    --filename=/etc/gdm/banner \
+    --no-markup \
+    --checkbox="Accept." 10 10; then
+    sleep 1;
+    exit 1;
+    fi</pre>
+
+    If the beginning of the file does not contain the above text immediately after the line (<tt>#!/bin/sh</tt>), this is a finding.

--- a/shared/checks/oval/installed_env_has_sssd-common_package.xml
+++ b/shared/checks/oval/installed_env_has_sssd-common_package.xml
@@ -21,7 +21,7 @@
     <linux:object object_ref="obj_env_has_sssd-common_installed" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_env_has_sssd-common_installed" version="1">
-    <linux:name>sssd-common</linux:name>
+    <linux:name>{{% if product == "sle12" %}}sssd{{% else %}}sssd-common{{% endif %}}</linux:name>
   </linux:rpminfo_object>
 {{% elif pkg_system == "dpkg" %}}
   <linux:dpkginfo_test check="all" check_existence="all_exist"

--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -42,7 +42,7 @@ service_sssd_disabled:
   name: service_disabled
   vars:
     servicename: sssd
-    packagename: sssd-common
+    packagename: "{{% if product == 'sle12' %}}sssd{{% else %}}sssd-common{{% endif %}}"
 
 service_syslog_disabled:
   name: service_disabled

--- a/sle12/product.yml
+++ b/sle12/product.yml
@@ -27,3 +27,6 @@ cpes:
 platform_package_overrides:
   login_defs: "shadow"
   grub2: "grub2"
+  sssd: "sssd"
+
+auid: 1000

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -90,7 +90,6 @@ selections:
     - auditd_data_retention_action_mail_acct
     - auditd_data_retention_space_left
     - banner_etc_issue
-    - banner_etc_motd
     - chronyd_or_ntpd_set_maxpoll
     - dir_perms_world_writable_sticky_bits
     - disable_ctrlaltdel_reboot


### PR DESCRIPTION
This adds/updates the rules and remediations for the following,
but does not update the stig.profile, that will be updated
after all the enabling rule updates have landed.

- SLES-12-010020 'gui_login_dod_acknowledgement'
- SLES-12-010040 'dconf_gnome_banner_enabled'
- SLES-12-010050 'dconf_gnome_login_banner_text'
- SLES-12-010030 'banner_etc_issue'
- SLES-12-010670 'sssd_memcache_timeout'
- SLES-12-010680 'sssd_offline_cred_expiration'
- SLES-12-030170 'sshd_use_approved_ciphers'
- SLES-12-030020 'banner_etc_gdm_banner'

#### Description:

- Enable checks and remediations for the following SLES-12 STIGs: 
- SLES-12-010020 'gui_login_dod_acknowledgement'
- SLES-12-010040 'dconf_gnome_banner_enabled'
- SLES-12-010050 'dconf_gnome_login_banner_text'
- SLES-12-010030 'banner_etc_issue'
- SLES-12-010670 'sssd_memcache_timeout'
- SLES-12-010680 'sssd_offline_cred_expiration'
- SLES-12-030170 'sshd_use_approved_ciphers'
- SLES-12-030020 'banner_etc_gdm_banner'

#### Rationale:

- Enable more tests and remediation for SLES 12 Security Technical Implementation Guide.

