### PR TITLE
Add new rules to sle12/profiles/stig.profile

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/ansible/shared.yml
@@ -8,5 +8,5 @@
 - name: "{{{ rule_title }}}"
   lineinfile:
     dest: /etc/gdm/banner
-    line: '{{{ ansible_deregexify_banner_dconf_gnome("login_banner_text") }}}'
+    line: '{{{ ansible_deregexify_banner_etc_issue("login_banner_text") }}}'
     create: yes

--- a/shared/bash_remediation_functions/ensure_pam_module_options.sh
+++ b/shared/bash_remediation_functions/ensure_pam_module_options.sh
@@ -1,0 +1,56 @@
+function ensure_pam_module_options {
+	if [ $# -lt 7 ] || [ $# -gt 8 ] ; then
+                echo "$0 requires seven or eight arguments" >&2
+                exit 1
+        fi
+	local _pamFile="$1" _type="$2" _control="$3" _module="$4" _option="$5" _valueRegex="$6" _defaultValue="$7"
+	local _remove_argument=""
+	if [ $# -eq 8 ] ; then
+        	_remove_argument="$8"
+		# convert it to lowercase
+		_remove_argument=${_remove_argument,,}
+	fi
+
+	# make sure that we have a line like this in ${_pamFile} (additional options are left as-is):
+	# ${_type} ${_control} ${_module} ${_option}=${_valueRegex}
+
+	if ! [ -e "$_pamFile" ] ; then
+		echo "$_pamFile doesn't exist" >&2
+		exit 1
+	fi
+
+	# if remove argument only
+	if [ "${_remove_argument}" = "yes" -o "${_remove_argument}" = "true" ] ; then
+		sed --follow-symlinks -i -E -e "s/^(\\s*${_type}\\s+\\S+\\s+${_module}(\\s.+)?)\\s${_option}(=\\S+)?/\\1/" "${_pamFile}"
+		exit 0
+	fi
+
+	# non-empty values need to be preceded by an equals sign
+	[ -n "${_valueRegex}" ] && _valueRegex="=${_valueRegex}"
+	# add an equals sign to non-empty values
+	[ -n "${_defaultValue}" ] && _defaultValue="=${_defaultValue}"
+
+	# fix 'type' if it's wrong
+	if grep -q -P "^\\s*(?"'!'"${_type}\\s)[[:alnum:]]+\\s+[[:alnum:]]+\\s+${_module}" < "${_pamFile}" ; then
+		sed --follow-symlinks -i -E -e "s/^(\\s*)[[:alnum:]]+(\\s+[[:alnum:]]+\\s+${_module})/\\1${_type}\\2/" "${_pamFile}"
+	fi
+
+	# fix 'control' if it's wrong
+	if grep -q -P "^\\s*${_type}\\s+(?"'!'"${_control})[[:alnum:]]+\\s+${_module}" < "${_pamFile}" ; then
+		sed --follow-symlinks -i -E -e "s/^(\\s*${_type}\\s+)[[:alnum:]]+(\\s+${_module})/\\1${_control}\\2/" "${_pamFile}"
+	fi
+
+	# fix the value for 'option' if one exists but does not match '_valueRegex'
+    if grep -q -P "^\\s*${_type}\\s+${_control}\\s+${_module}(\\s.+)?\\s+${_option}(?"'!'"${_valueRegex}(\\s|\$))" < "${_pamFile}" ; then
+		sed --follow-symlinks -i -E -e "s/^(\\s*${_type}\\s+${_control}\\s+${_module}(\\s.+)?\\s)${_option}=[^[:space:]]+/\\1${_option}${_defaultValue}/" "${_pamFile}"
+
+    # add 'option=default' if option is not set
+	elif grep -q -E "^\\s*${_type}\\s+${_control}\\s+${_module}" < "${_pamFile}" &&
+         grep    -E "^\\s*${_type}\\s+${_control}\\s+${_module}" < "${_pamFile}" | grep -q -E -v "\\s${_option}(=|\\s|\$)" ; then
+
+		sed --follow-symlinks -i -E -e "s/^(\\s*${_type}\\s+${_control}\\s+${_module}[^\\n]*)/\\1 ${_option}${_defaultValue}/" "${_pamFile}"
+	# add a new entry if none exists
+	elif ! grep -q -P "^\\s*${_type}\\s+${_control}\\s+${_module}(\\s.+)?\\s+${_option}${_valueRegex}(\\s|\$)" < "${_pamFile}" ; then
+		echo "${_type} ${_control} ${_module} ${_option}${_defaultValue}" >> "${_pamFile}"
+	fi
+}

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -1,10 +1,17 @@
 documentation_complete: true
 
+metadata:
+    version: V2R2
+    SMEs:
+        - abergmann
+
+reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+
 title: 'DISA STIG for SUSE Linux Enterprise 12'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG for SUSE Linux Enterprise 12 V1R2.
+    DISA STIG for SUSE Linux Enterprise 12 V2R2.
 
 selections:
     - sshd_approved_macs=stig
@@ -20,27 +27,46 @@ selections:
     - var_password_pam_remember=5
     - var_password_pam_retry=3
     - var_password_pam_ucredit=1
+    #
+    # Note: must configure "var_accounts_authorized_local_users_regex" when
+    # "accounts_authorized_local_users" rule is enabled
+    # - var_accounts_authorized_local_users_regex=<authorized local user accounts>
+    #
     # NOTE: must configure "var_audispd_remote_server" when
     # "auditd_audispd_configure_remote_server" rule is enabled
     #
     # - var_audispd_remote_server=<remote audit server name/IP>
     - var_removable_partition=dev_cdrom
+    - var_sssd_memcache_timeout=1_day
     - var_time_service_set_maxpoll=system_default
     - account_disable_post_pw_expiration
+    - account_emergency_admin
+    #
+    # NOTE: must configure "var_accounts_authorized_local_users_regex" variable
+    # when "accounts_authorized_local_users" rule is enabled
+    #
+    # - accounts_authorized_local_users
     - accounts_have_homedir_login_defs
     - accounts_logon_fail_delay
     - accounts_max_concurrent_login_sessions
     - accounts_maximum_age_login_defs
     - accounts_minimum_age_login_defs
     - accounts_no_uid_except_zero
+    - accounts_password_all_shadowed_sha512
+    - accounts_passwords_pam_faildelay_delay
+    - accounts_passwords_pam_tally2
+    - accounts_password_pam_pwhistory_remember
     - accounts_password_set_max_life_existing
     - accounts_password_set_min_life_existing
+    - accounts_tmout
     - accounts_umask_etc_login_defs
+    - account_unique_id
     - accounts_user_dot_no_world_writable_programs
     - accounts_user_home_paths_only
     - accounts_user_interactive_home_directory_defined
     - accounts_user_interactive_home_directory_exists
     - account_temp_expire_date
+    - aide_check_audit_tools
     - aide_scan_notification
     - aide_verify_acls
     - aide_verify_ext_attributes
@@ -48,38 +74,53 @@ selections:
     - audit_rules_dac_modification_chown
     - audit_rules_dac_modification_fchmod
     - audit_rules_dac_modification_fchmodat
-    - audit_rules_dac_modification_fremovexattr
     - audit_rules_dac_modification_fchown
     - audit_rules_dac_modification_fchownat
+    - audit_rules_dac_modification_fremovexattr
+    - audit_rules_dac_modification_fsetxattr
     - audit_rules_dac_modification_lchown
     - audit_rules_dac_modification_lremovexattr
     - audit_rules_dac_modification_removexattr
-    - audit_rules_dac_modification_fsetxattr
     - audit_rules_dac_modification_setxattr
+    - audit_rules_dac_modification_umount
+    - audit_rules_dac_modification_umount2
     - audit_rules_enable_syscall_auditing
+    - audit_rules_execution_chacl
+    - audit_rules_execution_chcon
+    - audit_rules_execution_chmod
+    - audit_rules_execution_rm
+    - audit_rules_execution_setfacl
     - audit_rules_kernel_module_loading_delete
     - audit_rules_kernel_module_loading_finit
     - audit_rules_kernel_module_loading_init
+    - audit_rules_login_events_faillog
     - audit_rules_login_events_lastlog
     - audit_rules_login_events_tallylog
+    - audit_rules_media_export
     - audit_rules_privileged_commands_chage
+    - audit_rules_privileged_commands_chfn
     - audit_rules_privileged_commands_chsh
     - audit_rules_privileged_commands_crontab
     - audit_rules_privileged_commands_gpasswd
+    - audit_rules_privileged_commands_kmod
     - audit_rules_privileged_commands_mount
     - audit_rules_privileged_commands_newgrp
     - audit_rules_privileged_commands_pam_timestamp_check
+    - audit_rules_privileged_commands_passmass
     - audit_rules_privileged_commands_passwd
+    - audit_rules_privileged_commands_ssh_agent
     - audit_rules_privileged_commands_ssh_keysign
-    - audit_rules_privileged_commands_sudo
     - audit_rules_privileged_commands_su
+    - audit_rules_privileged_commands_sudo
     - audit_rules_privileged_commands_umount
     - audit_rules_privileged_commands_unix_chkpwd
+    - audit_rules_privileged_commands_usermod
+    - audit_rules_suid_privilege_function
     - audit_rules_unsuccessful_file_modification_creat
     - audit_rules_unsuccessful_file_modification_ftruncate
     - audit_rules_unsuccessful_file_modification_open
-    - audit_rules_unsuccessful_file_modification_open_by_handle_at
     - audit_rules_unsuccessful_file_modification_openat
+    - audit_rules_unsuccessful_file_modification_open_by_handle_at
     - audit_rules_unsuccessful_file_modification_truncate
     - audit_rules_usergroup_modification_group
     - audit_rules_usergroup_modification_gshadow
@@ -98,70 +139,99 @@ selections:
     - auditd_data_disk_full_action
     - auditd_data_retention_action_mail_acct
     - auditd_data_retention_space_left
+    - banner_etc_gdm_banner
     - banner_etc_issue
     - chronyd_or_ntpd_set_maxpoll
+    - clean_components_post_updating
+    - cracklib_accounts_password_pam_dcredit
+    - cracklib_accounts_password_pam_difok
+    - cracklib_accounts_password_pam_lcredit
+    - cracklib_accounts_password_pam_minlen
+    - cracklib_accounts_password_pam_ocredit
+    - cracklib_accounts_password_pam_retry
+    - cracklib_accounts_password_pam_ucredit
+    - dconf_db_up_to_date
+    - dconf_gnome_banner_enabled
+    - dconf_gnome_login_banner_text
     - dir_perms_world_writable_sticky_bits
+    - dir_perms_world_writable_system_owned_group
     - disable_ctrlaltdel_reboot
     - display_login_attempts
+    - enable_dconf_user_profile
     - encrypt_partitions
     - ensure_gpgcheck_globally_activated
+    - file_etc_security_opasswd
     - file_groupownership_home_directories
     - file_permissions_home_directories
     - file_permissions_sshd_private_key
     - file_permissions_sshd_pub_key
     - file_permissions_ungroupowned
-    - file_permission_user_init_files
     - file_permissions_var_log_messages
+    - file_permission_user_init_files
     - ftp_present_banner
     - gnome_gdm_disable_automatic_login
     - grub2_password
     - grub2_uefi_password
+    - gui_login_dod_acknowledgement
+    - installed_OS_is_FIPS_certified
     - installed_OS_is_vendor_supported
+    - install_smartcard_packages
     - kernel_module_usb-storage_disabled
     - mount_option_home_nosuid
     - mount_option_noexec_remote_filesystems
     - mount_option_nosuid_remote_filesystems
+    - mount_option_nosuid_removable_partitions
     - network_sniffer_disabled
     - no_empty_passwords
     - no_files_unowned_by_user
     - no_host_based_files
     - no_user_host_based_files
-    - mount_option_nosuid_removable_partitions
     - package_aide_installed
     - package_audit-audispd-plugins_installed
     - package_audit_installed
     - package_MFEhiplsm_installed
     - package_SuSEfirewall2_installed
     - package_telnet-server_removed
-    - partition_for_var
     - pam_disable_automatic_configuration
     - partition_for_home
+    - partition_for_var
     - partition_for_var_log_audit
     - permissions_local_audit_binaries
     - permissions_local_var_log_audit
+    - policy_temp_passwords_immediate_change
     - postfix_client_configure_mail_alias
+    - rsyslog_remote_loghost
     - run_chkstat
     - security_patches_up_to_date
     - service_auditd_enabled
+    - service_autofs_disabled
     - service_kdump_disabled
     - service_SuSEfirewall2_enabled
     - set_password_hashing_algorithm_logindefs
+    - set_password_hashing_algorithm_systemauth
+    - set_password_hashing_min_rounds_logindefs
+    - smartcard_pam_enabled
+    - smartcard_configure_ca
+    - smartcard_configure_cert_checking
     - sshd_disable_compression
     - sshd_disable_empty_passwords
     - sshd_disable_root_login
     - sshd_disable_user_known_hosts
     - sshd_do_not_permit_user_env
     - sshd_enable_strictmodes
+    - sshd_enable_warning_banner
     - sshd_enable_x11_forwarding
+    - sssd_memcache_timeout
     - sshd_print_last_log
     - sshd_set_idle_timeout
     - sshd_set_keepalive
     - sshd_set_loglevel_verbose
-    - sudo_remove_no_authenticate
-    - sudo_remove_nopasswd
-    - sshd_enable_warning_banner
+    - sshd_use_approved_ciphers
     - sshd_use_approved_macs
     - sshd_use_priv_separation
+    - sssd_offline_cred_expiration
+    - sudo_remove_no_authenticate
+    - sudo_remove_nopasswd
     - susefirewall2_ddos_protection
     - susefirewall2_only_required_services
     - sysctl_kernel_kptr_restrict
@@ -174,6 +244,8 @@ selections:
     - sysctl_net_ipv4_conf_default_send_redirects
     - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
     - sysctl_net_ipv4_ip_forward
+    - sysctl_net_ipv4_tcp_syncookies
     - sysctl_net_ipv6_conf_all_accept_source_route
     - sysctl_net_ipv6_conf_default_accept_source_route
+    - vlock_installed
     - wireless_disable_interfaces


### PR DESCRIPTION
   This adds all rules in last PR sle12 stig.profile


Fix banner oval check:
   Appropriately encode GDM banner
   The OVAL check doesn't allow the banner text to be in single quote
   so use the approprate macro to format it correctly.

Add missing bash remediation. 

#### Description:

- add sl12 rules to stig.profile, fix a found bug

#### Rationale:

-  Add newly supported sle12 rules to stig.profile
-  Add shared/bash_remediation_functions/ensure_pam_module_options.sh which was dropped from earlier changes.

- banner oval check: Appropriately encode GDM banner. The OVAL check doesn't allow the banner text to be in single quote  so use the appropriate macro to format it correctly.

