### PR TITLE
Select dconf_gnome_lock_screen_on_smartcard_removal in STIG profile.

### DIFF
--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -338,3 +338,4 @@ selections:
     - package_usbguard_installed
     - service_usbguard_enabled
     - network_sniffer_disabled
+    - dconf_gnome_lock_screen_on_smartcard_removal

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -87,6 +87,7 @@ selections:
 - coredump_disable_storage
 - dconf_gnome_banner_enabled
 - dconf_gnome_disable_ctrlaltdel_reboot
+- dconf_gnome_lock_screen_on_smartcard_removal
 - dconf_gnome_login_banner_text
 - dconf_gnome_screensaver_idle_delay
 - dconf_gnome_screensaver_lock_enabled


### PR DESCRIPTION
#### Description:

- Select dconf_gnome_lock_screen_on_smartcard_removal in STIG profile.

#### Rationale:

- Follow up of: https://github.com/ComplianceAsCode/content/pull/6824
