### PR TITLE
Add documentation links for OL7 and OL8

### DIFF
--- a/jre/guide/java/group.yml
+++ b/jre/guide/java/group.yml
@@ -15,5 +15,5 @@ description: |-
     for a list of currently supported Java version 6 settings.</ul>
     <ul>Refer to <li>{{{ weblink(link="https://docs.oracle.com/javase/7/docs/technotes/guides/jweb/jcp/properties.html") }}}</li>
     for a list of currently supported Java version 7 settings.</ul>
-    <ul>Refer to <li>{{{ weblink(link="https://docs.oracle.com/javase/8/docs/technotes/guides/jweb/jcp/properties.html") }}}</li>
+    <ul>Refer to <li>{{{ weblink(link="https://docs.oracle.com/javase/8/docs/technotes/guides/deploy/properties.html") }}}</li>
     for a list of currently supported Java version 8 settings.</ul>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -9,8 +9,10 @@ description: |-
     production environment, the {{{ full_name }}} system can be
     configured to utilize the services of the <tt>chronyd</tt> NTP daemon (the
     default), or services of the <tt>ntpd</tt> NTP daemon. Refer to
-    {{% if product in ["ol7", "ol8"] %}}
+    {{% if product == "ol7" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
+    {{% elif product == "ol8" %}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% else %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
     {{% endif %}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -9,8 +9,10 @@ description: |-
     production environment, the {{{ full_name }}} system can be
     configured to utilize the services of the <tt>chronyd</tt> NTP daemon (the
     default), or services of the <tt>ntpd</tt> NTP daemon. Refer to
-    {{% if product in ["ol7", "ol8"] %}}
+    {{% if product == "ol7" %}}
          {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
+     {{% elif product == "ol8" %}}
+         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% else %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
     {{% endif %}}

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -51,6 +51,8 @@ description: |-
     Refer to
     {{% if product == "ol7" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
+    {{% elif product == "ol8" %}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% elif product == "rhel7" %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
     {{% elif "ubuntu" in product  %}}

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -12,8 +12,10 @@ description: |-
     Note: The <tt>ntpd</tt> daemon is not enabled by default. Though as mentioned
     in the previous sections in certain environments the <tt>ntpd</tt> daemon might
     be preferred to be used rather than the <tt>chronyd</tt> one. Refer to:
-    {{% if product in ["ol7", "ol8"] %}}
+    {{% if product == "ol7" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
+    {{% elif product == "ol8" %}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% else %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
     {{% endif %}}

--- a/linux_os/guide/services/sssd/group.yml
+++ b/linux_os/guide/services/sssd/group.yml
@@ -13,9 +13,11 @@ description: |-
     {{%- if product == "rhel7" -%}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/SSSD.html") }}}
     {{%- elif product == "rhel8" -%}}
-    {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_identity_management/installing-an-ipa-client-basic-scenario_installing-identity-management#sssd-deployment-operations_install-client-basic") }}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_identity_management/installing-an-ipa-client-basic-scenario_installing-identity-management#sssd-deployment-operations_install-client-basic") }}}
     {{%- elif product == "ol7" -%}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/ol7-auth.html#ol7-sssd-auth") }}}
+    {{%- elif product == "ol8" -%}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/userauth/auth.html#sssd-auth") }}}
     {{%- endif %}}
 
 platform: sssd

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -31,8 +31,10 @@ description: |-
     <br /><br />
     Detailed information on encrypting partitions using LUKS or LUKS ciphers can be found on
     the {{{ full_name }}} Documentation web site:<br />
-    {{% if product in ["ol7", "ol8"] %}}
+    {{% if product == "ol7" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/security/ol7-install-sec.html") }}}.
+    {{% elif product == "ol8" %}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/install/ol8-install-basic.html#install-storage-network") }}}.
     {{% elif product in ["sle12", "sle15"] %}}
         {{{ weblink(link="https://www.suse.com/documentation/sled-12/book_security/data/sec_security_cryptofs_y2.html") }}}
     {{% else %}}


### PR DESCRIPTION
Signed-off-by: Federico Ramirez <federico.r.ramirez@oracle.com>

#### Description:

- Add OL7/OL8 documentation links
- Fix java 8 supported settings documentation link

#### Rationale:

- There were no links to existing OL8 documentation
- Java 8 supported settings link didn't directly point to the relevant doc site
