### PR TITLE
Add ansible and bash remediation for wireless_disable_interfaces.

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+
+- name: Deactivate Wireless Network Interfaces
+  command: nmcli radio wifi off

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_all
+
+nmcli radio wifi off

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
@@ -94,3 +94,5 @@ ocil: |-
     The output should contain the following:
     <pre>wifi disconnected</pre>
     {{% endif %}}
+
+platform: machine


### PR DESCRIPTION
#### Description:

- Add ansible and bash remediation for wireless_disable_interfaces.

#### Rationale:

- Fixes [bz#1859487](https://bugzilla.redhat.com/show_bug.cgi?id=1859487)

#### Notes

I don't how to create a test scenario for that since the machine needs to have a wifi device enabled. I've manually verified that the `/proc/net/wireless` on my laptop doesn't contain any wireless devices after running `nmcli radio wifi off` and the OVAL check would pass.