### PR TITLE
Add tests for no files unowned by user/group rules

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -8,7 +8,12 @@ description: |-
     If any files are not owned by a group, then the
     cause of their lack of group-ownership should be investigated.
     Following this, the files should be deleted or assigned to an
-    appropriate group.
+    appropriate group. The following command will discover and print
+    any files on local partitions which do not belong to a valid group:
+    <pre>$ df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -nogroup</pre>
+    To search all filesystems on a system including network mounted
+    filesystems the following command can be run manually for each partition:
+    <pre>$ sudo find PARTITION -xdev -nogroup</pre>
 
 rationale: |-
     Unowned files do not directly imply a security problem, but they are generally
@@ -51,7 +56,7 @@ ocil_clause: 'there is output'
 ocil: |-
     The following command will discover and print any
     files on local partitions which do not belong to a valid group.
-    <pre>$ sudo find / -xdev -fstype local -nogroup</pre>
+    <pre>$ df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -nogroup</pre>
     <br />
     Either remove all files and directories from the system that do not have a valid group,
     or assign a valid group with the chgrp command:

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/all_owned.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/all_owned.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_file.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_file.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# remediation = none
+
+touch /root/test
+chown 9999:9999 /root/test

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -8,7 +8,12 @@ description: |-
     If any files are not owned by a user, then the
     cause of their lack of ownership should be investigated.
     Following this, the files should be deleted or assigned to an
-    appropriate user.
+    appropriate user. The following command will discover and print
+    any files on local partitions which do not belong to a valid user:
+    <pre>$ df --local -P | awk {'if (NR!=1) print $6'} | sudo xargs -I '{}' find '{}' -xdev -nouser</pre>
+    To search all filesystems on a system including network mounted
+    filesystems the following command can be run manually for each partition:
+    <pre>$ sudo find PARTITION -xdev -nouser</pre>
 
 rationale: |-
     Unowned files do not directly imply a security problem, but they are generally
@@ -51,7 +56,7 @@ ocil_clause: 'files exist that are not owned by a valid user'
 ocil: |-
     The following command will discover and print any
     files on local partitions which do not belong to a valid user.
-    <pre>$ sudo find / -xdev -fstype local -nouser</pre>
+    <pre>$ df --local -P | awk {'if (NR!=1) print $6'} | sudo xargs -I '{}' find '{}' -xdev -nouser</pre>
     <br /><br />
     Either remove all files and directories from the system that do not have a
     valid user, or assign a valid user to all unowned files and directories on

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/all_owned.pass.sh
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/all_owned.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/unowned_file.fail.sh
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/unowned_file.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# remediation = none
+
+touch /root/test
+chown 9999:9999 /root/test


### PR DESCRIPTION
#### Description:

- Add tests for rule `no_files_unowned_by_user`.
- Add tests for rule `file_permissions_ungroupowned`.
- Update descriptions of these rules as the `-fstype local` is not supported in the GNU find, see: https://www.gnu.org/software/findutils/manual/html_node/find_html/Filesystems.html#Filesystems
