### PR TITLE
mount_option_* test scenarios

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_given_partition_line /dev/shm ext2 noexec
+
+mount_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_correct_partition_line /dev/shm
+
+mount_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/separate.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_correct_partition_line /dev/shm
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/entry_in_fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/entry_in_fstab.fail.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "tmpfs /dev/shm tmpfs rw,seclabel,nodev,nosuid 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_given_partition_line /dev/shm ext2 nosuid
+
+mount_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/multiple_entries_in_mtab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/multiple_entries_in_mtab.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-cat /etc/mtab > /etc/mtab.old
-# destroy symlink
-rm -f /etc/mtab
-cp /etc/mtab.old /etc/mtab
-echo "tmpfs /dev/shm tmpfs rw,seclabel,relatime 0 0" >> /etc/mtab
-echo "tmpfs /dev/shm tmpfs rw,seclabel,relatime 0 0" >> /etc/mtab

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/no_entry_in_fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/no_entry_in_fstab.fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# make sure there is no entry for /dev/shm
-sed -i '/\/dev\/shm/d' /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_correct_partition_line /dev/shm
+
+mount_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/separate.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_correct_partition_line /dev/shm
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_given_partition_line /dev/shm ext2 noexec
+
+mount_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_correct_partition_line /dev/shm
+
+mount_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/separate.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm
+
+create_partition
+
+make_fstab_correct_partition_line /dev/shm
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /home
+
+create_partition
+
+make_fstab_given_partition_line /home ext2 noexec
+
+mount_partition /home

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /home
+
+create_partition
+
+make_fstab_correct_partition_line /home
+
+mount_partition /home

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/tests/separate.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /home
+
+create_partition
+
+make_fstab_correct_partition_line /home
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_bad_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_bad_opts.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /var/cdrom iso9660 ro 0 0" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_good_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_good_opts.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /var/cdrom iso9660 nodev 0 0" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,noexec,nosuid,defaults 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,nodev,noexec 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_first.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_first.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 nodev,ro,noauto,nosuid,noexec 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_last.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_last.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,noexec,nodev 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/no_partitions.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/no_partitions.pass.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /dev/cdrom
 echo "" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_bad_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_bad_opts.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /var/cdrom iso9660 ro 0 0" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_good_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_good_opts.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /var/cdrom iso9660 nosuid 0 0" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,noexec,nodev,defaults 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,noexec,nodev 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_first.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_first.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 nosuid,ro,noauto,noexec,nodev 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_last.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_last.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /dev/cdrom
+echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,noexec,nodev,nosuid 0 0" >> /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/no_partitions.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/no_partitions.pass.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_C2S
 
 touch /dev/cdrom
 echo "" > /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /tmp
+
+create_partition
+
+make_fstab_given_partition_line /tmp ext2 noexec
+
+mount_partition /tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /tmp
+
+create_partition
+
+make_fstab_correct_partition_line /tmp
+
+mount_partition /tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/tests/separate.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Remediating would mount /tmp, which would break the test environment.
+# remediation = none
+
+. $SHARED/partition.sh
+
+clean_up_partition /tmp
+
+create_partition
+
+make_fstab_correct_partition_line /tmp
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /tmp
+
+create_partition
+
+make_fstab_given_partition_line /tmp ext2 noexec
+
+mount_partition /tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /tmp
+
+create_partition
+
+make_fstab_correct_partition_line /tmp
+
+mount_partition /tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/tests/separate.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Remediating would mount /tmp, which would break the test environment.
+# remediation = none
+
+. $SHARED/partition.sh
+
+clean_up_partition /tmp
+
+create_partition
+
+make_fstab_correct_partition_line /tmp
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /var/tmp
+
+create_partition
+
+make_fstab_given_partition_line /var/tmp ext2 noexec
+
+mount_partition /var/tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /var/tmp
+
+create_partition
+
+make_fstab_correct_partition_line /var/tmp
+
+mount_partition /var/tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/separate.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Remediating would mount /tmp, which would break the test environment.
+# remediation = none
+
+. $SHARED/partition.sh
+
+clean_up_partition /var/tmp
+
+create_partition
+
+make_fstab_correct_partition_line /var/tmp
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/tests/fstab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /var/tmp
+
+create_partition
+
+make_fstab_given_partition_line /var/tmp ext2 noexec
+
+mount_partition /var/tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/tests/runtime.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /var/tmp
+
+create_partition
+
+make_fstab_correct_partition_line /var/tmp
+
+mount_partition /var/tmp

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/tests/separate.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Remediating would mount /tmp, which would break the test environment.
+# remediation = none
+
+. $SHARED/partition.sh
+
+clean_up_partition /var/tmp
+
+create_partition
+
+make_fstab_correct_partition_line /var/tmp
+
+# $SHARED/fstab is correct, but we are not mounted.

--- a/tests/shared/partition.sh
+++ b/tests/shared/partition.sh
@@ -53,5 +53,7 @@ clean_up_partition() {
     path="$1"
     escaped_path=${path//$'/'/$'\/'}
     sed -i "/${escaped_path}/d" /etc/fstab
-    umount ${path} || true  # no problem if not mounted
+    if mountpoint -q -- "${path}"; then
+        umount -l ${path}
+    fi
 }


### PR DESCRIPTION
#### Description:
Most of the test scenarios are copy-paste from other mount rules with small adjustments.

Previous `mount_option_dev_shm_noexec` test scenarios were removed because they did not test the rule properly - they just changed line in fstab/mtab and that isn't enough. All these test scenarios were passing because the default configuration of a machine is exactly the same as the test scenarios expected as result.

#### Rationale:
Increase test coverage of rules from CIS profile.
