### PR TITLE
service_nfs_disabled - change name of nfs service to nfs-server

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -8,7 +8,7 @@ description: |-
     The Network File System (NFS) service allows remote hosts to mount
     and interact with shared filesystems on the local system. If the local system
     is not designated as a NFS server then this service should be disabled.
-    {{{ describe_service_disable(service="nfs") }}}
+    {{{ describe_service_disable(service="nfs-server") }}}
 
 rationale: 'Unnecessary services should be disabled to decrease the attack surface of the system.'
 
@@ -33,12 +33,12 @@ references:
 ocil_clause: 'it does not'
 
 ocil: |-
-    {{{ ocil_service_disabled(service="nfs") }}}
+    {{{ ocil_service_disabled(service="nfs-server") }}}
 
 platform: machine
 
 template:
     name: service_disabled
     vars:
-        servicename: nfs
+        servicename: nfs-server
         packagename: nfs-utils

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,sle15
+prodtype: fedora,rhel7,rhel8
 
 title: 'Disable Network File System (nfs)'
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/tests/disabled.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/tests/disabled.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+# packages = nfs-utils
+
+systemctl stop nfs-server
+systemctl disable nfs-server
+systemctl mask nfs-server

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/tests/enabled.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/tests/enabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+# packages = nfs-utils
+
+systemctl start nfs-server
+systemctl enable nfs-server


### PR DESCRIPTION
#### Description:
There is no `nfs` service in rhel8 nor in Fedora. The service is called `nfs-server`.
In rhel7, the `nfs` service exists but it is actually the same as `nfs-server`:
```
[root@localhost ~]# systemctl status nfs
● nfs-server.service - NFS server and services
   Loaded: loaded (/usr/lib/systemd/system/nfs-server.service; disabled; vendor preset: disabled)
...

[root@localhost ~]# systemctl status nfs-server
● nfs-server.service - NFS server and services
   Loaded: loaded (/usr/lib/systemd/system/nfs-server.service; disabled; vendor preset: disabled)
...
``` 

Unfortunately, I don't have sle15 so I can't check the service there. However, in the [sle15 documentation](https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-nfs.html#sec-nfs-import), `nfs` service is mentioned.