### PR TITLE
Enable `dir_perms_world_writable_sticky_bits` ansible remediation in RHEL.

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

- Enable `dir_perms_world_writable_sticky_bits` ansible remediation in RHEL.

#### Rationale:

- update [RHEL-08-010190](https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_8_security_technical_implementation_guide/V-230243)
