### PR TITLE
RHCOS4: Remove rules that use rpmverifypackage_test

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -575,8 +575,6 @@ selections:
     - chronyd_or_ntpd_specify_multiple_servers
 
     # AU-9
-    - rpm_verify_ownership
-    - rpm_verify_permissions
     - selinux_confinement_of_daemons
     # TODO - we should update this rule to parameterize the rotation cadence.
     # The check curently expects it to be daily, but OCP4 nodes rotate weekly.

--- a/rhcos4/profiles/ncp.profile
+++ b/rhcos4/profiles/ncp.profile
@@ -554,8 +554,6 @@ selections:
     - chronyd_or_ntpd_specify_multiple_servers
 
     # AU-9
-    #- rpm_verify_ownership
-    #- rpm_verify_permissions
     - selinux_confinement_of_daemons
     #- ensure_logrotate_activated
     - file_permissions_var_log_audit


### PR DESCRIPTION
These are meant to check that files match the ownership and permissions
that the RPMS define... however, in RHCOS these checks are not reliable
as ostree might handle some of these files differently.

On the other hand, ostree does ensure that some of these are kept in a
correct state as it mounts /usr as read-only. We'll ultimately address
the integrity of files using FIO/AIDE, so we don't completely loose
compliance here.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>