### PR TITLE
remove ensure_logrotate_configured from CIS profiles

### DIFF
--- a/rhel7/profiles/cis.profile
+++ b/rhel7/profiles/cis.profile
@@ -537,7 +537,6 @@ selections:
     ### 4.2.4 Ensure permissions on all logfiles are configured (Scored)
 
     ## 4.3 Ensure logrotate is configured (Not Scored)
-    - ensure_logrotate_activated
 
     # 5 Access, Authentication and Authorization
     ## 5.1 Configure cron

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -716,8 +716,7 @@ selections:
     ### 4.2.3 Ensure permissions on all logfiles are configured (Scored)
     # NEEDS RULE - https://github.com/ComplianceAsCode/content/issues/5523
 
-    ## 4.3 Ensure logrotate is conifgured (Not Scored)
-    - ensure_logrotate_activated
+    ## 4.3 Ensure logrotate is configured (Not Scored)
 
     # 5 Access, Authentication and Authorization
 

--- a/sle15/profiles/cis.profile
+++ b/sle15/profiles/cis.profile
@@ -575,8 +575,7 @@ selections:
 
     ### 4.2.3 Ensure permissions on all logfiles are configured (Scored)
 
-    ### 4.2.4 Ensure logrotate is conifgured (Not Scored)
-    - ensure_logrotate_activated
+    ### 4.2.4 Ensure logrotate is configured (Not Scored)
 
     # 5 Access, Authentication and Authorization
 


### PR DESCRIPTION
#### Description:

- remove the rule from cis for rhel7, rhel8, sle15

#### Rationale:

- the rule is marked as unscored/ manual.