### PR TITLE
mount_option ansible remediation - remediate when mount point is not in mounted

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/tests/no_partition.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/tests/no_partition.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/no_partition.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/tests/no_partition.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /dev/shm

--- a/shared/templates/mount_option/ansible.template
+++ b/shared/templates/mount_option/ansible.template
@@ -5,9 +5,9 @@
 # disruption = high
 
 {{% if MOUNT_HAS_TO_EXIST == "no" %}}
-   {{% set TABFILE="" %}}
+   {{% set TABFILE='' %}}
 {{% else %}}
-   {{% set TABFILE="--fstab" %}}
+   {{% set TABFILE='--fstab' %}}
 {{% endif %}}
 
 - name: Check information associated to mountpoint
@@ -26,6 +26,16 @@
     - device_name.stdout is defined and device_name.stdout_lines is defined
     - (device_name.stdout | length > 0)
 
+- name: If {{{ MOUNTPOINT }}} not mounted, craft mount_info manually
+  set_fact:
+    mount_info: '{{ mount_info|default({})|combine({item.0: item.1}) }}'
+  with_together:
+    - ["target", "source", "fstype", "options"]
+    - ["{{{ MOUNTPOINT }}}", "{{{ FILESYSTEM }}}", "{{{ TYPE }}}", "defaults"]
+  when:
+    - ("{{{ TABFILE }}}" | length == 0)
+    - (device_name.stdout | length == 0)
+
 - name: Make sure {{{ MOUNTOPTION }}} option is part of the to {{{ MOUNTPOINT }}} options
   set_fact:
     mount_info: "{{ mount_info | combine( {'options':''~mount_info.options~',{{{ MOUNTOPTION }}}' }) }}"
@@ -40,5 +50,4 @@
     state: "mounted"
     fstype: "{{ mount_info.fstype }}"
   when:
-    - device_name.stdout is defined
-    - (device_name.stdout | length > 0)
+    - (device_name.stdout is defined and (device_name.stdout | length > 0)) or ("{{{ TABFILE }}}" | length == 0)


### PR DESCRIPTION
#### Description:
Add task that crafts line for fstab if a mount point is not mounted.
Add new test scenario that tests if a remediation is able to create partition from scratch.

#### Rationale:
If a mount point is not expected to exist and it is not mounted, then ansbile remediation didn't perform any remediation. This case occurred when  `mount_has_to_exist: 'no'` (only moun_option_dev_shm_* rules).
Bash remediation doesn't require any change, its behavior is different:

Bash remediation:

1. if `mount_has_to_exist: 'yes'`, check the mount point has record in fstab - if no record, no remediation is performed
2. ensure the mount option is in fstab
3. ensure the mount point is mounted

Ansible remediation:

1. if `mount_has_to_exist: 'yes'`, check the mount point has record in fstab - if no record, other tasks are skipped
2. **if `mount_has_to_exist: 'no'`, check the mount point is mounted, if not mounted, other tasks are skipped**
3. create a variable with mount information
4. ensure the mount option is in fstab
5. ensure the mount point is mounted

PR changes ansible remediation step 2 to:
- if `mount_has_to_exist: 'no'`, check the mount point is mounted, if not mounted, craft fstab record