### PR TITLE
usbguard: Take rules.d directory into account

### DIFF
--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/correct_rules_d.pass.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/correct_rules_d.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+
+source $SHARED/utils.sh
+
+get_packages usbguard
+
+echo "allow with-interface match-all { 03:*:* }" >> /etc/usbguard/rules.d/30-hid-and-hub.conf

--- a/shared/checks/oval/usbguard_rules_not_empty_not_missing.xml
+++ b/shared/checks/oval/usbguard_rules_not_empty_not_missing.xml
@@ -8,16 +8,16 @@
       <description>Check that file storing USBGuard rules at /etc/usbguard/rules.conf exists and is not empty</description>
     </metadata>
     <criteria comment="Check that file storing USBGuard rules exists and is not empty" operator="AND">
-      <criterion comment="Check that the file /etc/usbguard/rules.conf contains at least one non white space character." test_ref="test_usbguard_rules_nonempty" />
+        <criterion comment="Check that the usbguard rules in either /etc/usbguard/rules.conf or /etc/usbguard/rules.d/ contain at least one non white space character." test_ref="test_usbguard_rules_nonempty" />
     </criteria>
   </definition>
   <ind:textfilecontent54_test check_existence="at_least_one_exists" check="all"
-    comment="Check that /etc/usbguard/rules.conf contains at least one non whitespace character and exists"
+    comment="Check the usbguard rules in either /etc/usbguard/rules.conf or /etc/usbguard/rules.d/ contain at least one non whitespace character and exists"
     id="test_usbguard_rules_nonempty" version="1">
     <ind:object object_ref="obj_usbguard_rules_nonempty" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_usbguard_rules_nonempty" version="1">
-    <ind:filepath>/etc/usbguard/rules.conf</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/usbguard/(rules|rules\.d/.*)\.conf$</ind:filepath>
     <ind:pattern operation="pattern match">^.*\S+.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
The OVAL was just checking for /etc/usbguard/rules.conf, while folks can
also set up rules in the /etc/usbguard/rules.d directory.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>