### PR TITLE
fix remediations of ensure_logrotate_activated

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -15,7 +15,7 @@
   lineinfile:
     create: no
     dest: "/etc/logrotate.conf"
-    regexp: "^(weekly|monthly|yearly)$"
+    regexp: '^[\s]*(weekly|monthly|yearly)$'
     state: absent
 
 - name: Configure cron.daily if not already

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
@@ -7,7 +7,7 @@ CRON_DAILY_LOGROTATE_FILE="/etc/cron.daily/logrotate"
 grep -q "^daily$" $LOGROTATE_CONF_FILE|| echo "daily" >> $LOGROTATE_CONF_FILE
 
 # remove any line configuring weekly, monthly or yearly rotation
-sed -i -r "/^(weekly|monthly|yearly)$/d" $LOGROTATE_CONF_FILE
+sed -i '/^\s*\(weekly\|monthly\|yearly\).*$/d' $LOGROTATE_CONF_FILE
 
 # configure cron.daily if not already
 if ! grep -q "^[[:space:]]*/usr/sbin/logrotate[[:alnum:][:blank:][:punct:]]*$LOGROTATE_CONF_FILE$" $CRON_DAILY_LOGROTATE_FILE; then

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # fix logrotate config
-sed -i "s/weekly/daily/" /etc/logrotate.conf
+sed -i "s/\(weekly\|monthly\|yearly\)/daily/" /etc/logrotate.conf
 
 # default for cron.daily for RHEL7 is already correct


### PR DESCRIPTION
#### Description:

- fix regexes in Bash and Ansible remediation
- fix regex in test

#### Rationale:

It turned out that regex was too strict and some occurences of "weekly / monthly / yearly" did not get removed properly.