### PR TITLE
Add Rule for SLES-15-040382

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
@@ -11,7 +11,6 @@ rationale: |-
     interface to another. The ability to forward packets between two networks is
     only appropriate for systems acting as routers.
 
-
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
@@ -11,16 +11,19 @@ rationale: |-
     interface to another. The ability to forward packets between two networks is
     only appropriate for systems acting as routers.
 
+
 severity: medium
 
 identifiers:
-    cce@sle15: CCE-85716-9
+    cce@sle15: CCE-85725-0 
 
 references:
     disa@sle15: CCI-000366
     srg@sle15: SRG-OS-000480-GPOS-00227
     nist@sle15: CM-6(b),CM-6.1(iv)
     stigid@sle15: SLES-15-040382
+
+ocil_clause: 'IPv6 Forwading is not disabled'
 
 ocil: |-
     {{{ ocil_sysctl_option_value(sysctl="net.ipv6.conf.default.forwarding", value="0") }}}

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: sle15
+
+title: 'Disable Kernel Parameter for IPv6 Forwarding by default'
+
+description: '{{{ describe_sysctl_option_value(sysctl="net.ipv6.conf.default.forwarding", value="0") }}}'
+
+rationale: |-
+    IP forwarding permits the kernel to forward packets from one network
+    interface to another. The ability to forward packets between two networks is
+    only appropriate for systems acting as routers.
+
+severity: medium
+
+identifiers:
+    cce@sle15: CCE-85716-9
+
+references:
+    disa@sle15: CCI-000366
+    srg@sle15: SRG-OS-000480-GPOS-00227
+    nist@sle15: CM-6(b),CM-6.1(iv)
+    stigid@sle15: SLES-15-040382
+
+ocil: |-
+    {{{ ocil_sysctl_option_value(sysctl="net.ipv6.conf.default.forwarding", value="0") }}}
+    The ability to forward packets is only appropriate for routers.
+
+platform: machine
+
+template:
+    name: sysctl
+    vars:
+        sysctlvar: net.ipv6.conf.default.forwarding
+        datatype: int

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding_value.var
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding_value.var
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: net.ipv6.conf.default.forwarding
+
+description: 'Toggle IPv6 default Forwarding'
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "0"
+    disabled: "0"
+    enabled: 1

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -248,5 +248,6 @@ selections:
     - sysctl_net_ipv6_conf_all_accept_source_route
     - sysctl_net_ipv6_conf_default_accept_redirects
     - sysctl_net_ipv6_conf_default_accept_source_route
+    - sysctl_net_ipv6_conf_default_forwarding
     - vlock_installed
     - wireless_disable_interfaces


### PR DESCRIPTION
SLES-15-040382 'Disable Kernel Parameter for IPv6 Forwarding by default'

#### Description:

-  SLES-15-040382 'Disable Kernel Parameter for IPv6 Forwarding by default'

#### Rationale:
- Create rule and tests sysctl_net_ipv6_conf_default_forwarding


    

