### PR TITLE
Updated no_rsh_trust_files rule and added tests

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/ansible/shared.yml
@@ -4,17 +4,24 @@
 # complexity = low
 # disruption = low
 - block:
-    - name: "Detect shosts.equiv Files on the System"
+    - name: "Detect .rhosts files in users home directories"
       find:
-          paths: /
+          paths: ["/root","/home"]
           recurse: yes
-          patterns: shosts.equiv
+          patterns: .rhosts
+          hidden: yes
+          file_type: file
       check_mode: no
-      register: shosts_equiv_locations
+      register: rhosts_locations
 
-    - name: "Remove Rsh Trust Files"
+    - name: "Remove .rhosts files"
       file:
-          path: "{{ item.path }}"
+          path: "{{ item }}"
           state: absent
-      with_items: "{{ shosts_equiv_locations.files }}"
-      when: shosts_equiv_locations
+      with_items: "{{ rhosts_locations.files | map(attribute='path') | list }}"
+      when: rhosts_locations is success
+
+    - name: "Remove /etc/hosts.equiv file"
+      file:
+          path: /etc/hosts.equiv
+          state: absent

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/bash/shared.sh
@@ -1,6 +1,5 @@
 # platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
-find /home -maxdepth 2 -type f -name .rhosts -exec rm -f '{}' \;
 
-if [ -f /etc/hosts.equiv ]; then
-	/bin/rm -f /etc/hosts.equiv
-fi
+find /root -xdev -type f -name ".rhosts" -exec rm -f {} \;
+find /home -maxdepth 2 -xdev -type f -name ".rhosts" -exec rm -f {} \;
+rm -f /etc/hosts.equiv

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/oval/shared.xml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/oval/shared.xml
@@ -7,26 +7,26 @@
       <criterion test_ref="test_no_rsh_trust_files_etc" negate="true" />
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for .rhosts or .shosts in /root" id="test_no_rsh_trust_files_root" version="1">
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for .rhosts in /root" id="test_no_rsh_trust_files_root" version="1">
     <unix:object object_ref="object_no_rsh_trust_files_root" />
   </unix:file_test>
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for .rhosts or .shosts in /home" id="test_no_rsh_trust_files_home" version="1">
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for .rhosts in /home" id="test_no_rsh_trust_files_home" version="1">
     <unix:object object_ref="object_no_rsh_trust_files_home" />
   </unix:file_test>
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for /etc/hosts.equiv or /etc/shosts.equiv" id="test_no_rsh_trust_files_etc" version="1">
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="look for /etc/hosts.equiv" id="test_no_rsh_trust_files_etc" version="1">
     <unix:object object_ref="object_no_rsh_trust_files_etc" />
   </unix:file_test>
-  <unix:file_object comment="look for .rhosts or .shosts in /root" id="object_no_rsh_trust_files_root" version="1">
+  <unix:file_object comment="look for .rhosts in /root" id="object_no_rsh_trust_files_root" version="1">
     <unix:path operation="equals">/root</unix:path>
-    <unix:filename operation="pattern match">^\.(r|s)hosts$</unix:filename>
+    <unix:filename operation="pattern match">^\.rhosts$</unix:filename>
   </unix:file_object>
-  <unix:file_object comment="look for .rhosts or .shosts in /home" id="object_no_rsh_trust_files_home" version="1">
+  <unix:file_object comment="look for .rhosts in /home" id="object_no_rsh_trust_files_home" version="1">
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="1" recurse_file_system="all" />
     <unix:path operation="equals">/home</unix:path>
-    <unix:filename operation="pattern match">^\.(r|s)hosts$</unix:filename>
+    <unix:filename operation="pattern match">^\.rhosts$</unix:filename>
   </unix:file_object>
-  <unix:file_object comment="look for /etc/hosts.equiv or /etc/shosts.equiv" id="object_no_rsh_trust_files_etc" version="1">
+  <unix:file_object comment="look for /etc/hosts.equiv" id="object_no_rsh_trust_files_etc" version="1">
     <unix:path operation="equals">/etc</unix:path>
-    <unix:filename operation="pattern match">^s?hosts\.equiv$</unix:filename>
+    <unix:filename operation="pattern match">^hosts\.equiv$</unix:filename>
   </unix:file_object>
 </def-group>

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/hosts_etc.fail.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/hosts_etc.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. shared.sh
+remove_hosts_files
+
+touch /etc/hosts.equiv

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/no_rhosts.pass.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/no_rhosts.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+. shared.sh
+remove_hosts_files

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/rhosts_home.fail.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/rhosts_home.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. shared.sh
+remove_hosts_files
+
+touch /home/.rhosts

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/rhosts_root.fail.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/rhosts_root.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. shared.sh
+remove_hosts_files
+
+touch /root/.rhosts

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/tests/shared.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+function remove_hosts_files() {
+	find /root -xdev -type f -name ".rhosts" -exec rm -f {} \;
+	find /home -maxdepth 2 -xdev -type f -name ".rhosts" -exec rm -f {} \;
+	rm -f /etc/hosts.equiv
+}


### PR DESCRIPTION
This rule should cover only rhosts files. The OVAL has
been updated to not search for shosts files which are
handled by different rules:
* `no_host_based_files`
* `no_user_host_based_files`  

Both Bash and Ansible remediations have been aligned
with the OVAL check and new tests have been added.