### PR TITLE
add info about bugfix label to release doc

### DIFF
--- a/release_tools/README.md
+++ b/release_tools/README.md
@@ -77,6 +77,9 @@ The stabilization phase is typically two weeks long. To start the stabilization:
 
 During the stabilization:
 
+- PRs containing bug fixes should be labeled with the "bugfix" label so that
+  they can be easily identified
+
 - If a bug is fixed, cherry-pick the PR from the master branch into the
   stabilization branch
 


### PR DESCRIPTION
The info about marking PRs which are desired to be cherry-picked into stabilization is only in the mail which is sent at the begining of the stabilization phase. I believe it should be in the release docs as well.