### PR TITLE
Switch to generic python shebang

### DIFF
--- a/build-scripts/add_stig_references.py
+++ b/build-scripts/add_stig_references.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/build_all_guides.py
+++ b/build-scripts/build_all_guides.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/build_profile_remediations.py
+++ b/build-scripts/build_profile_remediations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/build_templated_content.py
+++ b/build-scripts/build_templated_content.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/combine_ovals.py
+++ b/build-scripts/combine_ovals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import os
 import os.path

--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/generate_bash_remediation_functions.py
+++ b/build-scripts/generate_bash_remediation_functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os

--- a/build-scripts/generate_fixes_xml.py
+++ b/build-scripts/generate_fixes_xml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os

--- a/build-scripts/oscap_svg_support.py
+++ b/build-scripts/oscap_svg_support.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import tempfile
 import sys

--- a/build-scripts/relabel_ids.py
+++ b/build-scripts/relabel_ids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/sds_move_ocil_to_checks.py
+++ b/build-scripts/sds_move_ocil_to_checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # OpenSCAP as of version 1.2.8 doesn't support OCIL check system yet. For
 # example attempt to build rhel7 SSG benchmark produces the following error:

--- a/build-scripts/unselect_empty_xccdf_groups.py
+++ b/build-scripts/unselect_empty_xccdf_groups.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 Takes given *resolved* XCCDF, goes through every profile. For every profile,

--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/shared/transforms/pcidss/generate_pcidss_json.py
+++ b/shared/transforms/pcidss/generate_pcidss_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright 2016 Red Hat Inc., Durham, North Carolina.
 #

--- a/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
+++ b/shared/transforms/pcidss/transform_benchmark_to_pcidss.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright 2016 Red Hat Inc., Durham, North Carolina.
 #

--- a/tests/ensure_paths_are_short.py
+++ b/tests/ensure_paths_are_short.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function
 

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import argparse
 import os

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 
 import logging

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 
 import logging

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 
 import logging

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 
 import libvirt

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import xml.etree.cElementTree as ET
 
 import logging

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 
 import argparse

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function

--- a/utils/count_oval_objects.py
+++ b/utils/count_oval_objects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 '''
 count_oval_objects.py

--- a/utils/find_duplicates.py
+++ b/utils/find_duplicates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
     This script should find duplicates e.g. specific template is same as shared one
 """

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os

--- a/utils/generate_contributors.py
+++ b/utils/generate_contributors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import os.path
 import codecs

--- a/utils/testoval.py
+++ b/utils/testoval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import sys
 import os

--- a/utils/xccdf2csv-stig.py
+++ b/utils/xccdf2csv-stig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 This script creates a CSV file from an XCCDF file formatted in the


### PR DESCRIPTION
This should let us autodetect whichever python version is default on a
given platform. As long as we continue to maintain python2/python3
compatibility, this should be fine.

Resolves: #6729

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`
