### PR TITLE
OCP: Add OVAL for api_server_anonymous_auth

### DIFF
--- a/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
@@ -42,8 +42,29 @@ ocil_clause: 'anonymous requests are not authorized'
 ocil: |-
     Run the following command to view the authorization rules for anonymous requests:
     <pre>$ oc describe clusterrolebindings</pre>
+    Make sure that there exists at least one <tt>clusterrolebinding</tt> that binds
+    either the <tt>system:unauthenticated</tt> group or the <tt>system:anonymous</tt>
+    user.
     To test that an anonymous request is authorized to access the <tt>readyz</tt>
     endpoint, run:
     <pre>$ oc get --as="system:anonymous" --raw='/readyz?verbose'</pre>
     In contrast, a request to list all projects should not be authorized:
     <pre>$ oc get --as="system:anonymous" projects</pre>
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/apis/rbac.authorization.k8s.io/v1/clusterrolebindings") | indent(4) }}}
+
+template:
+    name: yamlfile_value
+    vars:
+        ocp_data: "true"
+        filepath: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings
+        yamlpath: ".items[:]['subjects'][:].name"
+        check_existence: "at_least_one_exists"
+        entity_check: "at least one"
+        values:
+          - value: "system:unauthenticated"
+            entity_check: "at least one"
+            operation: "pattern match"
+            check_existence: "at_least_one_exists"

--- a/applications/openshift/api-server/api_server_anonymous_auth/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
#### Description:

This covers control 1.2.1 of CIS. We deviate from CIS in the sense that
CIS itself prescribes that anonymous access should be disabled. OCP
allows anonymous access, but all requests are instead authorized and any
requests that are not authenticated reach the authorization layer as
user=system:anonymous and group=system:unauthenticated.

This rule takes that into account by making sure that there exists at
least one clusterrolebinding that binds the system:unauthenticated group
to a role, which in turn ensures that requests bound to the
system:unauthenticated group cannot do more that what that role allows
them to.



#### Rationale:

- Increases the CIS benchmark coverage