### PR TITLE
V-204578 change order of SSH cipher suites for stig

### DIFF
--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -11,5 +11,5 @@ operator: equals
 interactive: false
 
 options:
-    stig: aes128-ctr,aes192-ctr,aes256-ctr
+    stig: aes256-ctr,aes192-ctr,aes128-ctr
     default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se


### PR DESCRIPTION
Latest stig requires specific order for SSH ciphers.

#### Description:

Change the order of SSH cipher suites.

#### Rationale:

https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-12-08/finding/V-204578

Inspect the "Ciphers" configuration with the following command:


```
# grep -i ciphers /etc/ssh/sshd_config
Ciphers aes256-ctr,aes192-ctr,aes128-ctr

```
If any ciphers other than "aes256-ctr", "aes192-ctr", or "aes128-ctr" are listed, **the order differs from the example above**, the "Ciphers" keyword is missing, or the returned line is commented out, this is a finding.
