### PR TITLE
SLES-12 add checks and remediations.

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -38,6 +38,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-27343-3
     cce@rhel8: CCE-80863-4
+    cce@sle12: CCE-83180-0
 
 references:
     stigid@ol7: OL07-00-031000
@@ -51,8 +52,10 @@ references:
     nist-csf: PR.DS-4,PR.PT-1
     ospp: FAU_GEN.1.1.c
     srg: SRG-OS-000480-GPOS-00227
+    srg@sle12: SRG-OS-000479-GPOS-00224
     vmmsrg: SRG-OS-000032-VMM-000130
     stigid@rhel7: RHEL-07-031000
+    stigid@sle12: SLES-12-030340
     isa-62443-2013: 'SR 2.10,SR 2.11,SR 2.12,SR 2.8,SR 2.9,SR 7.1,SR 7.2'
     isa-62443-2009: 4.3.3.3.9,4.3.3.5.8,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4
     cobit5: APO11.04,APO13.01,BAI03.05,BAI04.04,DSS05.04,DSS05.07,MEA02.01

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,sle12
 
 title: 'Enable Kernel Parameter to Use TCP Syncookies on IPv4 Interfaces'
 
@@ -20,6 +20,8 @@ identifiers:
     cce@rhel7: CCE-27495-1
     cce@rhel8: CCE-80923-6
     cce@rhcos4: CCE-82492-0
+    cce@sle12: CCE-83179-2
+ 
 
 references:
     anssi: BP28(R22)
@@ -27,9 +29,11 @@ references:
     cjis: 5.10.1.1
     cui: 3.1.20
     disa: CCI-000366
+    disa@sle12: CCI-001095
     nist: CM-7(a),CM-7(b),SC-5(1),SC-5(2),SC-5(3)(a),CM-6(a)
     nist-csf: DE.AE-1,DE.CM-1,ID.AM-3,PR.AC-5,PR.DS-4,PR.DS-5,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000420-GPOS-00186,SRG-OS-000142-GPOS-00071
+    stigid@sle12: SLES-12-030350
     isa-62443-2013: 'SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 6.2,SR 7.1,SR 7.2,SR 7.6'
     isa-62443-2009: 4.2.3.4,4.3.3.4,4.4.3.3
     cobit5: APO01.06,APO13.01,BAI04.04,DSS01.03,DSS01.05,DSS03.01,DSS03.05,DSS05.02,DSS05.04,DSS05.07,DSS06.02

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -1,0 +1,17 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Get all world-writable directories with no sticky bits set
+  shell: |
+    df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null
+  register: dir_output
+
+- name: ensure sticky bit is set
+  file:
+    path: "{{ item }}"
+    mode: a+t
+  with_items:
+    - "{{ dir_output.stdout_lines }}"

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/ansible/shared.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Ensure /etc/security/opasswd exist and has the correct permissions
+  file:
+    path: /etc/security/opasswd
+    owner: root
+    group: root
+    mode: 0600
+    state: touch

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/oval/shared.xml
@@ -1,0 +1,46 @@
+<def-group>
+  <definition class="compliance" id="file_etc_security_opasswd" version="2">
+    {{{ oval_metadata("Verify Permissions and Ownership of Old Passwords File", title="Verify Permissions and Ownership of Old Passwords File") }}}
+    <criteria comment="root should own /etc/security/opasswd">
+      <criterion test_ref="test_file_etc_security_opasswd" />
+    </criteria>
+  </definition>
+
+
+  <unix:file_test check="all" check_existence="all_exist" comment="/etc/security/opasswd is owned by root:root / 0600" id="test_file_etc_security_opasswd" version="1">
+    <unix:object object_ref="object_file_etc_security_opasswd" />
+    <unix:state state_ref="state_file_etc_security_opasswd" />
+    <unix:state state_ref="state_file_group_etc_security_opasswd" />
+  </unix:file_test>
+
+  <unix:file_object id="object_file_etc_security_opasswd" version="1">
+      <unix:filepath>/etc/security/opasswd</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_state id="state_file_etc_security_opasswd" version="1">
+      <unix:user_id operation="equals" datatype="int">0</unix:user_id>
+
+      <unix:suid operation="equals" datatype="boolean">0</unix:suid>
+      <unix:sticky operation="equals" datatype="boolean">0</unix:sticky>
+
+      <unix:uread operation="equals" datatype="boolean">1</unix:uread>
+      <unix:uwrite operation="equals" datatype="boolean">1</unix:uwrite>
+      <unix:uexec operation="equals" datatype="boolean">0</unix:uexec>
+
+      <unix:oread operation="equals" datatype="boolean">0</unix:oread>
+      <unix:owrite operation="equals" datatype="boolean">0</unix:owrite>
+      <unix:oexec operation="equals" datatype="boolean">0</unix:oexec>
+
+      <unix:has_extended_acl operation="equals" datatype="boolean">0</unix:has_extended_acl>
+  </unix:file_state>
+
+  <unix:file_state id="state_file_group_etc_security_opasswd" version="1">
+      <unix:group_id operation="equals" datatype="int">0</unix:group_id>
+
+      <unix:sgid operation="equals" datatype="boolean">0</unix:sgid>
+      <unix:gread operation="equals" datatype="boolean">0</unix:gread>
+      <unix:gwrite operation="equals" datatype="boolean">0</unix:gwrite>
+      <unix:gexec operation="equals" datatype="boolean">0</unix:gexec>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Verify Permissions and Ownership of Old Passwords File'
+
+description: '{{{ describe_file_owner(file="/etc/security/opasswd", owner="root") }}}
+{{{ describe_file_group_owner(file="/etc/security/opasswd", group="root") }}}
+{{{ describe_file_permissions(file="/etc/security/opasswd", perms="0600") }}}'
+
+rationale: |-
+    The <tt>/etc/security/opasswd</tt> file stores old passwords to prevent
+    password reuse. Protection of this file is critical for system security.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83172-7
+
+references:
+    stigid@sle12: SLES-12-010300
+    disa@sle12: CCI-000200
+    nist@sle12: IA-5(1)(e),IA-5(1).1(v)
+    srg@sle12: SRG-OS-000077-GPOS-00045
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/security/opasswd", owner="root") }}} and {{{ ocil_clause_file_group_owner(file="/etc/security/opasswd", group="root") }}} and {{{ ocil_clause_file_permissions(file="/etc/security/opasswd", perms="0600") }}}'
+
+ocil: '{{{ ocil_file_owner(file="/etc/security/opasswd", owner="root") }}}
+{{{ ocil_file_group_owner(file="/etc/security/opasswd", group="root") }}}
+{{{ ocil_file_permissions(file="/etc/security/opasswd", perms="0600") }}}'

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,ubuntu1804
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019,ubuntu1804
 
 title: 'Disable the Automounter'
 
@@ -28,6 +28,7 @@ identifiers:
     cce@rhel7: CCE-27498-5
     cce@rhel8: CCE-80873-3
     cce@rhcos4: CCE-82663-6
+    cce@sle12: CCE-83070-3
 
 references:
     stigid@ol7: OL07-00-020110
@@ -46,6 +47,7 @@ references:
     iso27001-2013: A.11.2.6,A.13.1.1,A.13.2.1,A.18.1.4,A.6.2.1,A.6.2.2,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5
     cis@sle15: 1.1.23
+    stigid@sle12: SLES-12-010590
     stigid@rhel8: RHEL-08-040070
 
 ocil: '{{{ ocil_service_disabled(service="autofs") }}}'

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
@@ -1,0 +1,7 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+- name: "Run dconf update"
+  shell: dconf update

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
 dconf update

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12
 
 title: 'Make sure that the dconf databases are up-to-date with regards to respective keyfiles'
 
@@ -19,6 +19,7 @@ severity: high
 identifiers:
     cce@rhel8: CCE-81003-6
     cce@rhel7: CCE-81004-4
+    cce@sle12: CCE-83182-6
 
 references:
     srg: SRG-OS-000480-GPOS-00227

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/ansible/shared.yml
@@ -1,0 +1,12 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+
+- name: "Configure GNOME3 DConf User Profile"
+  lineinfile:
+    dest: "/etc/dconf/profile/gdm"
+    line: "user-db:user\nsystem-db:gdm"
+    create: yes
+    state: present

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_sle
+
+echo -e 'user-db:user\nsystem-db:gdm' > /etc/dconf/profile/gdm

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
@@ -13,8 +13,13 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_dconf_user_profile"
   version="2">
-    <ind:filepath>/etc/dconf/profile/user</ind:filepath>
-    <ind:pattern operation="pattern match">^user-db:user\nsystem-db:local$</ind:pattern>
+    {{% if product == "sle12" %}}
+      <ind:filepath>/etc/dconf/profile/gdm</ind:filepath>
+      <ind:pattern operation="pattern match">^user-db:user\nsystem-db:gdm$</ind:pattern>
+    {{% else %}}
+      <ind:filepath>/etc/dconf/profile/user</ind:filepath>
+      <ind:pattern operation="pattern match">^user-db:user\nsystem-db:local$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12,sle15
 
 title: 'Configure GNOME3 DConf User Profile'
 
@@ -10,6 +10,13 @@ description: |-
     highest priority. As such the DConf User profile should always exist and be
     configured correctly.
     <br /><br />
+    {{% if product == "sle12" %}}
+    To make sure that the user profile is configured correctly, the <tt>/etc/dconf/profile/gdm</tt>
+    should be set as follows:
+    <pre>user-db:user
+    system-db:gdm
+    </pre>
+    {{% else %}}
     To make sure that the user profile is configured correctly, the <tt>/etc/dconf/profile/user</tt>
     should be set as follows:
     <pre>user-db:user
@@ -17,6 +24,7 @@ description: |-
     system-db:site
     system-db:distro
     </pre>
+    {{% endif %}}
 
 rationale: |-
     Failure to have a functional DConf profile prevents GNOME3 configuration settings
@@ -26,17 +34,25 @@ severity: high
 
 identifiers:
     cce@rhel7: CCE-27446-4
+    cce@sle12: CCE-83006-7
 
 ocil_clause: 'DConf User profile does not exist or is not configured correctly'
 
 ocil: |-
     To verify that the DConf User profile is configured correctly, run the following
     command:
+    {{% if product == "sle12" %}}
+    <pre>$ cat /etc/dconf/profile/gdm</pre>
+    The output should show the following:
+    <pre>user-db:user
+    system-db:gdm</pre>
+    {{% else %}}
     <pre>$ cat /etc/dconf/profile/user</pre>
     The output should show the following:
     <pre>user-db:user
     system-db:local
     system-db:site
     system-db:distro</pre>
+    {{% endif %}}
 
 platform: machine

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -1,0 +1,34 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Install aide package
+  zypper:
+    name: aide
+    state: latest
+
+- name: Set audit_tools fact
+  set_fact:
+    audit_tools:
+      - /usr/sbin/audispd
+      - /usr/sbin/auditctl
+      - /usr/sbin/auditd
+      - /usr/sbin/augenrules
+      - /usr/sbin/aureport
+      - /usr/sbin/ausearch
+      - /usr/sbin/autrace
+
+- name: Ensure existing AIDE configuration for audit tools are correct
+  lineinfile:
+    path: /etc/aide.conf
+    regexp: ^{{ item }}\s
+    line: "{{ item }} p+i+n+u+g+s+b+acl+selinux+xattrs+sha512"
+  with_items: "{{ audit_tools }}"
+
+- name: Configure AIDE to properly protect audit tools
+  lineinfile:
+    path: /etc/aide.conf
+    line: "{{ item }} p+i+n+u+g+s+b+acl+selinux+xattrs+sha512"
+  with_items: "{{ audit_tools }}"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
@@ -1,0 +1,112 @@
+<def-group>
+  <definition class="compliance" id="aide_check_audit_tools" version="1">
+    {{{ oval_metadata("The SUSE operating system file integrity tool must be configured to protect the integrity of the audit tools.", title="Configure AIDE to Verify the Audit Tools") }}}
+    <criteria operator="AND">
+      <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
+      <criterion comment="auditctl is checked in /etc/aide.conf" test_ref="test_aide_verify_auditctl" />
+      <criterion comment="auditd is checked in /etc/aide.conf" test_ref="test_aide_verify_auditd" />
+      <criterion comment="ausearch is checked in /etc/aide.conf" test_ref="test_aide_verify_ausearch" />
+      <criterion comment="aureport is checked in /etc/aide.conf" test_ref="test_aide_verify_aureport" />
+      <criterion comment="autrace is checked in /etc/aide.conf" test_ref="test_aide_verify_autrace" />
+      <criterion comment="audispd is checked in /etc/aide.conf" test_ref="test_aide_verify_audispd" />
+      <criterion comment="augenrules is checked in /etc/aide.conf" test_ref="test_aide_verify_augenrules" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_state id="state_aide_check_attributes" version="1">
+    <ind:subexpression operation="equals">p+i+n+u+g+s+b+acl+selinux+xattrs+sha512</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_aide_verify_auditctl"
+  comment="auditctl is checked in /etc/aide.conf" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_auditctl" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_auditctl"
+  version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\/usr\/sbin\/auditctl\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_auditd"
+  comment="auditd is checked in /etc/aide.conf" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_auditd" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_auditd"
+  version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^/usr/sbin/auditd\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_ausearch"
+  comment="ausearch is checked in /etc/aide.conf" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_ausearch" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_ausearch"
+  version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^/usr/sbin/ausearch\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_aureport"
+  comment="aureport is checked in /etc/aide.conf" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_aureport" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_aureport"
+  version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^/usr/sbin/aureport\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_autrace"
+  comment="autrace is checked in /etc/aide.conf" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_autrace" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_autrace"
+  version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^/usr/sbin/autrace\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_audispd"
+  comment="audispd is checked in /etc/aide.conf" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_audispd" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_audispd"
+  version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^/usr/sbin/audispd\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_aide_verify_augenrules"
+  comment="augenrules is checked in /etc/aide.conf" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_augenrules" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_augenrules"
+  version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^/usr/sbin/augenrules\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+</def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -1,0 +1,61 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Configure AIDE to Verify the Audit Tools'
+
+description: |-
+    The SUSE operating system file integrity tool must be configured to protect the integrity of the audit tools.
+
+rationale: |-
+    Protecting the integrity of the tools used for auditing purposes is a
+    critical step toward ensuring the integrity of audit information. Audit
+    information includes all information (e.g., audit records, audit settings,
+    and audit reports) needed to successfully audit information system
+    activity.
+
+    Audit tools include but are not limited to vendor-provided and open-source
+    audit tools needed to successfully view and manipulate audit information
+    system activity and records. Audit tools include custom queries and report
+    generators.
+
+    It is not uncommon for attackers to replace the audit tools or inject code
+    into the existing tools to provide the capability to hide or erase system
+    activity from the audit logs.
+
+    To address this risk, audit tools must be cryptographically signed to
+    provide the capability to identify when the audit tools have been modified,
+    manipulated, or replaced. An example is a checksum hash of the file or
+    files.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83204-8
+
+references:
+    disa@sle12: CCI-001496
+    nist@sle12: AU-9(3),AU-9(3).1
+    stigid@sle12: SLES-12-010540
+    srg@sle12: SRG-OS-000278-GPOS-00108
+
+ocil_clause: 'integrity checks of the audit tools are missing or incomplete'
+
+ocil: |-
+    Check that AIDE is properly configured to protect the integrity of the
+    audit tools by running the following command:
+
+    <pre># sudo cat /etc/aide.conf | grep /usr/sbin/au
+
+    /usr/sbin/auditctl p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+    /usr/sbin/auditd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+    /usr/sbin/ausearch p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+    /usr/sbin/aureport p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+    /usr/sbin/autrace p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+    /usr/sbin/audispd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+    /usr/sbin/augenrules p+i+n+u+g+s+b+acl+selinux+xattrs+sha512</pre>
+
+    If AIDE is configured properly to protect the integrity of the audit tools,
+    all lines listed above will be returned from the command.
+
+    If one or more lines are missing, this is a finding.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -1,0 +1,23 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "Gather list of packages"
+  package_facts:
+    manager: auto
+
+- name: get rules groups
+  shell: |
+    LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
+  when: "'aide' in ansible_facts.packages"
+  register: find_rules_groups_results
+
+- name: ensure the acl rule is present when aide is installed.
+  replace:
+    path: /etc/aide.conf
+    regexp: (^\s*{{ item }}\s*=\s*)(?!.*acl)([^\s]*)
+    replace: \g<1>\g<2>+acl
+  when: "'aide' in ansible_facts.packages"
+  with_items: "{{ find_rules_groups_results.stdout_lines | map('trim') | list }}"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -1,0 +1,24 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "Gather list of packages"
+  package_facts:
+    manager: auto
+
+- name: get rules groups
+  shell: |
+    LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
+  when: "'aide' in ansible_facts.packages"
+  register: find_rules_groups_results
+
+- name: ensure the xattrs rule is present when aide is installed.
+  replace:
+    path: /etc/aide.conf
+    regexp: (^\s*{{ item }}\s*=\s*)(?!.*xattrs)([^\s]*)
+    replace: \g<1>\g<2>+xattrs
+  when: "'aide' in ansible_facts.packages"
+  with_items: "{{ find_rules_groups_results.stdout_lines | map('trim') | list }}"
+

--- a/linux_os/guide/system/software/sap_host/accounts_authorized_local_users/ansible/shared.yml
+++ b/linux_os/guide/system/software/sap_host/accounts_authorized_local_users/ansible/shared.yml
@@ -1,0 +1,19 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("var_accounts_authorized_local_users_regex") }}}
+
+- name: Read /etc/shadow
+  getent:
+    database: shadow
+
+# TODO(gyee): should we remove user's home dir and mail spool?
+- name: Remove unauthorized accounts
+  user:
+    name: "{{ item.key }}"
+    force: yes
+    state: absent
+  when: item.key is not regex(var_accounts_authorized_local_users_regex)
+  with_dict: "{{ getent_shadow }}"

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/sle12.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/sle12.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Ensure Zypper Removes Previous Package Versions
+  ini_file:
+    dest: /etc/zypp/zypp.conf
+    section: main
+    option: solver.upgradeRemoveDroppedPackages
+    value: true
+    create: False

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/bash/sle12.sh
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/bash/sle12.sh
@@ -1,0 +1,4 @@
+# platform = SUSE Linux Enterprise 12
+. /usr/share/scap-security-guide/remediation_functions
+
+replace_or_append '/etc/zypp/zypp.conf' '^solver.upgradeRemoveDroppedPackages' 'true' '@CCENUM@' '%s=%s'

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/oval/sle12.xml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/oval/sle12.xml
@@ -1,0 +1,25 @@
+<def-group oval_version="5.10">
+  <definition class="compliance" id="clean_components_post_updating" version="1">
+    <metadata>
+      <title>Ensure Zypper Removes Previous Package Versions</title>
+      <affected family="unix">
+        <platform>SUSE Linux Enterprise 12</platform>
+      </affected>
+      <description>The solver.upgradeRemoveDroppedPackages option should be used to ensure that old
+      versions of software components are removed after updating.</description>
+    </metadata>
+    <criteria>
+        <criterion comment="check value of solver.upgradeRemoveDroppedPackages in /etc/zypp/zypp.conf" test_ref="test_zypp_clean_components_post_updating" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of solver.upgradeRemoveDroppedPackages in /etc/zypp/zypp.conf" id="test_zypp_clean_components_post_updating" version="1">
+    <ind:object object_ref="object_zypp_clean_components_post_updating" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_zypp_clean_components_post_updating" comment="solver.upgradeRemoveDroppedPackages set in /etc/zypp/zypp.conf" version="1">
+    <ind:filepath>/etc/zypp/zypp.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^solver.upgradeRemoveDroppedPackages\s*=\s*(?i)true(?-i)\s*$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>
+


### PR DESCRIPTION
This adds/updates the rules and remediations for the following,
but does not update the stig.profile, that will be updated
after all the enabling rule updates have landed.

- SLES-12-010300 'file_etc_security_opasswd'
- SLES-12-010540 'aide_check_audit_tools'
- SLES-12-010570 'clean_components_post_updating'
- SLES-12-010590 'service_autofs_disabled'
- SLES-12-010630 'accounts_authorized_local_users'
- SLES-12-030340 'rsyslog_remote_loghost'
- SLES-12-030350 'sysctl_net_ipv4_tcp_syncookies'

#### Description:

- Enable checks and remediations for the following SLES-12 STIGs: 
- SLES-12-010300 'file_etc_security_opasswd'
- SLES-12-010540 'aide_check_audit_tools'
- SLES-12-010570 'clean_components_post_updating'
- SLES-12-010590 'service_autofs_disabled'
- SLES-12-010630 'accounts_authorized_local_users'
- SLES-12-030340 'rsyslog_remote_loghost'
- SLES-12-030350 'sysctl_net_ipv4_tcp_syncookies'


#### Rationale:

- Enable more tests and remediation for SLES 12 Security Technical Implementation Guide.

