### PR TITLE
RHCOS4: Fix `require_singleuser_auth` rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -20,7 +20,7 @@
   {{%- if init_system == "systemd" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product in ["fedora", "rhel8", "ol8"] -%}}
+    {{% if product in ["fedora", "rhel8", "ol8", "rhcos4"] -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -32,7 +32,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
-    {{%- if product in ["fedora", "rhel8", "ol8"] -%}}
+    {{%- if product in ["fedora", "rhel8", "ol8", "rhcos4"] -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
     To check if authentication is required for single-user mode, run the following command:
     <pre>$ grep sulogin /usr/lib/systemd/system/rescue.service</pre>
     The output should be similar to the following, and the line must begin with
-    {{% if product in ["fedora", "rhel8", "ol8"] -%}}
+    {{% if product in ["fedora", "rhel8", "ol8", "rhcos4"] -%}}
         ExecStart and /usr/lib/systemd/systemd-sulogin-shell.
         <pre>ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue</pre>
     {{%- else -%}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
RHCOS4, similarly to RHEL8 uses `/usr/lib/systemd/systemd-sulogin-shell rescue`.

So let's ensure the content takes rhcos4 into account so the rule
is evaluated correctly.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>