### PR TITLE
remove service_nfs_disabled sle15/profiles/cis.profile

### DIFF
--- a/sle15/profiles/cis.profile
+++ b/sle15/profiles/cis.profile
@@ -261,9 +261,6 @@ selections:
     ### 2.2.6 Ensure LDAP server is not enabled (Scored)
     - package_openldap-servers_removed
 
-    ### 2.2.7 Ensure NFS and RPC are not enabled (Scored)
-    - service_nfs_disabled
-
     ### 2.2.8 Ensure rpcbind is not enabled (Scored)
     - service_rpcbind_disabled
 


### PR DESCRIPTION
 service_nfs_disabled was added in initial creation,
 but has not been validated for SLES.

#### Description:

- remove service_nfs_disabled sle15/profiles/cis.profile

#### Rationale:

-  blocking change https://github.com/ComplianceAsCode/content/pull/6777

