### PR TITLE
CIS: Fix api_server_admission_control_plugin_AlwaysAdmit value

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
@@ -41,6 +41,6 @@ template:
     filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
     yamlpath: '.data["config.yaml"]'
     values:
-    - value: 'AlwaysAdmit'
+    - value: '"enable-admission-plugins":\[[^]]*"AlwaysAdmit"'
       operation: "pattern match"
       type: "string"


### PR DESCRIPTION
"AlwaysAdmit" is part of the "enable-admission-plugins" field