### PR TITLE
RHCOS4:  Remove account_disable_post_pw_expiration from moderate profile

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -589,9 +589,6 @@ selections:
     - auditd_data_retention_num_logs
     - auditd_data_retention_max_log_file
 
-    # AC-2(3)
-    - account_disable_post_pw_expiration
-
     # AC-2(5), AC-12
     #- accounts_tmout
 


### PR DESCRIPTION
Accounts shouldn't be set on the nodes themselves and should instead be
handled via an external IdP configured at the cluster level.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>