### PR TITLE
service_rsyncd_disabled - update package name to rsync-daemon

### DIFF
--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,ol7,rhel8,ol8,fedora,rhv4,rhcos4,sle15
+prodtype: rhel7,ol7,rhel8,ol8,fedora,rhv4,sle15
 
 title: 'Ensure rsyncd service is diabled'
 

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -33,4 +33,7 @@ template:
     name: service_disabled
     vars:
         servicename: rsyncd
-        packagename: rsync
+        packagename: rsync-daemon
+        packagename@rhel7: rsync
+        packagename@ol7: rsync
+        packagename@sle15: rsync

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/disabled.pass.sh
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/disabled.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Oracle Linux 8,multi_platform_fedora,multi_platform_rhv
+# packages = rsync-daemon
+
+systemctl stop rsyncd
+systemctl disable rsyncd
+systemctl mask rsyncd

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/enabled.fail.sh
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/enabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Oracle Linux 8,multi_platform_fedora,multi_platform_rhv
+# packages = rsync-daemon
+
+systemctl start rsyncd
+systemctl enable rsyncd


### PR DESCRIPTION
#### Description:
Some products have the `rsyncd` service in the `rsync-daemon` package, not in `rsync`.

- rhel8 and Fedora - I have verified that these two products have `rsyncd` in the `rsync-daemon` package,
- ol8 and rhv4 - this is guess (they should be based on rhel8 so I'd say it should be similar as rhel8),
- sle15 - I didn't find any `rsync-daemon` package for sle15, @brett060102 can you verify that the `rsyncd` service is in the `rsync` package?

The `rhcos4` prodtype was removed because `rsyncd` is not available in RHCOS4 (neither `rsync` nor `rsync-daemon` is available there). And this rule is not present in any RHCOS4 profile.