### PR TITLE
RHCOS4: Remove instances of audit_rules_privileged_commands

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -429,7 +429,6 @@ selections:
     - audit_rules_mac_modification
     - audit_rules_media_export
     - audit_rules_networkconfig_modification
-    - audit_rules_privileged_commands
     - audit_rules_privileged_commands_at
     - audit_rules_privileged_commands_chage
     - audit_rules_privileged_commands_chsh

--- a/rhcos4/profiles/ncp.profile
+++ b/rhcos4/profiles/ncp.profile
@@ -434,7 +434,6 @@ selections:
     - audit_rules_mac_modification
     - audit_rules_media_export
     - audit_rules_networkconfig_modification
-    - audit_rules_privileged_commands
     - audit_rules_privileged_commands_at
     - audit_rules_privileged_commands_chage
     - audit_rules_privileged_commands_chsh


### PR DESCRIPTION
This rule traverses the whole file system in order to find instances of
executables that have setuid and setgid enabled. This is not scalable in
hosts running container orchestration engines since we'll have assorted
filesystems of the containers which might differ at a given point in
time.

Therefore, it's no use trying to audit this. We'll have to find another
way to address this.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>