### PR TITLE
ocp4/etcd: Fix rule checks for 4.8

### DIFF
--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -5,11 +5,14 @@ prodtype: ocp4
 title: 'Ensure That The etcd Client Certificate Is Correctly Set'
 
 description: |-
-    To ensure the <tt>etcd</tt> service is serving TLS to clients,
-    make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
+    To ensure the etcd service is serving TLS to clients,
+    make sure the <tt>etcd-pod*</tt> ConfigMaps in the
     <tt>openshift-etcd</tt> namespace contain the following argument
     for the <tt>etcd</tt> binary in the <tt>etcd</tt> pod:
-    <pre>--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt</pre>
+    <pre>--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.crt</pre>.
+
+    Note that the <pre>[a-z]+</pre> is being used since the directory might
+    change between OpenShift versions.
 
 rationale: |-
     Without cryptographic integrity protections, information can be
@@ -27,7 +30,7 @@ ocil_clause: 'the etcd client certificate is not configured'
 
 ocil: |-
     Run the following command:
-    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt"</pre>
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep -E "\-\-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.crt"</pre>
     Verify that there is a certificate configured.
 
 warnings:
@@ -41,5 +44,5 @@ template:
         filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
         yamlpath: ".data['pod.yaml']"
         values:
-          - value: ".*--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.crt \\.*"
+          - value: ".*--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.crt \\.*"
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -5,11 +5,14 @@ prodtype: ocp4
 title: 'Ensure That The etcd Key File Is Correctly Set'
 
 description: |-
-    To ensure the <tt>etcd</tt> service is serving TLS to clients,
-    make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
+    To ensure the etcd service is serving TLS to clients,
+    make sure the <tt>etcd-pod*</tt> ConfigMaps in the
     <tt>openshift-etcd</tt> namespace contain the following argument
     for the <tt>etcd</tt> binary in the <tt>etcd</tt> pod:
-    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key"</pre>
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.key"</pre>.
+
+    Note that the <pre>[a-z]+</pre> is being used since the directory might
+    change between OpenShift versions.
 
 rationale: |-
     Without cryptographic integrity protections, information can be
@@ -27,7 +30,7 @@ ocil_clause: 'the etcd client key file is not configured'
 
 ocil: |-
     Run the following command:
-    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key"</pre>
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.key"</pre>
     Verify that there is a private key configured.
 
 warnings:
@@ -41,5 +44,5 @@ template:
         filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
         yamlpath: ".data['pod.yaml']"
         values:
-          - value: ".*--key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-serving/etcd-serving-NODE_NAME.key \\.*"
+          - value: ".*--key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.key \\.*"
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
@@ -5,11 +5,14 @@ prodtype: ocp4
 title: 'Ensure That The etcd Peer Client Certificate Is Correctly Set'
 
 description: |-
-    To ensure the <tt>etcd</tt> service is serving TLS to peers,
-    make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
+    To ensure the etcd service is serving TLS to peers,
+    make sure the <tt>etcd-pod*</tt> ConfigMaps in the
     <tt>openshift-etcd</tt> namespace contain the following argument
     for the <tt>etcd</tt> binary in the <tt>etcd</tt> pod:
-    <pre>--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt</pre>
+    <pre>--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.crt</pre>
+
+    Note that the <pre>[a-z]+</pre> is being used since the directory might
+    change between OpenShift versions.
 
 rationale: |-
     Without cryptographic integrity protections, information can be
@@ -28,7 +31,7 @@ ocil_clause: 'the etcd peer client certificate is not configured'
 
 ocil: |-
     Run the following command:
-    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt"</pre>
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.crt"</pre>
     Verify that there is a certificate configured.
 
 warnings:
@@ -42,5 +45,5 @@ template:
         filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
         yamlpath: ".data['pod.yaml']"
         values:
-          - value: ".*--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.crt \\.*"
+          - value: ".*--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.crt \\.*"
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_peer_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/rule.yml
@@ -5,11 +5,14 @@ prodtype: ocp4
 title: 'Ensure That The etcd Peer Key File Is Correctly Set'
 
 description: |-
-    To ensure the <tt>etcd</tt> service is serving TLS to peers,
-    make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
+    To ensure the etcd service is serving TLS to peers,
+    make sure the <tt>etcd-pod*</tt> ConfigMaps in the
     <tt>openshift-etcd</tt> namespace contain the following argument
     for the <tt>etcd</tt> binary in the <tt>etcd</tt> pod:
-    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key"</pre>
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.key"</pre>
+
+    Note that the <pre>[a-z]+</pre> is being used since the directory might
+    change between OpenShift versions.
 
 rationale: |-
     Without cryptographic integrity protections, information can be
@@ -28,7 +31,7 @@ ocil_clause: 'the etcd peer client key file is not configured'
 
 ocil: |-
     Run the following command:
-    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key"</pre>
+    <pre>oc get -nopenshift-etcd cm etcd-pod -oyaml | grep "\-\-peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.key"</pre>
     Verify that there is a private key configured.
 
 warnings:
@@ -42,5 +45,5 @@ template:
         filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
         yamlpath: ".data['pod.yaml']"
         values:
-          - value: ".*--peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-peer/etcd-peer-NODE_NAME.key \\.*"
+          - value: ".*--peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.key \\.*"
             operation: "pattern match"


### PR DESCRIPTION
From 4.7 to 4.8 the directory with the etcd certificate/keys changed. So
an update to the rules is needed in order for us to cater for the
changes and still have these checks applicable in order versions.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>