### PR TITLE
Change dhcp server package name to dhcp-server in rhel8

### DIFF
--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -36,3 +36,4 @@ template:
     name: package_removed
     vars:
         pkgname: dhcp
+        pkgname@rhel8: dhcp-server

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
@@ -42,3 +42,4 @@ template:
     vars:
         servicename: dhcpd
         packagename: dhcp
+        packagename@rhel8: dhcp-server

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/disabled.pass.sh
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/disabled.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,SUSE Linux Enterprise 15
+# packages = dhcp
+
+systemctl stop dhcpd
+systemctl disable dhcpd
+systemctl mask dhcpd

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/enabled.fail.sh
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/enabled.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,SUSE Linux Enterprise 15
+# packages = dhcp
+
+# Simple configuration for dhcp so we can start the service
+cat << EOF >> /etc/dhcp/dhcpd.conf
+subnet 192.168.122.0 netmask 255.255.255.248 {
+}
+EOF
+
+systemctl start dhcpd
+systemctl enable dhcpd

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/rhel8_disabled.pass.sh
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/rhel8_disabled.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+# packages = dhcp-server
+
+systemctl stop dhcpd
+systemctl disable dhcpd
+systemctl mask dhcpd

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/rhel8_enabled.fail.sh
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/rhel8_enabled.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+# packages = dhcp-server
+
+# Simple configuration for dhcp so we can start the service
+cat << EOF >> /etc/dhcp/dhcpd.conf
+subnet 192.168.122.0 netmask 255.255.255.248 {
+}
+EOF
+
+systemctl start dhcpd
+systemctl enable dhcpd


### PR DESCRIPTION
#### Description:
There is no `dhcp` package in rhel8 repositories, the package with the dhcpd service is `dhcp-server`.
On rhel7 and sle15, no change is needed because the `dhcp` package with dhcpd is there.

Also add test scenarios for service_dhcpd_disabled to increase CIS profile test coverage.