### PR TITLE
SLES-12 add checks and remediations.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Check that vlock is installed to allow session locking'
+
+description: |-
+    The SUSE operating system must have vlock installed to allow for session locking.
+
+    {{{ describe_package_install(package="kbd") }}}
+
+rationale: |-
+    A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
+
+    The session lock is implemented at the point where session activity can be determined.
+
+    Regardless of where the session lock is determined and implemented, once invoked, the session lock must remain in place until the user reauthenticates. No other activity aside from reauthentication must unlock the system.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83009-1
+
+references:
+    stigid@sle12: SLES-12-010070
+    disa@sle12: CCI-000056,CCI-000058,CCI-000060
+    nist@sle12: AC-11(a),AC-11(b),AC-11(1)
+    srg@sle12: SRG-OS-000028-GPOS-00009
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="kbd") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: kbd

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/ansible/shared.yml
@@ -1,0 +1,22 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+- name: Set smartcard packages fact
+  set_fact:
+    smartcard_packages:
+      - pam_pkcs11
+      - mozilla-nss
+      - mozilla-nss-tools
+      - pcsc-ccid
+      - pcsc-lite
+      - pcsc-tools
+      - opensc
+      - coolkey
+
+- name: Ensure {{ smartcard_packages }} are installed
+  package:
+    name: "{{ smartcard_packages }}"
+    state: present

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
@@ -1,0 +1,18 @@
+{{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc', 'coolkey'] %}}
+
+<def-group>
+  <definition class="compliance" id="install_smartcard_packages"
+  version="1">
+    {{{ oval_metadata("The " + pkg_system|upper + " packages " + smartcard_packages|join(',') + " should be installed.", affected_platforms=["multi_platform_sle"]) }}}
+    <criteria operator="AND" comment="Make sure all smartcard packages are installed">
+{{% for pkg in smartcard_packages %}}
+      <criterion comment="package {{{ pkg }}} is installed"
+      test_ref="test_package_{{{ pkg }}}_installed" />
+{{% endfor %}}
+    </criteria>
+  </definition>
+
+{{% for pkg in smartcard_packages %}}
+{{{ oval_test_package_installed(package=pkg, evr=EVR, test_id="test_package_" + pkg + "_installed") }}}
+{{% endfor %}}
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -1,17 +1,23 @@
+{{% if product == 'sle12' %}}
+{{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc', 'coolkey'] %}}
+{{% elif product in ["rhel7", "ol7"] %}}
+{{% set smartcard_packages = ['pam_pkcs11'] %}}
+{{% else %}}
+{{% set smartcard_packages = ['openssl-pkcs11'] %}}
+{{% endif %}}
+
 documentation_complete: true
 
-prodtype: fedora,ol7,rhel7,rhel8
+prodtype: fedora,ol7,rhel7,rhel8,sle12
 
 title: 'Install Smart Card Packages For Multifactor Authentication'
 
 description: |-
     Configure the operating system to implement multifactor authentication by
     installing the required package with the following command:
-    {{%- if product in ["rhel7", "ol7"] %}}
-    {{{ describe_package_install(package="pam_pkcs11") }}}
-    {{%- else %}}
-    {{{ describe_package_install(package="openssl-pkcs11") }}}
-    {{%- endif %}}
+    {{% for pkg in smartcard_packages %}}
+    {{{ describe_package_install(package=pkg) }}}
+    {{% endfor %}}
 
 rationale: |-
     Using an authentication device, such as a CAC or token that is separate from
@@ -29,6 +35,7 @@ severity: medium
 
 identifiers:
     cce@rhel7: CCE-80519-2
+    cce@sle12: CCE-83177-6
     cce@rhel8: CCE-84029-8
 
 references:
@@ -37,19 +44,21 @@ references:
     nist: CM-6(a)
     srg: SRG-OS-000105-GPOS-00052,SRG-OS-000375-GPOS-00160,SRG-OS-000375-GPOS-00161,SRG-OS-000377-GPOS-00162
     stigid@rhel7: RHEL-07-041001
+    stigid@sle12: SLES-12-030500
     stigid@rhel8: RHEL-08-010390
 
 ocil_clause: 'smartcard software is not installed'
 
-{{%- if product in ["rhel7", "ol7"] %}}
-ocil: '{{{ ocil_package(package="pam_pkcs11") }}}'
-{{%- else %}}
-ocil: '{{{ ocil_package(package="openssl-pkcs11") }}}'
-{{%- endif %}}
+ocil: |-
+    {{% for pkg in smartcard_packages %}}
+    '{{{ ocil_package(package=pkg) }}}'
+    {{% endfor %}}
 
+{{% if product != 'sle12' %}}
 template:
     name: package_installed
     vars:
         pkgname: openssl-pkcs11
         pkgname@rhel7: pam_pkcs11
         pkgname@ol7: pam_pkcs11
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/ansible/shared.yml
@@ -1,0 +1,22 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: package facts
+  package_facts:
+
+- name: Replace 'none' from cert_policy
+  replace:
+    path: /etc/pam_pkcs11/pam_pkcs11.conf
+    regexp: (^\s*cert_policy\s*=\s*)none\s*;(\s*$)
+    replace: \g<1>ocsp_on,ca,signature;\g<2>
+  when: "'pam_pkcs11' in ansible_facts.packages"
+
+- name: Add 'ca' parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf
+  replace:
+    path: /etc/pam_pkcs11/pam_pkcs11.conf
+    regexp: (^\s*cert_policy\s*=\s*)(?!.*ca)(.*)
+    replace: \g<1>ca,\g<2>
+  when: "'pam_pkcs11' in ansible_facts.packages"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="smartcard_configure_ca" version="3">
+    {{{ oval_metadata("Enable Smart Card CA Checks") }}}
+    <criteria comment="smart card authentication is configured" operator="AND">
+      <extend_definition comment="smartcard package is installed" definition_ref="install_smartcard_packages" />
+      <criterion comment="cert_policy directive contains ca" test_ref="test_pam_pkcs11_cert_policy_ca" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_pam_pkcs11_cert_policy_ca" check="all" check_existence="all_exist"
+  comment="Test ca in /etc/pam_pkcs11/pkcs11.conf" version="1">
+    <ind:object object_ref="object_pam_pkcs11_cert_policy_ca" />
+    <ind:state state_ref="state_pam_pkcs11_cert_policy_ca" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_pam_pkcs11_cert_policy_ca" version="1">
+    <ind:filepath>/etc/pam_pkcs11/pam_pkcs11.conf</ind:filepath>
+    <!-- PKCS #11 module can be either CoolKey or OpenSC. Check cert_policy for all of them. -->
+    <ind:pattern operation="pattern match">^[\s]*cert_policy[ ]=\s*(.*);$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_pam_pkcs11_cert_policy_ca" version="1">
+    <ind:subexpression operation="pattern match">(^|,\s*)ca(\s*,|$)</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
@@ -1,13 +1,13 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,sle12
+prodtype: sle12
 
-title: 'Configure Smart Card Certificate Status Checking'
+title: 'Configure Smart Card Certificate Authority Validation'
 
 description: |-
     Configure the operating system to do certificate status checking for PKI
     authentication. Modify all of the <tt>cert_policy</tt> lines in
-    <tt>/etc/pam_pkcs11/pam_pkcs11.conf</tt> to include <tt>ocsp_on</tt> like so:
+    <tt>/etc/pam_pkcs11/pam_pkcs11.conf</tt> to include <tt>ca</tt> like so:
     <pre>cert_policy = ca, ocsp_on, signature;</pre>
 
 rationale: |-
@@ -25,18 +25,15 @@ rationale: |-
 severity: medium
 
 identifiers:
-    cce@rhel7: CCE-80520-0
-    cce@rhel8: CCE-82475-5
-    cce@sle12: CCE-83178-4
+    cce@sle12: CCE-83198-2
 
 references:
-    stigid@ol7: OL07-00-041003
-    disa: CCI-001948,CCI-001953,CCI-001954
-    srg: SRG-OS-000375-GPOS-00160,SRG-OS-000376-GPOS-00161,SRG-OS-000377-GPOS-00162,SRG-OS-000384-GPOS-00167
-    stigid@rhel7: RHEL-07-041003
-    stigid@sle12: SLES-12-030510
+    disa@sle12: CCI-000185,CCI-001991
+    nist@sle12: IA-5 (2),IA-5(2)(a),IA-5 (2).1,IA-5(2)(d)
+    stigid@sle12: SLES-12-030530
+    srg@sle12: SRG-OS-000066-GPOS-00034,SRG-OS-000384-GPOS-00167
 
-ocil_clause: 'ocsp_on is not configured'
+ocil_clause: 'ca is not configured'
 
 ocil: |-
     To verify the operating system implements certificate status checking for PKI
@@ -46,3 +43,5 @@ ocil: |-
     <pre>cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;</pre>
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/ansible/shared.yml
@@ -1,0 +1,22 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: package facts
+  package_facts:
+
+- name: Replace 'none' from cert_policy
+  replace:
+    path: /etc/pam_pkcs11/pam_pkcs11.conf
+    regexp: (^\s*cert_policy\s*=\s*)none\s*;(\s*$)
+    replace: \g<1>ocsp_on,ca,signature;\g<2>
+  when: "'pam_pkcs11' in ansible_facts.packages"
+
+- name: Add 'ocsp_on' parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf
+  replace:
+    path: /etc/pam_pkcs11/pam_pkcs11.conf
+    regexp: (^\s*cert_policy\s*=\s*)(?!.*ocsp_on)(.*)
+    replace: \g<1>ocsp_on,\g<2>
+  when: "'pam_pkcs11' in ansible_facts.packages"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="smartcard_configure_cert_checking" version="4">
+    <metadata>
+      <title>Enable Smart Card Login</title>
+      <affected family="unix">
+        <platform>multi_platform_sle</platform>
+      </affected>
+      <description>Enable Smart Card logins</description>
+    </metadata>
+    <criteria comment="smart card authentication is configured" operator="AND">
+      {{% if product == "sle12" %}}
+      <extend_definition comment="pam_pkcs11 package is installed" definition_ref="install_smartcard_packages" />
+      {{% endif %}}
+      <criterion comment="cert_policy directive contains ocsp_on" test_ref="test_pam_pkcs11_cert_policy_ocsp_on" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_pam_pkcs11_cert_policy_ocsp_on" check="all" check_existence="all_exist"
+  comment="Test ocsp_on in /etc/pam_pkcs11/pam_pkcs11.conf" version="1">
+    <ind:object object_ref="object_pam_pkcs11_cert_policy_ocsp_on" />
+    <ind:state state_ref="state_pam_pkcs11_cert_policy_ocsp_on" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_pam_pkcs11_cert_policy_ocsp_on" version="1">
+    <ind:filepath>/etc/pam_pkcs11/pam_pkcs11.conf</ind:filepath>
+    <!-- PKCS #11 module can be either CoolKey or OpenSC. Check cert_policy for all of them. -->
+    <ind:pattern operation="pattern match">^[\s]*cert_policy[ ]=(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_pam_pkcs11_cert_policy_ocsp_on" version="1">
+    <ind:subexpression operation="pattern match">^.*ocsp_on.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -1,0 +1,33 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "Gather list of packages"
+  package_facts:
+    manager: auto
+
+- name: Check to see if 'pam_pkcs11' module is configured in '/etc/pam.d/common-auth'
+  shell: |
+    grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth | cat
+  register: check_pam_pkcs11_module_result
+  when: '"pam_pkcs11" in ansible_facts.packages'
+
+- name: Configure 'pam_pkcs11' module in '/etc/pam.d/common-auth'
+  lineinfile:
+    path: /etc/pam.d/common-auth
+    line: 'auth sufficient pam_pkcs11.so'
+    insertafter: '^\s*#'
+    state: present
+  when:
+    - '"pam_pkcs11" in ansible_facts.packages'
+    - '"pam_pkcs11.so" not in check_pam_pkcs11_module_result.stdout'
+
+- name: Ensure 'pam_pkcs11' module has 'sufficient' control flag
+  lineinfile:
+    path: /etc/pam.d/common-auth
+    regexp: '^(\s*auth\s+)\S+(\s+pam_pkcs11\.so.*)'
+    line: '\g<1>sufficient\g<2>'
+    backrefs: yes
+  when: '"pam_pkcs11" in ansible_facts.packages'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/oval/shared.xml
@@ -1,0 +1,23 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="smartcard_pam_enabled" version="3">
+   {{{ oval_metadata("Enable Smart Card logins using PAM") }}}
+
+    <criteria operator="OR" comment="smart card authentication is configured">
+      <extend_definition comment="packages needed for smartcard support are installed" definition_ref="install_smartcard_packages" negate="true" />
+      <criterion comment="smart card is configured in /etc/pam.d/common-auth" test_ref="test_smart_card_common_auth" />
+    </criteria>
+  </definition>
+
+  <!-- Test the smart card authentication required case (login is allowed only by smartcard) -->
+  <ind:textfilecontent54_test id="test_smart_card_common_auth" check="all" check_existence="all_exist"
+  comment="Test smartcard authentication is required in /etc/pam.d/common-auth file" version="1">
+    <ind:object object_ref="object_smart_card_common_auth" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_smart_card_common_auth" version="1">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">^\s*auth\s+(?:sufficient|required)\s+pam_pkcs11.so(?:\s|$)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
@@ -1,0 +1,76 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Enable Smart Card Logins in PAM'
+
+description: |-
+    This requirement only applies to components where this is specific to the
+    function of the device or has the concept of an organizational user (e.g.,
+    VPN, proxy capability). This does not apply to authentication for the
+    purpose of configuring the device itself (management).
+
+    Check that the <tt>pam_pkcs11.so</tt> option is configured in the
+    <tt>etc/pam.d/common-auth</tt> file with the following command:
+
+    <pre># grep pam_pkcs11.so /etc/pam.d/common-auth
+
+    auth sufficient pam_pkcs11.so</pre>
+
+    For general information about enabling smart card authentication, consult
+    the documentation at:
+    <ul>
+    <li><b>{{{ weblink(link="https://www.suse.com/c/configuring-smart-card-authentication-suse-linux-enterprise/") }}}</b></li>
+    </ul>
+
+rationale: |-
+    Smart card login provides two-factor authentication stronger than
+    that provided by a username and password combination. Smart cards leverage PKI
+    (public key infrastructure) in order to provide and verify credentials.
+
+    Using an authentication device, such as a CAC or token that is separate
+    from the information system, ensures that even if the information system is
+    compromised, that compromise will not affect credentials stored on the
+    authentication device.
+
+    Multifactor solutions that require devices separate from information
+    systems gaining access include, for example, hardware tokens providing
+    time-based or challenge-response authenticators and smart cards such as the
+    U.S. Government Personal Identity Verification card and the DoD Common
+    Access Card.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83208-9
+
+references:
+    disa@sle12: CCI-000765,CCI-000766,CCI-000767,CCI-000768,CCI-000187,CCI-001948,CCI-001953,CCI-001954
+    nist@sle12: IA-2(1),IA-2(1).1,IA-2(2),IA-2(2).1,IA-2(3),IA-2(3).1,IA-2(4),IA-2(4).1,IA-5(2),IA-5(2).1,IA-5(2)(c),IA-2(11),IA-2(12)
+    stigid@sle12: SLES-12-030520
+    srg@sle12: SRG-OS-000068-GPOS-00036,SRG-OS-000105-GPOS-00052,SRG-OS-000106-GPOS-00053,SRG-OS-000107-GPOS-00054,SRG-OS-000108-GPOS-00055,SRG-OS-000375-GPOS-00160,SRG-OS-000375-GPOS-00161,SRG-OS-000375-GPOS-00162
+
+ocil_clause: 'non-exempt accounts are not using CAC authentication'
+
+ocil: |-
+    Remote access is access to DoD nonpublic information systems by an
+    authorized user (or an information system) communicating through an
+    external, non-organization-controlled network. Remote access methods
+    include, for example, dial-up, broadband, and wireless.
+
+    This requirement only applies to components where this is specific to the
+    function of the device or has the concept of an organizational user (e.g.,
+    VPN, proxy capability). This does not apply to authentication for the
+    purpose of configuring the device itself (management).
+
+    Check that the <tt>pam_pkcs11.so</tt> option is configured in the
+    <tt>etc/pam.d/common-auth</tt> file with the following command:
+
+    <pre># grep pam_pkcs11.so /etc/pam.d/common-auth
+
+    auth sufficient pam_pkcs11.so</pre>
+
+    If <tt>pam_pkcs11.so</tt> is not set in <tt>etc/pam.d/common-auth</tt> this
+    is a finding.
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_admin/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_admin/rule.yml
@@ -1,0 +1,59 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Never Automatically Remove or Disable Emergency Administrator Accounts'
+
+description: |-
+    Emergency accounts are privileged accounts that are established in response
+    to crisis situations where the need for rapid account activation is
+    required. Therefore, emergency account activation may bypass normal account
+    authorization processes. If these accounts are automatically disabled,
+    system maintenance during emergencies may not be possible, thus adversely
+    affecting system availability.
+
+    Check to see if an emergency administrator account password or account expires with the following command:
+
+    <pre># sudo chage -l [Emergency_Administrator]
+
+    Password expires:never</pre>
+
+    If <tt>Password expires</tt> or <tt>Account expires</tt> is set to anything other than <tt>never</tt>, this is a finding.
+
+
+rationale: |-
+    Emergency accounts are different from infrequently used accounts (i.e.,
+    local logon accounts used by the organization's system administrators when
+    network or normal logon/access is not available). Infrequently used
+    accounts are not subject to automatic termination dates. Emergency accounts
+    are accounts created in response to crisis situations, usually for use by
+    maintenance personnel. The automatic expiration or disabling time period
+    may be extended as needed until the crisis is resolved; however, it must
+    not be extended indefinitely. A permanent account should be established for
+    privileged users who need long-term maintenance accounts.
+
+    To address access requirements the SUSE operating system can be integrated
+    with enterprise-level authentication/access mechanisms that meet or exceed
+    access control policy requirements.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83175-0
+
+references:
+    disa@sle12: CCI-001682
+    nist@sle12: AC-2(2),AC-2(2).1(ii)
+    stigid@sle12: SLES-12-010330
+    srg@sle12: SRG-OS-000123-GPOS-00064
+
+ocil_clause: 'any emergency administrator account or account password has an expiration date set'
+
+ocil: |-
+    Check to see if an emergency administrator account password or account expires with the following command:
+
+    <pre># sudo chage -l [Emergency_Administrator]
+
+    Password expires:never</pre>
+
+    If <tt>Password expires</tt> or <tt>Account expires</tt> is set to anything other than <tt>never</tt>, this is a finding.

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/policy_temp_passwords_immediate_change/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/policy_temp_passwords_immediate_change/rule.yml
@@ -1,0 +1,54 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Policy Requires Immediate Change of Temporary Passwords'
+
+description: |-
+    Temporary passwords for SUSE operating system logons must require an
+    immediate change to a permanent password.
+
+    Verify that a policy exists that ensures when a user is created, it is
+    creating using a method that forces a user to change their password upon
+    their next login.
+
+
+rationale: |-
+    Without providing this capability, an account may be created without a
+    password. Nonrepudiation cannot be guaranteed once an account is created if
+    a user is not forced to change the temporary password upon initial logon.
+
+    Temporary passwords are typically used to allow access when new accounts
+    are created or passwords are changed. It is common practice for
+    administrators to create temporary passwords for user accounts that allow
+    the users to log on, yet force them to change the password once they have
+    successfully authenticated.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83205-5
+
+references:
+    disa@sle12: CCI-002041
+    nist@sle12: IA-5(1)(f)
+    stigid@sle12: SLES-12-010660
+    srg@sle12: SRG-OS-000380-GPOS-00165
+
+ocil_clause: 'any temporary or emergency accounts have no expiration date set or do not expire within a documented time frame'
+
+ocil: |-
+    Verify that a policy exists that ensures when a user is created, it is
+    creating using a method that forces a user to change their password upon
+    their next login.
+
+    Configure the SUSE operating system to allow the use of a temporary
+    password for system logons with an immediate change to a permanent
+    password.
+
+    Using one of the acceptable methods listed below, force a user to change
+    their password on their next logon by replacing "[UserName]" in the one of the
+    following commands:
+
+    <pre># chage -d 0 [UserName]
+    # passwd -e [UserName]</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/oval/shared.xml
@@ -1,0 +1,51 @@
+<def-group>
+  <definition class="compliance" id="account_unique_id" version="1">
+    {{{ oval_metadata("All accounts on the system should have unique IDs for proper accountability.") }}}
+      <criteria comment="There should not exist duplicate user IDs entries in /etc/passwd">
+        <criterion test_ref="test_etc_passwd_no_duplicate_user_ids" />
+      </criteria>
+
+  </definition>
+
+  <!-- collect informatino about all users -->
+  <unix:password_object id="obj_all_uids" version="1">
+    <unix:username operation="pattern match">.*</unix:username>
+  </unix:password_object>
+
+  <!-- variable storing count of all uids - including duplicates -->
+  <local_variable id="variable_count_of_all_uids" datatype="int" version="1"
+  comment="Count of all uids (including duplicates if any)">
+    <count>
+      <object_component item_field="user_id" object_ref="obj_all_uids" />
+    </count>
+  </local_variable>
+
+  <!-- Turn the OVAL variable representing count of user ids into OVAL object
+       (for use in <variable_test> below)-->
+  <ind:variable_object id="obj_count_of_all_uids" version="1">
+    <ind:var_ref>variable_count_of_all_uids</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- OVAL variable to hold the count of unique user ids defined in /etc/passwd -->
+  <local_variable id="variable_count_of_unique_uids" datatype="int" version="1"
+  comment="Count of unique uids">
+    <count>
+      <unique>
+        <object_component item_field="user_id" object_ref="obj_all_uids" />
+      </unique>
+    </count>
+  </local_variable>
+
+  <!-- this state checks that both counts (unique and non-unique) are the same -->
+  <ind:variable_state id="state_no_duplicate_uids" version="1">
+    <ind:value var_ref="variable_count_of_unique_uids" datatype="int"
+    operation="equals" var_check="at least one" />
+  </ind:variable_state>
+
+  <ind:variable_test id="test_etc_passwd_no_duplicate_user_ids" check="all" check_existence="all_exist"
+  comment="There should not exist duplicate user ids in /etc/passwd" version="1">
+    <ind:object object_ref="obj_count_of_all_uids" />
+    <ind:state state_ref="state_no_duplicate_uids" />
+  </ind:variable_test>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Ensure All Accounts on the System Have Unique User IDs'
+
+description: 'Change user IDs (UIDs), or delete accounts, so each has a unique name.'
+
+rationale: 'To assure accountability and prevent unauthenticated access, interactive users must be identified and authenticated to prevent potential misuse and compromise of the system.'
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83196-6
+
+references:
+    stigid@sle12: SLES-12-010640
+    disa@sle12: CCI-000764,CCI-000804
+    nist@sle12: IA-2,IA-2.1,IA-8,IA-8.1
+    srg@sle12: SRG-OS-000104-GPOS-00051,SRG-OS-000121-GPOS-00062
+
+ocil_clause: 'a line is returned'
+
+ocil: |-
+    Run the following command to check for duplicate account names:
+    Check that the SUSE operating system contains no duplicate UIDs for interactive users by running the following command:
+    <pre># awk -F ":" 'list[$3]++{print $1, $3}' /etc/passwd</pre>
+    If output is produced, this is a finding.
+    Configure the SUSE operating system to contain no duplicate UIDs for interactive users.
+    Edit the file "/etc/passwd" and provide each interactive user account that has a duplicate UID with a unique UID.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -1,0 +1,22 @@
+<def-group>
+  <definition class="compliance" id="accounts_password_all_shadowed_sha512" version="1">
+    {{{ oval_metadata("All password hashes should be shadowed.") }}}
+    <criteria>
+      <criterion comment="password hashes are shadowed using sha512" test_ref="test_accounts_password_all_shadowed_sha512" />
+    </criteria>
+  </definition>
+  <unix:shadow_test check="all" check_existence="none_exist" comment="password hashes are shadowed using sha512" id="test_accounts_password_all_shadowed_sha512" version="1">
+    <unix:object object_ref="object_accounts_password_all_shadowed_sha512" />
+  </unix:shadow_test>
+  <unix:shadow_object id="object_accounts_password_all_shadowed_sha512" version="1">
+    <unix:username operation="pattern match">.*</unix:username>
+    <filter action="exclude">state_accounts_password_all_shadowed_has_no_password</filter>
+    <filter action="exclude">state_accounts_password_all_shadowed_sha512</filter>
+  </unix:shadow_object>
+  <unix:shadow_state id="state_accounts_password_all_shadowed_has_no_password" version="1">
+      <unix:password operation="pattern match">^(!|!!|\*)$</unix:password>
+  </unix:shadow_state>
+  <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">
+      <unix:encrypt_method operation="equals">SHA-512</unix:encrypt_method>
+  </unix:shadow_state>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
@@ -1,0 +1,51 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Verify All Account Password Hashes are Shadowed with SHA512'
+
+description: |-
+    Verify the SUSE operating system requires the shadow password suite
+    configuration be set to encrypt interactive user passwords using a strong
+    cryptographic hash.
+    Check that the interactive user account passwords are using a strong
+    password hash with the following command:
+    <pre># sudo cut -d: -f2 /etc/shadow
+    $6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/</pre>
+    Password hashes <tt>!</tt> or <tt>*</tt> indicate inactive accounts not
+    available for logon and are not evaluated.
+    If any interactive user password hash does not begin with <tt>$6</tt>,
+    this is a finding.
+
+rationale: |-
+    The system must use a strong hashing algorithm to store the password. The
+    system must use a sufficient number of hashing rounds to ensure the required
+    level of entropy.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83038-0
+
+references:
+    nist: IA-5(1)(c),IA-5(1).1(v),IA-7,IA-7.1
+    stigid@sle12: SLES-12-010220
+    disa@sle12: CCI-000196,CCI-000803
+    srg@sle12:  SRG-OS-000073-GPOS-00041,SRG-OS-000120-GPOS-00061
+
+
+ocil_clause: 'passwords hashed with an unauthorized algorithm are found in /etc/shadow'
+
+ocil: |-
+    Check that the interactive user account passwords are using a strong
+    password hash with the following command:
+
+    <pre># sudo cut -d: -f2 /etc/shadow
+
+    $6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/</pre>
+
+    Password hashes <tt>!</tt> or <tt>*</tt> indicate inactive accounts not
+    available for logon and are not evaluated.
+
+    If any interactive user password hash does not begin with <tt>$6</tt>,
+    this is a finding.

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
@@ -1,0 +1,16 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: get all /etc/passwd file entries
+  getent:
+    database: passwd
+    split: ':'
+
+- name: lock the password of the user accounts other than root with uid 0
+  shell: |
+    passwd -l {{ item.key }}
+  loop: "{{ getent_passwd | dict2items | rejectattr('key', 'search', 'root') | list }}"
+  when: item.value.1  == '0'

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle12.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle12.yml
@@ -1,0 +1,15 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("var_accounts_tmout") }}}
+
+{{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='TMOUT', separator='=', separator_regex='=', value='{{ var_accounts_tmout }}', create='yes') }}}
+{{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='readonly', separator=' ', value='TMOUT', create='yes') }}}
+{{{ ansible_set_config_file(file='/etc/profile.d/autologout.sh', parameter='export', separator=' ', value='TMOUT', create='yes') }}}
+
+- name: Set the permission for /etc/profile.d/autologout.sh
+  file:
+    path: /etc/profile.d/autologout.sh
+    mode: '0755'

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/sle12.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/sle12.sh
@@ -1,0 +1,20 @@
+# platform = multi_platform_sle
+. /usr/share/scap-security-guide/remediation_functions
+{{{ bash_instantiate_variables("var_accounts_tmout") }}}
+
+if [ -f /etc/profile.d/autologout.sh ]; then
+    if grep --silent '^\s*TMOUT' /etc/profile.d/autologout.sh ; then
+        sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/\1TMOUT=$var_accounts_tmout\3/g" /etc/profile.d/autologout.sh
+    fi
+else
+    echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile.d/autologout.sh
+    echo "TMOUT=$var_accounts_tmout" >> /etc/profile.d/autologout.sh
+fi
+if ! grep --silent '^\s*readonly TMOUT' /etc/profile.d/autologout.sh ; then
+    echo "readonly TMOUT" >> /etc/profile.d/autologout.sh
+fi
+
+if ! grep --silent '^\s*export TMOUT' /etc/profile.d/autologout.sh ; then
+    echo "export TMOUT" >> /etc/profile.d/autologout.sh
+fi
+chmod +x /etc/profile.d/autologout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -25,7 +25,11 @@
     {{% if filepath %}}
     <ind:filepath>{{{ filepath }}}</ind:filepath>
     {{% endif %}}
+    {{% if product == "sle12" %}}
+    <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+)[\s]*readonly TMOUT[\s]*export TMOUT$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+).*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endmacro %}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -1,14 +1,21 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,rhcos4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019,rhcos4
 
 title: 'Set Interactive Session Timeout'
 
 description: |-
     Setting the <tt>TMOUT</tt> option in <tt>/etc/profile</tt> ensures that
     all user sessions will terminate based on inactivity. The <tt>TMOUT</tt>
+    {{% if product == "sle12" %}}
+    setting in <tt>/etc/profile.d/autologout.sh</tt> should read as follows:
+    <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+    readonly TMOUT
+    export TMOUT
+    {{% else %}}
     setting in <tt>/etc/profile</tt> should read as follows:
     <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+    {{% endif %}}
 
 rationale: |-
     Terminating an idle session within a short time period reduces
@@ -21,17 +28,21 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-27557-8
     cce@rhel8: CCE-80673-7
+    cce@sle12: CCE-83011-7
 
 references:
     stigid@ol7: OL07-00-040160
     cui: 3.1.11
     disa: CCI-002361,CCI-001133
+    disa@sle12: CCI-000057
     nist: AC-12,SC-10,AC-2(5),CM-6(a)
+    nist@sle12: AC-11(a)
     nist-csf: PR.AC-7
     ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000029-GPOS-00010
     vmmsrg: SRG-OS-000163-VMM-000700,SRG-OS-000279-VMM-001010
     stigid@rhel7: RHEL-07-040160
+    stigid@sle12: SLES-12-010090
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
     cobit5: DSS05.04,DSS05.10,DSS06.10
@@ -45,8 +56,16 @@ ocil_clause: 'value of TMOUT is not less than or equal to expected setting'
 ocil: |-
     Run the following command to ensure the <tt>TMOUT</tt> value is configured for all users
     on the system:
+    {{% if product == "sle12" %}}
+    <pre>$ sudo grep TMOUT /etc/profile.d/autologout.sh</pre>
+    {{% else %}}
     <pre>$ sudo grep TMOUT /etc/profile</pre>
+    {{% endif %}}
     The output should return the following:
     <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+    {{% if product == "sle12" %}}
+    readonly TMOUT
+    export TMOUT
+    {{% endif %}}
 
 platform: machine


### PR DESCRIPTION
This adds/updates the rules and remediations for the following,
but does not update the stig.profile, that will be updated
after all of the enabling rule updates have landed.

- SLES-12-010070 'vlock_installed'
- SLES-12-010090 'accounts_tmout'
- SLES-12-010220 'accounts_password_all_shadowed_sha512'
- SLES-12-010330 'account_emergency_admin'
- SLES-12-010640 'account_unique_id'
- SLES-12-010660 'policy_temp_passwords_immediate_change'
- SLES-12-030500 'install_smartcard_packages'
- SLES-12-030510 'smartcard_configure_cert_checking'
- SLES-12-030520 'smartcard_pam_enabled'
- SLES-12-030530 'smartcard_configure_ca'

#### Description:

- Enable checks and remediations for the following SLES-12 STIGs: 
- SLES-12-010070 'vlock_installed'
- SLES-12-010090 'accounts_tmout'
- SLES-12-010220 'accounts_password_all_shadowed_sha512'
- SLES-12-010330 'account_emergency_admin'
- SLES-12-010640 'account_unique_id'
- SLES-12-010660 'policy_temp_passwords_immediate_change'
- SLES-12-030500 'install_smartcard_packages'
- SLES-12-030510 'smartcard_configure_cert_checking'
- SLES-12-030520 'smartcard_pam_enabled'
- SLES-12-030530 'smartcard_configure_ca'

#### Rationale:

- Enable more tests and remediation for SLES 12 Security Technical Implementation Guide.

