### PR TITLE
Reorganize env and product yaml

### DIFF
--- a/build-scripts/build_templated_content.py
+++ b/build-scripts/build_templated_content.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import os
 import argparse
 
-import ssg.yaml
+import ssg.environment
 import ssg.templates
 
 
@@ -48,7 +48,7 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
-    env_yaml = ssg.yaml.open_environment(
+    env_yaml = ssg.environment.open_environment(
         args.build_config_yaml, args.product_yaml)
     builder = ssg.templates.Builder(
         env_yaml, args.resolved_rules_dir, args.templates_dir,

--- a/build-scripts/combine_ovals.py
+++ b/build-scripts/combine_ovals.py
@@ -13,7 +13,7 @@ import ssg.build_ovals
 import ssg.constants
 import ssg.utils
 import ssg.xml
-import ssg.yaml
+import ssg.environment
 
 
 def parse_args():
@@ -45,7 +45,7 @@ def main():
 
     oval_ns = ssg.constants.oval_namespace
     footer = ssg.constants.oval_footer
-    env_yaml = ssg.yaml.open_environment(
+    env_yaml = ssg.environment.open_environment(
         args.build_config_yaml, args.product_yaml)
 
     header = ssg.xml.oval_generated_header(

--- a/build-scripts/combine_remediations.py
+++ b/build-scripts/combine_remediations.py
@@ -11,7 +11,7 @@ import codecs
 import ssg.build_remediations as remediation
 import ssg.rules
 import ssg.jinja
-import ssg.yaml
+import ssg.environment
 import ssg.utils
 import ssg.xml
 
@@ -49,7 +49,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    env_yaml = ssg.yaml.open_environment(
+    env_yaml = ssg.environment.open_environment(
         args.build_config_yaml, args.product_yaml)
 
     product = ssg.utils.required_key(env_yaml, "product")

--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -54,7 +54,7 @@ def get_env_yaml(build_config_yaml, product_yaml):
     if build_config_yaml is None or product_yaml is None:
         return None
 
-    env_yaml = ssg.yaml.open_environment(build_config_yaml, product_yaml)
+    env_yaml = ssg.environment.open_environment(build_config_yaml, product_yaml)
     return env_yaml
 
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -112,7 +112,7 @@ def main():
     translator = ssg.id_translate.IDTranslator(args.idname)
     ovaltree = translator.translate(ovaltree)
 
-    product_yaml = ssg.products.get_product_yaml(args.product_yaml)
+    product_yaml = ssg.products.load_product_yaml(args.product_yaml)
     product = product_yaml["product"]
     newovalfile = args.idname + "-" + product + "-" + os.path.basename(args.ovalfile)
     newovalfile = newovalfile.replace("oval-unlinked", "cpe-oval")

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -7,7 +7,6 @@ import os
 import os.path
 import sys
 
-import ssg.build_cpe
 import ssg.build_yaml
 import ssg.utils
 import ssg.environment
@@ -75,8 +74,7 @@ def main():
         p.validate_rules(loader.all_rules, loader.all_groups)
         p.validate_refine_rules(loader.all_rules)
 
-    product_cpes = ssg.build_cpe.ProductCPEs(env_yaml)
-    loader.export_group_to_file(args.output, product_cpes)
+    loader.export_group_to_file(args.output)
 
 
 if __name__ == "__main__":

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -10,7 +10,7 @@ import sys
 import ssg.build_cpe
 import ssg.build_yaml
 import ssg.utils
-import ssg.yaml
+import ssg.environment
 
 
 def parse_args():
@@ -45,7 +45,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    env_yaml = ssg.yaml.open_environment(
+    env_yaml = ssg.environment.open_environment(
         args.build_config_yaml, args.product_yaml)
     base_dir = os.path.dirname(args.product_yaml)
     benchmark_root = ssg.utils.required_key(env_yaml, "benchmark_root")
@@ -75,7 +75,7 @@ def main():
         p.validate_rules(loader.all_rules, loader.all_groups)
         p.validate_refine_rules(loader.all_rules)
 
-    product_cpes = ssg.build_cpe.ProductCPEs(env_yaml["product"])
+    product_cpes = ssg.build_cpe.ProductCPEs(env_yaml)
     loader.export_group_to_file(args.output, product_cpes)
 
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -372,7 +372,7 @@ macro(ssg_build_cpe_dictionary PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" ${PRODUCT} ssg "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ssg "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
         DEPENDS generate-internal-${PRODUCT}-oval-unlinked.xml
@@ -909,7 +909,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml" ${ORIGINAL} ${DERIVATIVE} --id-name ssg
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml" "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${DERIVATIVE} --id-name ssg
         DEPENDS generate-ssg-${ORIGINAL}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml"
         DEPENDS "${SSG_BUILD_SCRIPTS}/enable_derivatives.py"
@@ -923,8 +923,8 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" ${ORIGINAL} ${DERIVATIVE} --id-name ssg
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" ${ORIGINAL} ${DERIVATIVE} --id-name ssg
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${DERIVATIVE} --id-name ssg
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${DERIVATIVE} --id-name ssg
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
         DEPENDS generate-ssg-${ORIGINAL}-ds.xml

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -25,10 +25,8 @@ class ProductCPEs(object):
     and provides them in a structured way.
     """
 
-    def __init__(self, product):
-        self.ssg_root = \
-            os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-        self.product_yaml = get_product_yaml(self.ssg_root, product)
+    def __init__(self, product_yaml):
+        self.product_yaml = product_yaml
 
         self.cpes_by_id = {}
         self.cpes_by_name = {}
@@ -57,7 +55,7 @@ class ProductCPEs(object):
         cpes_root = required_key(self.product_yaml, "cpes_root")
         # we have to "absolutize" the paths the right way, relative to the product_yaml path
         if not os.path.isabs(cpes_root):
-            cpes_root = os.path.join(self.ssg_root, self.product_yaml["product"], cpes_root)
+            cpes_root = os.path.join(self.product_yaml["product_dir"], cpes_root)
 
         for dir_item in sorted(os.listdir(cpes_root)):
             dir_item_path = os.path.join(cpes_root, dir_item)

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -9,7 +9,6 @@ import sys
 
 from .constants import oval_namespace
 from .constants import PREFIX_TO_NS
-from .products import get_product_yaml
 from .utils import merge_dicts, required_key
 from .xml import ElementTree as ET
 from .yaml import open_raw

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -10,6 +10,7 @@ from .xml import ElementTree
 from .constants import standard_profiles, OSCAP_VENDOR, PREFIX_TO_NS, oval_namespace
 from .build_cpe import ProductCPEs
 from .id_translate import IDTranslator
+from .products import get_product_yaml
 
 
 def add_cpes(elem, namespace, mapping):
@@ -43,10 +44,11 @@ def add_cpes(elem, namespace, mapping):
     return affected
 
 
-def add_cpe_item_to_dictionary(tree_root, product, cpe_ref, cpe_oval_filename, id_name):
+def add_cpe_item_to_dictionary(tree_root, product_yaml_path, cpe_ref, cpe_oval_filename, id_name):
     cpe_list = tree_root.find(".//{%s}cpe-list" % (PREFIX_TO_NS["cpe-dict"]))
     if cpe_list:
-        product_cpes = ProductCPEs(product)
+        product_yaml = get_product_yaml(product_yaml_path)
+        product_cpes = ProductCPEs(product_yaml)
         cpe_item = product_cpes.get_cpe(cpe_ref)
         translator = IDTranslator(id_name)
         cpe_item.check_id = translator.generate_id("{" + oval_namespace + "}definition", cpe_item.check_id)

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -10,7 +10,7 @@ from .xml import ElementTree
 from .constants import standard_profiles, OSCAP_VENDOR, PREFIX_TO_NS, oval_namespace
 from .build_cpe import ProductCPEs
 from .id_translate import IDTranslator
-from .products import get_product_yaml
+from .products import load_product_yaml
 
 
 def add_cpes(elem, namespace, mapping):
@@ -47,7 +47,7 @@ def add_cpes(elem, namespace, mapping):
 def add_cpe_item_to_dictionary(tree_root, product_yaml_path, cpe_ref, cpe_oval_filename, id_name):
     cpe_list = tree_root.find(".//{%s}cpe-list" % (PREFIX_TO_NS["cpe-dict"]))
     if cpe_list:
-        product_yaml = get_product_yaml(product_yaml_path)
+        product_yaml = load_product_yaml(product_yaml_path)
         product_cpes = ProductCPEs(product_yaml)
         cpe_item = product_cpes.get_cpe(cpe_ref)
         translator = IDTranslator(id_name)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -157,7 +157,7 @@ class Profile(object):
                 try:
                     profile.cpe_names.add(env_yaml["product_cpes"].get_cpe_name(platform))
                 except CPEDoesNotExist:
-                    print( "Unsupported platform '%s' in profile '%s'." % (platform, profile.id_))
+                    print("Unsupported platform '%s' in profile '%s'." % (platform, profile.id_))
                     raise
 
         # At the moment, metadata is not used to build content
@@ -802,7 +802,8 @@ class Benchmark(object):
             return
         self.values[value.id_] = value
 
-    # The benchmark is also considered a group, so this function signature needs to match Group()'s add_group()
+    # The benchmark is also considered a group, so this function signature needs to match
+    # Group()'s add_group()
     def add_group(self, group, env_yaml=None):
         if group is None:
             return
@@ -876,7 +877,7 @@ class Group(object):
                 try:
                     group.cpe_names.add(env_yaml["product_cpes"].get_cpe_name(platform))
                 except CPEDoesNotExist:
-                    print( "Unsupported platform '%s' in group '%s'." % (platform, group.id_))
+                    print("Unsupported platform '%s' in group '%s'." % (platform, group.id_))
                     raise
 
         for warning_list in group.warnings:
@@ -997,7 +998,7 @@ class Group(object):
                 try:
                     group.cpe_names.add(env_yaml["product_cpes"].get_cpe_name(platform))
                 except CPEDoesNotExist:
-                    print( "Unsupported platform '%s' in group '%s'." % (platform, self.id_))
+                    print("Unsupported platform '%s' in group '%s'." % (platform, self.id_))
                     raise
 
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1101,8 +1101,9 @@ class Rule(object):
             rule.platforms.add(rule.platform)
 
         # Convert the platform names to CPE names
-        # But there is no reason to do it without an env_yaml, as there are no product CPEs defined
-        if env_yaml:
+        # But only do it if an env_yaml was specified (otherwise there would be no product CPEs
+        # to lookup), and the rule's prodtype matches the product being built
+        if env_yaml and env_yaml["product"] in parse_prodtype(rule.prodtype):
             for platform in rule.platforms:
                 try:
                     rule.cpe_names.add(env_yaml["product_cpes"].get_cpe_name(platform))

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -61,7 +61,7 @@ class Control():
                     if rule_yaml is None:
                         # item not found in benchmark_root
                         continue
-                    rule = ssg.build_yaml.Rule.from_yaml(rule_yaml)
+                    rule =  ssg.build_yaml.Rule.from_yaml(rule_yaml, env_yaml)
                     if rule.prodtype == "all" or product in rule.prodtype:
                         control.rules.append(item)
                     else:

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -61,7 +61,7 @@ class Control():
                     if rule_yaml is None:
                         # item not found in benchmark_root
                         continue
-                    rule =  ssg.build_yaml.Rule.from_yaml(rule_yaml, env_yaml)
+                    rule = ssg.build_yaml.Rule.from_yaml(rule_yaml, env_yaml)
                     if rule.prodtype == "all" or product in rule.prodtype:
                         control.rules.append(item)
                     else:

--- a/ssg/environment.py
+++ b/ssg/environment.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from .products import get_product_yaml
 from .yaml import open_raw
 
+
 def open_environment(build_config_yaml_path, product_yaml_path):
     contents = open_raw(build_config_yaml_path)
     contents.update(get_product_yaml(product_yaml_path))

--- a/ssg/environment.py
+++ b/ssg/environment.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 
-from .products import get_product_yaml
+from .products import load_product_yaml
 from .yaml import open_raw
 
 
 def open_environment(build_config_yaml_path, product_yaml_path):
     contents = open_raw(build_config_yaml_path)
-    contents.update(get_product_yaml(product_yaml_path))
+    contents.update(load_product_yaml(product_yaml_path))
     return contents

--- a/ssg/environment.py
+++ b/ssg/environment.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+from .products import get_product_yaml
+from .yaml import open_raw
+
+def open_environment(build_config_yaml_path, product_yaml_path):
+    contents = open_raw(build_config_yaml_path)
+    contents.update(get_product_yaml(product_yaml_path))
+    return contents

--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -14,7 +14,7 @@ from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs
 from .xml import ElementTree as ET
 from .xml import oval_generated_header
 from .jinja import process_file_with_macros, add_python_functions
-from .yaml import open_environment
+from .environment import open_environment
 from .id_translate import IDTranslator
 
 SHARED_OVAL = re.sub(r'ssg/.*', 'shared', __file__) + '/checks/oval/'

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -4,17 +4,65 @@ from __future__ import print_function
 import os
 from collections import namedtuple
 
-from .constants import product_directories
+from .constants import (product_directories,
+                        DEFAULT_UID_MIN,
+                        PKG_MANAGER_TO_SYSTEM,
+                        PKG_MANAGER_TO_CONFIG_FILE,
+                        XCCDF_PLATFORM_TO_PACKAGE)
+from .utils import merge_dicts
 from .yaml import open_raw
 
 
-def get_product_yaml(ssg_root, product):
+def _validate_product_oval_feed_url(contents):
+    if "oval_feed_url" not in contents:
+        return
+    url = contents["oval_feed_url"]
+    if not url.startswith("https"):
+        msg = (
+            "OVAL feed of product '{product}' is not available through an encrypted channel: {url}"
+            .format(product=contents["product"], url=url)
+        )
+        raise ValueError(msg)
+
+
+def _get_implied_properties(existing_properties):
+    result = dict()
+    if "pkg_manager" in existing_properties:
+        pkg_manager = existing_properties["pkg_manager"]
+        if "pkg_system" not in existing_properties:
+            result["pkg_system"] = PKG_MANAGER_TO_SYSTEM[pkg_manager]
+        if "pkg_manager_config_file" not in existing_properties:
+            if pkg_manager in PKG_MANAGER_TO_CONFIG_FILE:
+                result["pkg_manager_config_file"] = PKG_MANAGER_TO_CONFIG_FILE[pkg_manager]
+
+    if "uid_min" not in existing_properties:
+        result["uid_min"] = DEFAULT_UID_MIN
+
+    if "auid" not in existing_properties:
+        result["auid"] = existing_properties.get("uid_min", DEFAULT_UID_MIN)
+
+    return result
+
+
+def get_product_yaml(product_yaml_path):
     """
-    Given a project root directory and product name.
-    Reads the product data from disk and returns it.
+    Reads a product data from disk and returns it.
+    The returned product dictionary also contains derived useful information.
     """
-    product_yaml_path = os.path.join(ssg_root, product, "product.yml")
-    return open_raw(product_yaml_path)
+
+    product_yaml = open_raw(product_yaml_path)
+    _validate_product_oval_feed_url(product_yaml)
+
+    # The product directory is necessary to get absolute paths to benchmark, profile and cpe directories,
+    # which are all relative to the product directory
+    product_yaml["product_dir"] = os.path.dirname(product_yaml_path)
+
+    platform_package_overrides = product_yaml.get("platform_package_overrides", {})
+    # Merge common platform package mappings, while keeping product specific mappings
+    product_yaml["platform_package_overrides"] = merge_dicts(XCCDF_PLATFORM_TO_PACKAGE,
+                                                         platform_package_overrides)
+    product_yaml.update(_get_implied_properties(product_yaml))
+    return product_yaml
 
 
 def get_all(ssg_root):
@@ -28,10 +76,10 @@ def get_all(ssg_root):
     other_products = set()
 
     for product in product_directories:
-        product_dir = os.path.join(ssg_root, product)
-        product_yaml = get_product_yaml(ssg_root, product)
+        product_yaml_path = os.path.join(ssg_root, product, "product.yml")
+        product_yaml = get_product_yaml(product_yaml_path)
 
-        guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])
+        guide_dir = os.path.join(product_yaml["product_dir"], product_yaml['benchmark_root'])
         guide_dir = os.path.abspath(guide_dir)
 
         if 'linux_os' in guide_dir:

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -54,14 +54,14 @@ def get_product_yaml(product_yaml_path):
     product_yaml = open_raw(product_yaml_path)
     _validate_product_oval_feed_url(product_yaml)
 
-    # The product directory is necessary to get absolute paths to benchmark, profile and cpe directories,
-    # which are all relative to the product directory
+    # The product directory is necessary to get absolute paths to benchmark, profile and
+    # cpe directories, which are all relative to the product directory
     product_yaml["product_dir"] = os.path.dirname(product_yaml_path)
 
     platform_package_overrides = product_yaml.get("platform_package_overrides", {})
     # Merge common platform package mappings, while keeping product specific mappings
     product_yaml["platform_package_overrides"] = merge_dicts(XCCDF_PLATFORM_TO_PACKAGE,
-                                                         platform_package_overrides)
+                                                             platform_package_overrides)
     product_yaml.update(_get_implied_properties(product_yaml))
 
     # The product_yaml should be aware of the ProductCPEs

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -45,7 +45,7 @@ def _get_implied_properties(existing_properties):
     return result
 
 
-def get_product_yaml(product_yaml_path):
+def load_product_yaml(product_yaml_path):
     """
     Reads a product data from disk and returns it.
     The returned product dictionary also contains derived useful information.
@@ -82,7 +82,7 @@ def get_all(ssg_root):
 
     for product in product_directories:
         product_yaml_path = os.path.join(ssg_root, product, "product.yml")
-        product_yaml = get_product_yaml(product_yaml_path)
+        product_yaml = load_product_yaml(product_yaml_path)
 
         guide_dir = os.path.join(product_yaml["product_dir"], product_yaml['benchmark_root'])
         guide_dir = os.path.abspath(guide_dir)

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import os
 from collections import namedtuple
 
+from .build_cpe import ProductCPEs
 from .constants import (product_directories,
                         DEFAULT_UID_MIN,
                         PKG_MANAGER_TO_SYSTEM,
@@ -62,6 +63,10 @@ def get_product_yaml(product_yaml_path):
     product_yaml["platform_package_overrides"] = merge_dicts(XCCDF_PLATFORM_TO_PACKAGE,
                                                          platform_package_overrides)
     product_yaml.update(_get_implied_properties(product_yaml))
+
+    # The product_yaml should be aware of the ProductCPEs
+    product_yaml["product_cpes"] = ProductCPEs(product_yaml)
+
     return product_yaml
 
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -13,7 +13,7 @@ from ssg.build_cpe import ProductCPEs
 from ssg.constants import MULTI_PLATFORM_MAPPING
 from ssg.constants import FULL_NAME_TO_PRODUCT_MAPPING
 from ssg.constants import OSCAP_RULE
-from ssg.products  import get_product_yaml
+from ssg.products import get_product_yaml
 from ssg_test_suite.log import LogHelper
 
 Scenario_run = namedtuple(

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -13,7 +13,7 @@ from ssg.build_cpe import ProductCPEs
 from ssg.constants import MULTI_PLATFORM_MAPPING
 from ssg.constants import FULL_NAME_TO_PRODUCT_MAPPING
 from ssg.constants import OSCAP_RULE
-from ssg.products import get_product_yaml
+from ssg.products import load_product_yaml
 from ssg_test_suite.log import LogHelper
 
 Scenario_run = namedtuple(
@@ -174,7 +174,7 @@ def _get_platform_cpes(platform):
         platform_cpes = set()
         for p in products:
             product_yaml_path = os.path.join(ssg_root, p, "product.yml")
-            product_yaml = get_product_yaml(product_yaml_path)
+            product_yaml = load_product_yaml(product_yaml_path)
             p_cpes = ProductCPEs(product_yaml)
             platform_cpes |= set(p_cpes.get_product_cpe_names())
         return platform_cpes
@@ -188,7 +188,7 @@ def _get_platform_cpes(platform):
                 % (platform, ", ".join(FULL_NAME_TO_PRODUCT_MAPPING.keys())))
             raise ValueError
         product_yaml_path = os.path.join(ssg_root, product, "product.yml")
-        product_yaml = get_product_yaml(product_yaml_path)
+        product_yaml = load_product_yaml(product_yaml_path)
         product_cpes = ProductCPEs(product_yaml)
         platform_cpes = set(product_cpes.get_product_cpe_names())
         return platform_cpes

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -13,6 +13,7 @@ from ssg.build_cpe import ProductCPEs
 from ssg.constants import MULTI_PLATFORM_MAPPING
 from ssg.constants import FULL_NAME_TO_PRODUCT_MAPPING
 from ssg.constants import OSCAP_RULE
+from ssg.products  import get_product_yaml
 from ssg_test_suite.log import LogHelper
 
 Scenario_run = namedtuple(
@@ -161,6 +162,7 @@ def _run_cmd(command_list, verbose_path, env=None):
 
 
 def _get_platform_cpes(platform):
+    ssg_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     if platform.startswith("multi_platform_"):
         try:
             products = MULTI_PLATFORM_MAPPING[platform]
@@ -171,7 +173,9 @@ def _get_platform_cpes(platform):
             raise ValueError
         platform_cpes = set()
         for p in products:
-            p_cpes = ProductCPEs(p)
+            product_yaml_path = os.path.join(ssg_root, p, "product.yml")
+            product_yaml = get_product_yaml(product_yaml_path)
+            p_cpes = ProductCPEs(product_yaml)
             platform_cpes |= set(p_cpes.get_product_cpe_names())
         return platform_cpes
     else:
@@ -183,7 +187,9 @@ def _get_platform_cpes(platform):
                 "Unknown product name: %s is not from %s"
                 % (platform, ", ".join(FULL_NAME_TO_PRODUCT_MAPPING.keys())))
             raise ValueError
-        product_cpes = ProductCPEs(product)
+        product_yaml_path = os.path.join(ssg_root, product, "product.yml")
+        product_yaml = get_product_yaml(product_yaml_path)
+        product_cpes = ProductCPEs(product_yaml)
         platform_cpes = set(product_cpes.get_product_cpe_names())
         return platform_cpes
 

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import ssg.constants
+import ssg.environment
 import ssg.jinja
 import ssg.oval
 import ssg.rules
@@ -36,7 +37,7 @@ def main():
         product_yaml_path = os.path.join(product_dir, "product.yml")
         product_yaml = ssg.yaml.open_raw(product_yaml_path)
 
-        env_yaml = ssg.yaml.open_environment(ssg_build_config_yaml, product_yaml_path)
+        env_yaml = ssg.environment.open_environment(ssg_build_config_yaml, product_yaml_path)
         ssg.jinja.add_python_functions(env_yaml)
 
         guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -5,7 +5,7 @@ import os
 import ssg.controls
 import ssg.build_yaml
 from ssg.environment import open_environment
-from ssg.products import get_product_yaml
+from ssg.products import load_product_yaml
 
 data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 controls_dir = os.path.join(data_dir, "controls_dir")

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -4,7 +4,7 @@ import os
 
 import ssg.controls
 import ssg.build_yaml
-from ssg.yaml import open_environment
+from ssg.environment import open_environment
 from ssg.products import get_product_yaml
 
 data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))

--- a/utils/render-policy.py
+++ b/utils/render-policy.py
@@ -9,7 +9,7 @@ import argparse
 
 import ssg.build_yaml
 import ssg.controls
-import ssg.yaml
+import ssg.environment
 import ssg.jinja
 import template_renderer
 

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -41,7 +41,7 @@ def walk_products(root, all_products):
         product_dir = os.path.join(root, product)
         product_yaml_path = os.path.join(product_dir, "product.yml")
         product_yaml = ssg.yaml.open_raw(product_yaml_path)
-        product_yaml.update(ssg.yaml._get_implied_properties(product_yaml))
+        product_yaml.update(ssg.products._get_implied_properties(product_yaml))
         product_yamls[product] = product_yaml
 
         guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -40,8 +40,7 @@ def walk_products(root, all_products):
     for product in all_products:
         product_dir = os.path.join(root, product)
         product_yaml_path = os.path.join(product_dir, "product.yml")
-        product_yaml = ssg.yaml.open_raw(product_yaml_path)
-        product_yaml.update(ssg.products._get_implied_properties(product_yaml))
+        product_yaml = ssg.products.get_product_yaml(product_yaml_path)
         product_yamls[product] = product_yaml
 
         guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -40,7 +40,7 @@ def walk_products(root, all_products):
     for product in all_products:
         product_dir = os.path.join(root, product)
         product_yaml_path = os.path.join(product_dir, "product.yml")
-        product_yaml = ssg.products.get_product_yaml(product_yaml_path)
+        product_yaml = ssg.products.load_product_yaml(product_yaml_path)
         product_yamls[product] = product_yaml
 
         guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])


### PR DESCRIPTION
#### Description:

- This adds 393fbdc and ea7dad8 on top of #6725 reorganzing a bit the `env_yaml` and the `product_yaml`.
- Moves loading of `product_cpes` to `get_product_yaml()`.

#### Rationale:

- A few aspects that were product specific were being amalgamated in `open_environment()`
