### PR TITLE
Add rule for checking selinux is not disabled in coreos

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1268,6 +1268,21 @@ the following to `rule.yml`:
 
 -   Languages: OVAL
 
+#### coreos_kernel_option
+-   Checks that `argument=value` pair is present in the kernel arguments.
+    Note that this applies to Red Hat CoreOS.
+
+-   Parameters:
+
+    -   **arg_name** - Argument name, eg. `audit`
+
+    -   **arg_value** - Argument value, eg. `'1'`
+
+    -   **negate** - negates the check, which then ensures that
+        `argument=value` is not present in the kernel arguments.
+
+-   Languages: OVAL, Kubernetes
+
 #### dconf_ini_file
 -   Checks for `dconf` configuration. Additionally checks if the
     configuration is locked so it cannot be overriden by the user.

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1278,7 +1278,7 @@ the following to `rule.yml`:
 
     -   **arg_value** - Argument value, eg. `'1'`
 
-    -   **negate** - negates the check, which then ensures that
+    -   **arg_negate** - negates the check, which then ensures that
         `argument=value` is not present in the kernel arguments.
 
 -   Languages: OVAL, Kubernetes

--- a/linux_os/guide/system/selinux/coreos_enable_selinux_kernel_argument/rule.yml
+++ b/linux_os/guide/system/selinux/coreos_enable_selinux_kernel_argument/rule.yml
@@ -1,0 +1,53 @@
+documentation_complete: true
+
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+
+title: 'Ensure SELinux Not Disabled in the kernel arguments'
+
+description: |-
+    SELinux can be disabled at boot time by disabling it via a kernel argument.
+    Remove any instances of <tt>selinux=0</tt> from the kernel arguments in that
+    file to prevent SELinux from being disabled at boot.
+
+rationale: |-
+    Disabling a major host protection feature, such as SELinux, at boot time prevents
+    it from confining system services at boot time.  Further, it increases
+    the chances that it will remain off during system operation.
+
+severity: medium
+
+identifiers:
+    cce@rhcos4: CCE-83899-5
+
+references:
+    cui: 3.1.2,3.7.2
+    disa: CCI-000022,CCI-000032
+    hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3),164.308(a)(4),164.310(b),164.310(c),164.312(a),164.312(e)
+    nist: AC-3,AC-3(3)(a)
+    nist-csf: DE.AE-1,ID.AM-3,PR.AC-4,PR.AC-5,PR.AC-6,PR.DS-5,PR.PT-1,PR.PT-3,PR.PT-4
+    vmmsrg: SRG-OS-000445-VMM-001780
+    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.10,SR 2.11,SR 2.12,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7,SR 2.8,SR 2.9,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 7.1,SR 7.6'
+    isa-62443-2009: 4.2.3.4,4.3.3.2.2,4.3.3.3.9,4.3.3.4,4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4,4.4.3.3
+    cobit5: APO01.06,APO11.04,APO13.01,BAI03.05,DSS01.05,DSS03.01,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.02,DSS06.03,DSS06.06,MEA02.01
+    iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.12.1.1,A.12.1.2,A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.7.1,A.13.1.1,A.13.1.2,A.13.1.3,A.13.2.1,A.13.2.2,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.1,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
+    cis-csc: 1,11,12,13,14,15,16,18,3,4,5,6,8,9
+
+ocil_clause: 'SELinux is disabled at boot time'
+
+ocil: |-
+    Inspect <tt>/proc/cmdline</tt> for any instances of <tt>selinux=0</tt>
+    in the kernel boot arguments.  Presence of <tt>selinux=0</tt> indicates
+    that SELinux is disabled at boot time.
+
+    If it would be disabled anywhere, make sure to enable it via a
+    <tt>MachineConfig</tt> object.
+
+template:
+    name: coreos_kernel_option
+    vars:
+        arg_name: selinux
+        arg_value: '0'
+        arg_negate: 'true'
+    backends:
+        kubernetes: "off"
+

--- a/linux_os/guide/system/selinux/coreos_enable_selinux_kernel_argument/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/selinux/coreos_enable_selinux_kernel_argument/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -540,7 +540,7 @@ selections:
     - sshd_limit_user_access
     - sshd_disable_rhosts
     #- xwindows_runlevel_target
-    - grub2_enable_selinux
+    - coreos_enable_selinux_kernel_argument
     #- require_emergency_target_auth
     - no_netrc_files
 

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -275,11 +275,12 @@
     - name (String): Argument name
     - value (String): Argument value
     - application (String): The application which the configuration file is being checked. Can be any value and does not affect the actual OVAL check.
+    - negate (Boolean): Whether to negate this criterion or not
 #}}
-{{%- macro oval_argument_value_in_line_criterion(filepath, name, value, application='') -%}}
+{{%- macro oval_argument_value_in_line_criterion(filepath, name, value, application='', negate=False) -%}}
 {{%- set name_value = name+"="+value -%}}
-  <criterion comment="Check if argument {{{ name_value }}}{{% if application %}} for {{{ application }}}{{% endif %}} is present in {{{ filepath }}}" 
-  test_ref="test_{{{ rule_id }}}_{{{ name_value|escape_id }}}_argument_in_{{{ filepath|escape_id }}}"/>
+  <criterion comment="Check if argument {{{ name_value }}}{{% if application %}} for {{{ application }}}{{% endif %}} is {{% if negate %}}not {{% endif %}}present in {{{ filepath }}}" 
+  test_ref="test_{{{ rule_id }}}_{{{ name_value|escape_id }}}_argument_in_{{{ filepath|escape_id }}}" {{% if negate %}}negate="true" {{% endif %}}/>
 {{%- endmacro -%}}
 
 {{#

--- a/shared/templates/coreos_kernel_option/kubernetes.template
+++ b/shared/templates/coreos_kernel_option/kubernetes.template
@@ -12,4 +12,3 @@ spec:
       version: 3.1.0
   kernelArguments:
     - {{{ ARG_NAME }}}={{{ ARG_VALUE }}}
-

--- a/shared/templates/coreos_kernel_option/oval.template
+++ b/shared/templates/coreos_kernel_option/oval.template
@@ -1,18 +1,23 @@
+{{% if ARG_NEGATE %}}
+{{% set negate_string = "not " %}}
+{{%- else %}}
+{{% set negate_string = "" %}}
+{{%- endif %}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
-    {{{ oval_metadata("Ensure " + ARG_NAME + "=" + ARG_VALUE +" argument is present in the 'options' line of /boot/loader/entries/ostree-2-*.conf (or ostree-1-*.conf if there is no ostree-2-*.conf as ostree has only two enries at the most, with *-2-*.conf entry always being the most recent). Also, ensure that kernel is currently running with this argument by checking /proc/cmdline.") }}}
+    {{{ oval_metadata("Ensure " + ARG_NAME + "=" + ARG_VALUE +" argument is " + negate_string + "present in the 'options' line of /boot/loader/entries/ostree-2-*.conf (or ostree-1-*.conf if there is no ostree-2-*.conf as ostree has only two enries at the most, with *-2-*.conf entry always being the most recent). Also, ensure that kernel is currently running with this argument by checking /proc/cmdline.") }}}
     <criteria operator="AND">
       <criteria operator="OR">
         <criteria operator="AND">
             {{{- oval_file_absent_criterion('/boot/loader/entries/ostree-2-.*.conf')}}}
-            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-1-.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel') }}}
+            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-1-.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel', negate=ARG_NEGATE) }}}
         </criteria>
         <criteria operator="AND">
-            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-2-.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel') }}}
+            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-2-.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel', negate=ARG_NEGATE) }}}
         </criteria>
       </criteria>
       <criteria operator="AND">
-        {{{- oval_argument_value_in_line_criterion('/proc/cmdline', ARG_NAME, ARG_VALUE, 'Linux kernel') }}}
+        {{{- oval_argument_value_in_line_criterion('/proc/cmdline', ARG_NAME, ARG_VALUE, 'Linux kernel', negate=ARG_NEGATE) }}}
       </criteria>
     </criteria>
   </definition>

--- a/shared/templates/coreos_kernel_option/template.py
+++ b/shared/templates/coreos_kernel_option/template.py
@@ -1,0 +1,6 @@
+from ssg.utils import parse_template_boolean_value
+
+
+def preprocess(data, lang):
+    data["arg_negate"] = parse_template_boolean_value(data, parameter="arg_negate", default_value=False)
+    return data


### PR DESCRIPTION
This also enables the `oval_argument_value_in_line_criterion` template
to be negated and it adds to the `coreos_kernel_option` OVAL template as well.