### PR TITLE
Mark the e2e tests results of tests without OVAL as MANUAL

### DIFF
--- a/applications/openshift/scc/scc_drop_container_capabilities/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_drop_container_capabilities/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL

--- a/applications/openshift/scc/scc_limit_ipc_namespace/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_ipc_namespace/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL

--- a/applications/openshift/scc/scc_limit_net_raw_capability/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_net_raw_capability/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL

--- a/applications/openshift/scc/scc_limit_network_namespace/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_network_namespace/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL

--- a/applications/openshift/scc/scc_limit_privilege_escalation/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_privilege_escalation/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL

--- a/applications/openshift/scc/scc_limit_privileged_containers/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL

--- a/applications/openshift/scc/scc_limit_process_id_namespace/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_process_id_namespace/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL

--- a/applications/openshift/scc/scc_limit_root_containers/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_root_containers/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: INFO
+default_result: MANUAL


### PR DESCRIPTION
#### Description:

The latest Compliance Operator release uses a new state for rules that
don't have any OVAL for an automated check: MANUAL instead of INFO.

This patch reflects that in our e2e YAMLs.

#### Rationale:

- This should fix our e2e tests