### PR TITLE
Optimize rules that traverse whole root filesystem by exclusion of /dev, /proc, and /sys where appropriate

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -23,21 +23,17 @@
 
   <!-- First define OVAL entities that can be reused across tests below -->
   <unix:file_object id="object_system_privileged_commands" comment="system files with setuid or setgid permission set" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" max_depth="-1" />
-    <unix:path operation="equals">/</unix:path>
+    <unix:behaviors recurse_file_system="local"/>
+    <!-- don't search /dev, /proc, /sys -->
+    <unix:path operation="pattern match">^\/(?!(dev|proc|sys)(\/|$)).*$</unix:path>
     <!-- [a-z]+ regex below is a workaround for OpenSCAP https://fedorahosted.org/openscap/ticket/457 bug -->
     <unix:filename operation="pattern match">[a-z]+</unix:filename>
     <filter action="include">state_setuid_or_setgid_set</filter>
-    <filter action="exclude">state_dev_proc_sys_dirs</filter>
   </unix:file_object>
 
   <unix:file_state id="state_setuid_or_setgid_set" version="1" operator="OR">
     <unix:suid datatype="boolean">true</unix:suid>
     <unix:sgid datatype="boolean">true</unix:sgid>
-  </unix:file_state>
-
-  <unix:file_state id="state_dev_proc_sys_dirs" version="1">
-    <unix:filepath operation="pattern match">^\/(dev|proc|sys)\/.*$</unix:filepath>
   </unix:file_state>
 
   <local_variable id="variable_all_privileged_commands" comment="All privileged commands" datatype="string" version="1">

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
@@ -11,8 +11,9 @@
     </unix:file_test>
 
     <unix:file_object comment="files with sgid set which are not owned by any RPM package" id="obj_file_permissions_unauthorized_sgid_unowned" version="1">
-        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-        <unix:path operation="equals">/</unix:path>
+        <unix:behaviors recurse_file_system="local" />
+        <!-- don't search /dev, /proc, /sys -->
+        <unix:path operation="pattern match">^\/(?!(dev|proc|sys)(\/|$)).*$</unix:path>
         <unix:filename operation="pattern match">^.*$</unix:filename>
         <filter action="include">state_file_permissions_unauthorized_sgid_sgid_set</filter>
         <filter action="exclude">state_file_permissions_unauthorized_sgid_filepaths</filter>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
@@ -11,8 +11,9 @@
     </unix:file_test>
 
     <unix:file_object comment="files with suid set which are not owned by any RPM package" id="obj_file_permissions_unauthorized_suid_unowned" version="1">
-        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-        <unix:path operation="equals">/</unix:path>
+        <unix:behaviors recurse_file_system="local" />
+        <!-- don't search /dev, /proc, /sys -->
+        <unix:path operation="pattern match">^\/(?!(dev|proc|sys)(\/|$)).*$</unix:path>
         <unix:filename operation="pattern match">^.*$</unix:filename>
         <filter action="include">state_file_permissions_unauthorized_suid_suid_set</filter>
         <filter action="exclude">state_file_permissions_unauthorized_suid_filepaths</filter>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -13,14 +13,12 @@
     <unix:object object_ref="object_file_permissions_unauthorized_world_write" />
   </unix:file_test>
   <unix:file_object comment="world writable" id="object_file_permissions_unauthorized_world_write" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-    <unix:path operation="equals">/</unix:path>
+    <unix:behaviors recurse_file_system="local" />
+    <!-- don't search /proc, /sys, and some special files from /selinux -->
+    <unix:path operation="pattern match">^\/(?!(proc|sys)(\/|$)).*$</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
     <filter action="include">state_file_permissions_unauthorized_world_write</filter>
-    <!-- don't search /proc, /sys, and some special files from /selinux -->
     <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_special_selinux_files</filter>
-    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_proc</filter>
-    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_sys</filter>
   </unix:file_object>
   <unix:file_state id="state_file_permissions_unauthorized_world_write" version="1">
     <unix:type operation="equals">regular</unix:type>
@@ -28,11 +26,5 @@
   </unix:file_state>
   <unix:file_state id="state_file_permissions_unauthorized_world_write_exclude_special_selinux_files" version="1">
     <unix:filepath operation="pattern match">^/selinux/(?:(?:member)|(?:user)|(?:relabel)|(?:create)|(?:access)|(?:context))$</unix:filepath>
-  </unix:file_state>
-  <unix:file_state id="state_file_permissions_unauthorized_world_write_exclude_proc" version="1">
-    <unix:filepath operation="pattern match">^/proc/.*$</unix:filepath>
-  </unix:file_state>
-  <unix:file_state id="state_file_permissions_unauthorized_world_write_exclude_sys" version="1">
-    <unix:filepath operation="pattern match">^/sys/.*$</unix:filepath>
   </unix:file_state>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -30,12 +30,9 @@
   </unix:file_state>
 
   <unix:file_object comment="all local files" id="object_file_permissions_ungroupowned" version="1">
-    <!-- We can't traverse symlinks here since e.g. /sys file system might contain symlink loops
-         resulting into excessive memory use by the scanner process & possible subsequent OOM killer
-         termination of it. See e.g.: https://www.redhat.com/archives/open-scap-list/2014-May/msg00005.html
-         Therefore traverse only directories -->
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
-    <unix:path>/</unix:path>
+    <unix:behaviors recurse_file_system="local" />
+    <!-- don't search /proc, /sys -->
+    <unix:path operation="pattern match">^\/(?!(proc|sys)(\/|$)).*$</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
     <filter action="exclude">state_file_permissions_ungroupowned</filter>
   </unix:file_object>

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -19,8 +19,9 @@
   </unix:password_object>
 
   <unix:file_object comment="all local files" id="file_permissions_unowned_object" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
-    <unix:path>/</unix:path>
+    <unix:behaviors recurse_file_system="local" />
+    <!-- don't search /proc, /sys -->
+    <unix:path operation="pattern match">^\/(?!(proc|sys)(\/|$)).*$</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
     <filter action="exclude">file_permissions_unowned_userid_list_match</filter>
   </unix:file_object>


### PR DESCRIPTION
#### Rationale:

When these entries are excluded with the help of state entity using `<filter action="exclude" ...>` the data is being collected from the filesystem and then discarded, which is sub-optimal.

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1942208