### PR TITLE
Update selinux_confinement_of_daemons rule

### DIFF
--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
@@ -2,20 +2,20 @@
   <definition class="compliance" id="selinux_confinement_of_daemons" version="1">
     {{{ oval_metadata("All pids in /proc should be assigned an SELinux security context other than 'unconfined_service_t'.") }}}
     <criteria>
-      <criterion comment="device_t in /dev" test_ref="test_selinux_confinement_of_daemons" />
+      <criterion comment="no unconfined_service_t in /proc" test_ref="test_selinux_confinement_of_daemons" />
     </criteria>
   </definition>
-  <linux:selinuxsecuritycontext_test check="none satisfy" check_existence="any_exist" comment="device_t in /dev" id="test_selinux_confinement_of_daemons" version="2">
+  <linux:selinuxsecuritycontext_test check="none satisfy" check_existence="any_exist" comment="none satisfy unconfined_service_t in /proc" id="test_selinux_confinement_of_daemons" version="2">
     <linux:object object_ref="object_selinux_confinement_of_daemons" />
     <linux:state state_ref="state_selinux_confinement_of_daemons" />
   </linux:selinuxsecuritycontext_test>
-  <linux:selinuxsecuritycontext_object comment="none satisfy unconfined_service_t in /proc" id="object_selinux_confinement_of_daemons" version="1">
+  <linux:selinuxsecuritycontext_object comment="find unconfined_service_t in /proc" id="object_selinux_confinement_of_daemons" version="1">
     <linux:behaviors max_depth="1" recurse_direction="down" />
     <linux:path>/proc</linux:path>
     <linux:filename operation="pattern match">^.*$</linux:filename>
     <filter action="include">state_selinux_confinement_of_daemons</filter>
   </linux:selinuxsecuritycontext_object>
-  <linux:selinuxsecuritycontext_state comment="do it" id="state_selinux_confinement_of_daemons" version="1">
+  <linux:selinuxsecuritycontext_state comment="state unconfined_service_t" id="state_selinux_confinement_of_daemons" version="1">
     <linux:type datatype="string" operation="equals">unconfined_service_t</linux:type>
   </linux:selinuxsecuritycontext_state>
 </def-group>

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="selinux_confinement_of_daemons" version="1">
-    {{{ oval_metadata("All pids in /proc should be assigned an SELinux security context other than 'initrc_t'.") }}}
+    {{{ oval_metadata("All pids in /proc should be assigned an SELinux security context other than 'unconfined_service_t'.") }}}
     <criteria>
       <criterion comment="device_t in /dev" test_ref="test_selinux_confinement_of_daemons" />
     </criteria>
@@ -9,13 +9,13 @@
     <linux:object object_ref="object_selinux_confinement_of_daemons" />
     <linux:state state_ref="state_selinux_confinement_of_daemons" />
   </linux:selinuxsecuritycontext_test>
-  <linux:selinuxsecuritycontext_object comment="none satisfy initrc_t in /proc" id="object_selinux_confinement_of_daemons" version="1">
+  <linux:selinuxsecuritycontext_object comment="none satisfy unconfined_service_t in /proc" id="object_selinux_confinement_of_daemons" version="1">
     <linux:behaviors max_depth="1" recurse_direction="down" />
     <linux:path>/proc</linux:path>
     <linux:filename operation="pattern match">^.*$</linux:filename>
     <filter action="include">state_selinux_confinement_of_daemons</filter>
   </linux:selinuxsecuritycontext_object>
   <linux:selinuxsecuritycontext_state comment="do it" id="state_selinux_confinement_of_daemons" version="1">
-    <linux:type datatype="string" operation="equals">initrc_t</linux:type>
+    <linux:type datatype="string" operation="equals">unconfined_service_t</linux:type>
   </linux:selinuxsecuritycontext_state>
 </def-group>

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
@@ -7,15 +7,15 @@ title: 'Ensure No Daemons are Unconfined by SELinux'
 description: |-
     Daemons for which the SELinux policy does not contain rules will inherit the
     context of the parent process. Because daemons are launched during
-    startup and descend from the <tt>init</tt> process, they inherit the <tt>initrc_t</tt> context.
+    startup and descend from the <tt>init</tt> process, they inherit the <tt>unconfined_service_t</tt> context.
     <br />
     <br />
     To check for unconfined daemons, run the following command:
-    <pre>$ sudo ps -eZ | egrep "initrc" | egrep -vw "tr|ps|egrep|bash|awk" | tr ':' ' ' | awk '{ print $NF }'</pre>
+    <pre>$ sudo ps -eZ | grep "unconfined_service_t"</pre>
     It should produce no output in a well-configured system.
 
 rationale: |-
-    Daemons which run with the <tt>initrc_t</tt> context may cause AVC denials,
+    Daemons which run with the <tt>unconfined_service_t</tt> context may cause AVC denials,
     or allow privileges that the daemon does not require.
 
 severity: medium

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
@@ -37,6 +37,13 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.12.1.2,A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.5.1,A.12.6.2,A.12.7.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.14.2.2,A.14.2.3,A.14.2.4,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 1,11,12,13,14,15,16,18,3,5,6,9
 
+ocil_clause: 'There are unconfined daemons running on the system'
+
+ocil: |-
+    Ensure there are no unconfined daemons running on the system,
+    the following command should produce no output:
+    <pre>$ sudo ps -eZ | grep "unconfined_service_t"</pre>
+
 warnings:
     - general: |-
         Automatic remediation of this control is not available. Remediation

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/tests/no_unconfined_daemons.pass.sh
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/tests/no_unconfined_daemons.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# sshd should be running and should have specific rules in SELinux policy
+# so it should not be detected as unconfined_service_t.
+systemctl status sshd.service

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/tests/unconfined_daemon.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/tests/unconfined_daemon.fail.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# remediation = none
+
+cat > /usr/bin/dummydaemon.sh << EOF
+#!/bin/bash
+
+while true; do
+	date
+	sleep 60
+done
+EOF
+chmod +x /usr/bin/dummydaemon.sh
+
+cat > /etc/systemd/system/dummydaemon.service << EOF
+[Unit]
+Description=Dummy daemon
+
+[Service]
+ExecStart=/usr/bin/dummydaemon.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl start dummydaemon.service
+systemctl status dummydaemon.service


### PR DESCRIPTION
#### Description:

- The `initrc_t` context was used on RHEL5/RHEL6. Since RHEL7 the correct context for the unconfined daemons should be the `unconfined_service_t`.
- Also added test scenarios.