### PR TITLE
file_*_grub2_ctg and dir_perms_world_writable_sticky_bits test scenarios

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chown 0:0 /boot/grub2/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/tests/wrong.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/tests/wrong.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chown 0:1 /boot/grub2/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chown 0:0 /boot/grub2/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/wrong.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/wrong.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chown 1:0 /boot/grub2/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chmod 0600 /boot/grub2/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/wrong.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/wrong.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chmod 0644 /boot/grub2/grub.cfg

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Perform remediation
+df --local -P | awk '{if (NR!=1) print $6}' \
+| xargs -I '{}' find '{}' -xdev -type d \
+\( -perm -0002 -a ! -perm -1000 \) 2>/dev/null \
+| xargs chmod a+t
+
+# Create a new dir that has sticky bit but is not word-writable
+mkdir /test_dir_1
+chmod 1770 /test_dir_1
+
+# Create a new dir that is word-writable but doesn't have sticky bit
+mkdir /test_dir_2
+chmod 0774 /test_dir_2

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/tmp_no_sticky.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/tmp_no_sticky.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chmod o-t /tmp


### PR DESCRIPTION
#### Description:
Add test scenarios to file_*_grub2_ctg and dir_perms_world_writable_sticky_bits rules.

#### Rationale:
Increase test coverage of rules from CIS profile.