### PR TITLE
Add Ubuntu as a known platform for ssg_test_suite

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -326,6 +326,7 @@ INSTALL_COMMANDS = dict(
     fedora=("dnf", "install", "-y"),
     rhel7=("yum", "install", "-y"),
     rhel8=("yum", "install", "-y"),
+    ubuntu=("DEBIAN_FRONTEND=noninteractive", "apt", "install", "-y"),
 )
 
 
@@ -355,5 +356,7 @@ def cpes_to_platform(cpes):
             if match:
                 major_version = match.groups()[0].split(".")[0]
                 return "rhel" + major_version
+        if "ubuntu" in cpe:
+            return "ubuntu"
     msg = "Unable to deduce a platform from these CPEs: {cpes}".format(cpes=cpes)
     raise ValueError(msg)

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -139,7 +139,7 @@ def determine_ip(domain):
         domain_xml = ET.fromstring(domain.XMLDesc())
         for guest_agent_node in domain_xml.iter('channel'):
             if guest_agent_node.attrib['type'] == 'unix':
-                guest_agent_xml_string = ET.tostring(guest_agent_node)
+                guest_agent_xml_string = ET.tostring(guest_agent_node, encoding='unicode')
                 break
         if guest_agent_xml_string:
             domain.detachDevice(guest_agent_xml_string)


### PR DESCRIPTION
#### Description:

In order to run on Ubuntu (as a host and a guest) I ended up needing two
things:

 1. Add Ubuntu to the package installation capabilities,
 2. Fix libvirt<->xml interactions: `tostring` rendered as `bytes` not as a
    `str` object but the libvirt API expected a `str`.

I also needed to add `CPE_NAME` to the Ubuntu guest VM as our
`/etc/os-release` doesn't contain it by default.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`