### PR TITLE
CIS 5.1 and 5.2: More ocil updates

### DIFF
--- a/applications/openshift/accounts/accounts_restrict_service_account_tokens/rule.yml
+++ b/applications/openshift/accounts/accounts_restrict_service_account_tokens/rule.yml
@@ -20,7 +20,7 @@ severity: medium
 references:
     cis@ocp4: 5.1.6
 
-ocil_clause: 'service account tokens are automounting'
+ocil_clause: 'service account token usage needs review'
 
 ocil: |-
     For each pod in the cluster, review the pod specification and

--- a/applications/openshift/accounts/accounts_unique_service_account/rule.yml
+++ b/applications/openshift/accounts/accounts_unique_service_account/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure Usage of Unique Service Accounts '
 
 description: |-
     Using the <tt>default</tt> service account prevents accurate application
-    rights review and audit tracing. For each namespace, create
+    rights review and audit tracing. Instead of <tt>default</tt>, create
     a new and unique service account with the following command:
     <pre>$ oc create sa <i>service_account_name></i></pre>
     where <i>service_account_name></i> is the name of a service account
@@ -26,7 +26,7 @@ severity: medium
 references:
     cis@ocp4: 5.1.5
 
-ocil_clause: 'default service account is used and is not unique'
+ocil_clause: 'default service account usage needs review'
 
 ocil: |-
     For each namespace in the cluster, review the rights assigned

--- a/applications/openshift/rbac/rbac_pod_creation_access/rule.yml
+++ b/applications/openshift/rbac/rbac_pod_creation_access/rule.yml
@@ -19,11 +19,13 @@ severity: medium
 references:
     cis@ocp4: 5.1.4
 
-ocil_clause: 'pod creation privileges are in use by more roles than necessary'
+ocil_clause: 'pod creation privileges in roles needs review'
 
 ocil: |-
     To review the pod creation privileges in roles, run the following commands:
-    <pre>$ oc get roles --all-namespaces -o yaml</pre>
-    <pre>$ oc get clusterroles -o yaml</pre>
-    Review the output and ensure that pod creation privileged use is limited to
-    as small subset as possible.
+    <pre>$ oc describe roles --all-namespaces</pre>
+    <pre>$ oc describe clusterroles</pre>
+    Review the output, and for any role/clusterrole defining create permissions
+    for pods that are NOT an OpenShift "system:" or other system-provided
+    role/clusterrole, determine if the users bound to the role truly have the
+    need to create pods.

--- a/applications/openshift/rbac/rbac_wildcard_use/rule.yml
+++ b/applications/openshift/rbac/rbac_wildcard_use/rule.yml
@@ -23,11 +23,13 @@ severity: medium
 references:
     cis@ocp4: 5.1.3
 
-ocil_clause: 'wildcards are in use by more roles than necessary'
+ocil_clause: 'wildcard usage in roles needs review'
 
 ocil: |-
     To review the wildcard usage in roles, run the following commands:
-    <pre>$ oc get roles --all-namespaces -o yaml</pre>
-    <pre>$ oc get clusterroles -o yaml</pre>
-    Review the output and ensure that wildcard use is limited to
-    a small subset as possible.
+    <pre>$ oc describe roles --all-namespaces</pre>
+    <pre>$ oc describe clusterroles</pre>
+    Review the output, and for any role/clusterrole specifying a wildcard
+    resource that is NOT an OpenShift "system:" or other system-provided
+    role/clusterrole, determine if the wildcard access can be replaced with
+    specific resources.

--- a/applications/openshift/scc/scc_limit_ipc_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_ipc_namespace/rule.yml
@@ -24,14 +24,20 @@ identifiers:
 references:
     cis@ocp4: 5.2.3
 
-ocil_clause: 'allowHostIPC is set to true or too many SCCs have allowHostIPC enabled'
+ocil_clause: 'allowHostIPC usage in SCCs needs review'
 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that <tt>allowHostIPC</tt> is either
-    completely disabled, or that <tt>allowHostIPC</tt> is only enabled to
-    a small set of containers and SCCs.
+    Review each SCC for those that have <tt>allowHostIPC</tt> set to <tt>true</tt>.
+    Next, examine the outputs of the following commands:
+    <pre>$ oc describe roles --all-namespaces</pre>
+    <pre>$ oc describe clusterroles</pre>
+    For any role/clusterrole that reference the
+    <tt>securitycontextconstraints</tt> resource with the <tt>resourceNames</tt>
+    of the SCCs that have <tt>allowHostIPC</tt>, examine the associated
+    rolebindings to account for the users that are bound to the role. Review the
+    account to determine if <tt>allowHostIPC</tt> is truly required.
 
 #template:
 #    name: yamlfile_value

--- a/applications/openshift/scc/scc_limit_network_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_network_namespace/rule.yml
@@ -24,14 +24,20 @@ identifiers:
 references:
     cis@ocp4: 5.2.4
 
-ocil_clause: 'allowHostNetwork is set to true or too many SCCs have allowHostNetwork enabled'
+ocil_clause: 'allowHostNetwork usage in SCCs needs review'
 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that <tt>allowHostNetwork</tt> is either
-    completely disabled, or that <tt>allowHostNetwork</tt> is only enabled to
-    a small set of containers and SCCs.
+    Review each SCC for those that have <tt>allowHostNetwork</tt> set to <tt>true</tt>.
+    Next, examine the outputs of the following commands:
+    <pre>$ oc describe roles --all-namespaces</pre>
+    <pre>$ oc describe clusterroles</pre>
+    For any role/clusterrole that reference the
+    <tt>securitycontextconstraints</tt> resource with the <tt>resourceNames</tt>
+    of the SCCs that have <tt>allowHostNetwork</tt>, examine the associated
+    rolebindings to account for the users that are bound to the role. Review the
+    account to determine if <tt>allowHostNetwork</tt> is truly required.
 
 #template:
 #    name: yamlfile_value

--- a/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
@@ -21,14 +21,20 @@ severity: medium
 references:
     cis@ocp4: 5.2.1
 
-ocil_clause: 'allowPrivilegedContainer is set to true or too many SCCs have allowPrivilegedContainer enabled'
+ocil_clause: 'allowPrivilegedContainer usage in SCCs needs review'
 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that <tt>allowPrivilegedContainer</tt> is either
-    completely disabled, or that <tt>allowPrivilegedContainer</tt> is only enabled to
-    a small set of containers and SCCs.
+    Review each SCC for those that have <tt>allowPrivilegedContainer</tt> set to <tt>true</tt>.
+    Next, examine the outputs of the following commands:
+    <pre>$ oc describe roles --all-namespaces</pre>
+    <pre>$ oc describe clusterroles</pre>
+    For any role/clusterrole that reference the
+    <tt>securitycontextconstraints</tt> resource with the <tt>resourceNames</tt>
+    of the SCCs that have <tt>allowPrivilegedContainer</tt>, examine the associated
+    rolebindings to account for the users that are bound to the role. Review the
+    account to determine if <tt>allowPrivilegedContainer</tt> is truly required.
 
 
 #template:

--- a/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
@@ -20,14 +20,21 @@ severity: medium
 references:
     cis@ocp4: 5.2.2
 
-ocil_clause: 'allowHostPID is set to true or too many SCCs have allowHostPID enabled'
+ocil_clause: 'allowHostPID usage in SCCs needs review'
 
 ocil: |-
     Inspect each SCC returned from running the following command:
     <pre>$ oc get scc</pre>
-    Review each SCC and determine that <tt>allowHostPID</tt> is either
-    completely disabled, or that <tt>allowHostPID</tt> is only enabled to
-    a small set of containers and SCCs.
+    Review each SCC for those that have <tt>allowHostPID</tt> set to <tt>true</tt>.
+    Next, examine the outputs of the following commands:
+    <pre>$ oc describe roles --all-namespaces</pre>
+    <pre>$ oc describe clusterroles</pre>
+    For any role/clusterrole that reference the
+    <tt>securitycontextconstraints</tt> resource with the <tt>resourceNames</tt>
+    of the SCCs that have <tt>allowHostPID</tt>, examine the associated
+    rolebindings to account for the users that are bound to the role. Review the
+    account to determine if <tt>allowHostPID</tt> is truly required.
+
 
 #template:
 #    name: yamlfile_value


### PR DESCRIPTION
The new wording here accounts for the fact that SCC's, when used correctly, should be bound by roles that give `use` access to the SCC resource. Examining the SCC alone for the privilege in question is not enough to audit the SCCs that are in use.