### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import datetime
 import os.path
+import os
+import time
 
 product_directories = [
     'chromium',
@@ -124,7 +125,10 @@ oval_header = (
         {0}#linux linux-definitions-schema.xsd">"""
     .format(oval_namespace))
 
-timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+timestamp = time.strftime(
+    "%Y-%m-%dT%H:%M:%S",
+    time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
+)
 
 PKG_MANAGER_TO_SYSTEM = {
     "yum": "rpm",


### PR DESCRIPTION
#### Description:

- Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).

#### Rationale:

- See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.
- Without this patch, `.xml` files varied for each build in

```
    <oval:timestamp>2021-02-22T21:05:22</oval:timestamp>
```