### PR TITLE
fix: rule for kubelet_authorization_mode

### DIFF
--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -42,7 +42,7 @@ template:
     vars:
         filepath: /etc/kubernetes/kubelet.conf
         yamlpath: ".authorization.mode"
-        check_existence: "none_exist"
+        check_existence: "any_exist"
         values:
          - value: "AlwaysAllow"
-           operation: "equals"
+           operation: "not equal"


### PR DESCRIPTION
#### Description:

- Fix rule for `kubelet_authorization_mode`

#### Rationale:

- current rule always fails if `.authorization.mode` is defined, while only `"AlwaysAllow"` should be treated as `FAIL`
- Fixes #6658 
