### PR TITLE
ocp4: Fix audit log forwarding rule

### DIFF
--- a/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
@@ -42,6 +42,7 @@ template:
     ocp_data: "true"
     filepath: /apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance
     yamlpath: "spec.pipelines[:].inputRefs[:]"
+    entity_check: "at least one"
     values:
     - value: "audit"
       entity_check: "at least one"

--- a/ocp-resources/e2e/forward-logs.yaml
+++ b/ocp-resources/e2e/forward-logs.yaml
@@ -5,10 +5,15 @@ metadata:
   namespace: openshift-logging
 spec:
   pipelines:
-   - name: audit-logs
+   - name: most-logs
      inputRefs:
        - application
        - audit
        - infrastructure
+     outputRefs:
+      - default
+   - name: audit-logs
+     inputRefs:
+       - audit
      outputRefs:
       - default


### PR DESCRIPTION
The current state of the rule assumes that the audit input is present in
all pipelines, this fixes that since it's only necessary in one pipeline
(hopefully to a SIEM). This also fixes the test to reflect such a case.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>