### PR TITLE
Need to set pipefail when using shell in ansible

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -5,7 +5,9 @@
 # disruption = low
 - block:
     - name: "Find local mount points"
-      shell: df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
+      shell: |
+          set -o pipefail
+          df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
       register: local_mount_points
 
     - name: "Detect the shosts.equiv files on the system"

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
@@ -5,7 +5,9 @@
 # disruption = low
 - block:
     - name: "Find local mount points"
-      shell: df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
+      shell: |
+          set -o pipefail
+          df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
       register: local_mount_points
 
     - name: "Detect the .shosts files on the system"

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/gui_login_dod_acknowledgement/ansible/shared.yml
@@ -30,4 +30,6 @@
       fi
     insertafter: "#!/bin/sh"
     state: present
-  when: presence.changed == false and file_stat.stat.executable == true
+  when:
+    - not presence.changed | bool
+    - file_stat.stat.executable | bool

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
@@ -6,6 +6,7 @@
 
 - name: Check to see if pam_tally2.so is configured in /etc/pam.d/common-auth
   shell: |
+    set -o pipefail
     grep -e '^\s*auth\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-auth | cat
   register: check_pam_tally2_result
 
@@ -18,6 +19,7 @@
 
 - name: Check to see if 'onerr' parameter is present
   shell: |
+    set -o pipefail
     grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sonerr=.*' /etc/pam.d/common-auth | cat
   register: check_onerr_result
 
@@ -40,6 +42,7 @@
 
 - name: Check to see if 'deny' parameter is present
   shell: |
+    set -o pipefail
     grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sdeny=.*' /etc/pam.d/common-auth | cat
   register: check_deny_result
 
@@ -62,6 +65,7 @@
 
 - name: Check to see if pam_tally2.so is configured in /etc/pam.d/common-account
   shell: |
+    set -o pipefail
     grep -e '^\s*account\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-account | cat
   register: check_account_pam_tally2_result
 

--- a/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/ansible/shared.yml
@@ -14,6 +14,7 @@
 
 - name: Remove soft links in /etc/pam.d/
   shell: |
+    set -o pipefail
     target=$(readlink -f "{{ item.path }}")
     cp -p --remove-destination "$target" "{{ item.path }}"
   with_items: "{{ find_pam_soft_links_result.files }}"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -12,7 +12,8 @@
     backup: no
 
 - name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
-  shell:
+  shell: |
+    set -o pipefail
     grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs | cat
   register: check_sha_crypt_min_rounds_result
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -10,6 +10,7 @@
 
 - name: Check to see if 'pam_pkcs11' module is configured in '/etc/pam.d/common-auth'
   shell: |
+    set -o pipefail
     grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth | cat
   register: check_pam_pkcs11_module_result
   when: '"pam_pkcs11" in ansible_facts.packages'

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
@@ -11,6 +11,7 @@
 
 - name: lock the password of the user accounts other than root with uid 0
   shell: |
+    set -o pipefail
     passwd -l {{ item.key }}
   loop: "{{ getent_passwd | dict2items | rejectattr('key', 'search', 'root') | list }}"
   when: item.value.1  == '0'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -5,7 +5,9 @@
 # disruption = low
 
 - name: Search for privileged commands
-  shell: find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null
+  shell: |
+    set -o pipefail
+    find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null
   args:
     warn: False
     executable: /bin/bash

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -6,6 +6,7 @@
 
 - name: Get all world-writable directories with no sticky bits set
   shell: |
+    set -o pipefail
     df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type d \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null
   register: dir_output
 

--- a/linux_os/guide/system/permissions/permissions_local/file_permissions_var_log_messages/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/permissions_local/file_permissions_var_log_messages/ansible/shared.yml
@@ -8,5 +8,6 @@
 
 - name: "Correct file permissions after update /etc/permissions.local"
   shell: >
+    set -o pipefail
     chkstat --set --system
   when: update_permissions_local_result.changed

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
@@ -4,4 +4,6 @@
 # complexity = low
 # disruption = medium
 - name: "Run dconf update"
-  shell: dconf update
+  shell: |
+    set -o pipefail
+    dconf update

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -10,6 +10,7 @@
 
 - name: get rules groups
   shell: |
+    set -o pipefail
     LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -10,6 +10,7 @@
 
 - name: get rules groups
   shell: |
+    set -o pipefail
     LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -4,7 +4,9 @@
 # complexity = low
 # disruption = medium
 - name: Grep for {{{ pkg_manager }}} repo section names
-  shell: grep -HEr '^\[.+\]' -r /etc/yum.repos.d/
+  shell: |
+    set -o pipefail
+    grep -HEr '^\[.+\]' -r /etc/yum.repos.d/
   register: repo_grep_results
   ignore_errors: True
   changed_when: False

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -24,6 +24,7 @@
 
 - name: Check to see if '{{{ MODULE }}}' module is configured in '{{{ PATH }}}'
   shell: |
+    set -o pipefail
     grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} | cat
   register: check_pam_module_result
 
@@ -65,6 +66,7 @@
 
 - name: Check the presence of "{{{ arg['variable'] }}}" argument in "{{{ MODULE }}}" module
   shell: |
+    set -o pipefail
     grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} | cat
   register: check_pam_module_argument_result
 
@@ -90,6 +92,7 @@
 
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
   shell: |
+    set -o pipefail
     grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} | cat
   register: check_pam_module_argument_result
 


### PR DESCRIPTION
Upstream ansible lint tests require pipefail when using shell
in ansible.

#### Description:

- fix ansible-lint pipefail check failures
- Added set pipefail where possible
- Added #noqa 306 in cases were grep was used
#### Rationale:

- no ansible link failures

