### PR TITLE
Add rules for SLES-12-010060

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -4,10 +4,9 @@
 # complexity = low
 # disruption = medium
 
-{{% if product in ["sle12", "sle15"] %}}
 - name: Dconf Update
   command: dconf update
-{{% endif %}}
+  when: ansible_distribution == 'SLES'
 
 - name: "Enable GNOME3 Screensaver Lock After Idle Period"
   ini_file:

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -1,8 +1,14 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low
 # disruption = medium
+
+{{% if product in ["sle12", "sle15"] %}}
+- name: Dconf Update
+  command: dconf update
+{{% endif %}}
+
 - name: "Enable GNOME3 Screensaver Lock After Idle Period"
   ini_file:
     dest: "/etc/dconf/db/local.d/00-security-settings"
@@ -18,6 +24,15 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
+
+- name: "Check GNOME3 screenserver disable-lock-screen false"
+  command: gsettings get org.gnome.desktop.lockdown disable-lock-screen
+  register: cmd_out
+  when: ansible_distribution == 'SLES'
+
+- name: "Update GNOME3 screenserver disable-lock-screen false"
+  command: gsettings set org.gnome.desktop.lockdown disable-lock-screen false
+  when: ansible_distribution == 'SLES'
 
 - name: Dconf Update
   command: dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12
 
 title: 'Enable GNOME3 Screensaver Lock After Idle Period'
 
@@ -26,13 +26,16 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80112-6
     cce@rhel8: CCE-80777-6
+    cce@sle12: CCE-83222-0
 
 references:
     stigid@ol7: OL07-00-010060
     cjis: 5.5.5
     cui: 3.1.10
     disa: CCI-000056,CCI-000058
+    disa@sle12: CCI-000060
     nist: CM-6(a)
+    nist@sle12: AC-11(b),AC-11(a),AC-11(1),AC-11(1).1,AC-11.1(iii),AC-11
     nist-csf: PR.AC-7
     ospp: FMT_MOF_EXT.1
     pcidss: Req-8.1.8
@@ -44,15 +47,24 @@ references:
     iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16
     stigid@rhel8: RHEL-08-020030
+    stigid@sle12: SLES-12-010060
 
 ocil_clause: 'screensaver locking is not enabled and/or has not been set or configured correctly'
 
 ocil: |-
     To check the status of the idle screen lock activation, run the following command:
+    {{% if product in ['sle12','sle15'] %}}
+    <pre>gsettings get org.gnome.desktop.lockdown disable-lock-screen</pre>
+    If the result is "true", this is a finding.
+    Configure the SUSE operating system to allow the user to lock the GUI.
+    Run the following command to configure the SUSE operating system to allow the user to lock the GUI:
+    <pre>gsettings set org.gnome.desktop.lockdown disable-lock-screen false</pre>
+    {{% else %}}
     <pre>$ gsettings get org.gnome.desktop.screensaver lock-enabled</pre>
     If properly configured, the output should be <tt>true</tt>.
     To ensure that users cannot change how long until the the screensaver locks, run the following:
     <pre>$ grep lock-enabled /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output for <tt>lock-enabled</tt> should be <tt>/org/gnome/desktop/screensaver/lock-enabled</tt>
+    {{% endif %}}
 
 platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -5,6 +5,13 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12
 title: 'Enable GNOME3 Screensaver Lock After Idle Period'
 
 description: |-
+    {{% if product in ['sle12','sle15'] %}}
+    To activate locking of the screensaver in the GNOME3 desktop when it is activated,
+    run the following command to configure the SUSE operating system to allow the user to lock the GUI:
+    <pre>gsettings set org.gnome.desktop.lockdown disable-lock-screen false</pre>
+    Validate that <tt>disable-lock-screen</tt> has been set to <tt>false</tt> with the command:
+    <pre>gsettings get org.gnome.desktop.lockdown disable-lock-screen</pre>
+    {{% else %}}
     To activate locking of the screensaver in the GNOME3 desktop when it is activated,
     add or set <tt>lock-enabled</tt> to <tt>true</tt> in
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
@@ -16,6 +23,7 @@ description: |-
     For example:
     <pre>/org/gnome/desktop/screensaver/lock-enabled</pre>
     After the settings have been set, run <tt>dconf update</tt>.
+    {{% endif %}}
 
 rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -153,6 +153,7 @@ selections:
     - dconf_db_up_to_date
     - dconf_gnome_banner_enabled
     - dconf_gnome_login_banner_text
+    - dconf_gnome_screensaver_lock_enabled
     - dir_perms_world_writable_sticky_bits
     - dir_perms_world_writable_system_owned_group
     - disable_ctrlaltdel_reboot


### PR DESCRIPTION
- SLES-12-010060 'Enable GNOME3 Screensaver Lock After Idle Period'

#### Description:

- Add rules for SLES-12-010060
- required slight changes to ansible/shared.yml to accommodate what is in SLES-12-010060 from DISA

#### Rationale:

- enable GNOME3 Screensaver Lock for SLE-12

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
