### PR TITLE
Add test for auditd_data_retention_admin_space_left_action and CIS profile

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt_cis.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt_cis.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_cis
+# remediation = bash
+
+. $SHARED/auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/auditd.conf "admin_space_left_action" "halt"


### PR DESCRIPTION
Just adds one positive test scenario for the `auditd_data_retention_admin_space_left_action` rule and CIS profile.