### PR TITLE
ocp4: Fix file_permissions_etcd_data_dir rule

### DIFF
--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -33,3 +33,4 @@ template:
     vars:
         filepath: /var/lib/etcd/member/
         filemode: '0700'
+        allow_stricter_permissions: "false"


### PR DESCRIPTION
This is done by setting the `allow_stricter_permissions` flag to false.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>