### PR TITLE
implement support for multiple platforms connected with disjunction

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -144,9 +144,10 @@ A rule itself contains these attributes:
 
     The severity of the rule can be overridden by a profile with
     `refine-rule` selector. \* `platform`: Defines applicability of a
-    rule. For example, if a rule is not applicable to containers, this
-    should be set to `machine`, which means it will be evaluated only if
-    the targeted scan environment is either bare-metal or virtual
+    rule. It is specified as a list of platforms. For example, if a rule is not
+    applicable to containers, the list should contain the item `machine`, which
+    means it will be evaluated only if the targeted scan environment is either
+    bare-metal or virtual
     machine. Also, it can restrict applicability on higher software
     layers. By setting to `shadow-utils`, the rule will have its
     applicability restricted to only environments which have
@@ -154,9 +155,11 @@ A rule itself contains these attributes:
     in the file &lt;product&gt;/cpe/&lt;product&gt;-cpe-dictionary.xml
     (e.g.: rhel8/cpe/rhel8-cpe-dictionary.xml). In order to support a
     new value, an OVAL check (of `inventory` class) must be created
-    under `shared/checks/oval/` and referenced in the dictionary
-    file. \* `ocil`: Defines asserting statements to check whether or
-    not the rule is valid. \* `ocil_clause`: This attribute contains the
+    under `shared/checks/oval/` and referenced in the dictionary file. It is
+    possible to specify multiple platforms in the list. In that case, they are
+    implicitly connected with "OR" operand. \* `ocil`: Defines asserting
+    statements to check whether or not the rule is valid. \* `ocil_clause`: This
+    attribute contains the
     statement which describes how to determine whether the statement is
     true or false. Check out `rule.yml` in
     `linux_os/guide/system/software/disk_partitioning/encrypt_partitions/`:

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
@@ -4,14 +4,12 @@
       to continuously poll the time source servers.") }}}
     <criteria operator="OR">
       <criteria operator="AND">
-        <extend_definition comment="service ntpd enabled" definition_ref="service_ntpd_enabled" />
         <criterion comment="check if maxpoll is set in /etc/ntp.conf"
         test_ref="test_ntp_set_maxpoll" />
         <criterion comment="check if all server entries have maxpoll set in /etc/ntp.conf"
         test_ref="test_ntp_all_server_has_maxpoll"/>
       </criteria>
       <criteria operator="AND">
-        <extend_definition comment="service chronyd enabled" definition_ref="service_chronyd_enabled" />
         <criterion comment="check if maxpoll is set in /etc/chrony.conf"
         test_ref="test_chrony_set_maxpoll" />
         <criterion comment="check if all server entries have maxpoll set in /etc/chrony.conf"

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -21,7 +21,9 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+platforms:
+    - ntp
+    - chrony
 
 identifiers:
     cce@rhel7: CCE-80439-3

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -17,7 +17,6 @@ from . import constants
 from .jinja import process_file_with_macros as jinja_process_file
 
 from .xml import ElementTree
-from concurrent.futures._base import ALL_COMPLETED
 
 REMEDIATION_TO_EXT_MAP = {
     'anaconda': '.anaconda',

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -306,7 +306,7 @@ class BashRemediation(Remediation):
                 all_conditions += " && ".join(inherited_conditionals)
             if rule_specific_conditionals:
                 if all_conditions:
-                    all_conditions += " && ( " + " || ".join(rule_specific_conditionals) + " )"
+                    all_conditions += " && { " + " || ".join(rule_specific_conditionals) + "; }"
                 else:
                     all_conditions = " || ".join(rule_specific_conditionals)
             wrapped_fix_text.append("if {0}; then".format(all_conditions))

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -287,13 +287,16 @@ class BashRemediation(Remediation):
             # There can be repeated inherited platforms and rule platforms
             inherited_platforms.update(self.associated_rule.inherited_platforms)
             if self.associated_rule.platforms is not None:
-                rule_specific_platforms = {p for p in self.associated_rule.platforms if p not in inherited_platforms }
+                rule_specific_platforms = {
+                    p for p in self.associated_rule.platforms if p not in inherited_platforms}
 
-        inherited_conditionals = [self.generate_platform_conditional(p) for p in inherited_platforms]
-        rule_specific_conditionals = [self.generate_platform_conditional(p) for p in rule_specific_platforms]
+        inherited_conditionals = [
+            self.generate_platform_conditional(p) for p in inherited_platforms]
+        rule_specific_conditionals = [
+            self.generate_platform_conditional(p) for p in rule_specific_platforms]
         # remove potential "None" from lists
-        inherited_conditionals = [p for p in inherited_conditionals if p != None]
-        rule_specific_conditionals = [p for p in rule_specific_conditionals if p != None]
+        inherited_conditionals = [p for p in inherited_conditionals if p is not None]
+        rule_specific_conditionals = [p for p in rule_specific_conditionals if p is not None]
 
         if inherited_conditionals or rule_specific_conditionals:
             wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]
@@ -460,19 +463,24 @@ class AnsibleRemediation(Remediation):
         rule_specific_platforms = set()
         inherited_platforms.update(self.associated_rule.inherited_platforms)
         if self.associated_rule.platforms is not None:
-            rule_specific_platforms = {p for p in self.associated_rule.platforms if p not in inherited_platforms }
+            rule_specific_platforms = {
+                p for p in self.associated_rule.platforms if p not in inherited_platforms}
 
-        inherited_conditionals = [self.generate_platform_conditional(p) for p in inherited_platforms]
-        rule_specific_conditionals = [self.generate_platform_conditional(p) for p in rule_specific_platforms]
+        inherited_conditionals = [
+            self.generate_platform_conditional(p) for p in inherited_platforms]
+        rule_specific_conditionals = [
+            self.generate_platform_conditional(p) for p in rule_specific_platforms]
         # remove potential "None" from lists
-        inherited_conditionals = [p for p in inherited_conditionals if p != None]
-        rule_specific_conditionals = [p for p in rule_specific_conditionals if p != None]
+        inherited_conditionals = [p for p in inherited_conditionals if p is not None]
+        rule_specific_conditionals = [p for p in rule_specific_conditionals if p is not None]
 
         # remove conditionals related to package CPEs if the updated task
         # collects package facts
         if "package_facts" in to_update:
-            inherited_conditionals = [c for c in inherited_conditionals if "in ansible_facts.packages" not in c]
-            rule_specific_conditionals = [c for c in rule_specific_conditionals if "in ansible_facts.packages" not in c]
+            inherited_conditionals = [
+                c for c in inherited_conditionals if "in ansible_facts.packages" not in c]
+            rule_specific_conditionals = [
+                c for c in rule_specific_conditionals if "in ansible_facts.packages" not in c]
 
         print (to_update)
         print (inherited_conditionals)
@@ -522,7 +530,8 @@ class AnsibleRemediation(Remediation):
 
     def generate_platform_conditional(self, platform):
         if platform == "machine":
-            return 'ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]'
+            return 'ansible_virtualization_type not in '\
+                '["docker", "lxc", "openvz", "podman", "container"]'
         elif platform is not None:
             # Assume any other platform is a Package CPE
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -284,7 +284,8 @@ class BashRemediation(Remediation):
         if self.associated_rule:
             # There can be repeated inherited platforms and rule platforms
             rule_platforms.update(self.associated_rule.inherited_platforms)
-            rule_platforms.add(self.associated_rule.platform)
+            if self.associated_rule.platforms is not None:
+                rule_platforms.update(self.associated_rule.platforms)
 
         platform_conditionals = []
         for platform in rule_platforms:
@@ -441,8 +442,10 @@ class AnsibleRemediation(Remediation):
         additional_when = []
 
         # There can be repeated inherited platforms and rule platforms
+        rule_platforms = set()
         rule_platforms = set(self.associated_rule.inherited_platforms)
-        rule_platforms.add(self.associated_rule.platform)
+        if self.associated_rule.platforms is not None:
+            rule_platforms.update(self.associated_rule.platforms)
 
         for platform in rule_platforms:
             if platform == "machine":

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -482,9 +482,6 @@ class AnsibleRemediation(Remediation):
             rule_specific_conditionals = [
                 c for c in rule_specific_conditionals if "in ansible_facts.packages" not in c]
 
-        print (to_update)
-        print (inherited_conditionals)
-        print (rule_specific_conditionals)
         if inherited_conditionals:
             additional_when = additional_when + inherited_conditionals
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -114,7 +114,7 @@ class Profile(object):
         self.refine_rules = defaultdict(list)
         self.metadata = None
         self.reference = None
-        self.platforms = []
+        self.platforms = None
 
     def read_yaml_contents(self, yaml_contents):
         self.title = required_key(yaml_contents, "title")
@@ -143,10 +143,12 @@ class Profile(object):
         # platforms
         platform = yaml_contents.pop("platform", None)
         platforms = yaml_contents.pop("platforms", None)
-        if platforms:
+        if platforms is not None:
             profile.platforms = platforms
-        if platform:
-            profile.platforms.append(platform)
+            if platform is not None:
+                profile.platforms.append(platform)
+        elif platform is not None:
+            profile.platforms = [platform]
 
         # At the moment, metadata is not used to build content
         if "metadata" in yaml_contents:
@@ -830,7 +832,7 @@ class Group(object):
         self.values = {}
         self.groups = {}
         self.rules = {}
-        self.platforms = []
+        self.platforms = None
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None):
@@ -850,12 +852,16 @@ class Group(object):
         group.requires = yaml_contents.pop("requires", [])
         # check both platform and platforms keyword and construct list of
         # platforms
+        # platforms keyword is expected to be a list of strings platform should
+        # represent only single platform as a string
         platform = yaml_contents.pop("platform", None)
         platforms = yaml_contents.pop("platforms", None)
-        if platforms:
+        if platforms is not None:
             group.platforms = platforms
-        if platform:
-            group.platforms.append(platform)
+            if platform is not None:
+                group.platforms.append(platform)
+        elif platform is not None:
+            group.platforms = [platform]
 
         for warning_list in group.warnings:
             if len(warning_list) != 1:
@@ -1033,7 +1039,7 @@ class Rule(object):
         self.requires = []
         self.conflicts = []
         self.platform = None
-        self.platforms = []
+        self.platforms = None
         self.inherited_platforms = [] # platforms inherited from the group
         self.template = None
 
@@ -1066,10 +1072,12 @@ class Rule(object):
         # platforms
         platform = yaml_contents.pop("platform", None)
         platforms = yaml_contents.pop("platforms", None)
-        if platforms:
+        if platforms is not None:
             rule.platforms = platforms
-        if platform:
-            rule.platforms.append(platform)
+            if platform is not None:
+                rule.platforms.append(platform)
+        elif platform is not None:
+            rule.platforms = [platform]
 
 
         if yaml_contents:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -231,7 +231,8 @@ class Profile(object):
                 try:
                     platform_cpe = product_cpes.get_cpe_name(platform)
                 except KeyError:
-                    raise ValueError("Unsupported platform '%s' in profile '%s'." % (self.platform, self.id_))
+                    raise ValueError(
+                        "Unsupported platform '%s' in profile '%s'." % (self.platform, self.id_))
                 plat = ET.SubElement(element, "platform")
                 plat.set("idref", platform_cpe)
 

--- a/tests/unit/ssg-module/data/file_owner_grub2_cfg.yml
+++ b/tests/unit/ssg-module/data/file_owner_grub2_cfg.yml
@@ -16,9 +16,10 @@ ocil: ' To check the ownership of <code>/boot/grub2/grub.cfg</code>, run the com
   indicate the following owner: <code>root</code>'
 ocil_clause: ' /boot/grub2/grub.cfg has owner root'
 oval_external_content: null
-platform: machine
+platforms:
+  - machine
 # TODO: Make Rule get this from group, so it can be saved here
-# platform: null
+# platforms: null
 prodtype: rhel7,rhel8,fedora,ol7,ol8
 rationale: Only root should be able to modify important boot parameters.
 references: {cis: 1.4.1, cis-csc: '12,13,14,15,16,18,3,5', cjis: 5.5.2.2, cobit5: 'APO01.06,DSS05.04,DSS05.07,DSS06.02',

--- a/tests/unit/ssg-module/data/sshd_disable_root_login.yml
+++ b/tests/unit/ssg-module/data/sshd_disable_root_login.yml
@@ -20,7 +20,7 @@ ocil: 'To determine how the SSH daemon''s <tt>PermitRootLogin</tt> option is set
   '
 ocil_clause: the required value is not set
 oval_external_content: null
-platform: null
+platforms: null
 prodtype: all
 rationale: 'Even though the communications channel may be encrypted, an additional
   layer of

--- a/tests/unit/ssg-module/test_playbook_builder_data/rules/selinux_state.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/rules/selinux_state.yml
@@ -12,7 +12,8 @@ ocil: 'Check the file <tt>/etc/selinux/config</tt> and ensure the following line
   <pre>SELINUX=<sub idref="var_selinux_state" /></pre>'
 ocil_clause: SELINUX is not set to enforcing
 oval_external_content: null
-platform: machine
+platforms:
+  - machine
 prodtype: rhel7,rhel8,fedora,ol7,ol8,rhv4
 rationale: 'Setting the SELinux state to enforcing ensures SELinux is able to confine
 


### PR DESCRIPTION
#### Description:

- modify build system so that it consumes platforms in two possible way
either
```
 platform: <single_platform>
```
or
```
platforms:
  - platform_1
  - platform_2
```
- internally, the list of platforms in compiled rules is called "platforms"
- platforms are added in the xccdf rule definition, implicitly connected with OR
- modify generation of Bash remediations so that rule-specific platforms are placed after inherited platforms and correctly connected with OR
- the same for Ansible remediations
- modify ssg test suite unit tests, in particular precompiled rules
- update documentation

#### Rationale:

This PR is part of an initiative which plans to implement support for CPE applicability language. This support will allow content authors to specify more granular definition of rule applicability.