### PR TITLE
Profiles generated from policy contains only rules applicable for the product

### DIFF
--- a/build-scripts/build_rule_playbooks.py
+++ b/build-scripts/build_rule_playbooks.py
@@ -36,14 +36,14 @@ def parse_args():
         "--ssg-root."
     )
     p.add_argument(
-        "--ssg-root", required=True,
-        help="Directory containing the source tree. "
-        "e.g. ~/scap-security-guide/"
+        "--build-config-yaml", required=True, dest="build_config_yaml",
+        help="YAML file with information about the build configuration. "
+        "e.g.: ~/scap-security-guide/build/build_config.yml"
     )
     p.add_argument(
-        "--product", required=True,
-        help="ID of the product for which we are building Playbooks. "
-        "e.g.: 'fedora'"
+        "--product-yaml", required=True, dest="product_yaml",
+        help="YAML file with information about the product we are building. "
+        "e.g.: ~/scap-security-guide/rhel7/product.yml"
     )
     p.add_argument(
         "--profile",
@@ -62,33 +62,36 @@ def parse_args():
 
 def main():
     args = parse_args()
-    product_yaml = os.path.join(args.ssg_root, args.product, "product.yml")
+    env_yaml = ssg.yaml.open_environment(
+        args.build_config_yaml, args.product_yaml)
+    ssg_root = env_yaml["ssg_root"]
+    product = env_yaml["product"]
     if args.input_dir:
         input_dir = args.input_dir
     else:
         input_dir = os.path.join(
-            args.ssg_root, "build", args.product, "fixes", "ansible"
+            ssg_root, "build", product, "fixes", "ansible"
         )
     if args.output_dir:
         output_dir = args.output_dir
     else:
         output_dir = os.path.join(
-            args.ssg_root, "build", args.product, "playbooks"
+            ssg_root, "build", product, "playbooks"
         )
     if args.resolved_rules_dir:
         resolved_rules_dir = args.resolved_rules_dir
     else:
         resolved_rules_dir = os.path.join(
-            args.ssg_root, "build", args.product, "rules"
+            ssg_root, "build", product, "rules"
         )
     if args.resolved_profiles_dir:
         resolved_profiles_dir = args.resolved_profiles_dir
     else:
         resolved_profiles_dir = os.path.join(
-            args.ssg_root, "build", args.product, "profiles"
+            ssg_root, "build", product, "profiles"
         )
     playbook_builder = ssg.playbook_builder.PlaybookBuilder(
-        product_yaml, input_dir, output_dir, resolved_rules_dir, resolved_profiles_dir
+        args.product_yaml, input_dir, output_dir, resolved_rules_dir, resolved_profiles_dir
     )
     playbook_builder.build(args.profile, args.rule)
 

--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import argparse
+import logging
 import sys
 import os.path
 from glob import glob
@@ -71,6 +72,8 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
     env_yaml = get_env_yaml(args.build_config_yaml, args.product_yaml)
+
+    logging.basicConfig(filename=f"{env_yaml.get('ssg_root')}/build/{env_yaml.get('product')}/control_profiles.log", level=logging.INFO)
 
     if args.controls_dir:
         controls_manager = ssg.controls.ControlsManager(args.controls_dir, env_yaml)

--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -47,6 +47,11 @@ def parse_args():
                       action="store", help="XML Tree content")
     parser.add_option("--id-name", dest="id_name", default="ssg",
                       action="store", help="ID naming scheme")
+    parser.add_option("--build-config-yaml", dest="build_config_yaml",
+                      help="YAML file with information about the build configuration")
+    parser.add_option("--product-yaml", dest="product_yaml",
+                      help="YAML file with information about the product we are building"
+    )
     (options, args) = parser.parse_args()
 
     if options.centos and options.sl:
@@ -66,6 +71,9 @@ def parse_args():
 
 def main():
     options, args = parse_args()
+
+    env_yaml = ssg.yaml.open_environment(
+        options.build_config_yaml, options.product_yaml)
 
     if options.centos:
         mapping = ssg.constants.RHEL_CENTOS_CPE_MAPPING
@@ -112,7 +120,7 @@ def main():
             )
 
     ssg.build_derivatives.replace_platform(root, oval_ns, derivative)
-    ssg.build_derivatives.add_cpe_item_to_dictionary(root, args[0], args[1], "ssg-%s-cpe-oval.xml" % args[0], options.id_name)
+    ssg.build_derivatives.add_cpe_item_to_dictionary(root, env_yaml, args[0], "ssg-%s-cpe-oval.xml" % env_yaml["product"], options.id_name)
 
     tree.write(options.output)
 

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -75,7 +75,7 @@ def main():
         p.validate_rules(loader.all_rules, loader.all_groups)
         p.validate_refine_rules(loader.all_rules)
 
-    product_cpes = ssg.build_cpe.ProductCPEs(env_yaml["product"])
+    product_cpes = ssg.build_cpe.ProductCPEs(env_yaml)
     loader.export_group_to_file(args.output, product_cpes)
 
 

--- a/build_config.yml.in
+++ b/build_config.yml.in
@@ -2,6 +2,8 @@ cmake_build_type: "@CMAKE_BUILD_TYPE@"
 
 ssg_version: [@SSG_MAJOR_VERSION@, @SSG_MINOR_VERSION@, @SSG_PATCH_VERSION@]
 ssg_version_str: "@SSG_VERSION@"
+ssg_root: @PROJECT_SOURCE_DIR@
+
 target_oval_version: [@SSG_TARGET_OVAL_MAJOR_VERSION@, @SSG_TARGET_OVAL_MINOR_VERSION@]
 target_oval_version_str: "@SSG_TARGET_OVAL_VERSION@"
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -271,7 +271,7 @@ macro(ssg_build_ansible_playbooks PRODUCT)
     set(ANSIBLE_PLAYBOOKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/playbooks")
     add_custom_command(
         OUTPUT "${ANSIBLE_PLAYBOOKS_DIR}"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --ssg-root "${CMAKE_SOURCE_DIR}" --product "${PRODUCT}" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --resolved-profiles-dir "${CMAKE_CURRENT_BINARY_DIR}/profiles" --output-dir "${ANSIBLE_PLAYBOOKS_DIR}"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml"  --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --resolved-profiles-dir "${CMAKE_CURRENT_BINARY_DIR}/profiles" --output-dir "${ANSIBLE_PLAYBOOKS_DIR}"
         DEPENDS "${ANSIBLE_FIXES_DIR}"
         DEPENDS generate-internal-${PRODUCT}-ansible-all-fixes
         DEPENDS "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -372,7 +372,7 @@ macro(ssg_build_cpe_dictionary PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" ${PRODUCT} ssg "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml"  --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ssg "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
         DEPENDS generate-internal-${PRODUCT}-oval-unlinked.xml

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -897,7 +897,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml" ${ORIGINAL} ${DERIVATIVE} --id-name ssg
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml" ${DERIVATIVE} --id-name ssg
         DEPENDS generate-ssg-${ORIGINAL}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml"
         DEPENDS "${SSG_BUILD_SCRIPTS}/enable_derivatives.py"
@@ -911,8 +911,8 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" ${ORIGINAL} ${DERIVATIVE} --id-name ssg
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" ${ORIGINAL} ${DERIVATIVE} --id-name ssg
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py"  --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" ${DERIVATIVE} --id-name ssg
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py"  --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" ${DERIVATIVE} --id-name ssg
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
         DEPENDS generate-ssg-${ORIGINAL}-ds.xml

--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -125,14 +125,12 @@ controls:
     automated: yes
     rules:
     - security_patches_up_to_date
-{{% if product in ['fedora', 'ol8', 'rhel8'] %}}
     - package_dnf-automatic_installed
     - timer_dnf-automatic_enabled
     # Configure dnf-automatic to Install Available Updates Automatically
     - dnf-automatic_apply_updates
     # Configure dnf-automatic to Install Only Security Updates
     - dnf-automatic_security_updates_only
-{{% endif %}}
 
   - id: R9
     level: intermediary
@@ -750,11 +748,9 @@ controls:
     - rsyslog_remote_loghost
 
     # Derived from DAT-NT-012 R12
-{{% if product in ['fedora', 'ol8', 'rhel8'] %}}
     - package_rsyslog-gnutls_installed
     - rsyslog_remote_tls
     - rsyslog_remote_tls_cacert
-{{% endif %}}
 
     # Based on DAT-NT-012 R18
     # The rules sets the rotation frequency to daily

--- a/rhcos4/profiles/anssi_bp28_enhanced.profile
+++ b/rhcos4/profiles/anssi_bp28_enhanced.profile
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (enhanced)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+    - anssi:all:enhanced
+    - '!selinux_state'

--- a/rhcos4/profiles/anssi_bp28_high.profile
+++ b/rhcos4/profiles/anssi_bp28_high.profile
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (high)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+    - anssi:all:high

--- a/rhcos4/profiles/anssi_bp28_intermediary.profile
+++ b/rhcos4/profiles/anssi_bp28_intermediary.profile
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (intermediary)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+  - anssi:all:intermediary

--- a/rhcos4/profiles/anssi_bp28_minimal.profile
+++ b/rhcos4/profiles/anssi_bp28_minimal.profile
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (minimal)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+  - anssi:all:minimal
+

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -25,10 +25,8 @@ class ProductCPEs(object):
     and provides them in a structured way.
     """
 
-    def __init__(self, product):
-        self.ssg_root = \
-            os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-        self.product_yaml = get_product_yaml(self.ssg_root, product)
+    def __init__(self, env_yaml):
+        self.env_yaml = env_yaml
 
         self.cpes_by_id = {}
         self.cpes_by_name = {}
@@ -45,19 +43,19 @@ class ProductCPEs(object):
     def load_product_cpes(self):
 
         try:
-            product_cpes_list = self.product_yaml["cpes"]
+            product_cpes_list = self.env_yaml["cpes"]
             self._load_cpes_list(self.product_cpes, product_cpes_list)
 
         except KeyError:
-            print("Product %s does not define 'cpes'" % (self.product_yaml["product"]))
+            print("Product %s does not define 'cpes'" % (self.env_yaml["product"]))
             raise
 
     def load_content_cpes(self):
 
-        cpes_root = required_key(self.product_yaml, "cpes_root")
-        # we have to "absolutize" the paths the right way, relative to the product_yaml path
+        cpes_root = required_key(self.env_yaml, "cpes_root")
+        # we have to "absolutize" the paths the right way, relative to the env_yaml path
         if not os.path.isabs(cpes_root):
-            cpes_root = os.path.join(self.ssg_root, self.product_yaml["product"], cpes_root)
+            cpes_root = os.path.join(self.env_yaml["ssg_root"], self.env_yaml["product"], cpes_root)
 
         for dir_item in sorted(os.listdir(cpes_root)):
             dir_item_path = os.path.join(cpes_root, dir_item)
@@ -97,7 +95,7 @@ class ProductCPEs(object):
             else:
                 return self.cpes_by_id[ref]
         except KeyError:
-            raise CPEDoesNotExist("CPE %s is not defined in %s" %(ref, self.product_yaml["cpes_root"]))
+            raise CPEDoesNotExist("CPE %s is not defined in %s" %(ref, self.env_yaml["cpes_root"]))
 
 
     def get_cpe_name(self, cpe_id):

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -43,10 +43,10 @@ def add_cpes(elem, namespace, mapping):
     return affected
 
 
-def add_cpe_item_to_dictionary(tree_root, product, cpe_ref, cpe_oval_filename, id_name):
+def add_cpe_item_to_dictionary(tree_root, env_yaml, cpe_ref, cpe_oval_filename, id_name):
     cpe_list = tree_root.find(".//{%s}cpe-list" % (PREFIX_TO_NS["cpe-dict"]))
     if cpe_list:
-        product_cpes = ProductCPEs(product)
+        product_cpes = ProductCPEs(env_yaml)
         cpe_item = product_cpes.get_cpe(cpe_ref)
         translator = IDTranslator(id_name)
         cpe_item.check_id = translator.generate_id("{" + oval_namespace + "}definition", cpe_item.check_id)

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -51,6 +51,9 @@ class Control():
                 rule =  ssg.build_yaml.Rule.from_yaml(rule_yaml)
                 if rule.prodtype == "all" or product in rule.prodtype:
                     control.rules.append(item)
+                else:
+                    logging.info(f"Rule {item} doesn't apply to {product}")
+
         control.related_rules = control_dict.get("related_rules", [])
         control.note = control_dict.get("note")
         return control

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -3,8 +3,11 @@ import logging
 import os
 from glob import glob
 
+import ssg.build_yaml
 import ssg.yaml
 import ssg.utils
+
+from ssg.rules import get_rule_path_by_id
 
 
 class Control():
@@ -19,7 +22,7 @@ class Control():
         self.automated = ""
 
     @classmethod
-    def from_control_dict(cls, control_dict, default_level=""):
+    def from_control_dict(cls, control_dict, env_yaml, default_level=""):
         control = cls()
         control.id = ssg.utils.required_key(control_dict, "id")
         control.title = control_dict.get("title")
@@ -34,12 +37,20 @@ class Control():
         control.level = control_dict.get("level", default_level)
         control.notes = control_dict.get("notes", "")
         selections = control_dict.get("rules", [])
+
+        product = env_yaml.get('product')
+        ssg_root = env_yaml.get('ssg_root')
+
         for item in selections:
             if "=" in item:
                 varname, value = item.split("=", 1)
                 control.variables[varname] = value
             else:
-                control.rules.append(item)
+                # Check if rule is applicable to product, i.e.: prodtype has product id
+                rule_yaml = get_rule_path_by_id(ssg_root, item)
+                rule =  ssg.build_yaml.Rule.from_yaml(rule_yaml)
+                if rule.prodtype == "all" or product in rule.prodtype:
+                    control.rules.append(item)
         control.related_rules = control_dict.get("related_rules", [])
         control.note = control_dict.get("note")
         return control
@@ -64,7 +75,7 @@ class Policy():
 
         for node in tree:
             control = Control.from_control_dict(
-                node, default_level=default_level)
+                node, self.env_yaml, default_level=default_level)
             if "controls" in node:
                 for sc in self._parse_controls_tree(node["controls"]):
                     yield sc

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
+from glob import glob
 
 
 def get_rule_dir_yaml(dir_path):
@@ -103,3 +104,12 @@ def find_rule_dirs_in_paths(base_dirs):
         for cur_dir in base_dirs:
             for d in find_rule_dirs(cur_dir):
                 yield d
+
+
+def get_rule_path_by_id(base_dir, rule_id):
+    paths = glob(f'{base_dir}/**/{rule_id}/rule.yml', recursive=True)
+    if len(paths) == 1:
+        return paths[0]
+    else:
+        # Muliple rules were found, the rule_id is not specific enough
+        return None

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ add_test(
 
 add_test(
     NAME "validate-parse-affected"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_parse_affected.py" "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/build_config.yml"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_parse_affected.py" "${CMAKE_BINARY_DIR}/build_config.yml"
 )
 
 add_test(

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -13,6 +13,7 @@ from ssg.build_cpe import ProductCPEs
 from ssg.constants import MULTI_PLATFORM_MAPPING
 from ssg.constants import FULL_NAME_TO_PRODUCT_MAPPING
 from ssg.constants import OSCAP_RULE
+from ssg.yaml import open_raw, open_environment
 from ssg_test_suite.log import LogHelper
 
 Scenario_run = namedtuple(
@@ -160,7 +161,7 @@ def _run_cmd(command_list, verbose_path, env=None):
     return returncode, output.decode('utf-8')
 
 
-def _get_platform_cpes(platform):
+def _get_platform_cpes(build_config_yaml_path, ssg_root, platform):
     if platform.startswith("multi_platform_"):
         try:
             products = MULTI_PLATFORM_MAPPING[platform]
@@ -171,7 +172,11 @@ def _get_platform_cpes(platform):
             raise ValueError
         platform_cpes = set()
         for p in products:
-            p_cpes = ProductCPEs(p)
+            # The test assumes the products are in the default path
+            product_yaml_path = os.path.join(ssg_root, p, "product.yml")
+            env_yaml = open_environment(
+                build_config_yaml_path, product_yaml_path)
+            p_cpes = ProductCPEs(env_yaml)
             platform_cpes |= set(p_cpes.get_product_cpe_names())
         return platform_cpes
     else:
@@ -183,7 +188,11 @@ def _get_platform_cpes(platform):
                 "Unknown product name: %s is not from %s"
                 % (platform, ", ".join(FULL_NAME_TO_PRODUCT_MAPPING.keys())))
             raise ValueError
-        product_cpes = ProductCPEs(product)
+        # The test assumes the products are in the default path
+        product_yaml_path = os.path.join(ssg_root, product, "product.yml")
+        env_yaml = open_environment(
+            build_config_yaml_path, product_yaml_path)
+        product_cpes = ProductCPEs(env_yaml)
         platform_cpes = set(product_cpes.get_product_cpe_names())
         return platform_cpes
 
@@ -192,8 +201,12 @@ def matches_platform(scenario_platforms, benchmark_cpes):
     if "multi_platform_all" in scenario_platforms:
         return True
     scenario_cpes = set()
+    ssg_root = \
+            os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+    build_config_yaml_path = os.path.join(ssg_root, "build", "build_config.yml")
+    build_config_yaml = open_raw(build_config_yaml_path)
     for p in scenario_platforms:
-        scenario_cpes |= _get_platform_cpes(p)
+        scenario_cpes |= _get_platform_cpes(build_config_yaml_path, ssg_root, p)
     return len(scenario_cpes & benchmark_cpes) > 0
 
 

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -22,13 +22,14 @@ def main():
     ssg.oval.parse_affected(...).
     """
 
-    if len(sys.argv) != 3:
-        print("Error! Must supply only path to root of ssg directory and the build_config.yml file path",
+    if len(sys.argv) != 2:
+        print("Error! Must supply only the build_config.yml file path",
               file=sys.stderr)
         sys.exit(1)
 
-    ssg_root = sys.argv[1]
-    ssg_build_config_yaml = sys.argv[2]
+    ssg_build_config_yaml = sys.argv[1]
+    build_config = ssg.yaml.open_raw(ssg_build_config_yaml)
+    ssg_root = build_config["ssg_root"]
 
     known_dirs = set()
     for product in ssg.constants.product_directories:

--- a/tests/unit/ssg-module/data/controls_dir/abcd.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd.yml
@@ -14,9 +14,6 @@ controls:
     - sshd_set_idle_timeout
     - accounts_tmout
     - var_accounts_tmout=10_min
-{{% if product == "rhel9" %}}
-    - cockpit_session_timeout
-{{% endif %}}
     notes: >-
       Certain period of inactivity is vague.
   - id: R2
@@ -54,3 +51,14 @@ controls:
           - accounts_password_pam_minlen
           - accounts_password_pam_ocredit
           - var_password_pam_ocredit=1
+  - id: R5
+    title: Enable FIPS mode
+    description: >-
+      FIPS mode should be enabled
+    automated: yes
+    rules:
+    -  grub2_enable_fips_mode
+    -  enable_fips_mode
+    notes: >-
+      Each system has its own way of enabling FIPS mode.
+      The selected rules are applicable to their relevant systems.


### PR DESCRIPTION
#### Description:

- When generating profiles based on the policy file, include only rules that are applicable to the product.
  i.e.: Only include rules with `prodtype` matching the `product` being built.

#### Rationale:

- The control should be useful for many products, adding a lot of product Jinja conditionals would make it hard to read.
