### PR TITLE
configure_crypto_policy update for CIS profile

### DIFF
--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -248,7 +248,7 @@ selections:
     - security_patches_up_to_date
 
     ## 1.10 Ensure system-wide crypto policy is not legacy (Scored)
-    #- var_system_crypto_policy
+    - var_system_crypto_policy=future
     - configure_crypto_policy
 
     ## 1.11 Ensure system-wide crytpo policy is FUTURE or FIPS (Scored)


### PR DESCRIPTION
#### Description:
`1.11` requires FUTURE/FIPS crypto policy. However, default value of `var_system_crypto_policy` is `DEFAULT` thus non-compliant to CIS.