### PR TITLE
fix remaining ansible-lint issue for sle

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
@@ -10,6 +10,6 @@
     split: ':'
 
 - name: lock the password of the user accounts other than root with uid 0
-  shell: passwd -l {{ item.key }}
+  command: passwd -l {{ item.key }}
   loop: "{{ getent_passwd | dict2items | rejectattr('key', 'search', 'root') | list }}"
   when: item.value.1  == '0'


### PR DESCRIPTION
#### Description:

- change shell module to command in accounts_no_uid_except_zero

#### Rationale:

- this was reported by ansible-lint in Jenkins