### PR TITLE
OCP4: Add applicability warnings

### DIFF
--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -25,6 +25,12 @@ references:
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Etcd service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 ocil_clause: 'The etcd CA certificate is not unique'
 
 ocil: |-

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Controller
+      Manager service. The aforementioned service is only running on
+      the nodes labeled "master" by default.
+
 template:
   name: file_groupowner
   vars:

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -28,6 +28,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_groupowner
     vars:

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -28,6 +28,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_groupowner
     vars:

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -29,6 +29,12 @@ ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_groupowner
     vars:

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -30,6 +30,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Etcd service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -26,6 +26,12 @@ ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Kubernetes API Server service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_groupowner
     vars:

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -26,6 +26,12 @@ ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Kubernetes Controller Manager service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_groupowner
     vars:

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -26,6 +26,12 @@ ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Kubernetes Scheduler service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_groupowner
     vars:

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
@@ -33,6 +33,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Kubernetes API server service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
   name: file_groupowner
   vars:

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -30,6 +30,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -30,6 +30,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Scheduler service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_groupowner
   vars:

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Controller Manager service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_owner
   vars:

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -28,6 +28,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_owner
     vars:

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -28,6 +28,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_owner
     vars:

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify User Who Owns The etcd Member Pod Specification File'
+title: 'Verify User Who Owns The Etcd Member Pod Specification File'
 
 description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
@@ -28,6 +28,12 @@ ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*
 
 platforms:
     - ocp4-master-node
+
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
@@ -30,6 +30,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Etcd service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -26,6 +26,12 @@ ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apise
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Kubernetes API Server service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_owner
     vars:

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -26,6 +26,12 @@ ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-contr
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Kubernetes Controller Manager service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_owner
     vars:

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -26,6 +26,12 @@ ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-sched
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Kubernetes Scheduler service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_owner
     vars:

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
@@ -33,6 +33,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_owner
   vars:

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
@@ -30,6 +30,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
@@ -28,6 +28,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Scheduler service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_owner
   vars:

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -30,6 +30,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Controller Manager service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_permissions
   vars:

--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_permissions
     vars:

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
+
 template:
     name: file_permissions
     vars:

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-title: 'Verify Permissions on the etcd Member Pod Specification File'
+title: 'Verify Permissions on the Etcd Member Pod Specification File'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0644") }}}
@@ -30,6 +30,12 @@ ocil: |-
 
 platforms:
     - ocp4-master-node
+
+warnings:
+    - dependency: |-
+        This rule is only applicable for nodes that run the Etcd service.
+        The aforementioned service is only running on the nodes labeled
+        "master" by default.
 
 template:
     name: file_permissions

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Etcd service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes API Server service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_permissions
   vars:

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Controller Manager service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
     name: file_permissions
     vars:

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
@@ -33,6 +33,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_permissions
   vars:

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.key

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Control Plane.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 # Note that this recursively checks for files, and the form is as follows:
 #
 #  /etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key

--- a/applications/openshift/master/file_permissions_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler/rule.yml
@@ -29,6 +29,12 @@ ocil: |-
 platforms:
     - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Scheduler service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
     name: file_permissions
     vars:

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
@@ -30,6 +30,12 @@ ocil: |-
 platforms:
   - ocp4-master-node
 
+warnings:
+  - dependency: |-
+      This rule is only applicable for nodes that run the Kubernetes Scheduler service.
+      The aforementioned service is only running on the nodes labeled
+      "master" by default.
+
 template:
   name: file_permissions
   vars:


### PR DESCRIPTION
These will show up as part of the results and guide users to why a check
is marked as NOT-APPLICABLE.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>