### PR TITLE
pipefail not really compatible with grep

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -5,8 +5,9 @@
 # disruption = low
 - block:
     - name: "Find local mount points"
-      shell: | #noqa 306 we don't care about grep failure in this case
-          df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
+      shell: |
+          set -o pipefail
+          { df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true; }
       register: local_mount_points
 
     - name: "Detect the shosts.equiv files on the system"

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -5,8 +5,7 @@
 # disruption = low
 - block:
     - name: "Find local mount points"
-      shell: |
-          set -o pipefail
+      shell: | #noqa 306 we don't care about grep failure in this case
           df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
       register: local_mount_points
 

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -7,7 +7,7 @@
     - name: "Find local mount points"
       shell: |
           set -o pipefail
-          { df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true; }
+          df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true
       register: local_mount_points
 
     - name: "Detect the shosts.equiv files on the system"

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
@@ -5,8 +5,7 @@
 # disruption = low
 - block:
     - name: "Find local mount points"
-      shell: |
-          set -o pipefail
+      shell: | #noqa 306 we don't care about grep failure in this case
           df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
       register: local_mount_points
 

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
@@ -7,7 +7,7 @@
     - name: "Find local mount points"
       shell: |
           set -o pipefail
-          { df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true; }
+          df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true
       register: local_mount_points
 
     - name: "Detect the .shosts files on the system"

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
@@ -5,8 +5,9 @@
 # disruption = low
 - block:
     - name: "Find local mount points"
-      shell: | #noqa 306 we don't care about grep failure in this case
-          df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev'
+      shell: |
+          set -o pipefail
+          { df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true; }
       register: local_mount_points
 
     - name: "Detect the .shosts files on the system"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
@@ -5,8 +5,7 @@
 # disruption = low
 
 - name: Check to see if pam_tally2.so is configured in /etc/pam.d/common-auth
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -e '^\s*auth\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-auth | cat
+  shell: grep -e '^\s*auth\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-auth || true
   register: check_pam_tally2_result
 
 - name: Configure pam_tally2.so module in /etc/pam.d/common-auth
@@ -17,8 +16,7 @@
   when: '"pam_tally2" not in check_pam_tally2_result.stdout'
 
 - name: Check to see if 'onerr' parameter is present
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sonerr=.*' /etc/pam.d/common-auth | cat
+  shell: grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sonerr=.*' /etc/pam.d/common-auth || true
   register: check_onerr_result
 
 - name: Make sure pam_tally2.so has 'onerr' parameter set 'fail'
@@ -39,8 +37,7 @@
   when: '"onerr=" not in check_onerr_result.stdout'
 
 - name: Check to see if 'deny' parameter is present
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sdeny=.*' /etc/pam.d/common-auth | cat
+  shell: grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sdeny=.*' /etc/pam.d/common-auth || true
   register: check_deny_result
 
 - name: Make sure pam_tally2.so has 'deny' parameter set to less than 4
@@ -61,8 +58,7 @@
   when: '"deny=" not in check_deny_result.stdout'
 
 - name: Check to see if pam_tally2.so is configured in /etc/pam.d/common-account
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -e '^\s*account\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-account | cat
+  shell: grep -e '^\s*account\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-account || true
   register: check_account_pam_tally2_result
 
 - name: Configure pam_tally2.so module in /etc/pam.d/common-account

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
@@ -5,8 +5,7 @@
 # disruption = low
 
 - name: Check to see if pam_tally2.so is configured in /etc/pam.d/common-auth
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -e '^\s*auth\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-auth | cat
   register: check_pam_tally2_result
 
@@ -18,8 +17,7 @@
   when: '"pam_tally2" not in check_pam_tally2_result.stdout'
 
 - name: Check to see if 'onerr' parameter is present
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sonerr=.*' /etc/pam.d/common-auth | cat
   register: check_onerr_result
 
@@ -41,8 +39,7 @@
   when: '"onerr=" not in check_onerr_result.stdout'
 
 - name: Check to see if 'deny' parameter is present
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -e '^\s*auth\s\+required\s\+pam_tally2\.so.*\sdeny=.*' /etc/pam.d/common-auth | cat
   register: check_deny_result
 
@@ -64,8 +61,7 @@
   when: '"deny=" not in check_deny_result.stdout'
 
 - name: Check to see if pam_tally2.so is configured in /etc/pam.d/common-account
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -e '^\s*account\s\+required\s\+pam_tally2\.so' /etc/pam.d/common-account | cat
   register: check_account_pam_tally2_result
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -12,8 +12,7 @@
     backup: no
 
 - name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs | cat
+  shell: grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true
   register: check_sha_crypt_min_rounds_result
 
 # NOTE(gyee): there's a possibility that the value of SHA_CRYPT_MIN_ROUNDS is

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -12,7 +12,9 @@
     backup: no
 
 - name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
-  shell: grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true
+  shell:
+     set -o pipefail
+     { grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true; }
   register: check_sha_crypt_min_rounds_result
 
 # NOTE(gyee): there's a possibility that the value of SHA_CRYPT_MIN_ROUNDS is

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -12,8 +12,7 @@
     backup: no
 
 - name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs | cat
   register: check_sha_crypt_min_rounds_result
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -13,8 +13,8 @@
 
 - name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
   shell:
-     set -o pipefail
-     { grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true; }
+    set -o pipefail
+    { grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true; }
   register: check_sha_crypt_min_rounds_result
 
 # NOTE(gyee): there's a possibility that the value of SHA_CRYPT_MIN_ROUNDS is

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -12,7 +12,7 @@
     backup: no
 
 - name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
-  shell:
+  shell: |
     set -o pipefail
     { grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true; }
   register: check_sha_crypt_min_rounds_result

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -14,7 +14,7 @@
 - name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
   shell: |
     set -o pipefail
-    { grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true; }
+    grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true
   register: check_sha_crypt_min_rounds_result
 
 # NOTE(gyee): there's a possibility that the value of SHA_CRYPT_MIN_ROUNDS is

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -9,8 +9,7 @@
     manager: auto
 
 - name: Check to see if 'pam_pkcs11' module is configured in '/etc/pam.d/common-auth'
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth | cat
+  shell: grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth || true
   register: check_pam_pkcs11_module_result
   when: '"pam_pkcs11" in ansible_facts.packages'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -9,8 +9,7 @@
     manager: auto
 
 - name: Check to see if 'pam_pkcs11' module is configured in '/etc/pam.d/common-auth'
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth | cat
   register: check_pam_pkcs11_module_result
   when: '"pam_pkcs11" in ansible_facts.packages'

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
@@ -10,8 +10,6 @@
     split: ':'
 
 - name: lock the password of the user accounts other than root with uid 0
-  shell: |
-    set -o pipefail
-    passwd -l {{ item.key }}
+  shell: passwd -l {{ item.key }}
   loop: "{{ getent_passwd | dict2items | rejectattr('key', 'search', 'root') | list }}"
   when: item.value.1  == '0'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -9,8 +9,7 @@
     manager: auto
 
 - name: get rules groups
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -9,8 +9,9 @@
     manager: auto
 
 - name: get rules groups
-  shell: | #noqa 306 we don't care about grep failure in this case
-    LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
+  shell: |
+    set -o pipefail
+    { LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true; }
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -11,7 +11,7 @@
 - name: get rules groups
   shell: |
     set -o pipefail
-    { LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true; }
+    LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -9,8 +9,7 @@
     manager: auto
 
 - name: get rules groups
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -9,8 +9,9 @@
     manager: auto
 
 - name: get rules groups
-  shell: | #noqa 306 we don't care about grep failure in this case
-    LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u
+  shell: |
+    set -o pipefail
+    { LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true; }
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -11,7 +11,7 @@
 - name: get rules groups
   shell: |
     set -o pipefail
-    { LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true; }
+    LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results
 

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -23,7 +23,9 @@
     control_flag: '{{{ CONTROL_FLAG }}}'
 
 - name: Check to see if '{{{ MODULE }}}' module is configured in '{{{ PATH }}}'
-  shell: grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} || true
+  shell: |
+     set -o pipefail
+     { grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} || true; }
   register: check_pam_module_result
 
 - name: Configure '{{{ MODULE }}}' module in '{{{ PATH }}}'
@@ -63,7 +65,9 @@
     backrefs: yes
 
 - name: Check the presence of "{{{ arg['variable'] }}}" argument in "{{{ MODULE }}}" module
-  shell: grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true
+  shell: 
+     set -o pipefail
+     { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['variable'] }}}" argument to "{{{ MODULE }}}" module
@@ -87,7 +91,9 @@
   when: argument_value|length
 
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
-  shell: grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true
+  shell: 
+     set -o pipefail
+     { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['argument'] }}}" argument to "{{{ MODULE }}}" module

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -65,7 +65,7 @@
     backrefs: yes
 
 - name: Check the presence of "{{{ arg['variable'] }}}" argument in "{{{ MODULE }}}" module
-  shell: 
+  shell: |
      set -o pipefail
      { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
   register: check_pam_module_argument_result
@@ -91,7 +91,7 @@
   when: argument_value|length
 
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
-  shell: 
+  shell: |
      set -o pipefail
      { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
   register: check_pam_module_argument_result

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -23,8 +23,7 @@
     control_flag: '{{{ CONTROL_FLAG }}}'
 
 - name: Check to see if '{{{ MODULE }}}' module is configured in '{{{ PATH }}}'
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this casen
     grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} | cat
   register: check_pam_module_result
 
@@ -65,8 +64,7 @@
     backrefs: yes
 
 - name: Check the presence of "{{{ arg['variable'] }}}" argument in "{{{ MODULE }}}" module
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} | cat
   register: check_pam_module_argument_result
 
@@ -91,8 +89,7 @@
   when: argument_value|length
 
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
-  shell: |
-    set -o pipefail
+  shell: | #noqa 306 we don't care about grep failure in this case
     grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} | cat
   register: check_pam_module_argument_result
 

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -24,8 +24,8 @@
 
 - name: Check to see if '{{{ MODULE }}}' module is configured in '{{{ PATH }}}'
   shell: |
-     set -o pipefail
-     { grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} || true; }
+    set -o pipefail
+    { grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} || true; }
   register: check_pam_module_result
 
 - name: Configure '{{{ MODULE }}}' module in '{{{ PATH }}}'
@@ -66,8 +66,8 @@
 
 - name: Check the presence of "{{{ arg['variable'] }}}" argument in "{{{ MODULE }}}" module
   shell: |
-     set -o pipefail
-     { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
+    set -o pipefail
+    { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['variable'] }}}" argument to "{{{ MODULE }}}" module
@@ -92,8 +92,8 @@
 
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
   shell: |
-     set -o pipefail
-     { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
+    set -o pipefail
+    { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['argument'] }}}" argument to "{{{ MODULE }}}" module

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -25,7 +25,7 @@
 - name: Check to see if '{{{ MODULE }}}' module is configured in '{{{ PATH }}}'
   shell: |
     set -o pipefail
-    { grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} || true; }
+    grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} || true
   register: check_pam_module_result
 
 - name: Configure '{{{ MODULE }}}' module in '{{{ PATH }}}'
@@ -67,7 +67,7 @@
 - name: Check the presence of "{{{ arg['variable'] }}}" argument in "{{{ MODULE }}}" module
   shell: |
     set -o pipefail
-    { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
+    grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['variable'] }}}" argument to "{{{ MODULE }}}" module
@@ -93,7 +93,7 @@
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
   shell: |
     set -o pipefail
-    { grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true; }
+    grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['argument'] }}}" argument to "{{{ MODULE }}}" module

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -23,8 +23,7 @@
     control_flag: '{{{ CONTROL_FLAG }}}'
 
 - name: Check to see if '{{{ MODULE }}}' module is configured in '{{{ PATH }}}'
-  shell: | #noqa 306 we don't care about grep failure in this casen
-    grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} | cat
+  shell: grep -E '^\s*{{{ TYPE }}}\s+\S+\s+{{{ MODULE }}}' {{{ PATH }}} || true
   register: check_pam_module_result
 
 - name: Configure '{{{ MODULE }}}' module in '{{{ PATH }}}'
@@ -64,8 +63,7 @@
     backrefs: yes
 
 - name: Check the presence of "{{{ arg['variable'] }}}" argument in "{{{ MODULE }}}" module
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} | cat
+  shell: grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['variable'] }}}(=|\s|\s*$)' {{{ PATH }}} || true
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['variable'] }}}" argument to "{{{ MODULE }}}" module
@@ -89,8 +87,7 @@
   when: argument_value|length
 
 - name: Check the presence of "{{{ arg['argument'] }}}" argument in "{{{ MODULE }}}" module
-  shell: | #noqa 306 we don't care about grep failure in this case
-    grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} | cat
+  shell: grep -E '^\s*{{{ TYPE }}}\s+{{{ CONTROL_FLAG }}}\s+{{{ MODULE }}}.*\s+{{{ arg['argument'] }}}(=|\s|\s*$)' {{{ PATH }}} || true
   register: check_pam_module_argument_result
 
 - name: Add "{{{ arg['argument'] }}}" argument to "{{{ MODULE }}}" module


### PR DESCRIPTION
The pipefail option traps on all non 0 reurn codes, but grep exits
with 1 if the pattern is not found. So, just disable that ansible-lint
check if the shell snippet is using grep.

#### Description:

- Disable ansible-lint pipefail test, if going grep
#### Rationale:

- The pipefail option traps on all non 0 reurn codes, but grep exits with 1 if the pattern is not found. So, just disable that ansible-lint check if the shell snippet is using grep.

- Without this the ansible play will hit pipefail trap if pattern is not found, which pretty much breaks, if not found, add cases.
- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
