### PR TITLE
Update tests of accounts_tmout to work when overriding profiles

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# variables = var_accounts_tmout=700
+# variables = var_accounts_tmout=900
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=900; readonly TMOUT; export TMOUT/" /etc/profile
+	sed -i "s/.*TMOUT.*/TMOUT=950; readonly TMOUT; export TMOUT/" /etc/profile
 else
-	echo "TMOUT=900; readonly TMOUT; export TMOUT" >> /etc/profile
+	echo "TMOUT=950; readonly TMOUT; export TMOUT" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value.fail.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# variables = var_accounts_tmout=200
+# variables = var_accounts_tmout=900
 
 if grep -q "^TMOUT" /etc/profile; then
-	sed -i "s/^TMOUT.*/TMOUT=250/" /etc/profile
+	sed -i "s/^TMOUT.*/TMOUT=950/" /etc/profile
 else
-	echo "TMOUT=250" >> /etc/profile
+	echo "TMOUT=950" >> /etc/profile
 fi


### PR DESCRIPTION
When overriding test scenario profiles in rule mode
the variables metadata are not used. Therefore, this
commit updates 2 scenarios to work even in case when
a specific profile is forced in the rule mode using
the `--profile` option.