### PR TITLE
fix rule accounts_password_pam_unix_remember

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -5,14 +5,53 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("var_password_pam_unix_remember") }}}
 
-- name: "Do not allow users to reuse recent passwords - system-auth (change)"
-  replace:
-    dest: /etc/pam.d/system-auth
-    regexp: '^(password\s+sufficient\s+pam_unix\.so\s.*remember\s*=\s*)(\S+)(.*)$'
-    replace: '\g<1>{{ var_password_pam_unix_remember }}\g<3>'
+# this macro is used to correct existing instances of unix or pwhistory module
 
-- name: "Do not allow users to reuse recent passwords - system-auth (add)"
+{{% macro prevent_password_reuse(file, module) -%}}
+
+- name: "detect if {{{ module }}} module is used"
+  command: grep '^\s*password.*{{{ module }}}\.so.*$' /etc/pam.d/{{{ file }}}
+  register: pam_password_reuse_files
+  ignore_errors: true
+
+- name: "Do not allow users to reuse recent passwords - in {{{ file }}} for {{{ module }}} (change)"
   replace:
-    dest: /etc/pam.d/system-auth
-    regexp: '^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$'
+    dest: "/etc/pam.d/{{{ file }}}"
+    regexp: '^(password\s+.*{{{ module }}}\.so\s.*remember\s*=\s*)(\S+)(.*)$'
+    replace: '\g<1>{{ var_password_pam_unix_remember }}\g<3>'
+  when: pam_password_reuse_files.rc == 0
+
+- name: "Do not allow users to reuse recent passwords in {{{ file }}} for {{{ module }}} (add)"
+  replace:
+    dest: "/etc/pam.d/{{{ file }}}"
+    regexp: '^password\s+.*{{{ module }}}\.so\s(?!.*remember\s*=\s*).*$'
     replace: '\g<0> remember={{ var_password_pam_unix_remember }}'
+  when: pam_password_reuse_files.rc == 0
+
+{{%- endmacro %}}
+
+# this macro is used to insert pw_history module configuration of no prior unix
+# or pw_history configuration is found
+
+{{% macro prevent_password_reuse_no_module (file) -%}}
+- name: "Check that there is no unix or pw_history module in the file"
+  shell: grep '^\s*password.*\(pam_unix\|pam_pwhistory\)\.so.*$' /etc/pam.d/{{{ file }}}
+  register: pam_password_reuse_no_module_files
+  ignore_errors: true
+
+- name: "Insert correct line with pwhistory pam module"
+  lineinfile:
+    path: "/etc/pam.d/{{{ file }}}"
+    line: "password requisite pam_pwhistory.so remember={{ var_password_pam_unix_remember }}"
+    insertafter: '^password.*$'
+    firstmatch: yes
+  when: pam_password_reuse_no_module_files.rc == 1
+
+{{%- endmacro %}}
+
+{{{ prevent_password_reuse(file="system-auth", module="pam_unix") }}}
+{{{ prevent_password_reuse(file="system-auth", module="pam_pwhistory") }}}
+{{{ prevent_password_reuse(file="password-auth", module="pam_unix") }}}
+{{{ prevent_password_reuse(file="password-auth", module="pam_pwhistory") }}}
+{{{ prevent_password_reuse_no_module(file="system-auth") }}}
+{{{ prevent_password_reuse_no_module(file="password-auth") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -7,9 +7,15 @@ AUTH_FILES[1]="/etc/pam.d/password-auth"
 
 for pamFile in "${AUTH_FILES[@]}"
 do
-	if grep -q "remember=" $pamFile; then
-		sed -i --follow-symlinks "s/\(^password.*sufficient.*pam_unix.so.*\)\(\(remember *= *\)[^ $]*\)/\1remember=$var_password_pam_unix_remember/" $pamFile
+	if grep -q ".*pwhistory\.so.*remember=" $pamFile; then
+		sed -i -E --follow-symlinks "s/(^password.*pam_pwhistory\.so.*)(remember\s*=\s*[0-9]+)(.*$)/\1remember=$var_password_pam_unix_remember \3/" $pamFile
+	elif grep -q ".*pwhistory\.so.*" $pamFile; then
+		sed -i --follow-symlinks "/^password[[:space:]]\+.*[[:space:]]\+pam_pwhistory\.so/ s/$/ remember=$var_password_pam_unix_remember/" $pamFile
+	elif grep -q ".*unix\.so.*remember=" $pamFile; then
+		sed -i -E --follow-symlinks "s/(^password.*pam_unix\.so.*)(remember\s*=\s*[0-9]+)(.*$)/\1remember=$var_password_pam_unix_remember \3/" $pamFile
+	elif grep -q ".*unix\.so.*" $pamFile; then
+		sed -i --follow-symlinks "/^password[[:space:]]\+.*[[:space:]]\+pam_unix\.so/ s/$/ remember=$var_password_pam_unix_remember/" $pamFile
 	else
-		sed -i --follow-symlinks "/^password[[:space:]]\+sufficient[[:space:]]\+pam_unix.so/ s/$/ remember=$var_password_pam_unix_remember/" $pamFile
+		sed -i -E --follow-symlinks '0,/^password/s/(^password.*)/\1\npassword requisite pam_pwhistory.so remember=$var_password_pam_unix_remember/' $pamFile
 	fi
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -2,33 +2,59 @@
   <definition class="compliance" id="accounts_password_pam_unix_remember" version="2">
     {{{ oval_metadata("The passwords to remember should be set correctly.") }}}
     <criteria comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly" operator="OR">
-      <criterion comment="remember parameter of pam_unix.so is set correctly" test_ref="test_accounts_password_pam_unix_remember" />
-      <criterion comment="remember parameter of pam_pwhistory.so is set correctly" test_ref="test_accounts_password_pam_pwhistory_remember" />
+      <criterion comment="remember parameter of pam_unix.so is set correctly in system-auth" test_ref="test_accounts_password_pam_unix_remember_systemauth" />
+      <criterion comment="remember parameter of pam_pwhistory.so is set correctly in system-auth" test_ref="test_accounts_password_pam_pwhistory_remember_systemauth" />
+      <criterion comment="remember parameter of pam_unix.so is set correctly in password-auth" test_ref="test_accounts_password_pam_unix_remember_passwordauth" />
+      <criterion comment="remember parameter of pam_pwhistory.so is set correctly in password-auth" test_ref="test_accounts_password_pam_pwhistory_remember_passwordauth" />
     </criteria>
   </definition>
 
   <!-- Check the pam_unix.so remember case -->
-  <ind:textfilecontent54_test id="test_accounts_password_pam_unix_remember" check="all" check_existence="all_exist"
+  <ind:textfilecontent54_test id="test_accounts_password_pam_unix_remember_systemauth" check="all" check_existence="all_exist"
   comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/system-auth" version="1">
-    <ind:object object_ref="object_accounts_password_pam_unix_remember" />
+    <ind:object object_ref="object_accounts_password_pam_unix_remember_systemauth" />
     <ind:state state_ref="state_accounts_password_pam_unix_remember" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_accounts_password_pam_unix_remember" version="1">
+  <ind:textfilecontent54_object id="object_accounts_password_pam_unix_remember_systemauth" version="1">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so.*remember=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Check the pam_pwhistory.so remember case -->
-  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember" check="all" check_existence="all_exist"
-  comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/system-auth" version="1">
-    <ind:object object_ref="object_accounts_password_pam_pwhistory_remember" />
+  <ind:textfilecontent54_test id="test_accounts_password_pam_unix_remember_passwordauth" check="all" check_existence="all_exist"
+  comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/password-auth" version="1">
+    <ind:object object_ref="object_accounts_password_pam_unix_remember_passwordauth" />
     <ind:state state_ref="state_accounts_password_pam_unix_remember" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember" version="1">
+  <ind:textfilecontent54_object id="object_accounts_password_pam_unix_remember_passwordauth" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so.*remember=([0-9]*).*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Check the pam_pwhistory.so remember case -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember_systemauth" check="all" check_existence="all_exist"
+  comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/system-auth" version="1">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_remember_systemauth" />
+    <ind:state state_ref="state_accounts_password_pam_unix_remember" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember_systemauth" version="1">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:requisite)|(?:required))\s+pam_pwhistory\.so.*remember=([0-9]*).*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember_passwordauth" check="all" check_existence="all_exist"
+  comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/password-auth" version="1">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_remember_passwordauth" />
+    <ind:state state_ref="state_accounts_password_pam_unix_remember" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember_passwordauth" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:requisite)|(?:required))\s+pam_pwhistory\.so.*remember=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/missing_config.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/missing_config.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+for pamFile in "${AUTH_FILES[@]}"
+do
+  sed -i '/^.*remember.*$/d' $pamFile
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/pwhistory.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/pwhistory.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+for pamFile in "${AUTH_FILES[@]}"
+do
+	if grep -q ".*pwhistory\.so.*remember=" $pamFile; then
+		sed -i -E --follow-symlinks "s/(^password.*pam_pwhistory\.so.*)(remember\s*=\s*[0-9]+)(.*$)/\1remember=5 \3/" $pamFile
+	elif grep -q ".*pwhistory\.so.*" $pamFile; then
+		sed -i --follow-symlinks "/^password[[:space:]]\+.*[[:space:]]\+pam_pwhistory\.so/ s/$/ remember=5/" $pamFile
+	else
+		sed -i -E --follow-symlinks '0,/^password/s/(^password.*)/\1\npassword requisite pam_pwhistory.so remember=5/' $pamFile
+	fi
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/unix.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/unix.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+for pamFile in "${AUTH_FILES[@]}"
+do
+	if grep -q ".*unix\.so.*remember=" $pamFile; then
+		sed -i -E --follow-symlinks "s/(^password.*pam_unix\.so.*)(remember\s*=\s*[0-9]+)(.*$)/\1remember=5 \3/" $pamFile
+	elif grep -q ".*unix\.so.*" $pamFile; then
+		sed -i --follow-symlinks "/^password[[:space:]]\+.*[[:space:]]\+pam_unix\.so/ s/$/ remember=5/" $pamFile
+	else
+		sed -i -E --follow-symlinks '0,/^password/s/(^password.*)/\1\npassword sufficient pam_unix.so remember=5/' $pamFile
+	fi
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value_pwhistory.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value_pwhistory.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+for pamFile in "${AUTH_FILES[@]}"
+do
+	if grep -q ".*pwhistory\.so.*remember=" $pamFile; then
+		sed -i -E --follow-symlinks "s/(^password.*pam_pwhistory\.so.*)(remember\s*=\s*[0-9]+)(.*$)/\1remember=1 \3/" $pamFile
+	elif grep -q ".*pwhistory\.so.*" $pamFile; then
+		sed -i --follow-symlinks "/^password[[:space:]]\+.*[[:space:]]\+pam_pwhistory\.so/ s/$/ remember=1/" $pamFile
+	else
+		sed -i -E --follow-symlinks '0,/^password/s/(^password.*)/\1\npassword requisite pam_pwhistory.so remember=1/' $pamFile
+	fi
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value_unix.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+AUTH_FILES[0]="/etc/pam.d/system-auth"
+AUTH_FILES[1]="/etc/pam.d/password-auth"
+
+for pamFile in "${AUTH_FILES[@]}"
+do
+	if grep -q ".*unix\.so.*remember=" $pamFile; then
+		sed -i -E --follow-symlinks "s/(^password.*pam_unix\.so.*)(remember\s*=\s*[0-9]+)(.*$)/\1remember=1 \3/" $pamFile
+	elif grep -q ".*unix\.so.*" $pamFile; then
+		sed -i --follow-symlinks "/^password[[:space:]]\+.*[[:space:]]\+pam_unix\.so/ s/$/ remember=1/" $pamFile
+	else
+		sed -i -E --follow-symlinks '0,/^password/s/(^password.*)/\1\npassword sufficient pam_unix.so remember=1/' $pamFile
+	fi
+done


### PR DESCRIPTION
#### Description:

- add tests
- make oval check for both system-auth and password-auth like the description states
- rewrite remediations to keep pam_unix.so if already used but prefer pam_pwhistory.so, as pam_unix.so is not being supported in later pam versions

#### Rationale:

- remediations and checks were not aligned with rule description