### PR TITLE
Fix test scenario of rpm_verify_permissions rule

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/all_permissions_ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/tests/all_permissions_ok.pass.sh
@@ -14,8 +14,10 @@ FILES_WITH_INCORRECT_PERMS=($(rpm -Va --nofiledigest | awk '{ if (substr($0,2,1)
 
 for FILE_PATH in "${FILES_WITH_INCORRECT_PERMS[@]}"
 do
-	RPM_PACKAGE=$(rpm -qf "$FILE_PATH")
-	SETPERMS_RPM_LIST["$RPM_PACKAGE"]=1
+	RPM_PACKAGES=$(rpm -qf "$FILE_PATH")
+	for pkg in $RPM_PACKAGES; do
+		SETPERMS_RPM_LIST["$pkg"]=1
+	done
 done
 
 # For each of the RPM packages left in the list -- reset its permissions to the


### PR DESCRIPTION
Fixed test scenario which did not count with the
fact that a file migh be owned by more RPMs. Example
of such file is `/var/log/lastlog` on Fedora/RHEL
which is owned by both `setup` and `util-linux` RPMs.

Can be verified on Fedora/RHEL8 using `python3 test_suite.py rule --libvirt qemu:///session ssgts_vm --datastream ssg-rhel8-ds.xml --profile xccdf_org.ssgproject.content_profile_cis rpm_verify_permissions`.

Before:
```
...
INFO - xccdf_org.ssgproject.content_rule_rpm_verify_permissions
INFO - Script bad_permissions.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK
ERROR - Failed to execute 'cd /root/ssgts/rpm_verify_permissions; SHARED=/root/ssgts/shared bash -x all_permissions_ok.pass.sh' on root@192.168.122.17: Command '('ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'root@192.168.122.17', 'cd /root/ssgts/rpm_verify_permissions; SHARED=/root/ssgts/shared bash -x all_permissions_ok.pass.sh')' returned non-zero exit status 1.
ERROR - Terminating due to error: Failed to execute 'cd /root/ssgts/rpm_verify_permissions; SHARED=/root/ssgts/shared bash -x all_permissions_ok.pass.sh' on root@192.168.122.17.
```

After:
```
...
INFO - xccdf_org.ssgproject.content_rule_rpm_verify_permissions
INFO - Script bad_permissions.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK
INFO - Script all_permissions_ok.pass.sh using profile xccdf_org.ssgproject.content_profile_cis OK
```
