### PR TITLE
ocp4/moderate: Add e2e tests for rules that pass by default

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/package_audit_installed/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/package_audit_installed/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/auditing/service_auditd_enabled/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/selinux/selinux_policytype/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/selinux/selinux_policytype/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/selinux/selinux_state/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/selinux/selinux_state/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
This ensures that we don't regress on these rules, or that we're able to
accurately detect when they do.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>