### PR TITLE
ocp4/e2e: Replace instances of SKIP for NOT-APPLICABLE

### DIFF
--- a/applications/openshift/etcd/etcd_unique_ca/tests/ocp4/e2e.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_etcd_data_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_kube_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_etcd_data_dir/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_etcd_data_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_member/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_kube_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_data_dir/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_data_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_scheduler/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,4 @@
 ---
 default_result:
   master: PASS
-  worker: SKIP
+  worker: NOT-APPLICABLE


### PR DESCRIPTION
We changed this status in the compliance-operator, as it matches what
OpenSCAP outputs and is more self-explanatory.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>