### PR TITLE
Sort file lists

### DIFF
--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -89,7 +89,7 @@ def collect_fixes(product, rules_dirs, fix_dirs, remediation_type):
     rule_id_to_remediation_map = dict()
     for fixdir in fix_dirs:
         if os.path.isdir(fixdir):
-            for filename in os.listdir(fixdir):
+            for filename in sorted(os.listdir(fixdir)):
                 file_path = os.path.join(fixdir, filename)
                 rule_id, _ = os.path.splitext(filename)
                 rule_id_to_remediation_map[rule_id] = file_path

--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -62,8 +62,8 @@ def get_profile_files_from_root(env_yaml, product_yaml):
     if env_yaml:
         base_dir = os.path.dirname(product_yaml)
         profiles_root = ssg.utils.required_key(env_yaml, "profiles_root")
-        profile_files = glob("{base_dir}/{profiles_root}/*.profile"
-                             .format(profiles_root=profiles_root, base_dir=base_dir))
+        profile_files = sorted(glob("{base_dir}/{profiles_root}/*.profile"
+                             .format(profiles_root=profiles_root, base_dir=base_dir)))
     return profile_files
 
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -141,6 +141,8 @@ def main():
             refovalfilename = check.text
             refovalfilefound = False
             for dirpath, dirnames, filenames in os.walk(os.curdir, topdown=True):
+                dirnames.sort()
+                filenames.sort()
                 # Case when referenced OVAL file exists
                 for location in fnmatch.filter(filenames, refovalfilename + '.xml'):
                     refovalfilefound = True
@@ -153,6 +155,8 @@ def main():
                 os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
             if shared_dir is not None:
                 for dirpath, dirnames, filenames in os.walk(shared_dir, topdown=True):
+                    dirnames.sort()
+                    filenames.sort()
                     # Case when referenced OVAL file exists
                     for location in fnmatch.filter(filenames, refovalfilename + '.xml'):
                         refovalfilefound = True

--- a/build-scripts/generate_bash_remediation_functions.py
+++ b/build-scripts/generate_bash_remediation_functions.py
@@ -49,7 +49,7 @@ def main():
         "used by remediation scripts from the SCAP Security Guide Project."
 
     context = ssg.jinja.load_macros()
-    for file_ in os.listdir(args.input_dir):
+    for file_ in sorted(os.listdir(args.input_dir)):
         if not file_.endswith(".sh"):
             sys.stderr.write(
                 "File '%s' does not appear to be a bash script. Skipping!"

--- a/build-scripts/generate_fixes_xml.py
+++ b/build-scripts/generate_fixes_xml.py
@@ -37,7 +37,7 @@ def main():
         sys.exit(1)
 
     fixes = dict()
-    for filename in os.listdir(args.fixdir):
+    for filename in sorted(os.listdir(args.fixdir)):
         file_path = os.path.join(args.fixdir, filename)
         fix_name, _ = os.path.splitext(filename)
         result = remediation.parse_from_file_without_jinja(file_path)

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -59,7 +59,7 @@ class ProductCPEs(object):
         if not os.path.isabs(cpes_root):
             cpes_root = os.path.join(self.ssg_root, self.product_yaml["product"], cpes_root)
 
-        for dir_item in os.listdir(cpes_root):
+        for dir_item in sorted(os.listdir(cpes_root)):
             dir_item_path = os.path.join(cpes_root, dir_item)
             if not os.path.isfile(dir_item_path):
                 continue

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -618,7 +618,7 @@ def get_rule_dir_remediations(dir_path, remediation_type, product=None):
         return []
 
     results = []
-    for remediation_file in os.listdir(remediations_dir):
+    for remediation_file in sorted(os.listdir(remediations_dir)):
         file_name, file_ext = os.path.splitext(remediation_file)
         remediation_path = os.path.join(remediations_dir, remediation_file)
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -682,7 +682,7 @@ class Benchmark(object):
         return benchmark
 
     def add_profiles_from_dir(self, dir_, env_yaml):
-        for dir_item in os.listdir(dir_):
+        for dir_item in sorted(os.listdir(dir_)):
             dir_item_path = os.path.join(dir_, dir_item)
             if not os.path.isfile(dir_item_path):
                 continue
@@ -1344,7 +1344,7 @@ class DirectoryLoader(object):
         self.parent_group = None
 
     def _collect_items_to_load(self, guide_directory):
-        for dir_item in os.listdir(guide_directory):
+        for dir_item in sorted(os.listdir(guide_directory)):
             dir_item_path = os.path.join(guide_directory, dir_item)
             _, extension = os.path.splitext(dir_item)
 

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -108,7 +108,7 @@ class ControlsManager():
     def load(self):
         if not os.path.exists(self.controls_dir):
             return
-        for filename in glob(os.path.join(self.controls_dir, "*.yml")):
+        for filename in sorted(glob(os.path.join(self.controls_dir, "*.yml"))):
             logging.info("Found file %s" % (filename))
             filepath = os.path.join(self.controls_dir, filename)
             policy = Policy(filepath, self.env_yaml)

--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -264,7 +264,8 @@ def find_testfile(oval_id):
 
     found_file = None
     for path in ['.', SHARED_OVAL, LINUX_OS_GUIDE]:
-        for root, _, _ in os.walk(path):
+        for root, dirs, _ in os.walk(path):
+            dirs.sort()
             for candidate in candidates:
                 search_file = os.path.join(root, candidate).strip()
                 if os.path.isfile(search_file):

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -96,6 +96,8 @@ class PlaybookBuilder():
 
     def _get_rules_variables(self, base_dir):
         for dirpath, dirnames, filenames in os.walk(base_dir):
+            dirnames.sort()
+            filenames.sort()
             for filename in filenames:
                 root, ext = os.path.splitext(filename)
                 if ext == ".var":
@@ -222,7 +224,7 @@ class PlaybookBuilder():
     def create_playbooks_for_all_rules(self, variables):
         profile_playbooks_dir = os.path.join(self.output_dir, "all")
         os.makedirs(profile_playbooks_dir)
-        for rule in os.listdir(self.rules_dir):
+        for rule in sorted(os.listdir(self.rules_dir)):
             rule_id, _ = os.path.splitext(rule)
             snippet_path = os.path.join(self.input_dir, rule_id + ".yml")
             if not os.path.exists(snippet_path):
@@ -241,7 +243,7 @@ class PlaybookBuilder():
         """
         variables = self.get_benchmark_variables()
         profiles = {}
-        for profile_file in os.listdir(self.profiles_dir):
+        for profile_file in sorted(os.listdir(self.profiles_dir)):
             profile_path = os.path.join(self.profiles_dir, profile_file)
             try:
                 profile = self.open_profile(profile_path)

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -70,7 +70,7 @@ def get_rule_dir_ovals(dir_path, product=None):
         return []
 
     results = []
-    for oval_file in os.listdir(oval_dir):
+    for oval_file in sorted(os.listdir(oval_dir)):
         file_name, ext = os.path.splitext(oval_file)
         oval_path = os.path.join(oval_dir, oval_file)
 
@@ -88,6 +88,7 @@ def find_rule_dirs(base_dir):
     Generator which yields all rule directories within a given base_dir, recursively
     """
     for root, dirs, _ in os.walk(base_dir):
+        dirs.sort()
         for dir_name in dirs:
             dir_path = os.path.join(root, dir_name)
             if is_rule_dir(dir_path):

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -80,7 +80,7 @@ class Template():
             return False
         if os.path.islink(self.template_root_directory):
             return False
-        template_sources = glob.glob(os.path.join(self.template_path, "*.template"))
+        template_sources = sorted(glob.glob(os.path.join(self.template_path, "*.template")))
         if not os.path.isfile(self.template_yaml_path) and not template_sources:
             return False
         return True
@@ -116,7 +116,7 @@ class Builder(object):
             dir_ = os.path.join(output_dir, lang)
             self.output_dirs[lang] = dir_
         # scan directory structure and dynamically create list of templates
-        for item in os.listdir(self.templates_dir):
+        for item in sorted(os.listdir(self.templates_dir)):
             itempath = os.path.join(self.templates_dir, item)
             maybe_template = Template(templates_dir, item)
             if maybe_template.looks_like_template():
@@ -213,7 +213,7 @@ class Builder(object):
                 oval_def_id, oval_def_id, template, langs_to_generate)
 
     def build_all_rules(self):
-        for rule_file in os.listdir(self.resolved_rules_dir):
+        for rule_file in sorted(os.listdir(self.resolved_rules_dir)):
             rule_path = os.path.join(self.resolved_rules_dir, rule_file)
             try:
                 rule = ssg.build_yaml.Rule.from_yaml(rule_path, self.env_yaml)

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -443,7 +443,7 @@ def locally_clone_and_init_repositories(organization, repo_list):
 def select_roles_to_upload(product_whitelist, profile_whitelist,
                            build_playbooks_dir):
     selected_roles = dict()
-    for filename in os.listdir(build_playbooks_dir):
+    for filename in sorted(os.listdir(build_playbooks_dir)):
         root, ext = os.path.splitext(filename)
         if ext == ".yml":
             # the format is product-playbook-profile.yml

--- a/utils/duplicated_prodtypes.py
+++ b/utils/duplicated_prodtypes.py
@@ -18,7 +18,9 @@ def _create_profile_cache(ssg_root):
     for product in product_list:
         found_obj_name = False
         prod_profiles_dir = os.path.join(ssg_root, product, "profiles")
-        for _, _, files in os.walk(prod_profiles_dir):
+        for _, dirs, files in os.walk(prod_profiles_dir):
+            dirs.sort()
+            files.sort()
             for filename in files:
                 profile_path = os.path.join(prod_profiles_dir, filename)
                 parsed_profile = yaml.load(open(profile_path, 'r'))
@@ -222,6 +224,8 @@ def walk_dir(ssg_root, function):
 
     data = None
     for root, dirs, files in os.walk(product_guide):
+        dirs.sort()
+        files.sort()
         for filename in files:
             path = os.path.join(root, filename)
 

--- a/utils/find_duplicates.py
+++ b/utils/find_duplicates.py
@@ -27,6 +27,8 @@ def recursive_globi(mask):
     re_path_mask = re.compile(path_mask + "$")
 
     for root, dirnames, filenames in os.walk(search_root):
+        dirnames.sort()
+        filenames.sort()
         paths = filenames + dirnames
         for path in paths:
             full_path = os.path.join(root, path)
@@ -83,7 +85,7 @@ class DuplicatesFinder(object):
 
         # Walk all shared files
         shared_files_mask = os.path.join(self._shared_dir, self._shared_files_mask)
-        for shared_filename in glob.glob(shared_files_mask):
+        for shared_filename in sorted(glob.glob(shared_files_mask)):
 
             basename = os.path.basename(shared_filename)
 

--- a/utils/find_shadowed_files.py
+++ b/utils/find_shadowed_files.py
@@ -10,7 +10,7 @@ SSG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def safe_listdir(path):
     try:
-        return os.listdir(path)
+        return sorted(os.listdir(path))
     except:
         return []
 

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -96,7 +96,8 @@ def find_rules(directory, func):
     product_yaml = None
     product_yaml_path = None
     for root, dirs, files in os.walk(directory):
-
+        dirs.sort()
+        files.sort()
         if "product.yml" in files:
             product_yaml_path = os.path.join(root, "product.yml")
             product_yaml = yaml.open_raw(product_yaml_path)

--- a/utils/fix_file_ocilclause.py
+++ b/utils/fix_file_ocilclause.py
@@ -18,7 +18,9 @@ def _create_profile_cache(ssg_root):
     for product in product_list:
         found_obj_name = False
         prod_profiles_dir = os.path.join(ssg_root, product, "profiles")
-        for _, _, files in os.walk(prod_profiles_dir):
+        for _, dirs, files in os.walk(prod_profiles_dir):
+            dirs.sort()
+            files.sort()
             for filename in files:
                 profile_path = os.path.join(prod_profiles_dir, filename)
                 parsed_profile = yaml.load(open(profile_path, 'r'))
@@ -217,6 +219,8 @@ def walk_dir(ssg_root, function):
 
     data = None
     for root, dirs, files in os.walk(product_guide):
+        dirs.sort()
+        files.sort()
         for filename in files:
             path = os.path.join(root, filename)
 

--- a/utils/gen_tables.py
+++ b/utils/gen_tables.py
@@ -36,7 +36,7 @@ class References:
 class Output(object):
     def __init__(self, product, build_dir):
         path = "{build_dir}/{product}/rules".format(build_dir=build_dir, product=product)
-        rule_files = glob("{path}/*".format(path=path))
+        rule_files = sorted(glob("{path}/*".format(path=path)))
         if not rule_files:
             msg = (
                 "No files found in '{path}', please make sure that you select the build dir "

--- a/utils/ignition-remediation.py
+++ b/utils/ignition-remediation.py
@@ -166,6 +166,8 @@ def resolve_path(rule, path):
 
     # Otherwise we try to guess it based on the rule name
     for root, dirs, files in os.walk('./linux_os'):
+        dirs.sort()
+        files.sort()
         if root.endswith(rule):
             return os.path.join([root, "ignition", "shared.yml"])
 
@@ -177,6 +179,8 @@ def resolve_rule(rule):
 
     # Otherwise we try to guess it based on the rule name
     for root, dirs, files in os.walk('./linux_os'):
+        dirs.sort()
+        files.sort()
         if root.endswith(rule):
             return root
     return None

--- a/utils/migrate_template_csv_to_rule.py
+++ b/utils/migrate_template_csv_to_rule.py
@@ -627,7 +627,7 @@ class ProductCSVData(object):
     def _identify_csv_files(self, csv_dir):
         try:
             # get all CSV files
-            product_csvs = [csv_filename for csv_filename in os.listdir(csv_dir)
+            product_csvs = [csv_filename for csv_filename in sorted(os.listdir(csv_dir))
                             if csv_filename.endswith(".csv")]
         except FileNotFoundError as not_found:
             product_csvs = []
@@ -816,6 +816,8 @@ def walk_benchmarks(benchmark_dir, product, override_template=False):
     csv_data = product.csv_data
 
     for root, dirs, files in os.walk(benchmark_dir):
+        dirs.sort()
+        files.sort()
         rule_id = os.path.basename(root)
         if rule_id in ["oval", "bash", "ansible", "tests"]:
             continue

--- a/utils/move_rules.py
+++ b/utils/move_rules.py
@@ -354,6 +354,8 @@ def walk_dir(ssg_root, product, function):
 
     data = None
     for root, dirs, files in os.walk(product_guide):
+        dirs.sort()
+        files.sort()
         for filename in files:
             path = os.path.join(root, filename)
 


### PR DESCRIPTION
#### Description:

- Sort file lists

#### Rationale:

- so that xml files build in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

Together with #6642 and https://github.com/OpenSCAP/openscap/pull/1699 this allowed for bit-identical results.
Probably some of this change is not needed, but build was slow, so I did not try to reduce the patch.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).