### PR TITLE
increase /usr partition size in testing kicstart

### DIFF
--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -86,11 +86,11 @@ part pv.01 --grow --size=1
 volgroup VolGroup --pesize=4096 pv.01
 
 # Create particular logical volumes (optional)
-logvol / --fstype=xfs --name=root --vgname=VolGroup --size=8192 --grow
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=6144 --grow
 # Ensure /home Located On Separate Partition
 logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=2048 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=4096 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /opt Located On Separate Partition


### PR DESCRIPTION
#### Description:

- decrease size of root partition to 6G
- increase size of /usr partition to 4G
- both changes are done in kickstart used while provisioning testing VMs

#### Rationale:

- after installing of rhel7 there was not enouigh space to install gdm and dconf pacakges, this was required for testing