### PR TITLE
build-scripts/profile_tool.py - add option to not show overall statistics of a benchmark

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -87,6 +87,9 @@ def parse_args():
     parser_stats.add_argument("--all", default=False,
                         action="store_true", dest="all",
                         help="Show all available statistics.")
+    parser_stats.add_argument("--skip-stats", default=False,
+                              action="store_true", dest="skip_overall_stats",
+                              help="Do not show overall statistics.")
     parser_stats.add_argument("--format", default="plain",
                         choices=["plain", "json", "csv", "html"],
                         help="Which format to use for output.")

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -310,34 +310,35 @@ class XCCDFBenchmark(object):
         impl_cces_count = len(profile_stats['assigned_cces'])
 
         if options.format == "plain":
-            print("\nProfile %s:" % profile)
-            print("* rules:            %d" % rules_count)
-            print("* checks (OVAL):    %d\t[%d%% complete]" %
-                  (impl_ovals_count,
-                   profile_stats['implemented_ovals_pct']))
+            if not options.skip_overall_stats:
+                print("\nProfile %s:" % profile)
+                print("* rules:            %d" % rules_count)
+                print("* checks (OVAL):    %d\t[%d%% complete]" %
+                      (impl_ovals_count,
+                       profile_stats['implemented_ovals_pct']))
 
-            print("* fixes (bash):     %d\t[%d%% complete]" %
-                  (impl_bash_fixes_count,
-                   profile_stats['implemented_bash_fixes_pct']))
-            print("* fixes (ansible):  %d\t[%d%% complete]" %
-                  (impl_ansible_fixes_count,
-                   profile_stats['implemented_ansible_fixes_pct']))
-            print("* fixes (ignition):  %d\t[%d%% complete]" %
-                  (impl_ignition_fixes_count,
-                   profile_stats['implemented_ignition_fixes_pct']))
-            print("* fixes (kubernetes):  %d\t[%d%% complete]" %
-                  (impl_kubernetes_fixes_count,
-                   profile_stats['implemented_kubernetes_fixes_pct']))
-            print("* fixes (puppet):   %d\t[%d%% complete]" %
-                  (impl_puppet_fixes_count,
-                   profile_stats['implemented_puppet_fixes_pct']))
-            print("* fixes (anaconda): %d\t[%d%% complete]" %
-                  (impl_anaconda_fixes_count,
-                   profile_stats['implemented_anaconda_fixes_pct']))
+                print("* fixes (bash):     %d\t[%d%% complete]" %
+                      (impl_bash_fixes_count,
+                       profile_stats['implemented_bash_fixes_pct']))
+                print("* fixes (ansible):  %d\t[%d%% complete]" %
+                      (impl_ansible_fixes_count,
+                       profile_stats['implemented_ansible_fixes_pct']))
+                print("* fixes (ignition):  %d\t[%d%% complete]" %
+                      (impl_ignition_fixes_count,
+                       profile_stats['implemented_ignition_fixes_pct']))
+                print("* fixes (kubernetes):  %d\t[%d%% complete]" %
+                      (impl_kubernetes_fixes_count,
+                       profile_stats['implemented_kubernetes_fixes_pct']))
+                print("* fixes (puppet):   %d\t[%d%% complete]" %
+                      (impl_puppet_fixes_count,
+                       profile_stats['implemented_puppet_fixes_pct']))
+                print("* fixes (anaconda): %d\t[%d%% complete]" %
+                      (impl_anaconda_fixes_count,
+                       profile_stats['implemented_anaconda_fixes_pct']))
 
-            print("* CCEs:             %d\t[%d%% complete]" %
-                  (impl_cces_count,
-                   profile_stats['assigned_cces_pct']))
+                print("* CCEs:             %d\t[%d%% complete]" %
+                      (impl_cces_count,
+                       profile_stats['assigned_cces_pct']))
 
             if options.implemented_ovals and \
                profile_stats['implemented_ovals']:


### PR DESCRIPTION
#### Description:
Add new option `--skip-stats` to `build-scripts/profile_tool.py` to skip overall statistics that are shown at the beginning of plain format.

#### Rationale:
When a user needs to display e.g. missing refs, the statistics might not be useful.

Before:
```     
$ python3 build-scripts/profile_tool.py stats --benchmark build/ssg-rhel8-xccdf.xml --profile stig --missing-stig-ids

Profile stig:
* rules:            251
* checks (OVAL):    239 [95% complete]
* fixes (bash):     222 [88% complete]
* fixes (ansible):  199 [79% complete]
* fixes (ignition):  0  [0% complete]
* fixes (kubernetes):  58       [23% complete]
* fixes (puppet):   43  [17% complete]
* fixes (anaconda): 51  [20% complete]
* CCEs:             251 [100% complete]
*** rules of 'stig' profile missing STIG IDs: 210 of 251 have them [16% missing]
   auditd_data_retention_space_left_action      
   configure_bind_crypto_policy                    configure_crypto_policy                      
   configure_kerberos_crypto_policy             
   configure_libreswan_crypto_policy     
...       
```

After:
```
$ python3 build-scripts/profile_tool.py stats --benchmark build/ssg-rhel8-xccdf.xml --profile stig --missing-stig-ids --skip-stats
*** rules of 'stig' profile missing STIG IDs: 210 of 251 have them [16% missing]
   auditd_data_retention_space_left_action      
   configure_bind_crypto_policy                    configure_crypto_policy                      
   configure_kerberos_crypto_policy             
   configure_libreswan_crypto_policy  
...
```