### PR TITLE
fix test for smartcard_auth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
@@ -4,5 +4,6 @@
 
 
 systemctl enable pcscd.socket
+systemctl start pcscd.socket
 
 . ./configure_pam_stack.sh


### PR DESCRIPTION
#### Description:

- add line to start pcscd.socket

#### Rationale:

- if the socket is not started, the oval will fail

- Fixes #5213 
