### PR TITLE
rhcos4: Remove ssh crypto policy hardening from moderate policy

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -244,8 +244,8 @@ selections:
     - enable_fips_mode
     - var_system_crypto_policy=fips
     - configure_crypto_policy
-    - harden_sshd_crypto_policy
-    - harden_ssh_client_crypto_policy
+    #- harden_sshd_crypto_policy
+    #- harden_ssh_client_crypto_policy
     - configure_openssl_crypto_policy
     - configure_kerberos_crypto_policy
 


### PR DESCRIPTION
FedRAMP moderate only asks about FIPS and we are already checking for
the FIPS crypto policy. This should be enough for the benchmark.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>