### PR TITLE
CIS 1.2.4: Add api_server_https_for_kubelet_conn rule

### DIFF
--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'Ensure that the --kubelet-https argument is set to true'
+
+description: |-
+    The kube-apiserver ensures https to the kubelet by default. The apiserver
+    flag "--kubelet-https" is deprecated and should be either set to "true" or
+    omitted from the argument list.
+
+rationale: |-
+    Connections from the kube-apiserver to kubelets could potentially carry
+    sensitive data such as secrets and keys. It is thus important to use
+    in-transit encryption for any communication between the apiserver and
+    kubelets.
+
+severity: medium
+
+references:
+    cis: 1.2.4
+
+ocil_clause: '<tt>kubelet-https</tt> is set to false'
+
+ocil: |-
+    Run the following command:
+    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["kubelet-https"]'</pre>
+    The output should return <pre>true</pre>, or no output at all.
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    entity_check: "at least one"
+    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    yamlpath: '.data["config.yaml"]'
+    values:
+    - value: '"apiServerArguments":{.*"kubelet-https":\["false"\]'
+      operation: "pattern match"
+      type: "string"
+      entity_check: "none satisfy"

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/ocp4/profiles/cis.profile
+++ b/ocp4/profiles/cis.profile
@@ -32,8 +32,8 @@ selections:
   # 1.2.3 Ensure that the --token-auth-file parameter is not set
     - api_server_token_auth
   # 1.2.4 Ensure that the --kubelet-https argument is set to true
-  # OCP doesn't use --kubelet-https but relies on TLS which is checked for in 1.2.30
-  # This rule also makes sure that the services of openshift-apiserver and openshift-oauth-apiserver
+    - api_server_https_for_kubelet_conn
+  # These rules make sure that the services of openshift-apiserver and openshift-oauth-apiserver
   # serve TLS
     - api_server_openshift_https_serving_cert
     - api_server_oauth_https_serving_cert


### PR DESCRIPTION
Although `--kubelet-https` is a deprecated flag, it's still in use by OCP, being set in the apiserver arguments to true.
Being set to true or not included == good. Being set to false == bad.