### PR TITLE
Add package_* test scenarios

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y openldap-clients

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y openldap-clients

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/tests/removed.pass.sh
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y openldap-clients

--- a/linux_os/guide/services/ntp/package_chrony_installed/tests/installed.pass.sh
+++ b/linux_os/guide/services/ntp/package_chrony_installed/tests/installed.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y chrony

--- a/linux_os/guide/services/ntp/package_chrony_installed/tests/installed.pass.sh
+++ b/linux_os/guide/services/ntp/package_chrony_installed/tests/installed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y chrony

--- a/linux_os/guide/services/ntp/package_chrony_installed/tests/removed.fail.sh
+++ b/linux_os/guide/services/ntp/package_chrony_installed/tests/removed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y chrony

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y xinetd

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y xinetd

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/tests/removed.pass.sh
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y xinetd

--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y ypbind

--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y ypbind

--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/tests/removed.pass.sh
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y ypbind

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y telnet

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y telnet

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/tests/removed.pass.sh
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y telnet

--- a/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y squid

--- a/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y squid

--- a/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/tests/removed.pass.sh
+++ b/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y squid

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y xorg-x11-server-common

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/tests/installed.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y xorg-x11-server-common

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/tests/removed.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y xorg-x11-server-common

--- a/linux_os/guide/system/auditing/package_audit_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/auditing/package_audit_installed/tests/installed.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y audit

--- a/linux_os/guide/system/auditing/package_audit_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/auditing/package_audit_installed/tests/installed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y audit

--- a/linux_os/guide/system/auditing/package_audit_installed/tests/removed.fail.sh
+++ b/linux_os/guide/system/auditing/package_audit_installed/tests/removed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y audit

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/tests/installed.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y firewalld

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/tests/installed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y firewalld

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/tests/removed.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/tests/removed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y firewalld

--- a/linux_os/guide/system/selinux/package_libselinux_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/tests/installed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y libselinux

--- a/linux_os/guide/system/selinux/package_libselinux_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/tests/installed.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y libselinux

--- a/linux_os/guide/system/selinux/package_mcstrans_removed/tests/installed.fail.sh
+++ b/linux_os/guide/system/selinux/package_mcstrans_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y mcstrans

--- a/linux_os/guide/system/selinux/package_mcstrans_removed/tests/installed.fail.sh
+++ b/linux_os/guide/system/selinux/package_mcstrans_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y mcstrans

--- a/linux_os/guide/system/selinux/package_mcstrans_removed/tests/removed.pass.sh
+++ b/linux_os/guide/system/selinux/package_mcstrans_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y mcstrans

--- a/linux_os/guide/system/selinux/package_setroubleshoot_removed/tests/installed.fail.sh
+++ b/linux_os/guide/system/selinux/package_setroubleshoot_removed/tests/installed.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y setroubleshoot

--- a/linux_os/guide/system/selinux/package_setroubleshoot_removed/tests/installed.fail.sh
+++ b/linux_os/guide/system/selinux/package_setroubleshoot_removed/tests/installed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y setroubleshoot

--- a/linux_os/guide/system/selinux/package_setroubleshoot_removed/tests/removed.pass.sh
+++ b/linux_os/guide/system/selinux/package_setroubleshoot_removed/tests/removed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum remove -y setroubleshoot

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/installed.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yum install -y sudo

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/installed.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# package = yum
 
 yum install -y sudo

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/removed.fail.sh
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/removed.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rpm -e --nodeps sudo


### PR DESCRIPTION
#### Description:
Add test scenarios to `package_*_installed` and to `package_*_removed` rules from CIS profile.

Each rule has test scenario for installation and test scenario for removal of the package except `libselinux`. The `libselinux` package has only installation test scenario because after removal of the package, the system becomes unusable - commands start to print `libselinux.so.1: cannot open shared object file: No such file or directory` (libselinux is dependency of several core packages, e.g. systemd).
