### PR TITLE
fix service_sshd_enabled for SLE-15

### DIFF
--- a/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
@@ -52,3 +52,4 @@ template:
         servicename: sshd
         packagename: openssh-server
         packagename@sle12: openssh
+        packagename@sle15: openssh


### PR DESCRIPTION
Initial coding failed to set:
packagename@sle15: openssh

This is needed for this rule to work in SLE 15.

#### Description:

- Needed to set packagename@sle15: openssh

#### Rationale:

- fix service_sshd_enabled for SLE-15, SLES-15-010530

