### PR TITLE
Revert "change default for allow_stricter_permissions to true"

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1371,7 +1371,7 @@ the following to `rule.yml`:
 
     -   **allow_stricter_permissions** - If set to `"true"` the OVAL
         will also consider permissions stricter than **filemode** as compliant.
-        Default value is `"true"`.
+        Default value is `"false"`.
 
 -   Languages: Ansible, Bash, OVAL
 

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -3,7 +3,7 @@ def _file_owner_groupowner_permissions_regex(data):
     if "missing_file_pass" not in data:
         data["missing_file_pass"] = False
     if "allow_stricter_permissions" not in data:
-        data["allow_stricter_permissions"] = True
+        data["allow_stricter_permissions"] = False
     if "file_regex" in data and not data["is_directory"]:
         raise ValueError(
             "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "


### PR DESCRIPTION
This reverts commit d57f4f95801c3b5a9dafa7d6bfa715f9b61f6722.

This breaks the ocp4 check `file_permissions_etcd_data_dir`