### PR TITLE
SLES-12 add checks and remediations.

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
@@ -1,0 +1,46 @@
+documentation_complete: true
+
+title: 'Record Events that Modify the System''s Discretionary Access Controls - umount'
+
+description: |-
+    At a minimum, the audit system should collect file system umount
+    changes. If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following line to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F arch=b32 -S umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following line to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F arch=b32 -S umount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+
+rationale: |-
+    The changing of file permissions could indicate that a user is attempting to
+    gain access to information that would otherwise be disallowed. Auditing DAC modifications
+    can facilitate the identification of patterns of abuse among both authorized and
+    unauthorized users.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83218-8
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-3.1,AU-12.1(ii),AU-12(a),AU-12.1(iv),AU-12(c),MA-4(1)(a)
+    stigid@sle12: SLES-12-020300
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+
+{{{ complete_ocil_entry_audit_syscall(syscall="umount") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.
+
+template:
+    name: audit_rules_dac_modification
+    vars:
+        attr: umount

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+title: 'Record Events that Modify the System''s Discretionary Access Controls - umount2'
+
+description: |-
+    At a minimum, the audit system should collect file system umount2
+    changes. If the <tt>auditd</tt> daemon is configured
+    to use the <tt>augenrules</tt> program to read audit rules during daemon
+    startup (the default), add the following line to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F arch=b32 -S umount2 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    If the system is 64 bit then also add the following line:
+    <pre>-a always,exit -F arch=b64 -S umount2 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following line to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F arch=b32 -S umount2 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+    If the system is 64 bit then also add the following line:
+    <pre>-a always,exit -F arch=b64 -S umount2 -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
+
+rationale: |-
+    The changing of file permissions could indicate that a user is attempting to
+    gain access to information that would otherwise be disallowed. Auditing DAC modifications
+    can facilitate the identification of patterns of abuse among both authorized and
+    unauthorized users.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83219-6
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-3.1,AU-12.1(ii),AU-12(a),AU-12.1(iv),AU-12(c),MA-4(1)(a)
+    stigid@sle12: SLES-12-020300
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+
+{{{ complete_ocil_entry_audit_syscall(syscall="umount2") }}}
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect. Here the system calls
+        have been placed independent of other system calls. Grouping these system
+        calls with others as identifying earlier in this guide is more efficient.
+
+template:
+    name: audit_rules_dac_modification
+    vars:
+        attr: umount2

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Record Any Attempts to Run chacl'
+
+description: |-
+    At a minimum, the audit system should collect any execution attempt
+    of the <tt>chacl</tt> command for all users and root. If the <tt>auditd</tt>
+    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
+    during daemon startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83190-9
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-3.1,AU-12.1(ii),AU-12(a),AU-12.1(iv),AU-12(c),MA-4(1)(a)
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+    stigid@sle12: SLES-12-020620
+
+ocil: |-
+    To verify that execution of the command is being audited, run the following command:
+    Configure the SUSE operating system to generate an audit record for all uses of the "chacl" command.
+    Add or update the following rules in the "/etc/audit/audit.rules" file:
+    -a always,exit -F arch=b32 path=/usr/bin/chacl -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged
+    -a always,exit -F arch=b64 path=/usr/bin/chacl -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged
+    The audit daemon must be restarted for the changes to take effect.
+    # sudo systemctl restart auditd.service
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/chacl

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chmod/rule.yml
@@ -1,0 +1,49 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Record Any Attempts to Run chmod'
+
+description: |-
+    At a minimum, the audit system should collect any execution attempt
+    of the <tt>chmod</tt> command for all users and root. If the <tt>auditd</tt>
+    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
+    during daemon startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/chmod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F path=/usr/bin/chmod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83214-7
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-3.1,AU-12.1(ii),AU-12(a),AU-12.1(iv),AU-12(c),MA-4(1)(a)
+    stigid@sle12: SLES-12-020600
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+
+ocil: |-
+    To verify that execution of the command is being audited, run the following command:
+    <pre>$ sudo grep "path=/usr/bin/chmod" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    The output should return something similar to:
+    <pre>-a always,exit -F path=/usr/bin/chmod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/chmod
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/rule.yml
@@ -1,0 +1,53 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Record Any Attempts to Run setfacl'
+
+description: |-
+    At a minimum, the audit system should collect any execution attempt
+    of the <tt>setfacl</tt> command for all users and root. If the <tt>auditd</tt>
+    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
+    during daemon startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83189-1
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-3.1,AU-12.1(ii),AU-12(a),AU-12.1(iv),AU-12(c),MA-4(1)(a)
+    stigid@sle12: SLES-12-020610
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+
+ocil: |-
+    To verify that execution of the command is being audited, run the following command:
+    Configure the SUSE operating system to generate an audit record for all uses of the "setfacl" command.
+    Add or update the following rules in the "/etc/audit/audit.rules" file:
+    -a always,exit -F arch=b32 path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged
+    -a always,exit -F arch=b64 path=/usr/bin/setfacl -F perm=x -F auid>=1000 -F auid!=4294967295 -F key=privileged
+    The audit daemon must be restarted for the changes to take effect.
+    # sudo systemctl restart auditd.service
+    <pre>$ sudo grep "path=/usr/bin/setfacl" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    The output should return something similar to:
+    <pre>-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/setfacl

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/group.yml
@@ -1,0 +1,7 @@
+documentation_complete: true
+
+title: 'Record Execution Attempts to Run ACL Privileged Commands'
+
+description: |-
+    At a minimum, the audit system should collect the execution of
+    ACL privileged commands for all users and root.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -10,11 +10,19 @@ description: |-
     daemon is configured to use the <tt>augenrules</tt> program to read audit rules
     during daemon startup (the default), add the following lines to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    {{% if product in ["sle12", "sle15"] %}}
+    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{% else %}}
     <pre>-a always,exit -F path=/usr/bin/chcon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{% endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file:
+    {{% if product in ["sle12", "sle15"] %}}
+    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{% else %}}
     <pre>-a always,exit -F path=/usr/bin/chcon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{% endif %}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -61,7 +69,11 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>$ sudo grep "path=/usr/bin/chcon" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
     The output should return something similar to:
+    {{% if product in ["sle12", "sle15"] %}}
+    <pre>-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{% else %}}
     <pre>-a always,exit -F path=/usr/bin/chcon -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{% endif %}}
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_rm/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_rm/rule.yml
@@ -1,0 +1,49 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Record Any Attempts to Run rm'
+
+description: |-
+    At a minimum, the audit system should collect any execution attempt
+    of the <tt>rm</tt> command for all users and root. If the <tt>auditd</tt>
+    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
+    during daemon startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/rm -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F path=/usr/bin/rm -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83216-2
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-3.1,AU-12.1(ii),AU-12(a),AU-12.1(iv),AU-12(c),MA-4(1)(a)
+    stigid@sle12: SLES-12-020640
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+
+ocil: |-
+    To verify that execution of the command is being audited, run the following command:
+    <pre>$ sudo grep "path=/usr/bin/rm" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    The output should return something similar to:
+    <pre>-a always,exit -F path=/usr/bin/rm -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/rm
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/rule.yml
@@ -1,0 +1,49 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Record Attempts to Alter Logon and Logout Events - faillog'
+
+description: |-
+    The audit system already collects login information for all users
+    and root. If the <tt>auditd</tt> daemon is configured to use the
+    <tt>augenrules</tt> program to read audit rules during daemon startup (the
+    default), add the following lines to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
+    edits of files involved in storing logon events:
+    <pre>-w /var/log/faillog -p wa -k logins</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file in order to watch for unattempted manual
+    edits of files involved in storing logon events:
+    <pre>-w /var/log/faillog -p wa -k logins</pre>
+
+rationale: |-
+    Manual editing of these files may indicate nefarious activity, such
+    as an attacker attempting to remove evidence of an intrusion.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83192-5
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-12(a),AU-12(c),MA-4(1)(a)
+    srg@sle12: SRG-OS-000037-GPOS-00015
+    stigid@sle12: SLES-12-020760
+
+ocil_clause: 'there is no output'
+
+ocil: |-
+    To verify that auditing is configured for system administrator actions, run the following command:
+    Configure the SUSE operating system to generate an audit record for any all modifications to the "faillog" file occur.
+    Add or update the following rules in the "/etc/audit/audit.rules" file:
+    -w /var/log/faillog -p wa -k logins
+    The audit daemon must be restarted for the changes to take effect.
+    # sudo systemctl restart auditd.service
+
+template:
+    name: audit_rules_login_events
+    vars:
+        path: /var/log/faillog

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chfn/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chfn/rule.yml
@@ -1,0 +1,49 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chfn'
+
+description: |-
+    At a minimum, the audit system should collect the execution of
+    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
+    configured to use the <tt>augenrules</tt> program to read audit rules during
+    daemon startup (the default), add a line of the following form to a file with
+    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add a line of the following
+    form to <tt>/etc/audit/audit.rules</tt>:
+    <pre>-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83187-5
+
+references:
+    disa: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist: AU-3,AU-12(a),AU-12(c),MA-4(1)(a)
+    stigid@sle12: SLES-12-020280
+
+ocil_clause: 'it is not the case'
+
+ocil: |-
+    To verify that auditing of privileged command use is configured, run the
+    following command:
+    <pre>$ sudo grep chfn /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    It should return a relevant line in the audit rules.
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/chfn

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/shared.yml
@@ -1,0 +1,42 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Service facts
+  service_facts:
+
+- name: Check the rules script being used
+  command:
+    grep '^ExecStartPost' /usr/lib/systemd/system/auditd.service
+  register: check_rules_scripts_result
+
+- name: Update kmod in /etc/audit/rules.d/audit.rules
+  lineinfile:
+    path: /etc/audit/rules.d/audit.rules
+    line: '-w /usr/bin/kmod -p x -k modules'
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - '"augenrules" in check_rules_scripts_result.stdout'
+  register: augenrules_audit_rules_kmod_update_result
+
+- name: Update kmod in /etc/audit/audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-w /usr/bin/kmod -p x -k modules'
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - '"auditctl" in check_rules_scripts_result.stdout'
+  register: auditctl_audit_rules_kmod_update_result
+
+- name: Restart auditd.service
+  systemd:
+    name: auditd.service
+    state: restarted
+  when:
+    - (augenrules_audit_rules_kmod_update_result.changed or
+       auditctl_audit_rules_kmod_update_result.changed)
+    - ansible_facts.services["auditd.service"].state == "running"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/shared.xml
@@ -1,0 +1,39 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_privileged_commands_kmod" version="1">
+    {{{ oval_metadata("Ensure audit rule for all uses of the kmod command is enabled.") }}}
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit augenrules kmod" test_ref="test_kmod_augenrules" />
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit auditctl kmod" test_ref="test_kmod_auditctl" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit augenrules kmod" id="test_kmod_augenrules" version="1">
+    <ind:object object_ref="object_kmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_kmod_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/bin/kmod[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit auditctl kmod" id="test_kmod_auditctl" version="1">
+    <ind:object object_ref="object_kmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_kmod_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/bin/kmod[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -1,0 +1,52 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - kmod'
+
+description: |-
+    At a minimum, the audit system should collect the execution of
+    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
+    configured to use the <tt>augenrules</tt> program to read audit rules during
+    daemon startup (the default), add a line of the following form to a file with
+    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-w /usr/bin/kmod -p x -k modules</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add a line of the following
+    form to <tt>/etc/audit/audit.rules</tt>:
+    <pre>-w /usr/bin/kmod -p x -k modules</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83207-1
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist: AU-3,AU-3.1,AU-12(a),AU-12.1(ii),AU-12.1(iv)AU-12(c),MA-4(1)(a)
+    stigid@sle12: SLES-12-020360
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+
+ocil_clause: 'it is not the case'
+
+ocil: |-
+    To verify that auditing of privileged command use is configured, run the
+    following command:
+
+    <pre># sudo grep kmod /etc/audit/audit.rules
+    -w /usr/bin/kmod -p x -k modules</pre>
+
+    If the system is configured to audit the execution of the module management
+    program "kmod", the command will return a line. If the command does not
+    return a line, or the line is commented out, this is a finding.
+
+platform: machine

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passmass/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passmass/rule.yml
@@ -1,0 +1,52 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - passmass'
+
+description: |-
+    At a minimum, the audit system should collect the execution of
+    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
+    configured to use the <tt>augenrules</tt> program to read audit rules during
+    daemon startup (the default), add a line of the following form to a file with
+    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/passmass -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add a line of the following
+    form to <tt>/etc/audit/audit.rules</tt>:
+    <pre>-a always,exit -F path=/usr/bin/passmass -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Misuse of privileged functions, either intentionally or unintentionally by
+    authorized users, or by unauthorized external entities that have compromised system accounts,
+    is a serious and ongoing concern and can have significant adverse impacts on organizations.
+    Auditing the use of privileged functions is one way to detect such misuse and identify
+    the risk from insider and advanced persistent threats.
+    <br /><br />
+    Privileged programs are subject to escalation-of-privilege attacks,
+    which attempt to subvert their normal role of providing some necessary but
+    limited capability. As such, motivation exists to monitor these programs for
+    unusual activity.
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83193-3
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-12(a),AU-12(c),MA-4(1)(a)
+    srg@sle12: SRG-OS-000037-GPOS-00015
+    stigid@sle12: SLES-12-020670
+
+ocil_clause: 'it is not the case'
+
+ocil: |-
+    To verify that auditing of privileged command use is configured, run the
+    following command:
+    <pre>$ sudo grep passmass /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    It should return a relevant line in the audit rules.
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/passmass

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Record Any Attempts to Run ssh-agent'
+
+description: |-
+    At a minimum, the audit system should collect any execution attempt
+    of the <tt>ssh-agent</tt> command for all users and root. If the <tt>auditd</tt>
+    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
+    during daemon startup (the default), add the following lines to a file with suffix
+    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -k privileged-ssh-agent</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -k privileged-ssh-agent</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83199-0
+
+references:
+    disa@sle12: CCI-000130,CCI-000172
+    nist@sle12: AU-3,AU-3.1,AU-12(a),AU-12(c),AU-12.1(a),AU-12.1(ii),AU-12.1(iv),MA-4(1)(a)
+    stigid@sle12: SLES-12-020310
+    srg@sle12: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206SRG-OS-000471-GPOS-00215
+
+ocil_clause: 'it is not the case'
+
+ocil: |-
+    To verify that execution of the command is being audited, run the following command:
+    <pre>$ sudo grep "path=/usr/bin/ssh-agent" /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    The output should return something similar to:
+    <pre>-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -k privileged-ssh-agent</pre>
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/ssh-agent

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/rule.yml
@@ -1,0 +1,54 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - usermod'
+
+description: |-
+    At a minimum, the audit system should collect the execution of
+    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
+    configured to use the <tt>augenrules</tt> program to read audit rules during
+    daemon startup (the default), add a line of the following form to a file with
+    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/usr/bin/usermod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add a line of the following
+    form to <tt>/etc/audit/audit.rules</tt>:
+    <pre>-a always,exit -F path=/usr/bin/usermod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Misuse of privileged functions, either intentionally or unintentionally by
+    authorized users, or by unauthorized external entities that have compromised system accounts,
+    is a serious and ongoing concern and can have significant adverse impacts on organizations.
+    Auditing the use of privileged functions is one way to detect such misuse and identify
+    the risk from insider and advanced persistent threats.
+    <br /><br />
+    Privileged programs are subject to escalation-of-privilege attacks,
+    which attempt to subvert their normal role of providing some necessary but
+    limited capability. As such, motivation exists to monitor these programs for
+    unusual activity.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83191-7
+
+references:
+    disa@sle12: CCI-000130,CCI-000169,CCI-000172,CCI-002884
+    nist@sle12: AU-3,AU-12(a),AU-12(c),MA-4(1)(a)
+    srg@sle12: SRG-OS-000037-GPOS-00015
+    stigid@sle12: SLES-12-020700
+
+ocil_clause: 'it is not the case'
+
+ocil: |-
+    To verify that auditing of privileged command use is configured, run the
+    following command:
+    <pre>$ sudo grep usermod /etc/audit/audit.rules /etc/audit/rules.d/*</pre>
+    It should return a relevant line in the audit rules.
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /usr/bin/usermod
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -1,0 +1,52 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Service facts
+  service_facts:
+
+- name: Check the rules script being used
+  command:
+    grep '^ExecStartPost' /usr/lib/systemd/system/auditd.service
+  register: check_rules_scripts_result
+
+- name: Set suid_audit_rules fact
+  set_fact:
+    suid_audit_rules:
+      - '-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid'
+      - '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid'
+      - '-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid'
+      - '-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid'
+
+- name: Update /etc/audit/rules.d/audit.rules to audit privileged functions
+  lineinfile:
+    path: /etc/audit/rules.d/audit.rules
+    line: "{{  item  }}"
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - '"augenrules" in check_rules_scripts_result.stdout'
+  register: augenrules_audit_rules_privilege_function_update_result
+  with_items: "{{ suid_audit_rules }}"
+
+- name: Update Update /etc/audit/audit.rules to audit privileged functions
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: "{{  item  }}"
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - '"auditctl" in check_rules_scripts_result.stdout'
+  register: auditctl_audit_rules_privilege_function_update_result
+  with_items: "{{ suid_audit_rules }}"
+
+- name: Restart auditd.service
+  systemd:
+    name: auditd.service
+    state: restarted
+  when:
+    - (augenrules_audit_rules_privilege_function_update_result.changed or
+       auditctl_audit_rules_privilege_function_update_result.changed)
+    - ansible_facts.services["auditd.service"].state == "running"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
@@ -1,0 +1,100 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_suid_privilege_function" version="1">
+    {{{ oval_metadata("Ensure audit rule for all uses of privileged functions is enabled") }}}
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit augenrules 32-bit uid privileged function " test_ref="test_32bit_uid_privileged_function_augenrules" />
+        <criterion comment="audit augenrules 64-bit uid privileged function" test_ref="test_64bit_uid_privileged_function_augenrules" />
+        <criterion comment="audit augenrules 32-bit gid privileged function " test_ref="test_32bit_gid_privileged_function_augenrules" />
+        <criterion comment="audit augenrules 64-bit gid privileged function" test_ref="test_64bit_gid_privileged_function_augenrules" />
+        </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit auditctl 32-bit uid privileged function" test_ref="test_32bit_uid_privileged_function_auditctl" />
+        <criterion comment="audit auditctl 64-bit uid privileged function" test_ref="test_64bit_uid_privileged_function_auditctl" />
+        <criterion comment="audit auditctl 32-bit gid privileged function" test_ref="test_32bit_gid_privileged_function_auditctl" />
+        <criterion comment="audit auditctl 64-bit gid privileged function" test_ref="test_64bit_gid_privileged_function_auditctl" />
+        </criteria>
+
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit uid privileged function" id="test_32bit_uid_privileged_function_augenrules" version="1">
+    <ind:object object_ref="object_32bit_uid_privileged_function_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_uid_privileged_function_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit uid privileged function" id="test_64bit_uid_privileged_function_augenrules" version="1">
+    <ind:object object_ref="object_64bit_uid_privileged_function_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_uid_privileged_function_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit uid privileged function" id="test_32bit_uid_privileged_function_auditctl" version="1">
+    <ind:object object_ref="object_32bit_uid_privileged_function_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_uid_privileged_function_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit uid privileged_function" id="test_64bit_uid_privileged_function_auditctl" version="1">
+    <ind:object object_ref="object_64bit_uid_privileged_function_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_uid_privileged_function_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit gid privileged function" id="test_32bit_gid_privileged_function_augenrules" version="1">
+    <ind:object object_ref="object_32bit_gid_privileged_function_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_gid_privileged_function_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 64-bit gid privileged function" id="test_64bit_gid_privileged_function_augenrules" version="1">
+    <ind:object object_ref="object_64bit_gid_privileged_function_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_gid_privileged_function_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit gid privileged function" id="test_32bit_gid_privileged_function_auditctl" version="1">
+    <ind:object object_ref="object_32bit_gid_privileged_function_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_gid_privileged_function_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 64-bit gid privileged_function" id="test_64bit_gid_privileged_function_auditctl" version="1">
+    <ind:object object_ref="object_64bit_gid_privileged_function_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_64bit_gid_privileged_function_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
@@ -1,0 +1,57 @@
+documentation_complete: true
+
+prodtype: sle12
+
+title: 'Record Events When Privileged Executables Are Run'
+
+description: |-
+    Verify the SUSE operating system generates an audit record when privileged functions are executed.
+    <pre># grep -iw execve <tt>/etc/audit/audit.rules</tt></pre>
+
+    <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
+    <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
+    <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+    <pre>-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+
+    If both the "b32" and "b64" audit rules for "SUID" files are not defined, this is a finding.
+    If both the "b32" and "b64" audit rules for "SGID" files are not defined, this is a finding.
+
+rationale: |-
+    Misuse of privileged functions, either intentionally or unintentionally by
+    authorized users, or by unauthorized external entities that have
+    compromised information system accounts, is a serious and ongoing concern
+    and can have significant adverse impacts on organizations. Auditing the use
+    of privileged functions is one way to detect such misuse and identify the
+    risk from insider threats and the advanced persistent threat.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83200-6
+
+references:
+    disa@sle12: CCI-001814,CCI-001882,CCI-001889,CCI-001880,CCI-001881,CCI-001878,CCI-001879,CCI-001875,CCI-001877,CCI-001914,CCI-002234
+    nist: CM-5(1),AU-7(a),AU-7(b),AU-8(b),AU-12(3),AC-6(9)
+    stigid@sle12: SLES-12-020240
+    srg@sle12: SRG-OS-000327-GPOS-00127,SRG-OS-000337-GPOS-00129,SRG-OS-000348-GPOS-00136,SRG-OS-000349-GPOS-00137,SRG-OS-000350-GPOS-00138,SRG-OS-000351-GPOS-00139,SRG-OS-000352-GPOS-00140,SRG-OS-000353-GPOS-00141,SRG-OS-000354-GPOS-00142,SRG-OS-000358-GPOS-00145,SRG-OS-000359-GPOS-00146,SRG-OS-000365-GPOS-00152
+
+warnings:
+    - general: |-
+        Note that these rules can be configured in a
+        number of ways while still achieving the desired effect.
+
+ocil_clause: 'it is not the case'
+
+ocil: |-
+      Add or update the following rules in "<tt>/etc/audit/rules.d/audit.rules</tt>":
+
+      <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
+      <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
+      <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+      <pre>-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+
+      The audit daemon must be restarted for the changes to take effect.
+
+      <pre># sudo systemctl restart <tt>auditd.service</tt></pre>
+
+platform: machine

--- a/shared/templates/audit_rules_privileged_commands/ansible.template
+++ b/shared/templates/audit_rules_privileged_commands/ansible.template
@@ -26,6 +26,24 @@
       - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
   when: find_{{{ NAME }}}.matched is defined and find_{{{ NAME }}}.matched > 0
 
+{{% if product == "sle12" %}}
+
+- name: Inserts/replaces the {{{ NAME }}} rule in rules.d
+  lineinfile:
+    path: "{{ all_files[0] }}"
+    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+    create: yes
+
+# Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
+
+- name: Inserts/replaces the {{{ NAME }}} rule in audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-a always,exit -F path={{{ PATH }}} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+    create: yes
+
+{{% else %}}
+
 - name: Inserts/replaces the {{{ NAME }}} rule in rules.d
   lineinfile:
     path: "{{ all_files[0] }}"
@@ -39,3 +57,5 @@
     path: /etc/audit/audit.rules
     line: '-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
     create: yes
+
+{{% endif %}}

--- a/shared/templates/audit_rules_privileged_commands/oval.template
+++ b/shared/templates/audit_rules_privileged_commands/oval.template
@@ -23,7 +23,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+{{% if product in ["sle12", "sle15"] %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}(?:[\s]+-F[\s]+perm=x)?[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+{{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+{{% endif %}}
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -32,7 +36,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ ID }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+{{% if product in ["sle12", "sle15"] %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}(?:[\s]+-F[\s]+perm=x)?[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+{{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+{{% endif %}}
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
This adds/updates the rules and remediations for the following,
but does not update the stig.profile, that will be updated
after all the enabling rule updates have landed.

- SLES-12-020080 'auditd_audispd_encrypt_sent_records'
- SLES-12-020300 'audit_rules_privileged_commands_umount'
- SLES-12-020300 'audit_rules_dac_modification_umount'
- SLES-12-020300 'audit_rules_dac_modification_umount2'
- SLES-12-020240 'audit_rules_suid_privilege_function'
- SLES-12-020280 'audit_rules_privileged_commands_chfn'
- SLES-12-020290 'audit_rules_media_export'
- SLES-12-020310 'audit_rules_privileged_commands_ssh_agent'
- SLES-12-020360 'audit_rules_privileged_commands_kmod'
- SLES-12-020600 'audit_rules_execution_chmod'
- SLES-12-020610 'audit_rules_execution_setfacl'
- SLES-12-020620 'audit_rules_execution_chacl'
- SLES-12-020630 'audit_rules_execution_chcon'
- SLES-12-020640 'audit_rules_execution_rm'
- SLES-12-020670 'audit_rules_privileged_commands_passmass'
- SLES-12-020700 'audit_rules_privileged_commands_usermod'
- SLES-12-020760 'audit_rules_login_events_faillog'

#### Description:

- Enable checks and remediations for the following SLES-12 STIGs: 
- SLES-12-020080 'auditd_audispd_encrypt_sent_records'
- SLES-12-020300 'audit_rules_privileged_commands_umount'
- SLES-12-020300 'audit_rules_dac_modification_umount'
- SLES-12-020300 'audit_rules_dac_modification_umount2'
- SLES-12-020240 'audit_rules_suid_privilege_function'
- SLES-12-020280 'audit_rules_privileged_commands_chfn'
- SLES-12-020290 'audit_rules_media_export'
- SLES-12-020310 'audit_rules_privileged_commands_ssh_agent'
- SLES-12-020360 'audit_rules_privileged_commands_kmod'
- SLES-12-020600 'audit_rules_execution_chmod'
- SLES-12-020610 'audit_rules_execution_setfacl'
- SLES-12-020620 'audit_rules_execution_chacl'
- SLES-12-020630 'audit_rules_execution_chcon'
- SLES-12-020640 'audit_rules_execution_rm'
- SLES-12-020670 'audit_rules_privileged_commands_passmass'
- SLES-12-020700 'audit_rules_privileged_commands_usermod'
- SLES-12-020760 'audit_rules_login_events_faillog'


#### Rationale:

-  Enable checks and remediations for the following SLES-12 STIGs: 
