### PR TITLE
Introduce packit support

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: scap-security-guide.spec
+
+# add or remove files that should be synced
+synced_files:
+    - scap-security-guide.spec
+    - .packit.yaml
+
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_package_name: scap-security-guide
+# downstream (Fedora) RPM package name
+downstream_package_name: scap-security-guide
+
+actions:
+  post-upstream-clone: "wget https://src.fedoraproject.org/rpms/scap-security-guide/raw/rawhide/f/scap-security-guide.spec -O scap-security-guide.spec"


### PR DESCRIPTION
Packit enables integration with downstream Fedora packaging, and potentially with packaging of derived systems.

The setup uses the Rawhide spec file to create the srpm, so the upstream project doesn't require any adjustments.