### PR TITLE
accounts_umask_etc_* and accounts_password_pam_minclass test scenarios

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/correct.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf
+echo "minclass = 4" >> /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/line_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/wrong.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf
+echo "minclass = 0" >> /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
@@ -11,7 +11,7 @@
   <ind:textfilecontent54_object id="obj_umask_from_etc_bashrc"
   comment="Umask value from /etc/bashrc" version="1">
     <ind:filepath>/etc/bashrc</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*(?i)UMASK(?-i)[\s]+([^#\s]*)</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*umask[\s]+([^#\s]*)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/ospp_cis_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/ospp_cis_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_cis, xccdf_org.ssgproject.content_profile_ospp
+
+sed -i '/umask/d' /etc/bashrc
+echo "umask 027" >> /etc/bashrc
+umask 027

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/stig_correct.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Red Hat Enterprise Linux 8
+
+sed -i '/umask/d' /etc/bashrc
+echo "umask 077" >> /etc/bashrc
+umask 077

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/super_compliant.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/super_compliant.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/bashrc
+echo "umask 777" >> /etc/bashrc
+umask 777

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/bashrc
+echo "umask 000" >> /etc/bashrc
+umask 000

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/ospp_cis_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/ospp_cis_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_cis, xccdf_org.ssgproject.content_profile_ospp
+
+sed -i '/umask/d' /etc/profile
+echo "umask 027" >> /etc/profile
+umask 027

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/super_compliant.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/super_compliant.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/profile
+echo "umask 777" >> /etc/profile
+umask 777

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/wrong.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/profile
+echo "umask 000" >> /etc/profile
+umask 000


### PR DESCRIPTION
#### Description:
New test scenarios for `accounts_umask_etc_profile`, `accounts_umask_etc_bashrc`, and `accounts_password_pam_minclass`.

Remove case insensitiveness from `accounts_umask_etc_bashrc` check - not aware of any system where e.g. `UMASK` works.