### PR TITLE
Use helper function when parsing template boolean options.

### DIFF
--- a/shared/templates/auditd_lineinfile/template.py
+++ b/shared/templates/auditd_lineinfile/template.py
@@ -1,8 +1,6 @@
+from ssg.utils import parse_template_boolean_value
+
+
 def preprocess(data, lang):
-    missing_parameter_pass = data["missing_parameter_pass"]
-    if missing_parameter_pass == "true":
-        missing_parameter_pass = True
-    elif missing_parameter_pass == "false":
-        missing_parameter_pass = False
-    data["missing_parameter_pass"] = missing_parameter_pass
+    data["missing_parameter_pass"] = parse_template_boolean_value(data, parameter="missing_parameter_pass", default_value=False)
     return data

--- a/shared/templates/shell_lineinfile/template.py
+++ b/shared/templates/shell_lineinfile/template.py
@@ -1,3 +1,6 @@
+from ssg.utils import parse_template_boolean_value
+
+
 def preprocess(data, lang):
     value = data["value"]
     if value[0] in ("'", '"') and value[0] == value[-1]:
@@ -7,14 +10,8 @@ def preprocess(data, lang):
             "shell quoting is handled by the check/remediation code."
             .format(value=value, varname=data["parameter"]))
         raise Exception(msg)
-    missing_parameter_pass = data.get("missing_parameter_pass", "false")
-    if missing_parameter_pass == "true":
-        missing_parameter_pass = True
-    elif missing_parameter_pass == "false":
-        missing_parameter_pass = False
-    data["missing_parameter_pass"] = missing_parameter_pass
-    no_quotes = False
-    if data["no_quotes"] == "true":
-        no_quotes = True
-    data["no_quotes"] = no_quotes
+
+    data["missing_parameter_pass"] = parse_template_boolean_value(data, parameter="missing_parameter_pass", default_value=False)
+    data["no_quotes"] = parse_template_boolean_value(data, parameter="no_quotes", default_value=False)
+
     return data

--- a/shared/templates/sshd_lineinfile/template.py
+++ b/shared/templates/sshd_lineinfile/template.py
@@ -1,8 +1,6 @@
+from ssg.utils import parse_template_boolean_value
+
+
 def preprocess(data, lang):
-    missing_parameter_pass = data["missing_parameter_pass"]
-    if missing_parameter_pass == "true":
-        missing_parameter_pass = True
-    elif missing_parameter_pass == "false":
-        missing_parameter_pass = False
-    data["missing_parameter_pass"] = missing_parameter_pass
+    data["missing_parameter_pass"] = parse_template_boolean_value(data, parameter="missing_parameter_pass", default_value=False)
     return data

--- a/shared/templates/sudo_defaults_option/template.py
+++ b/shared/templates/sudo_defaults_option/template.py
@@ -1,26 +1,26 @@
-import ssg.utils
-import re
+from ssg.utils import parse_template_boolean_value
 
 
 def preprocess(data, lang):
     # Default value of default_is_enabled is false;
     # When variable_name is set, this option is disabled.
     # It is not easy to check if the value of an XCCDF Value is the default in a template.
-    if "default_is_enabled" not in data or "variable_name" in data:
-        data["default_is_enabled"] = "false"
+    data["default_is_enabled"] = parse_template_boolean_value(data, parameter="default_is_enabled", default_value=False)
+    if data.get("variable_name"):
+        data["default_is_enabled"] = False
 
-    if data["default_is_enabled"] == "true":
+    if data.get("default_is_enabled") is True:
         data["option_existence"] = "any_exist"
     else:
         data["option_existence"] = "at_least_one_exists"
 
     if lang == "oval":
-        if "variable_name" in data:
+        if data.get("variable_name"):
             data["option_regex"] = data["option"] + r"=(\w+)"
         else:
             data["option_regex"] = data["option"]
     elif lang == "bash":
-        if "variable_name" in data:
+        if data.get("variable_name"):
             data["option_regex"] = data["option"] + r"=\w+"
             data["option_value"] = "{opt}=${{{var}}}".format(opt=data["option"],
                                                              var=data["variable_name"])

--- a/shared/templates/yamlfile_value/template.py
+++ b/shared/templates/yamlfile_value/template.py
@@ -1,6 +1,12 @@
+from ssg.utils import parse_template_boolean_value
+
+
 def preprocess(data, lang):
 
-    if data.get("xccdf_variable") and data.get("embedded_data") == "true":
+    embedded_data = parse_template_boolean_value(data, parameter="embedded_data", default_value=False)
+    data["embedded_data"] = embedded_data
+
+    if data.get("xccdf_variable") and embedded_data:
         values = data.get("values", [{}])
         if len(values) > 1:
             raise ValueError(
@@ -13,13 +19,13 @@ def preprocess(data, lang):
                 "when querying for a 'xccdf_value' that returns an embedded value. "
                 "Rule ID: {}".format(data["_rule_id"]))
 
-    if data.get("xccdf_variable") and data.get("embedded_data") != "true":
+    if data.get("xccdf_variable") and not embedded_data:
         if data.get("values"):
             raise ValueError(
                 "You cannot specify the 'value' field when querying "
                 "for a 'xccdf_value' that doesn't return an embedded value. "
                 "Rule ID: {}".format(data["_rule_id"]))
 
-    data["embedded_data"] = data.get("embedded_data", "false") == "true"
-    data["ocp_data"] = data.get("ocp_data", "false") == "true"
+    data["ocp_data"] = parse_template_boolean_value(data, parameter="ocp_data", default_value=False)
+
     return data


### PR DESCRIPTION
#### Description:

- Use helper function (`parse_template_boolean_value`) when parsing template boolean options.

#### Rationale:

- Sanitize input using only one generic function.
