### PR TITLE
Handle profile selection correctly in SSG Test Suite

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -56,10 +56,10 @@ class CombinedChecker(rule.RuleChecker):
         # be tested using the self.profile and we return empty profiles
         # metadata.
         if not params["profiles"]:
-            params["profiles"].append(rule.OSCAP_PROFILE_ALL_ID)
+            params["profiles"].extend(self.profile)
             logging.debug(
                 "Added the {0} profile to the list of available profiles for {1}"
-                .format(rule.OSCAP_PROFILE_ALL_ID, script))
+                .format(self.profile, script))
         else:
             params['profiles'] = [item for item in params['profiles'] if re.search(self.profile, item)]
         return params

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -39,7 +39,7 @@ def get_viable_profiles(selected_profiles, datastream, benchmark, script=None):
     all_profiles.append(OSCAP_PROFILE_ALL_ID)
 
     for ds_profile in all_profiles:
-        if 'ALL' in selected_profiles:
+        if 'ALL' in selected_profiles or OSCAP_PROFILE_ALL_ID in selected_profiles:
             valid_profiles += [ds_profile]
             continue
         for sel_profile in selected_profiles:


### PR DESCRIPTION
#### Description:

    Validate scripts against combined's target profile
    
    When combined is executed, a specific list of profiles are supplied.
    Because these scripts are executed for each profile (within rule.py), we
    end up executing these scripts against each profile in the benchmark.
    However, combined already takes a profile argument and thus these
    scripts should be limited to the profiles the user already selected.
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

---

    Handle OSCAP_PROFILE_ALL_ID in rule testing
    
    When testing a script which applies to multiple profiles, we want to
    execute OSCAP against each profile in the DS, not once. Previously, we'd
    use '(all)' to indicate all profiles (e.g., in combined.py's
    _modify_parameters), but check it against ALL. IMO this is incorrect
    behavior and we should instead be adding all DS profiles individually.
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

#### Rationale:

I encountered both of these issues while attempting to run `combined` on the WIP Ubuntu profile. Note that Ubuntu currently ships with OpenSCAP version 1.2 (so perhaps `(all)` pseudo-profile wasn't added until 1.3)? 
