### PR TITLE
Update Ubuntu CPEs to match published CPEs

### DIFF
--- a/ubuntu1604/product.yml
+++ b/ubuntu1604/product.yml
@@ -14,6 +14,6 @@ oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xe
 cpes_root: "../shared/applicability"
 cpes:
   - ubuntu1604:
-      name: "cpe:/o:canonical:ubuntu_linux:16.04"
+      name: "cpe:/o:canonical:ubuntu_linux:16.04::~~lts~~~"
       title: "Ubuntu release 16.04 (Xenial)"
       check_id: installed_OS_is_ubuntu1604

--- a/ubuntu1804/product.yml
+++ b/ubuntu1804/product.yml
@@ -13,6 +13,6 @@ init_system: "systemd"
 cpes_root: "../shared/applicability"
 cpes:
   - ubuntu1804:
-      name: "cpe:/o:canonical:ubuntu_linux:18.04"
+      name: "cpe:/o:canonical:ubuntu_linux:18.04::~~lts~~~"
       title: "Ubuntu release 18.04 (Bionic Beaver)"
       check_id: installed_OS_is_ubuntu1804

--- a/ubuntu2004/product.yml
+++ b/ubuntu2004/product.yml
@@ -13,6 +13,6 @@ init_system: "systemd"
 cpes_root: "../shared/applicability"
 cpes:
   - ubuntu2004:
-      name: "cpe:/o:canonical:ubuntu_linux:20.04"
+      name: "cpe:/o:canonical:ubuntu_linux:20.04::~~lts~~~"
       title: "Ubuntu release 20.04 (Focal Fossa)"
       check_id: installed_OS_is_ubuntu2004


### PR DESCRIPTION
#### Description:

From both `official-cpe-dictionary_v2.3.xml` and
`official-cpe-dictionary_v2.2.xml`, Ubuntu's CPEs include the LTS suffix.
Update CaC/content's copies to match.

Note: this only applies for LTS releases. If non-LTS releases were to
be included later, they wouldn't include this suffix.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

#### Rationale:

Also working on a PR to get `CPE_NAME` added to `base-files`; figured we should make it consistent with the NIST NVD entries everywhere.
