### PR TITLE
Add rules from the Policy to profiles based on prodtype (Includes DRAFT ANSSI profiles for RHCOS)

### DIFF
--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -75,7 +75,9 @@ def main():
 
     build_root = os.path.dirname(args.build_config_yaml)
 
-    logfile = "{build_root}/{product}/control_profiles.log".format(build_root=build_root, product=env_yaml["product"])
+    logfile = "{build_root}/{product}/control_profiles.log".format(
+            build_root=build_root,
+            product=env_yaml["product"])
     logging.basicConfig(filename=logfile, level=logging.INFO)
 
     if args.controls_dir:

--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -75,7 +75,8 @@ def main():
 
     build_root = os.path.dirname(args.build_config_yaml)
 
-    logging.basicConfig(filename=f"{build_root}/{env_yaml.get('product')}/control_profiles.log", level=logging.INFO)
+    logfile = "{build_root}/{product}/control_profiles.log".format(build_root=build_root, product=env_yaml["product"])
+    logging.basicConfig(filename=logfile, level=logging.INFO)
 
     if args.controls_dir:
         controls_manager = ssg.controls.ControlsManager(args.controls_dir, env_yaml)

--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import argparse
+import logging
 import sys
 import os.path
 from glob import glob
@@ -71,6 +72,10 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
     env_yaml = get_env_yaml(args.build_config_yaml, args.product_yaml)
+
+    build_root = os.path.dirname(args.build_config_yaml)
+
+    logging.basicConfig(filename=f"{build_root}/{env_yaml.get('product')}/control_profiles.log", level=logging.INFO)
 
     if args.controls_dir:
         controls_manager = ssg.controls.ControlsManager(args.controls_dir, env_yaml)

--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -125,14 +125,12 @@ controls:
     automated: yes
     rules:
     - security_patches_up_to_date
-{{% if product in ['fedora', 'ol8', 'rhel8'] %}}
     - package_dnf-automatic_installed
     - timer_dnf-automatic_enabled
     # Configure dnf-automatic to Install Available Updates Automatically
     - dnf-automatic_apply_updates
     # Configure dnf-automatic to Install Only Security Updates
     - dnf-automatic_security_updates_only
-{{% endif %}}
 
   - id: R9
     level: intermediary
@@ -750,11 +748,9 @@ controls:
     - rsyslog_remote_loghost
 
     # Derived from DAT-NT-012 R12
-{{% if product in ['fedora', 'ol8', 'rhel8'] %}}
     - package_rsyslog-gnutls_installed
     - rsyslog_remote_tls
     - rsyslog_remote_tls_cacert
-{{% endif %}}
 
     # Based on DAT-NT-012 R18
     # The rules sets the rotation frequency to daily

--- a/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: fedora,ol8,rhel8
+
 title: 'Ensure rsyslog-gnutls is installed'
 
 description: |-

--- a/rhcos4/profiles/anssi_bp28_enhanced.profile
+++ b/rhcos4/profiles/anssi_bp28_enhanced.profile
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (enhanced)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+    - anssi:all:enhanced
+    - '!selinux_state'

--- a/rhcos4/profiles/anssi_bp28_high.profile
+++ b/rhcos4/profiles/anssi_bp28_high.profile
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (high)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+    - anssi:all:high

--- a/rhcos4/profiles/anssi_bp28_intermediary.profile
+++ b/rhcos4/profiles/anssi_bp28_intermediary.profile
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (intermediary)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+  - anssi:all:intermediary

--- a/rhcos4/profiles/anssi_bp28_minimal.profile
+++ b/rhcos4/profiles/anssi_bp28_minimal.profile
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'DRAFT - ANSSI-BP-028 (minimal)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+  - anssi:all:minimal
+

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -65,7 +65,7 @@ class Control():
                     if rule.prodtype == "all" or product in rule.prodtype:
                         control.rules.append(item)
                     else:
-                        logging.info(f"Rule {item} doesn't apply to {product}")
+                        logging.info("Rule {item} doesn't apply to {product}".format(item=item, product=product))
 
         control.related_rules = control_dict.get("related_rules", [])
         control.note = control_dict.get("note")

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -3,8 +3,11 @@ import logging
 import os
 from glob import glob
 
+import ssg.build_yaml
 import ssg.yaml
 import ssg.utils
+
+from ssg.rules import get_rule_path_by_id
 
 
 class Control():
@@ -19,7 +22,7 @@ class Control():
         self.automated = ""
 
     @classmethod
-    def from_control_dict(cls, control_dict, default_level=""):
+    def from_control_dict(cls, control_dict, env_yaml=None, default_level=""):
         control = cls()
         control.id = ssg.utils.required_key(control_dict, "id")
         control.title = control_dict.get("title")
@@ -34,12 +37,34 @@ class Control():
         control.level = control_dict.get("level", default_level)
         control.notes = control_dict.get("notes", "")
         selections = control_dict.get("rules", [])
+
+        product = None
+        product_dir =  None
+        benchmark_root =  None
+        if env_yaml is not None:
+            product = env_yaml.get('product', None)
+            product_dir = env_yaml.get('product_dir', None)
+            benchmark_root = env_yaml.get('benchmark_root', None)
+            content_dir = os.path.join(product_dir, benchmark_root)
+
         for item in selections:
             if "=" in item:
                 varname, value = item.split("=", 1)
                 control.variables[varname] = value
             else:
-                control.rules.append(item)
+                # Check if rule is applicable to product, i.e.: prodtype has product id
+                if product is None:
+                    # The product was not specified, simply add the rule
+                    control.rules.append(item)
+                else:
+                    rule_yaml = get_rule_path_by_id(content_dir, item)
+                    if rule_yaml is None:
+                        # item not found in benchmark_root
+                        continue
+                    rule =  ssg.build_yaml.Rule.from_yaml(rule_yaml)
+                    if rule.prodtype == "all" or product in rule.prodtype:
+                        control.rules.append(item)
+
         control.related_rules = control_dict.get("related_rules", [])
         control.note = control_dict.get("note")
         return control
@@ -64,7 +89,7 @@ class Policy():
 
         for node in tree:
             control = Control.from_control_dict(
-                node, default_level=default_level)
+                node, self.env_yaml, default_level=default_level)
             if "controls" in node:
                 for sc in self._parse_controls_tree(node["controls"]):
                     yield sc

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -64,6 +64,8 @@ class Control():
                     rule =  ssg.build_yaml.Rule.from_yaml(rule_yaml)
                     if rule.prodtype == "all" or product in rule.prodtype:
                         control.rules.append(item)
+                    else:
+                        logging.info(f"Rule {item} doesn't apply to {product}")
 
         control.related_rules = control_dict.get("related_rules", [])
         control.note = control_dict.get("note")

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -39,9 +39,9 @@ class Control():
         selections = control_dict.get("rules", [])
 
         product = None
-        product_dir =  None
-        benchmark_root =  None
-        if env_yaml is not None:
+        product_dir = None
+        benchmark_root = None
+        if env_yaml:
             product = env_yaml.get('product', None)
             product_dir = env_yaml.get('product_dir', None)
             benchmark_root = env_yaml.get('benchmark_root', None)
@@ -61,11 +61,13 @@ class Control():
                     if rule_yaml is None:
                         # item not found in benchmark_root
                         continue
-                    rule =  ssg.build_yaml.Rule.from_yaml(rule_yaml)
+                    rule = ssg.build_yaml.Rule.from_yaml(rule_yaml)
                     if rule.prodtype == "all" or product in rule.prodtype:
                         control.rules.append(item)
                     else:
-                        logging.info("Rule {item} doesn't apply to {product}".format(item=item, product=product))
+                        logging.info("Rule {item} doesn't apply to {product}".format(
+                            item=item,
+                            product=product))
 
         control.related_rules = control_dict.get("related_rules", [])
         control.note = control_dict.get("note")

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -106,11 +106,10 @@ def find_rule_dirs_in_paths(base_dirs):
                 yield d
 
 
-def get_rule_path_by_id(base_dir, rule_id):
-    rule_path = '{base_dir}/**/{rule_id}/rule.yml'.format(base_dir=base_dir, rule_id=rule_id)
-    paths = glob(rule_path, recursive=True)
-    if len(paths) == 1:
-        return paths[0]
-    else:
-        # Muliple rules were found, the rule_id is not specific enough
-        return None
+def get_rule_path_by_id(benchmark_dir, rule_id):
+    for root, _, files in os.walk(benchmark_dir):
+        if os.path.basename(root) == rule_id:
+            for f in files:
+                if f == "rule.yml":
+                    return os.path.join(root, f)
+    return None

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -107,7 +107,8 @@ def find_rule_dirs_in_paths(base_dirs):
 
 
 def get_rule_path_by_id(base_dir, rule_id):
-    paths = glob(f'{base_dir}/**/{rule_id}/rule.yml', recursive=True)
+    rule_path = '{base_dir}/**/{rule_id}/rule.yml'.format(base_dir=base_dir, rule_id=rule_id)
+    paths = glob(rule_path, recursive=True)
     if len(paths) == 1:
         return paths[0]
     else:

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os
+from glob import glob
 
 
 def get_rule_dir_yaml(dir_path):
@@ -103,3 +104,12 @@ def find_rule_dirs_in_paths(base_dirs):
         for cur_dir in base_dirs:
             for d in find_rule_dirs(cur_dir):
                 yield d
+
+
+def get_rule_path_by_id(base_dir, rule_id):
+    paths = glob(f'{base_dir}/**/{rule_id}/rule.yml', recursive=True)
+    if len(paths) == 1:
+        return paths[0]
+    else:
+        # Muliple rules were found, the rule_id is not specific enough
+        return None

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import codecs
 import yaml
+import os
 import sys
 import re
 
@@ -153,6 +154,7 @@ def _validate_product_oval_feed_url(contents):
 def open_environment(build_config_yaml, product_yaml):
     contents = open_raw(build_config_yaml)
     contents.update(open_raw(product_yaml))
+    contents["product_dir"] = os.path.dirname(product_yaml)
     _validate_product_oval_feed_url(contents)
     platform_package_overrides = contents.get("platform_package_overrides", {})
     # Merge common platform package mappings, while keeping product specific mappings

--- a/tests/unit/ssg-module/data/controls_dir/abcd.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd.yml
@@ -14,8 +14,8 @@ controls:
     - sshd_set_idle_timeout
     - accounts_tmout
     - var_accounts_tmout=10_min
-{{% if product == "rhel9" %}}
-    - cockpit_session_timeout
+{{% if product == "rhel8" %}}
+    - configure_crypto_policy
 {{% endif %}}
     notes: >-
       Certain period of inactivity is vague.

--- a/tests/unit/ssg-module/data/controls_dir/abcd.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd.yml
@@ -14,9 +14,7 @@ controls:
     - sshd_set_idle_timeout
     - accounts_tmout
     - var_accounts_tmout=10_min
-{{% if product == "rhel8" %}}
     - configure_crypto_policy
-{{% endif %}}
     notes: >-
       Certain period of inactivity is vague.
   - id: R2

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -26,9 +26,6 @@ def test_controls_load():
     assert "var_accounts_tmout=10_min" not in c_r1.rules
     assert "var_accounts_tmout" in c_r1.variables
     assert c_r1.variables["var_accounts_tmout"] == "10_min"
-    # we haven't specified product but this rule should appear
-    # only if product is rhel8
-    assert "configure_crypto_policy" not in c_r1.rules
 
     # abcd is a level-less policy
     assert c_r1.level == "default"
@@ -108,9 +105,6 @@ def test_controls_load_product():
     assert "var_accounts_tmout=10_min" not in c_r1.rules
     assert "var_accounts_tmout" in c_r1.variables
     assert c_r1.variables["var_accounts_tmout"] == "10_min"
-    # The rule configure_crypto_policy is guarded by Jinja macro
-    # that allows it only on rhel8 product.
-    assert "configure_crypto_policy" in c_r1.rules
 
 
 def test_profile_resolution_separate():


### PR DESCRIPTION
#### Description:

- Profiles generated by the Controls will skip rules that are not applicable to the product being built
  - `test_controls.py`was adapted to account for this new behavior
- Added logging feature to make it easy to check rules that were skipped by a certain product
- Added ANSSI profiles for RHCOS4
  - Rules in the ANSSI policy without `prodtype: rhcos4` are not included but logged.

#### Rationale:

- This avoids cluttering the control file with Jinja2 conditionals.

#### Note:
- I'm aware  `get_rule_path_by_id()` is not efficient, but I don't know how to improve that without major changes.