### PR TITLE
Updates to support ansible_playbook_to_role utility

### DIFF
--- a/.github/workflows/validate_ansible_roles.yaml
+++ b/.github/workflows/validate_ansible_roles.yaml
@@ -1,7 +1,7 @@
 name: Validate Ansible Roles
 on:
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 jobs:
@@ -12,15 +12,19 @@ jobs:
       - name: Install Deps
         uses: mstksg/get-package@master
         with:
-                apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml ansible-lint python3-github
+                apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml python3-github
+      - name: Install upstream ansible-lint
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible-lint ansible
       - name: Checkout
         uses: actions/checkout@v1
       - name: Build
         run: |
-          ./build_product rhel7 rhel8 rhv4
+          ./build_product rhel7 rhel8
       - name: Build Ansible Roles
         run: |
           PYTHONPATH=. python3 utils/ansible_playbook_to_role.py --build-playbooks-dir ./build/ansible/ --dry-run ./build/ansible_roles
       - name: Lint Ansible Roles
         run: |
-          ansible-lint -x 204 ./build/ansible_roles/*
+          ansible-lint -x 204 -x experimental ./build/ansible_roles/*

--- a/utils/ansible_galaxy_meta_template.yml
+++ b/utils/ansible_galaxy_meta_template.yml
@@ -10,24 +10,10 @@ galaxy_info:
   min_ansible_version: @MIN_ANSIBLE_VERSION@
 
   platforms:
-  - name: GenericBSD
+  - name: EL
     versions:
-    - any
-  - name: GenericLinux
-    versions:
-    - any
-  - name: GenericUNIX
-    versions:
-    - any
+    - @PLATFORM_VERSION@
 
-  galaxy_tags:
-  - system
-  - hardening
-  - openscap
-  - ssg
-  - scap
-  - security
-  - compliance
-  - compliaceascode
+  @GALAXY_TAGS@
 
 dependencies: []


### PR DESCRIPTION
#### Description:

Numerous updates were made to enhance the functionality
and to fix bugs:
* Updated GH actions to run on push events for verification. Also added a new tag skip.
* Updated galaxy meta template. Includes additions of variables
to be used as substitutions to support automating the creation
of that file, and to prevent manual additions as was handled in
the past.
* Added the anssi profiles to the whitelist (have not done any testing
on these roles yet)
* Updates/bug fixes to support meta templating. Fixed issue with
meta and readme files being overwritten with the wrong output.
* Updated syntax for python3 support. No need to use python2 for
this IMO.

#### Rationale:

Need to continue to provide a mechanism of translating our Ansible playbooks into roles that can be ingested into Ansible Galaxy.
