### PR TITLE
Ignore trailing whitespaces in the unique references test

### DIFF
--- a/tests/assert_reference_unique.sh
+++ b/tests/assert_reference_unique.sh
@@ -4,10 +4,10 @@ REF=$1
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 # 1. Find all references pointed by REF in all rule.yml files
-# 2. Collect the REF strings, don't care about product-qualification, and remove quotes
+# 2. Collect the REF strings, don't care about product-qualification, and remove quotes and trailing whitespaces
 # 3. Sort references
 readarray -t all_rule_files < <(find "$PROJECT_ROOT" -name rule.yml)
-all_matches=$(grep "^\s*\<${REF}\(@\w*\)\?:" "${all_rule_files[@]}" | sed -e "s/.*${REF}.*:\s*//" | tr -d "'\"" | sort)
+all_matches=$(grep "^\s*\<${REF}\(@\w*\)\?:" "${all_rule_files[@]}" | sed -e "s/.*${REF}.*:\s*//" | tr -d "'\"" | sed 's/[[:space:]]*$//' | sort)
 # 4. Get the differences
 
 readarray -t duplicated_list < <(uniq -d <<< "$all_matches")


### PR DESCRIPTION
#### Description:

- Ignore trailing whitespaces in the unique references test.

#### Rationale:

- Trailing whitespaces could mask duplicated content in the references section

- Fixes #6697

The commit f0313c0 is solely for testing purposes to check that the code works. After the PR is approved the commit will be stripped away.
