### PR TITLE
ocp: Add two missing OCILs

### DIFF
--- a/applications/openshift/authentication/idp_is_configured/rule.yml
+++ b/applications/openshift/authentication/idp_is_configured/rule.yml
@@ -58,6 +58,13 @@ identifiers:
 references:
   cis: 3.1.1
 
+ocil_clause: 'identity provider is not configured'
+
+ocil: |-
+    Run the following command to list the identity providers configured:
+    <pre>$ oc get oauths cluster -ojsonpath='{.spec.identityProviders}' | jq </pre>
+    Make sure that there exists at least one item referenced by the above path.
+
 severity: medium
 
 warnings:

--- a/applications/openshift/logging/audit_profile_set/rule.yml
+++ b/applications/openshift/logging/audit_profile_set/rule.yml
@@ -56,6 +56,14 @@ identifiers:
 references:
   cis: 3.2.1,3.2.2
 
+ocil_clause: 'The proper audit profile is not set'
+
+ocil: |-
+    Run the following command to retrieve the current audit profile:
+    <pre>$ oc get apiservers cluster -ojsonpath='{.spec.audit.profile}'</pre>
+    Make sure the profile returned matches the one that should be used.
+
+
 severity: medium
 
 warnings:


### PR DESCRIPTION
Two rules were missing both ocil_clause and ocil, let's add them to keep
our CIS coverage high.