### PR TITLE
Unmask service in service enable remediation, add test scenarios for service enable rules

### DIFF
--- a/linux_os/guide/services/cron_and_at/service_crond_enabled/tests/disabled.fail.sh
+++ b/linux_os/guide/services/cron_and_at/service_crond_enabled/tests/disabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = cronie
+
+systemctl stop crond
+systemctl disable crond
+systemctl mask crond

--- a/linux_os/guide/services/cron_and_at/service_crond_enabled/tests/enabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_crond_enabled/tests/enabled.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = cronie
+
+systemctl start crond
+systemctl enable crond

--- a/linux_os/guide/system/auditing/service_auditd_enabled/tests/disabled.fail.sh
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/tests/disabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = audit
+
+systemctl stop auditd
+systemctl disable auditd
+systemctl mask auditd

--- a/linux_os/guide/system/auditing/service_auditd_enabled/tests/enabled.pass.sh
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/tests/enabled.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+systemctl start auditd
+systemctl enable auditd

--- a/linux_os/guide/system/logging/service_rsyslog_enabled/tests/disabled.fail.sh
+++ b/linux_os/guide/system/logging/service_rsyslog_enabled/tests/disabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = rsyslog
+
+systemctl stop rsyslog
+systemctl disable rsyslog
+systemctl mask rsyslog

--- a/linux_os/guide/system/logging/service_rsyslog_enabled/tests/enabled.pass.sh
+++ b/linux_os/guide/system/logging/service_rsyslog_enabled/tests/enabled.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = rsyslog
+
+systemctl start rsyslog
+systemctl enable rsyslog

--- a/shared/templates/service_enabled/ansible.template
+++ b/shared/templates/service_enabled/ansible.template
@@ -14,5 +14,6 @@
       name: "{{{ DAEMONNAME }}}"
       enabled: "yes"
       state: "started"
+      masked: "no"
     when:
     - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'

--- a/shared/templates/service_enabled/bash.template
+++ b/shared/templates/service_enabled/bash.template
@@ -6,6 +6,7 @@
 {{%- if init_system == "systemd" %}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
 {{% elif init_system == "upstart" %}}


### PR DESCRIPTION
#### Description:
Add test scenarios for `service_crond_enabled`, `service_rsyslog_enabled`, and `service_auditd_enabled`.

During a creation of the test scenarios, I have noticed that remediations result in `error` when a service has been disabled and masked:
```
$ python3 tests/test_suite.py rule --profile cis --libvirt qemu:///system test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml service_crond_enabled service_rsyslog_enabled service_auditd_enabled               
INFO - xccdf_org.ssgproject.content_rule_service_auditd_enabled                                                        
INFO - Script disabled.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK                               
ERROR - Rule evaluation resulted in error, instead of expected fixed during remediation stage                          
ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_service_auditd_enabled'.                    
INFO - Script enabled.pass.sh using profile xccdf_org.ssgproject.content_profile_cis OK                                
INFO - xccdf_org.ssgproject.content_rule_service_rsyslog_enabled                                                       
INFO - Script disabled.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK                               
ERROR - Rule evaluation resulted in error, instead of expected fixed during remediation stage                                                                                                                                                 
ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_service_rsyslog_enabled'.                   
INFO - Script enabled.pass.sh using profile xccdf_org.ssgproject.content_profile_cis OK                                
INFO - xccdf_org.ssgproject.content_rule_service_crond_enabled                                                         
INFO - Script disabled.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK                               
ERROR - Rule evaluation resulted in error, instead of expected fixed during remediation stage                          
ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_service_crond_enabled'.                     
INFO - Script enabled.pass.sh using profile xccdf_org.ssgproject.content_profile_cis OK 
```

Unmask before starting/enabling of a service solves it:
```
$ python3 tests/test_suite.py rule --remediate-using ansible --profile cis --libvirt qemu:///system test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml service_crond_enabled service_rsyslog_enabled service_auditd_enabled                                                                                                                              
INFO - xccdf_org.ssgproject.content_rule_service_auditd_enabled                                                        
INFO - Script disabled.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK                               
INFO - Script enabled.pass.sh using profile xccdf_org.ssgproject.content_profile_cis OK                                
INFO - xccdf_org.ssgproject.content_rule_service_rsyslog_enabled                                                       
INFO - Script disabled.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK                               
INFO - Script enabled.pass.sh using profile xccdf_org.ssgproject.content_profile_cis OK                                
INFO - xccdf_org.ssgproject.content_rule_service_crond_enabled                                                         
INFO - Script disabled.fail.sh using profile xccdf_org.ssgproject.content_profile_cis OK                                                                                                                                                      
INFO - Script enabled.pass.sh using profile xccdf_org.ssgproject.content_profile_cis OK 
```