### PR TITLE
kernel_module_* test scenarios

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/comment.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/ipv6.conf
+echo "# options ipv6 disable=0" > /etc/modprobe.d/ipv6.conf

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/ipv6.conf

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_disabled.pass.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_disabled.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7
 
 echo "options ipv6 disable=1" > /etc/modprobe.d/ipv6.conf

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_enabled.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/tests/module_enabled.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7
 
 echo "options ipv6 disable=0" > /etc/modprobe.d/ipv6.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/dccp.conf ]; then
+    sed -i '/install dccp/d' /etc/modprobe.d/dccp.conf
+fi
+echo "# install dccp /bin/true" > /etc/modprobe.d/dccp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install dccp /bin/true" > /etc/modprobe.d/dccp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/dccp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/dccp.conf
+sed -i '/install dccp/d' /etc/modprobe.d/dccp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/rds.conf ]; then
+    sed -i '/install rds/d' /etc/modprobe.d/rds.conf
+fi
+echo "# install rds /bin/true" > /etc/modprobe.d/rds.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install rds /bin/true" > /etc/modprobe.d/rds.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/rds.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/rds.conf
+sed -i '/install rds/d' /etc/modprobe.d/rds.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/sctp.conf ]; then
+    sed -i '/install sctp/d' /etc/modprobe.d/sctp.conf
+fi
+echo "# install sctp /bin/true" > /etc/modprobe.d/sctp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install sctp /bin/true" > /etc/modprobe.d/sctp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/sctp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/sctp.conf
+sed -i '/install sctp/d' /etc/modprobe.d/sctp.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/tipc.conf ]; then
+    sed -i '/install tipc/d' /etc/modprobe.d/tipc.conf
+fi
+echo "# install tipc /bin/true" > /etc/modprobe.d/tipc.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install tipc /bin/true" > /etc/modprobe.d/tipc.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/tipc.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/tipc.conf
+sed -i '/install tipc/d' /etc/modprobe.d/tipc.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/cramfs.conf ]; then
+    sed -i '/install cramfs/d' /etc/modprobe.d/cramfs.conf
+fi
+echo "# install cramfs /bin/true" > /etc/modprobe.d/cramfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install cramfs /bin/true" > /etc/modprobe.d/cramfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/cramfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/cramfs.conf
+sed -i '/install cramfs/d' /etc/modprobe.d/cramfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/squashfs.conf ]; then
+    sed -i '/install squashfs/d' /etc/modprobe.d/squashfs.conf
+fi
+echo "# install squashfs /bin/true" > /etc/modprobe.d/squashfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install squashfs /bin/true" > /etc/modprobe.d/squashfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/squashfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/squashfs.conf
+sed -i '/install squashfs/d' /etc/modprobe.d/squashfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/udf.conf ]; then
+    sed -i '/install udf/d' /etc/modprobe.d/udf.conf
+fi
+echo "# install udf /bin/true" > /etc/modprobe.d/udf.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install udf /bin/true" > /etc/modprobe.d/udf.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/udf.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/udf.conf
+sed -i '/install udf/d' /etc/modprobe.d/udf.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/usb-storage.conf ]; then
+    sed -i '/install usb-storage/d' /etc/modprobe.d/usb-storage.conf
+fi
+echo "# install usb-storage /bin/true" > /etc/modprobe.d/usb-storage.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/usb-storage.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/wrong_value.fail.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
 
+touch /etc/modprobe.d/usb-storage.conf
+sed -i '/install usb-storage/d' /etc/modprobe.d/usb-storage.conf


### PR DESCRIPTION
#### Description:
Add/update test scenarios for kernel_module_* rules.
Test command:
```
python3 tests/test_suite.py rule --profile cis --libvirt qemu:///system test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml kernel_module_ipv6_option_disabled kernel_module_dccp_disabled kernel_module_rds_disabled kernel_module_sctp_disabled kernel_module_tipc_disabled kernel_module_cramfs_disabled kernel_module_squashfs_disabled kernel_module_udf_disabled kernel_module_usb-storage_disabled
```

#### Rationale:
Increase test coverage for rules from CIS profile.
