### PR TITLE
ocp4/e2e: Pin gitlab docker image to 13.8.4-ce.0

### DIFF
--- a/tests/ocp4e2e/vendor/github.com/openshift/cluster-authentication-operator/test/library/gitlabidp.go
+++ b/tests/ocp4e2e/vendor/github.com/openshift/cluster-authentication-operator/test/library/gitlabidp.go
@@ -41,7 +41,7 @@ func AddGitlabIDP( // TODO: possibly make this be a wrapper to a function to sim
 
 	nsName, gitlabHost, cleanup := deployPod(t, kubeClients, routeClient,
 		"gitlab",
-		"docker.io/gitlab/gitlab-ce:latest",
+		"docker.io/gitlab/gitlab-ce:13.8.4-ce.0",
 		[]corev1.EnvVar{
 			// configure password for GitLab root user
 			{Name: "GITLAB_OMNIBUS_CONFIG", Value: "gitlab_rails['initial_root_password']='password';"},


### PR DESCRIPTION
Using latest might be unstable.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>