### PR TITLE
Render set of rules as HTML

### DIFF
--- a/utils/html-template.html
+++ b/utils/html-template.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {{% block head %}}
+  <meta charset="UTF-8"/>
+  <title>{{{ title }}}</title>
+  {{% endblock %}}
+<style>
+</style>
+</head>
+<body>
+
+{{% block body %}}
+<h1>{{{ title }}}</h1>
+{{% endblock %}}
+
+</body>
+</html>

--- a/utils/render-rules.py
+++ b/utils/render-rules.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+
+from glob import glob
+import collections
+import os
+import pathlib
+
+import argparse
+
+import ssg.build_yaml
+import ssg.controls
+import ssg.yaml
+import ssg.jinja
+import template_renderer
+
+
+class HtmlOutput(template_renderer.Renderer):
+    TEMPLATE_NAME = "rules-template.html"
+
+    def _get_all_compiled_profiles(self):
+        compiled_profiles = glob(str(self.built_content_path / "profiles" / "*.profile"))
+        profiles = []
+        for p in compiled_profiles:
+            profiles.append(ssg.build_yaml.Profile.from_yaml(p))
+        return profiles
+
+    def _set_rule_profiles_membership(self, rule, profiles):
+        rule.in_profiles = []
+        for p in profiles:
+            if rule.id_ in p.selected:
+                rule.in_profiles.append(p)
+
+    def process_rules(self, rule_files, component):
+        rules = []
+        profiles = self._get_all_compiled_profiles()
+
+        for r_file in rule_files:
+            rule = ssg.build_yaml.Rule.from_yaml(r_file, self.env_yaml)
+            self._set_rule_relative_definition_location(rule)
+            self._set_rule_profiles_membership(rule, profiles)
+
+            rules.append(rule)
+
+        self.template_data["rules"] = rules
+        self.template_data["component"] = component
+
+
+def parse_args():
+    parser = HtmlOutput.create_parser(
+        "Pass a list of rule YAMLs (that are related to a component), and the script will "
+        "render their summary as an HTML along with links to the usage of these rules in profiles "
+        "and with links to the upstream rule source.")
+    parser.add_argument(
+        "--component", help="Name of the component.")
+    parser.add_argument(
+        "rule", metavar="FILENAME", nargs="+", help="The rule YAML files")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    renderer = HtmlOutput(args.product, args.build_dir)
+    renderer.process_rules(args.rule, args.component)
+    renderer.output_results(args)

--- a/utils/render-rules.py
+++ b/utils/render-rules.py
@@ -26,13 +26,15 @@ class HtmlOutput(template_renderer.Renderer):
         return profiles
 
     def _set_rule_profiles_membership(self, rule, profiles):
-        rule.in_profiles = []
-        for p in profiles:
-            if rule.id_ in p.selected:
-                rule.in_profiles.append(p)
+        rule.in_profiles = [p for p in profiles if rule.id_ in p.selected]
 
     def _resolve_var_substitutions(self, rule):
-        rule.description = re.sub('<sub\s+idref="([^"]*)"\s*/>', r"<tt>$\1</tt>", rule.description)
+        # The <sub .../> here is not the HTML subscript element <sub>...</sub>,
+        # and therefore is invalid HTML.
+        # so this code substitutes the whole sub element with contents of its idref prefixed by $
+        # as occurrence of sub with idref implies that substitution of XCCDF values takes place
+        rule.description = re.sub(
+            r'<sub\s+idref="([^"]*)"\s*/>', r"<tt>$\1</tt>", rule.description)
 
     def process_rules(self, rule_files):
         rules = []

--- a/utils/rules-template.html
+++ b/utils/rules-template.html
@@ -1,28 +1,20 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Rules related to {{{ component }}} on {{{ product }}}</title>
-<style>
-</style>
-</head>
-<body>
+{{% extends "html-template.html" %}}
 
-<h1>Rules related to {{{ component }}}</h1>
-
+{{% block body %}}
+{{{ super() }}}
 <div class="rules">
 {{% for rule in rules -%}}
 <div class="one_rule">
 	<h2>{{{ loop.index }}}. {{{ rule.title }}}</h2>
-  <p>{{{ rule.description | safe }}}</p>
+	<p>{{{ rule.description | safe }}}</p>
 {{% if rule.in_profiles -%}}
 Used in {{{ rule.in_profiles.__len__() }}} profiles:
   <ul>
   {{% for p in rule.in_profiles %}}
-  <li><a href="https://static.open-scap.org/ssg-guides/ssg-{{{ product }}}-guide-{{{ p.id_ }}}.html#xccdf_org.ssgproject.content_rule_{{{ rule.id_ }}}">{{{ p.title }}}</a></li>
-  {{% endfor %}}
+    <li><a href="https://static.open-scap.org/ssg-guides/ssg-{{{ product }}}-guide-{{{ p.id_ }}}.html#xccdf_org.ssgproject.content_rule_{{{ rule.id_ }}}">{{{ p.title }}}</a></li>
+  {{%- endfor %}}
   </ul>
-{{% else %}}
+{{%- else %}}
 <p>
 <strong>Not used in any {{{ product }}} profiles.</strong>
 </p>
@@ -31,6 +23,4 @@ Used in {{{ rule.in_profiles.__len__() }}} profiles:
 </div>  
 {{% endfor -%}}
 </div>  
-
-</body>
-</html>
+{{% endblock %}}

--- a/utils/rules-template.html
+++ b/utils/rules-template.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rules related to {{{ component }}} on {{{ product }}}</title>
+<style>
+</style>
+</head>
+<body>
+
+<h1>Rules related to {{{ component }}}</h1>
+
+<div class="rules">
+{{% for rule in rules -%}}
+<div class="one_rule">
+	<h2>{{{ loop.index }}}. {{{ rule.title }}}</h2>
+  <p>{{{ rule.description | safe }}}</p>
+{{% if rule.in_profiles -%}}
+Used in {{{ rule.in_profiles.__len__() }}} profiles:
+  <ul>
+  {{% for p in rule.in_profiles %}}
+  <li><a href="https://static.open-scap.org/ssg-guides/ssg-{{{ product }}}-guide-{{{ p.id_ }}}.html#xccdf_org.ssgproject.content_rule_{{{ rule.id_ }}}">{{{ p.title }}}</a></li>
+  {{% endfor %}}
+  </ul>
+{{% else %}}
+<p>
+<strong>Not used in any {{{ product }}} profiles.</strong>
+</p>
+{{% endif %}}
+  Link to upstream: <a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rule.relative_definition_location }}}">{{{ rule.id_ }}}</a>
+</div>  
+{{% endfor -%}}
+</div>  
+
+</body>
+</html>

--- a/utils/template_renderer.py
+++ b/utils/template_renderer.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+
+from glob import glob
+import collections
+import os
+import pathlib
+
+import argparse
+
+import ssg.build_yaml
+import ssg.controls
+import ssg.yaml
+import ssg.jinja
+
+
+class Renderer(object):
+    TEMPLATE_NAME = ""
+
+    def __init__(self, product, build_dir):
+        self.project_directory = pathlib.Path(os.path.dirname(__file__)).parent.resolve()
+
+        self.product = product
+        self.env_yaml = self.get_env_yaml(build_dir)
+
+        self.built_content_path = pathlib.Path(
+            "{build_dir}/{product}".format(build_dir=build_dir, product=product))
+
+        self.template_data = dict()
+
+    def get_env_yaml(self, build_dir):
+        product_yaml = self.project_directory / self.product / "product.yml"
+        build_config_yaml = pathlib.Path(build_dir) / "build_config.yml"
+        if not (product_yaml.exists() and build_config_yaml.exists()):
+            msg = (
+                "No product yaml and/or build config found in "
+                "'{product_yaml}' and/or '{build_config_yaml}', respectively, please make sure "
+                "that you got the product right, and that it is built."
+                .format(product_yaml=product_yaml, build_config_yaml=build_config_yaml)
+            )
+            raise ValueError(msg)
+        env_yaml = ssg.yaml.open_environment(build_config_yaml, product_yaml)
+        return env_yaml
+
+    def _set_rule_relative_definition_location(self, rule):
+        rule.relative_definition_location = (
+            pathlib.PurePath(rule.definition_location)
+            .relative_to(self.project_directory))
+
+    def get_result(self):
+        subst_dict = self.template_data.copy()
+        subst_dict.update(self.env_yaml)
+        html_jinja_template = os.path.join(os.path.dirname(__file__), self.TEMPLATE_NAME)
+        return ssg.jinja.process_file(html_jinja_template, subst_dict)
+
+    def output_results(self, args):
+        result = self.get_result()
+        if not args.output:
+            print(result)
+        else:
+            with open(args.output, "w") as outfile:
+                outfile.write(result)
+
+    @staticmethod
+    def create_parser(description):
+        parser = argparse.ArgumentParser(description=description)
+        parser.add_argument(
+            "product", help="The product to be built")
+        parser.add_argument("--build-dir", default="build", help="Path to the build directory")
+        parser.add_argument("--output", help="The filename to generate")
+        return parser

--- a/utils/template_renderer.py
+++ b/utils/template_renderer.py
@@ -13,6 +13,36 @@ import ssg.yaml
 import ssg.jinja
 
 
+"""
+Loader that extends the AbsolutePathFileSystemLoader so it accepts
+relative paths of templates if those are located in selected directories.
+
+This is intended to be used when templates reference other templates.
+"""
+class FlexibleLoader(ssg.jinja.AbsolutePathFileSystemLoader):
+    def __init__(self, lookup_dirs=None, ** kwargs):
+        super().__init__(** kwargs)
+        self.lookup_dirs = []
+        if lookup_dirs:
+            if isinstance(lookup_dirs, str):
+                self.lookup_dirs = [lookup_dirs]
+            else:
+                self.lookup_dirs = list(lookup_dirs)
+
+    def _find_absolute_path(self, path):
+        if os.path.isabs(path):
+            return path
+        for directory in self.lookup_dirs:
+            potential_location = pathlib.Path(directory / path)
+            if potential_location.exists():
+                return str(potential_location.absolute())
+        return path
+
+    def get_source(self, environment, template):
+        template = self._find_absolute_path(template)
+        return super().get_source(environment, template)
+
+
 class Renderer(object):
     TEMPLATE_NAME = ""
 
@@ -50,9 +80,12 @@ class Renderer(object):
         subst_dict = self.template_data.copy()
         subst_dict.update(self.env_yaml)
         html_jinja_template = os.path.join(os.path.dirname(__file__), self.TEMPLATE_NAME)
+        ssg.jinja._get_jinja_environment.env.loader = FlexibleLoader([self.project_directory / "utils"])
         return ssg.jinja.process_file(html_jinja_template, subst_dict)
 
     def output_results(self, args):
+        if "title" not in self.template_data:
+            self.template_data["title"] = args.title
         result = self.get_result()
         if not args.output:
             print(result)
@@ -66,5 +99,6 @@ class Renderer(object):
         parser.add_argument(
             "product", help="The product to be built")
         parser.add_argument("--build-dir", default="build", help="Path to the build directory")
+        parser.add_argument("--title", "-t", default="", help="Title of the document")
         parser.add_argument("--output", help="The filename to generate")
         return parser


### PR DESCRIPTION
There may be cases when it is convenient to present a set of manually selected rules to people who are not familiar with the project (e.g. to component maintainers who could assess impact of changes to their components on rules).
This PR introduces a script that can produce a human-readable summary of rule descriptions based on a selection of rule IDs that were built for a particular product.
Introduction of component metadata to rules could automate this task almost entirely, right now, the only way of selecting relevant rules would use `grep` or `find` commands.

Aside from that, this PR introduces a class that allows writing such HTML renderers with minimal code duplication.