### PR TITLE
Add SLES-12-010080 & SLES-15-010120 to dconf_gnome_screensaver_idle_delay

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -8,17 +8,17 @@
 - name: "Set GNOME3 Screensaver Inactivity Timeout"
   ini_file:
     dest: "/etc/dconf/db/local.d/00-security-settings"
-    section: "org/gnome/desktop/screensaver"
+    section: "org/gnome/desktop/session"
     option: idle-delay
-    value: "{{ inactivity_timeout_value }}"
+    value: "uint32 {{ inactivity_timeout_value }}"
     create: yes
     no_extra_spaces: yes
 
 - name: "Prevent user modification of GNOME idle-delay"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/idle-delay'
-    line: '/org/gnome/desktop/screensaver/idle-delay'
+    regexp: '^/org/gnome/desktop/session/idle-delay'
+    line: '/org/gnome/desktop/session/idle-delay'
     create: yes
 
 - name: Dconf Update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -55,7 +55,6 @@
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require the proper datatype to be specified in 'idle-delay' configuration too -->
     <ind:pattern operation="pattern match">^idle-delay[\s=]*uint32[\s]([^=\s]*)</ind:pattern>
-
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -24,7 +24,11 @@
     <!-- GSettings expects unsigned integer when setting 'idle-delay' per:
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require the proper datatype to be specified in 'idle-delay' configuration too -->
+    {{% if product in ['sle12', 'sle15'] %}}
+    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?idle-delay=[0-9]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^\[org/gnome/desktop/session]([^\n]*\n+)+?idle-delay=uint32[\s][0-9]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -37,7 +41,11 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/locks/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
+    {{% if product in ['sle12', 'sle15'] %}}
+    <ind:pattern operation="pattern match">^/org/gnome/desktop/screensaver/idle-delay$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^/org/gnome/desktop/session/idle-delay$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -54,7 +62,12 @@
     <!-- GSettings expects unsigned integer when setting 'idle-delay' per:
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require the proper datatype to be specified in 'idle-delay' configuration too -->
+    {{% if product in ['sle12', 'sle15'] %}}
+    <ind:pattern operation="pattern match">^idle-delay[\s=]([^=\s]*)</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^idle-delay[\s=]*uint32[\s]([^=\s]*)</ind:pattern>
+    {{% endif %}}
+
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -24,11 +24,7 @@
     <!-- GSettings expects unsigned integer when setting 'idle-delay' per:
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require the proper datatype to be specified in 'idle-delay' configuration too -->
-    {{% if product in ['sle12', 'sle15'] %}}
-    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?idle-delay=[0-9]*$</ind:pattern>
-    {{% else %}}
     <ind:pattern operation="pattern match">^\[org/gnome/desktop/session]([^\n]*\n+)+?idle-delay=uint32[\s][0-9]*$</ind:pattern>
-    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -41,11 +37,7 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/locks/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    {{% if product in ['sle12', 'sle15'] %}}
-    <ind:pattern operation="pattern match">^/org/gnome/desktop/screensaver/idle-delay$</ind:pattern>
-    {{% else %}}
     <ind:pattern operation="pattern match">^/org/gnome/desktop/session/idle-delay$</ind:pattern>
-    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -62,11 +54,7 @@
     <!-- GSettings expects unsigned integer when setting 'idle-delay' per:
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require the proper datatype to be specified in 'idle-delay' configuration too -->
-    {{% if product in ['sle12', 'sle15'] %}}
-    <ind:pattern operation="pattern match">^idle-delay[\s=]([^=\s]*)</ind:pattern>
-    {{% else %}}
     <ind:pattern operation="pattern match">^idle-delay[\s=]*uint32[\s]([^=\s]*)</ind:pattern>
-    {{% endif %}}
 
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12,sle15
 
 title: 'Set GNOME3 Screensaver Inactivity Timeout'
 
@@ -31,6 +31,8 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80110-0
     cce@rhel8: CCE-80775-0
+    cce@sle12: CCE-83010-9
+    cce@sle15: CCE-85669-0
 
 references:
     stigid@ol7: OL07-00-010070
@@ -38,11 +40,15 @@ references:
     cui: 3.1.10
     disa: CCI-000057
     nist: AC-11(a),CM-6(a)
+    nist@sle12: AC-11(a),AC-11.1 (ii)
+    nist@sle15: AC-11(a),AC-11.1 (ii)
     nist-csf: PR.AC-7
     ospp: FMT_MOF_EXT.1
     pcidss: Req-8.1.8
     srg: SRG-OS-000029-GPOS-00010
     stigid@rhel7: RHEL-07-010070
+    stigid@sle12: SLES-12-010080
+    stigid@sle15: SLES-15-010120
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
     cobit5: DSS05.04,DSS05.10,DSS06.10
@@ -54,10 +60,34 @@ ocil_clause: 'idle-delay is not equal to or less than the expected value'
 
 ocil: |-
     To check the current idle time-out value, run the following command:
-    <pre>$ gsettings get org.gnome.desktop.session idle-delay</pre>
+
+    {{% if product in ['sle12', 'sle15'] %}}
+
+     Verify the SUSE operating system initiates a session lock after a 15-minute period of inactivity via
+     the graphical user interface (GUI) by running the following command:
+
+     Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command
+     must be run from an X11 session, otherwise the command will not work correctly.
+
+     <pre># gsettings get org.gnome.desktop.session idle-delay
+            uint32 900</pre>
+
+     If the command does not return a value less than or equal to "900", this is a finding.
+     Fix Text: Configure the SUSE operating system to initiate a session lock after a 15-minute period of
+     inactivity of the graphical user interface (GUI) by running the following command:
+
+     Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command
+     must be run from an X11 session, otherwise the command will not work correctly.
+
+     <pre># gsettings set org.gnome.desktop.session idle-delay 900</pre>
+
+    {{% else %}}
+    To check the current idle time-out value, run the following command:
+      <pre>$ gsettings get org.gnome.desktop.session idle-delay</pre>
     If properly configured, the output should be <tt>'uint32 {{{ xccdf_value("inactivity_timeout_value") }}}'</tt>.
     To ensure that users cannot change the screensaver inactivity timeout setting, run the following:
     <pre>$ grep idle-delay /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/session/idle-delay</tt>
+    {{% endif %}}
 
 platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -60,34 +60,10 @@ ocil_clause: 'idle-delay is not equal to or less than the expected value'
 
 ocil: |-
     To check the current idle time-out value, run the following command:
-
-    {{% if product in ['sle12', 'sle15'] %}}
-
-     Verify the SUSE operating system initiates a session lock after a 15-minute period of inactivity via
-     the graphical user interface (GUI) by running the following command:
-
-     Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command
-     must be run from an X11 session, otherwise the command will not work correctly.
-
-     <pre># gsettings get org.gnome.desktop.session idle-delay
-            uint32 900</pre>
-
-     If the command does not return a value less than or equal to "900", this is a finding.
-     Fix Text: Configure the SUSE operating system to initiate a session lock after a 15-minute period of
-     inactivity of the graphical user interface (GUI) by running the following command:
-
-     Note: If the system does not have GNOME installed, this requirement is Not Applicable. This command
-     must be run from an X11 session, otherwise the command will not work correctly.
-
-     <pre># gsettings set org.gnome.desktop.session idle-delay 900</pre>
-
-    {{% else %}}
-    To check the current idle time-out value, run the following command:
       <pre>$ gsettings get org.gnome.desktop.session idle-delay</pre>
     If properly configured, the output should be <tt>'uint32 {{{ xccdf_value("inactivity_timeout_value") }}}'</tt>.
     To ensure that users cannot change the screensaver inactivity timeout setting, run the following:
     <pre>$ grep idle-delay /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/session/idle-delay</tt>
-    {{% endif %}}
 
 platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -60,7 +60,7 @@ ocil_clause: 'idle-delay is not equal to or less than the expected value'
 
 ocil: |-
     To check the current idle time-out value, run the following command:
-      <pre>$ gsettings get org.gnome.desktop.session idle-delay</pre>
+    <pre>$ gsettings get org.gnome.desktop.session idle-delay</pre>
     If properly configured, the output should be <tt>'uint32 {{{ xccdf_value("inactivity_timeout_value") }}}'</tt>.
     To ensure that users cannot change the screensaver inactivity timeout setting, run the following:
     <pre>$ grep idle-delay /etc/dconf/db/local.d/locks/*</pre>

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -18,6 +18,7 @@ selections:
     - var_account_disable_post_pw_expiration=35
     - var_accounts_fail_delay=4
     - var_accounts_tmout=15_min
+    - inactivity_timeout_value=15_minutes
     - var_password_pam_dcredit=1
     - var_password_pam_delay=4000000
     - var_password_pam_difok=8

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -170,6 +170,7 @@ selections:
     - file_permission_user_init_files
     - ftp_present_banner
     - gnome_gdm_disable_automatic_login
+    - dconf_gnome_screensaver_idle_delay
     - grub2_password
     - grub2_uefi_password
     - gui_login_dod_acknowledgement

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -17,6 +17,7 @@ selections:
     - var_account_disable_post_pw_expiration=35
     - var_accounts_fail_delay=4
     - var_accounts_tmout=15_min
+    - inactivity_timeout_value=15_minutes
     #
     # Note: must configure "var_accounts_authorized_local_users_regex" when
     # "accounts_authorized_local_users" rule is enabled

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -106,6 +106,7 @@ selections:
     - dconf_db_up_to_date
     - dconf_gnome_banner_enabled
     - dconf_gnome_login_banner_text
+    - dconf_gnome_screensaver_idle_delay
     - dir_perms_world_writable_sticky_bits
     - dir_perms_world_writable_system_owned_group
     - disable_ctrlaltdel_reboot


### PR DESCRIPTION
#### Description:

- Add SLES-12-010080 & SLES-15-010120 to dconf_gnome_screensaver_idle_delay

#### Rationale:

- Need to make sure session lock time out is set.

