### PR TITLE
Add partition_for_var_tmp SRG

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -25,6 +25,7 @@ references:
     cis@rhel8: 1.1.7
     cis@ubuntu1804: 1.1.6
     anssi: BP28(R12)
+    srg: SRG-OS-000480-GPOS-00227
     cis@sle15: 1.1.8
 
 {{{ complete_ocil_entry_separate_partition(part="/var/tmp") }}}


### PR DESCRIPTION
#### Description:
This requirement is not explicitly listed in DISA STIG requirements but its group should be same as other partitions rules.
See https://github.com/ComplianceAsCode/content/pull/6523 where the rule was added.

#### Rationale:
Rule must have SRG because it is in stig profile.