### PR TITLE
allow stricter permissions in certain file_permissions_* rules

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
@@ -41,3 +41,4 @@ template:
     vars:
         filepath: /etc/group
         filemode: '0644'
+        allow_stricter_permissions: true

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
@@ -43,3 +43,4 @@ template:
     vars:
         filepath: /etc/passwd
         filemode: '0644'
+        allow_stricter_permissions: true


### PR DESCRIPTION
#### Description:

- enable stricter file permissions for the following rules:
  - file_permissions_etc_group
  - file_permissions_etc_passwd

#### Rationale:

There are tests which should be passing, but without enabling of this option they are failing.

- Fixes part of #5213 
