### PR TITLE
rhcos4: Remove sssd configuration check from moderate profile

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -235,7 +235,7 @@ selections:
     - selinux_policytype
 
     ### Configure SSSD
-    - sssd_run_as_sssd_user
+    #- sssd_run_as_sssd_user
 
     ### Configure USBGuard
     - service_usbguard_enabled


### PR DESCRIPTION
The agreement has been that the control this would normaly address is
already address by the fact that OCP4 is configured to use an external
IdP. The identities of users accessing the system are then gotten from
that IdP, and therefore the usage of sssd is not needed.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>