### PR TITLE
fix oval of ensure_logrotate_activated

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
@@ -6,6 +6,8 @@
     <criteria comment="/etc/logrotate.conf contains daily setting and /etc/cron.daily/logrotate file exists" operator="AND">
       <criterion comment="Check if daily is set in /etc/logrotate.conf"
       test_ref="test_logrotate_conf_daily_setting" />
+      <criterion comment="check that there is no weekly/monthly/yearly keyword in logrotate.conf"
+      test_ref="test_logrotate_conf_no_other_keyword" />
       <criterion comment="Check if /etc/cron.daily/logrotate file exists (and calls logrotate)"
       test_ref="test_cron_daily_logrotate_existence" />
     </criteria>
@@ -18,36 +20,22 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_logrotate_conf_daily_setting" version="2">
-    <!-- Read whole /etc/logrotate.conf at once (as single line) -->
-    <ind:behaviors singleline="true" />
     <ind:filepath>/etc/logrotate.conf</ind:filepath>
-    <!-- From the content extract the text chunk after the last (uncommented)
-         occurrence of 'daily' keyword till the EOF (including the 'daily'
-         string itself) -->
-    <ind:pattern operation="pattern match">(?:daily)*.*(?=[\n][\s]*daily)(.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*daily[\s#]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
-    <!-- From the found object exclude that one containing some (uncommented)
-         occurrence of (weekly / monthly / yearly) outside the {} block section
-         of /etc/logrotate.conf -->
-    <filter action="exclude">state_another_rotate_interval_after_daily</filter>
   </ind:textfilecontent54_object>
 
-  <!-- This filter selects from previously found objects those containing
-       another (uncommented occurrence of) log files rotate interval setting
-       (one of weekly / monthly / yearly) present outside the {} block section
-       of /etc/logrotate.conf -->
-  <ind:textfilecontent54_state id="state_another_rotate_interval_after_daily" version="1">
-    <!-- if some of (weekly / monthly / yearly) uncommented setting is found
-         (in the previously selected chunk of text) in one of the following
-         parts:
-         * before the first '{' character,
-         * somewhere after '}' character and before another '{' character,
-         * after final '}' character and before end of the chunk
-         exclude such object from the found ones (since in that case earlier
-         daily setting would be replaced with the found setting) -->
-    <ind:subexpression datatype="string"
-    operation="pattern match">}[^{]+[\n][\s]*(weekly|monthly|yearly)|[\n][\s]*(weekly|monthly|yearly)[^}]+{</ind:subexpression>
-  </ind:textfilecontent54_state>
+<ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="Test if there is no weekly/monthly/yearly keyword"
+  id="test_logrotate_conf_no_other_keyword" version="1">
+    <ind:object object_ref="object_logrotate_conf_no_other_keyword" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_logrotate_conf_no_other_keyword" version="2">
+    <ind:filepath>/etc/logrotate.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*(weekly|monthly|yearly)[\s#]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="Tests the existence of /etc/cron.daily/logrotate file (and verify it actually calls logrotate utility)"


### PR DESCRIPTION
#### Description:

- rewrite oval
- now it checks if there is occurence of "daily" and NO occurences of weekly/monthly/yearly

#### Rationale:

- oval was not in accordance with rule description / remediation

- Fixes #5213 
