### PR TITLE
Change instances of cis to cis@ocp4 for openshift

### DIFF
--- a/applications/openshift/accounts/accounts_restrict_service_account_tokens/rule.yml
+++ b/applications/openshift/accounts/accounts_restrict_service_account_tokens/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.1.6
+    cis@ocp4: 5.1.6
 
 ocil_clause: 'service account tokens are automounting'
 

--- a/applications/openshift/accounts/accounts_unique_service_account/rule.yml
+++ b/applications/openshift/accounts/accounts_unique_service_account/rule.yml
@@ -24,7 +24,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.1.5
+    cis@ocp4: 5.1.5
 
 ocil_clause: 'default service account is used and is not unique'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.11
+    cis@ocp4: 1.2.11
 
 ocil_clause: '<tt>AlwaysAdmit</tt> admission control plugin is not set'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -30,7 +30,7 @@ rationale: |-
 severity: high
 
 references:
-    cis: 1.2.12
+    cis@ocp4: 1.2.12
 
 ocil_clause: '<tt>admissionConfig</tt> does not contain <tt>AlwaysPullImages</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -21,7 +21,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.15
+    cis@ocp4: 1.2.15
 
 ocil_clause: 'API server config contains <tt>NamespaceLifecycle</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -24,7 +24,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.17
+    cis@ocp4: 1.2.17
 
 ocil_clause: '<tt>enable-admission-plugins</tt> does not contain <tt>NodeRestriction</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
@@ -24,7 +24,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.16
+    cis@ocp4: 1.2.16
 
 ocil_clause: 'the list of enabled admission plugins contains <tt>SecurityContextConstraint</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -28,7 +28,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.13
+    cis@ocp4: 1.2.13
 
 ocil_clause: |-
     '<tt>enable-admission-plugins</tt>does not contain <tt>SecurityContextDeny</tt>'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -24,7 +24,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.14
+    cis@ocp4: 1.2.14
 
 ocil_clause: 'API server configuration contains <tt>ServiceAccount</tt>'
 

--- a/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
@@ -35,7 +35,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.2.1
+    cis@ocp4: 1.2.1
 
 ocil_clause: 'anonymous requests are not authorized'
 

--- a/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.2.10
+  cis@ocp4: 1.2.10
 
 ocil_clause: 'A FlowSchema object <tt>catch-all</tt> exists'
 

--- a/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.2.10
+  cis@ocp4: 1.2.10
 
 ocil_clause: '<tt>.apiServerArguments["feature-gates"]</tt> does not include <tt>APIPriorityAndFairness</tt>'
 

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: low
 
 references:
-    cis: 1.2.24
+    cis@ocp4: 1.2.24
 
 ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
 

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.25
+    cis@ocp4: 1.2.25
 
 ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
 

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 severity: high
 
 references:
-    cis: 1.2.22
+    cis@ocp4: 1.2.22
 
 ocil_clause: '<tt>audit-log-path</tt> does not contain a valid audit file path'
 

--- a/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
@@ -14,7 +14,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.7
+    cis@ocp4: 1.2.7
 
 ocil_clause: 'The Node authorization-mode is configured and enabled'
 

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -16,7 +16,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.8
+    cis@ocp4: 1.2.8
 
 ocil_clause: 'The Node authorization-mode is configured and enabled'
 

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -21,7 +21,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.9
+    cis@ocp4: 1.2.9
 
 ocil_clause: 'The RBAC authorization mode is enabled'
 

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -34,7 +34,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.2
+    cis@ocp4: 1.2.2
 
 ocil_clause: 'basic-auth-file is configured and enabled for the API server'
 

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: low
 
 references:
-    cis: 1.2.20
+    cis@ocp4: 1.2.20
 
 ocil_clause: '<tt>bindAddress</tt> allows unsecure connections'
 

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -31,7 +31,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.2.31
+    cis@ocp4: 1.2.31
     nist: SC-8(1),SC-8(2)
 
 identifiers:

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -24,7 +24,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.2.34
+    cis@ocp4: 1.2.34
     nist: SC-28(1)
 
 ocil_clause: '<tt>aescbc</tt> is not configured as the encryption provider'

--- a/applications/openshift/api-server/api_server_encryption_provider_config/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_config/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.33
+    cis@ocp4: 1.2.33
     nist: SC-28(1)
 
 

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -34,7 +34,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.32
+    cis@ocp4: 1.2.32
     nist: SC-8(1),SC-8(2)
 
 ocil_clause: '<tt>etcd-cafile</tt> is not set as appropriate for <tt>apiServerArguments</tt>'

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.29
+    cis@ocp4: 1.2.29
 
 ocil_clause: '<tt>etcd-certfile</tt> does not exist or is not configured to valid certificates'
 

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.29
+    cis@ocp4: 1.2.29
 
 ocil_clause: '<tt>keyFile</tt> does not exist or is not configured to valid certificates'
 

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.18
+    cis@ocp4: 1.2.18
 
 ocil_clause: 'insecure-bind-address is exists and has not been removed</tt>'
 

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -34,7 +34,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.19
+    cis@ocp4: 1.2.19
 
 ocil_clause: '<tt>insecure-port</tt> setting exists'
 

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -33,7 +33,7 @@ identifiers:
 severity: high
 
 references:
-    cis: 1.2.6
+    cis@ocp4: 1.2.6
 
 ocil_clause: '<tt>kubelet-certificate-authority</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: high
 
 references:
-    cis: 1.2.5
+    cis@ocp4: 1.2.5
 
 ocil_clause: '<tt>kubelet-client-certificate</tt> is not set as appropriate in <tt>apiServerArguments:</tt>'
 

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: high
 
 references:
-    cis: 1.2.5
+    cis@ocp4: 1.2.5
 
 ocil_clause: '<tt>kubelet-client-key</tt> is not set as appropriate in <tt>apiServerArguments:</tt>'
 

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -22,12 +22,12 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.13
-    cis: 1.2.14
-    cis: 1.2.14
-    cis: 1.2.15
-    cis: 1.2.16
-    cis: 1.2.17
+    cis@ocp4: 1.2.13
+    cis@ocp4: 1.2.14
+    cis@ocp4: 1.2.14
+    cis@ocp4: 1.2.15
+    cis@ocp4: 1.2.16
+    cis@ocp4: 1.2.17
 
 ocil_clause: 'No admission plugins are disabled'
 

--- a/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.2.4
+    cis@ocp4: 1.2.4
 
 ocil_clause: |-
     The openshift-apiserver serving-cert is not set to type

--- a/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.2.4
+    cis@ocp4: 1.2.4
 
 ocil_clause: |-
     The openshift-apiserver serving-cert is not set to type

--- a/applications/openshift/api-server/api_server_profiling_protected_by_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_profiling_protected_by_rbac/rule.yml
@@ -20,7 +20,7 @@ identifiers:
   cce@ocp4: CCE-84212-0
 
 references:
-  cis: 1.2.21
+  cis@ocp4: 1.2.21
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -30,7 +30,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.2.26
+    cis@ocp4: 1.2.26
 
 ocil_clause: '<tt>min-request-timeout</tt> is not set or is not set to an appropriate value'
 

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -21,7 +21,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.2.27
+  cis@ocp4: 1.2.27
 
 ocil_clause: 'API server argument <tt>--service-account-lookup</tt> contains <tt>true</tt>'
 

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.28
+    cis@ocp4: 1.2.28
 
 ocil_clause: 'serviceAccountPublicKeyFiles is not configured correctly'
 

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.30
+    cis@ocp4: 1.2.30
     nist: SC-8(1),SC-8(2)
 
 ocil_clause: '<tt>tls-cert-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -31,7 +31,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.2.35
+    cis@ocp4: 1.2.35
 
 ocil_clause: '<tt>cipherSuites</tt> is not configured, or contains ciphers (possibly insecure) other than TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, or TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 in servingInfo'
 

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.30
+    cis@ocp4: 1.2.30
     nist: SC-8(1),SC-8(2)
 
 ocil_clause: '<tt>tls-private-key-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: high
 
 references:
-    cis: 1.2.3
+    cis@ocp4: 1.2.3
 
 ocil_clause: '<tt>token-auth-file</tt> argument is configured'
 

--- a/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
@@ -16,7 +16,7 @@ rationale: |-
   tamper with the logs because of the logs being stored off-site.
 
 references:
-  cis: 1.2.23
+  cis@ocp4: 1.2.23
   nist: AU-9(2)
 
 identifiers:

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: low
 
 references:
-    cis: 1.2.24
+    cis@ocp4: 1.2.24
 
 ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
 

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.2.25
+    cis@ocp4: 1.2.25
 
 ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
 

--- a/applications/openshift/authentication/idp_is_configured/rule.yml
+++ b/applications/openshift/authentication/idp_is_configured/rule.yml
@@ -56,7 +56,7 @@ identifiers:
 
 
 references:
-  cis: 3.1.1
+  cis@ocp4: 3.1.1
 
 ocil_clause: 'identity provider is not configured'
 

--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -38,7 +38,7 @@ ocil: |-
     Verify that it's disabled (the value is <pre>0</pre>).
 
 references:
-    cis: 1.3.7
+    cis@ocp4: 1.3.7
 
 warnings:
 - general: |-

--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -51,7 +51,7 @@ warnings:
     of rotation yourself
 
 references:
-    cis: 1.3.6
+    cis@ocp4: 1.3.6
 
 template:
   name: yamlfile_value

--- a/applications/openshift/controller/controller_secure_port/rule.yml
+++ b/applications/openshift/controller/controller_secure_port/rule.yml
@@ -38,7 +38,7 @@ ocil: |-
     Verify that it's using an appropriate port (the value is not <pre>0</pre>).
 
 references:
-    cis: 1.3.7
+    cis@ocp4: 1.3.7
 
 warnings:
 - general: |-

--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.3.5
+    cis@ocp4: 1.3.5
 
 ocil_clause: '<tt>root-ca-file</tt> is not configured</tt>'
 

--- a/applications/openshift/controller/controller_service_account_private_key/rule.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 1.3.4
+    cis@ocp4: 1.3.4
 
 ocil_clause: '<tt>service-account-private-key-file</tt> does not exist or is configured properly'
 

--- a/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
+++ b/applications/openshift/controller/controller_terminated_pod_gc_threshhold/rule.yml
@@ -33,7 +33,7 @@ severity: low
 #    cce@ocp4:
 
 references:
-    cis: 1.3.1
+    cis@ocp4: 1.3.1
     
 ocil_clause: '<tt>terminated-pod-gc-threshold</tt> is not enabled'
 

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -35,7 +35,7 @@ identifiers:
     cce@ocp4: CCE-84208-8
 
 references:
-    cis: 1.3.3
+    cis@ocp4: 1.3.3
 
 ocil_clause: '<tt>use-service-account-credentials</tt> is set to <tt>false</tt>'
 

--- a/applications/openshift/etcd/etcd_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@ocp4: CCE-84199-9
 
 references:
-    cis: '2.3'
+    cis@ocp4: '2.3'
 
 ocil_clause: 'the etcd is using self-signed certificates'
 

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@ocp4: CCE-83553-8
 
 references:
-    cis: '2.1'
+    cis@ocp4: '2.1'
 
 ocil_clause: 'the etcd client certificate is not configured'
 

--- a/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
@@ -22,7 +22,7 @@ identifiers:
     cce@ocp4: CCE-84077-7
 
 references:
-    cis: '2.2'
+    cis@ocp4: '2.2'
 
 ocil_clause: 'the etcd client certificate authentication is not configured'
 

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@ocp4: CCE-83745-0
 
 references:
-    cis: '2.1'
+    cis@ocp4: '2.1'
 
 ocil_clause: 'the etcd client key file is not configured'
 

--- a/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@ocp4: CCE-84184-1
 
 references:
-    cis: '2.6'
+    cis@ocp4: '2.6'
 
 ocil_clause: 'the etcd is using peer self-signed certificates'
 

--- a/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@ocp4: CCE-83847-4
 
 references:
-    cis: '2.4'
+    cis@ocp4: '2.4'
     nist: SC-8(1),SC-8(2)
 
 ocil_clause: 'the etcd peer client certificate is not configured'

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
@@ -22,7 +22,7 @@ identifiers:
     cce@ocp4: CCE-83465-5
 
 references:
-   cis: '2.5'
+   cis@ocp4: '2.5'
 
 ocil_clause: 'the etcd peer client certificate authentication is not configured'
 

--- a/applications/openshift/etcd/etcd_peer_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@ocp4: CCE-83711-2
 
 references:
-    cis: '2.4'
+    cis@ocp4: '2.4'
     nist: SC-8(1),SC-8(2)
 
 ocil_clause: 'the etcd peer client key file is not configured'

--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -20,7 +20,7 @@ severity: medium
 #    cce@ocp4:
 
 references:
-  cis: '2.7'
+  cis@ocp4: '2.7'
 
 platform: ocp4-master-node
 

--- a/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
@@ -28,7 +28,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 4.2.1
+    cis@ocp4: 4.2.1
 
 identifiers:
       cce@ocp4: CCE-83815-1

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -27,7 +27,7 @@ identifiers:
 severity: medium
 
 references:
-    cis: 4.2.2
+    cis@ocp4: 4.2.2
 
 ocil_clause: '<tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>'
 

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
@@ -38,7 +38,7 @@ identifiers:
     cce@ocp4: CCE-83724-5
 
 references:
-    cis: 4.2.3
+    cis@ocp4: 4.2.3
 
 template:
   name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -52,7 +52,7 @@ identifiers:
     cce@ocp4: CCE-83576-9
 
 references:
-    cis: 4.2.9
+    cis@ocp4: 4.2.9
 
 # This check ensures that the option is not left defaulted in the config.  The
 # default of 5 might be sufficient for a deployment; here the point is to check

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -20,7 +20,7 @@ identifiers:
     cce@ocp4: CCE-83396-2
 
 references:
-    cis: 4.2.10
+    cis@ocp4: 4.2.10
     nist: SC-8(1),SC-8(2)
 
 ocil_clause: 'the kubelet certificate is not configured'

--- a/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
@@ -27,4 +27,4 @@ ocil: |-
 #    cce@ocp4:
 
 references:
-    cis: 4.2.8
+    cis@ocp4: 4.2.8

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -36,7 +36,7 @@ identifiers:
     cce@ocp4: CCE-83427-5
 
 references:
-    cis: 4.2.4
+    cis@ocp4: 4.2.4
 
 warnings:
     - general: |-

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
@@ -31,7 +31,7 @@ identifiers:
     cce@ocp4: CCE-83838-3
 
 references:
-    cis: 4.2.11
+    cis@ocp4: 4.2.11
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -32,7 +32,7 @@ identifiers:
     cce@ocp4: CCE-83352-5
 
 references:
-    cis: 4.2.11
+    cis@ocp4: 4.2.11
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
@@ -32,7 +32,7 @@ identifiers:
     cce@ocp4: CCE-83775-7
 
 references:
-    cis: 4.2.7
+    cis@ocp4: 4.2.7
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
@@ -28,7 +28,7 @@ ocil: |-
 #   cce@ocp4: 
 
 references:
-    cis: 4.2.6
+    cis@ocp4: 4.2.6
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -32,7 +32,7 @@ identifiers:
     cce@ocp4: CCE-83356-6
 
 references:
-    cis: 4.2.12
+    cis@ocp4: 4.2.12
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -30,7 +30,7 @@ identifiers:
     cce@ocp4: CCE-84097-5
 
 references:
-    cis: 4.2.5
+    cis@ocp4: 4.2.5
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84144-5

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84147-8

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84135-3

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84138-7

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84141-1

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84127-0

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84132-0

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84222-9

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84119-7

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
@@ -51,7 +51,7 @@ rationale: |-
 severity: medium
 
 references:
-  cis: 1.3.1
+  cis@ocp4: 1.3.1
 
 identifiers:
   cce@ocp4: CCE-84123-9

--- a/applications/openshift/logging/audit_profile_set/rule.yml
+++ b/applications/openshift/logging/audit_profile_set/rule.yml
@@ -54,7 +54,7 @@ identifiers:
   cce@ocp4: CCE-83577-7
 
 references:
-  cis: 3.2.1,3.2.2
+  cis@ocp4: 3.2.1,3.2.2
 
 ocil_clause: 'The proper audit profile is not set'
 

--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-84025-6
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.18
+  cis@ocp4: 1.1.18
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-83354-1
 
 references:
-    cis: 1.1.12
+    cis@ocp4: 1.1.12
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-83816-9
 
 references:
-    cis: 1.1.12
+    cis@ocp4: 1.1.12
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/wal/*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -20,7 +20,7 @@ identifiers:
     cce@ocp4: CCE-83664-3
 
 references:
-    cis: 1.1.8
+    cis@ocp4: 1.1.8
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.19
+  cis@ocp4: 1.1.19
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84211-2
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83530-6
 
 references:
-    cis: 1.1.2
+    cis@ocp4: 1.1.2
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83953-0
 
 references:
-    cis: 1.1.4
+    cis@ocp4: 1.1.4
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83614-8
 
 references:
-    cis: 1.1.6
+    cis@ocp4: 1.1.6
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_kubeconfig/rule.yml
@@ -17,7 +17,7 @@ severity: medium
 #    cce@ocp4: 80633-1
 
 references:
-    cis: 1.1.14
+    cis@ocp4: 1.1.14
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubeconfig", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
@@ -23,7 +23,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.14
+  cis@ocp4: 1.1.14
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-83818-5
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.19
+  cis@ocp4: 1.1.19
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.19
+  cis@ocp4: 1.1.19
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83605-6
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_groupowner_openvswitch/rule.yml
@@ -18,7 +18,7 @@ severity: medium
 #    cce@ocp4: 82172-8
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84226-0
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84219-5
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83630-4
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83677-5
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84129-6
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84166-8
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="openvswitch") }}}'
 

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.16
+  cis@ocp4: 1.1.16
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
 

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-83460-6
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.18
+  cis@ocp4: 1.1.18
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-83905-0
 
 references:
-    cis: 1.1.12
+    cis@ocp4: 1.1.12
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-84010-8
 
 references:
-    cis: 1.1.12
+    cis@ocp4: 1.1.12
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/wal/*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -20,7 +20,7 @@ identifiers:
     cce@ocp4: CCE-83988-6
 
 references:
-    cis: 1.1.8
+    cis@ocp4: 1.1.8
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.19
+  cis@ocp4: 1.1.19
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-84248-4
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83372-3
 
 references:
-    cis: 1.1.2
+    cis@ocp4: 1.1.2
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83795-5
 
 references:
-    cis: 1.1.4
+    cis@ocp4: 1.1.4
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83393-9
 
 references:
-    cis: 1.1.6
+    cis@ocp4: 1.1.6
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_kubeconfig/rule.yml
@@ -17,7 +17,7 @@ severity: medium
 #    cce@ocp4: 80633-1
 
 references:
-    cis: 1.1.14
+    cis@ocp4: 1.1.14
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
@@ -23,7 +23,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.14
+  cis@ocp4: 1.1.14
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-83603-1
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.19
+  cis@ocp4: 1.1.19
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.19
+  cis@ocp4: 1.1.19
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83932-4
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_owner_openvswitch/rule.yml
@@ -18,7 +18,7 @@ severity: medium
 #    cce@ocp4: 82172-8
 
 references:
-    cis: 1.1.10
+    cis@ocp4: 1.1.10
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83489-5
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/conf.db", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83462-2
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83937-3
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84085-0
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/system-id.conf", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83888-8
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83806-0
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@ocp4: CCE-84017-3
 
 references:
-  cis: 1.1.16
+  cis@ocp4: 1.1.16
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_var_lib_etcd/rule.yml
+++ b/applications/openshift/master/file_owner_var_lib_etcd/rule.yml
@@ -14,7 +14,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.1.12
+    cis@ocp4: 1.1.12
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd", owner="root") }}}'
 

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83379-8
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.17
+  cis@ocp4: 1.1.17
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84013-2
 
 references:
-    cis: 1.1.11
+    cis@ocp4: 1.1.11
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd", perms="drwx------") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83382-2
 
 references:
-    cis: 1.1.11
+    cis@ocp4: 1.1.11
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/member/wal/*", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@ocp4: CCE-83973-8
 
 references:
-    cis: 1.1.7
+    cis@ocp4: 1.1.7
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.20
+  cis@ocp4: 1.1.20
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-*/secrets/*/*.crt", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83469-7
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83983-7
 
 references:
-    cis: 1.1.1
+    cis@ocp4: 1.1.1
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84161-9
 
 references:
-    cis: 1.1.3
+    cis@ocp4: 1.1.3
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_scheduler/rule.yml
@@ -19,7 +19,7 @@ severity: medium
 #    cce@ocp4:
 
 references:
-    cis: 1.1.5
+    cis@ocp4: 1.1.5
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_kubeconfig/rule.yml
@@ -19,7 +19,7 @@ severity: medium
 #    cce@ocp4: 80633-1
 
 references:
-    cis: 1.1.13
+    cis@ocp4: 1.1.13
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/kubeconfig", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
@@ -23,7 +23,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.13
+  cis@ocp4: 1.1.13
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83467-1
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.20
+  cis@ocp4: 1.1.20
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-*/secrets/*/tls.crt", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.21
+  cis@ocp4: 1.1.21
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_openvswitch/rule.yml
+++ b/applications/openshift/master/file_permissions_openvswitch/rule.yml
@@ -19,7 +19,7 @@ severity: medium
 #    cce@ocp4: 82173-6
 
 references:
-    cis: 1.4.9
+    cis@ocp4: 1.4.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/.*", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83788-0
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/conf.db", perms="-rw-r-----") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84202-1
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/.conf.db.~lock~", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83666-8
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83400-2
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/system-id.conf", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83710-4
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83679-1
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovsdb-server.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84057-9
 
 references:
-    cis: 1.1.5
+    cis@ocp4: 1.1.5
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 severity: medium
 
 references:
-  cis: 1.1.15
+  cis@ocp4: 1.1.15
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_var_lib_etcd/rule.yml
+++ b/applications/openshift/master/file_permissions_var_lib_etcd/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 1.1.11
+    cis@ocp4: 1.1.11
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd", perms="-rwx------") }}}'
 

--- a/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83927-4
 
 references:
-    cis: 1.1.9
+    cis@ocp4: 1.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/openshift-sdn/cniserver/config.json", perms="-r--r--r--") }}}'
 

--- a/applications/openshift/networking/configure_network_policies/rule.yml
+++ b/applications/openshift/networking/configure_network_policies/rule.yml
@@ -24,4 +24,4 @@ ocil: |-
     A network policy should be properly configured to create network segmentation.
 
 references:
-    cis: 5.3.1
+    cis@ocp4: 5.3.1

--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -25,4 +25,4 @@ ocil: |-
     <pre>$ oc get networkpolicy --all-namespaces</pre>
 
 references:
-    cis: 5.3.2
+    cis@ocp4: 5.3.2

--- a/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
+++ b/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 severity: high
 
 references:
-    cis: 1.2.22
+    cis@ocp4: 1.2.22
 
 ocil_clause: '<tt>audit-log-path</tt> does not contain a valid audit file path'
 

--- a/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
+++ b/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
@@ -22,7 +22,7 @@ identifiers:
   cce@ocp4: CCE-84182-5
 
 references:
-  cis: 1.3.2,1.4.1
+  cis@ocp4: 1.3.2,1.4.1
 
 severity: medium
 

--- a/applications/openshift/rbac/rbac_limit_cluster_admin/rule.yml
+++ b/applications/openshift/rbac/rbac_limit_cluster_admin/rule.yml
@@ -20,7 +20,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.1.1
+    cis@ocp4: 5.1.1
 
 ocil_clause: 'cluster-admin role is in use by more personnel then necessary'
 

--- a/applications/openshift/rbac/rbac_limit_secrets_access/rule.yml
+++ b/applications/openshift/rbac/rbac_limit_secrets_access/rule.yml
@@ -22,7 +22,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.1.2
+    cis@ocp4: 5.1.2
 
 ocil_clause: 'Access to Kubernetes clusters is too wide'
 

--- a/applications/openshift/rbac/rbac_pod_creation_access/rule.yml
+++ b/applications/openshift/rbac/rbac_pod_creation_access/rule.yml
@@ -17,7 +17,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.1.4
+    cis@ocp4: 5.1.4
 
 ocil_clause: 'pod creation privileges are in use by more roles than necessary'
 

--- a/applications/openshift/rbac/rbac_wildcard_use/rule.yml
+++ b/applications/openshift/rbac/rbac_wildcard_use/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.1.3
+    cis@ocp4: 5.1.3
 
 ocil_clause: 'wildcards are in use by more roles than necessary'
 

--- a/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
+++ b/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
@@ -20,7 +20,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.2.7
+    cis@ocp4: 5.2.7
 
 ocil_clause: 'NET_RAW does not exist or is configured in defaultAddCapabilities or allowedCapabilities'
 

--- a/applications/openshift/scc/scc_limit_privilege_escalation/rule.yml
+++ b/applications/openshift/scc/scc_limit_privilege_escalation/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@ocp4: CCE-83447-3
 
 references:
-    cis: 5.2.5
+    cis@ocp4: 5.2.5
 
 ocil_clause: 'allowPrivilegeEscalation is set to true or too many SCCs have allowPrivilegeEscalation enabled'
 

--- a/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
@@ -19,7 +19,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.2.1
+    cis@ocp4: 5.2.1
 
 ocil_clause: 'allowPrivilegedContainer is set to true or too many SCCs have allowPrivilegedContainer enabled'
 

--- a/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.2.2
+    cis@ocp4: 5.2.2
 
 ocil_clause: 'allowHostPID is set to true or too many SCCs have allowHostPID enabled'
 

--- a/applications/openshift/scc/scc_limit_root_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_root_containers/rule.yml
@@ -20,7 +20,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.2.6
+    cis@ocp4: 5.2.6
 
 ocil_clause: 'allowPrivilegedContainer is set to true or too many SCCs have allowPrivilegedContainer enabled'
 

--- a/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
+++ b/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
@@ -19,7 +19,7 @@ rationale: |-
   components that monitor the kubelet health.
 
 references:
-  cis: 1.4.2
+  cis@ocp4: 1.4.2
 
 identifiers:
   cce@ocp4: CCE-83674-2

--- a/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
+++ b/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
@@ -19,7 +19,7 @@ rationale: |-
   components that monitor the kubelet health.
 
 references:
-  cis: 1.4.2
+  cis@ocp4: 1.4.2
 
 severity: medium
 

--- a/applications/openshift/secrets/secrets_no_environment_variables/rule.yml
+++ b/applications/openshift/secrets/secrets_no_environment_variables/rule.yml
@@ -16,7 +16,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis: 5.4.1
+    cis@ocp4: 5.4.1
 
 ocil_clause: 'environment variables are in use for secrets'
 

--- a/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
@@ -16,7 +16,7 @@ identifiers:
     cce@ocp4: CCE-84233-6
 
 references:
-    cis: 4.1.6
+    cis@ocp4: 4.1.6
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}'
 

--- a/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
@@ -21,7 +21,7 @@ severity: medium
 #    cce@ocp4: 80633-1
 
 references:
-  cis: 4.1.4
+  cis@ocp4: 4.1.4
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/config/kube-proxy-config.yaml", group="root") }}}'
 

--- a/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83440-8
 
 references:
-    cis: 4.1.8
+    cis@ocp4: 4.1.8
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubelet-ca.crt", group="root") }}}'
 

--- a/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83409-3
 
 references:
-    cis: 4.1.10
+    cis@ocp4: 4.1.10
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/kubelet/kubeconfig", group="root") }}}'
 

--- a/applications/openshift/worker/file_groupowner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_service/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83975-3
 
 references:
-    cis: 4.1.2
+    cis@ocp4: 4.1.2
 
 ocil_clause: |-
   '{{{ ocil_clause_file_group_owner(file="/etc/systemd/system/kubelet.service", group="root") }}}'

--- a/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83976-1
 
 references:
-    cis: 4.1.6
+    cis@ocp4: 4.1.6
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}'
 

--- a/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
@@ -21,7 +21,7 @@ severity: medium
 #    cce@ocp4: 80633-1
 
 references:
-  cis: 4.1.4
+  cis@ocp4: 4.1.4
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/config/kube-proxy-config.yaml", owner="root") }}}'
 

--- a/applications/openshift/worker/file_owner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_ca/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83495-2
 
 references:
-    cis: 4.1.8
+    cis@ocp4: 4.1.8
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubelet-ca.crt", owner="root") }}}'
 

--- a/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@ocp4: CCE-83408-5
 
 references:
-    cis: 4.1.10
+    cis@ocp4: 4.1.10
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/kubelet/kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/worker/file_owner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_service/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-84193-2
 
 references:
-    cis: 4.1.2
+    cis@ocp4: 4.1.2
 
 ocil_clause: |-
   '{{{ ocil_clause_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}'

--- a/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83470-5
 
 references:
-    cis: 4.1.5
+    cis@ocp4: 4.1.5
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/kubelet.conf", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
@@ -25,7 +25,7 @@ identifiers:
 
 
 references:
-  cis: 4.1.3
+  cis@ocp4: 4.1.3
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/config/kube-proxy-config.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/worker/file_permissions_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_ca/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83493-7
 
 references:
-    cis: 4.1.7
+    cis@ocp4: 4.1.7
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/kubelet-ca.crt", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@ocp4: CCE-83509-0
 
 references:
-    cis: 4.1.9
+    cis@ocp4: 4.1.9
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/kubelet/kubeconfig", perms="-rw-------") }}}'
 

--- a/applications/openshift/worker/file_permissions_worker_service/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_service/rule.yml
@@ -20,7 +20,7 @@ identifiers:
     cce@ocp4: CCE-83455-6
 
 references:
-    cis: 4.1.1
+    cis@ocp4: 4.1.1
 
 ocil_clause: |-
   {{{ ocil_clause_file_permissions(file="/etc/systemd/system/kubelet.service", perms="-rw-r--r--") }}}


### PR DESCRIPTION
This specifies that the CIS benchmark is relevant to openshift, as
opposed to using a generic reference.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>