### PR TITLE
Added test scenarios for partition rules

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/partition_for_boot/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_boot/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/boot"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_boot/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_boot/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/boot"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/home"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/home"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_opt/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_opt/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/opt"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_opt/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_opt/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/opt"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_srv/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_srv/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/srv"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_srv/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_srv/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/srv"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/tmp"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/tmp"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_usr/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_usr/tests/partition_mounted.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Note: We cannot test negative scenario for /usr as
+# unmounting it would break the test env (ssh).
+
+. $SHARED/partition.sh
+
+PARTITION="/usr"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/tests/partition_mounted.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Note: We cannot test negative scenario for /var as
+# unmounting it would break the test env (rpm db is
+# stored in /var).
+
+. $SHARED/partition.sh
+
+PARTITION="/var"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/var/log"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/var/log"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/var/log/audit"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/var/log/audit"
+mount_bind_partition "$PARTITION"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/tests/no_partition.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# remediation = none
+
+. $SHARED/partition.sh
+
+umount_partition "/var/tmp"

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/tests/partition_mounted.pass.sh
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/tests/partition_mounted.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+PARTITION="/var/tmp"
+mount_bind_partition "$PARTITION"

--- a/tests/shared/partition.sh
+++ b/tests/shared/partition.sh
@@ -38,6 +38,16 @@ mount_bind_partition() {
 	mount -B "$PARTITION" "$1"
 }
 
+umount_partition() {
+	local _mount_point="$1"
+	if mount | grep -E "\s+${_mount_point}\s+"; then
+		echo "'$_mount_point' is mounted, will unmount it.."
+		umount -nl "$_mount_point"
+	else
+		echo "'$_mount_point' is not mounted, skipping"
+	fi
+}
+
 # $1: The path to umount and remove from /etc/fstab
 clean_up_partition() {
     path="$1"


### PR DESCRIPTION
All `partition_for_` rules have new test pass/fail scenarios. The only exceptions
are fail scenarios for `/usr` and `/var` mounts which would break test environment
(ssh access / rpm database).

Test with `python3 test_suite.py rule --libvirt qemu:///session ssgts_vm --datastream ssg-rhel8-ds.xml partition_for_boot partition_for_home partition_for_opt partition_for_srv partition_for_tmp partition_for_usr partition_for_var partition_for_var_log partition_for_var_log_audit partition_for_var_tmp`.