### PR TITLE
SLES-15-010220 updates for firewalld

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -15,11 +15,15 @@ identifiers:
     cce@rhel7: CCE-82999-4
     cce@rhel8: CCE-82998-6
     cce@rhcos4: CCE-82521-6
+    cce@sle15: CCE-85698-9
 
 references:
     nist: CM-6(a)
+    nist@sle15: CM-7,CM-7.1(iii),CM-7(b),AC-17(1)
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000298-GPOS-00116
+    srg@sle15: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000480-GPOS-00232
     cis@rhel8: 3.4.1.1
+    stigid@sle15:  SLES-15-010220
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
@@ -37,10 +37,10 @@ references:
     cis-csc: 11,3,9
     cis@sle15: 3.5.1.4
     stigid@rhel8: RHEL-08-040100
-    stigid@sle15: SLES-15-010370
-    srg@sle15: SRG-OS-000298-GPOS-00116
-    nist@sle15: AC-17(9)
-    disa@sle15: CCI-002322
+    stigid@sle15: SLES-15-010220
+    srg@sle15: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000480-GPOS-00232
+    nist@sle15: CM-7,CM-7.1(iii),CM-7(b),AC-17(1)
+    disa@sle15: CCI-000382
 
 ocil: |-
     {{{ ocil_service_enabled(service="firewalld") }}}

--- a/linux_os/guide/system/network/network-susefirewall2/package_SuSEfirewall2_installed/rule.yml
+++ b/linux_os/guide/system/network/network-susefirewall2/package_SuSEfirewall2_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: sle12
 
 title: 'Install SuSEfirewall2 Package'
 
@@ -13,14 +13,12 @@ severity: medium
 
 identifiers:
     cce@sle12: CCE-83157-8
-    cce@sle15: CCE-85661-7
 
 references:
     disa@sle12: CCI-000382,CCI-002080,CCI-002314
     nist@sle12: CM-7,CA-3(5),AC-17(1)
     srg@sle12: SRG-OS-000420-GPOS-00186,SRG-OS-000096-GPOS-00050
     stigid@sle12: SLES-12-030030
-    stigid@sle15: SLES-15-010220
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/network/network-susefirewall2/service_SuSEfirewall2_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-susefirewall2/service_SuSEfirewall2_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: sle12
 
 title: 'Enable the SuSEfirewall 2'
 
@@ -24,14 +24,12 @@ severity: medium
 
 identifiers:
     cce@sle12: CCE-83164-4
-    cce@sle15: CCE-85662-5
 
 references:
     disa@sle12: CCI-000382
     nist@sle12: CM-7,CA-3(5),AC-17(1)
     srg@sle12: SRG-OS-000420-GPOS-00186,SRG-OS-000096-GPOS-00050
     stigid@sle12: SLES-12-030030
-    stigid@sle15: SLES-15-010220
 
 ocil: |-
     {{{ ocil_service_enabled(service="SuSEfirewall2") }}}

--- a/linux_os/guide/system/network/network-susefirewall2/susefirewall2_only_required_services/rule.yml
+++ b/linux_os/guide/system/network/network-susefirewall2/susefirewall2_only_required_services/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: sle12
 
 title: 'Only Allow Authorized Network Services in SuSEfirewall2'
 
@@ -42,13 +42,11 @@ severity: medium
 
 identifiers:
     cce@sle12: CCE-83165-1
-    cce@sle15: CCE-85660-9
 
 references:
     disa@sle12: CCI-000382
     nist@sle12: CM-7,CA-3(5),AC-17(1)
     stigid@sle12: SLES-12-030030
-    stigid@sle15: SLES-15-010220
     srg@sle12: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000480-GPOS-00231,SRG-OS-000480-GPOS-00232
 
 ocil_clause: 'unauthorized network services can be accessed from the network'

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
 
 title: 'Disable DCCP Support'
 
@@ -19,12 +19,10 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-82024-1
     cce@rhel8: CCE-80833-7
-    cce@sle15: CCE-83276-6
 
 references:
     stigid@ol7: OL07-00-020101
     stigid@rhel7: RHEL-07-020101
-    stigid@sle15: SLES-15-010220
     cis@rhel7: 3.5.1
     cis@rhel8: 3.3.1
     cjis: 5.10.1

--- a/sle15/profiles/cis.profile
+++ b/sle15/profiles/cis.profile
@@ -365,7 +365,7 @@ selections:
 
     ## 3.4 Uncommon Network Protocols
     ### 3.4.1 Ensure DCCP is disabled (Not Scored)
-    - kernel_module_dccp_disabled
+    ##- kernel_module_dccp_disabled
 
     ### 3.4.2 Ensure SCTP is disabled (Not Scored)
     - kernel_module_sctp_disabled

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -175,7 +175,6 @@ selections:
     - gui_login_dod_acknowledgement
     - installed_OS_is_vendor_supported
     - install_smartcard_packages
-    - kernel_module_dccp_disabled
     - kernel_module_usb-storage_disabled
     - mount_option_home_nosuid
     - mount_option_noexec_remote_filesystems
@@ -190,9 +189,8 @@ selections:
     - package_aide_installed
     - package_audit-audispd-plugins_installed
     - package_audit_installed
-    - package_SuSEfirewall2_installed
     - package_telnet-server_removed
-    - package_vsftpd_removed
+    - package_firewalld_installed
     - pam_disable_automatic_configuration
     - partition_for_home
     - partition_for_var
@@ -207,7 +205,6 @@ selections:
     - service_firewalld_enabled
     - service_kdump_disabled
     - service_sshd_enabled
-    - service_SuSEfirewall2_enabled
     - set_password_hashing_algorithm_logindefs
     - set_password_hashing_algorithm_systemauth
     - set_password_hashing_min_rounds_logindefs
@@ -236,7 +233,6 @@ selections:
     - sudo_remove_nopasswd
     - sudo_restrict_privilege_elevation_to_authorized
     - sudo_require_authentication
-    - susefirewall2_only_required_services
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_randomize_va_space
     - sysctl_net_ipv4_conf_all_accept_redirects

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -191,6 +191,7 @@ selections:
     - package_audit_installed
     - package_telnet-server_removed
     - package_firewalld_installed
+    - package_vsftpd_removed
     - pam_disable_automatic_configuration
     - partition_for_home
     - partition_for_var


### PR DESCRIPTION
SuSEfirewall2 was retired in SLE-12 in favor of firewalld
So, we need to remove SuSEfirewall2 references from SL15
and fix up the SLES-15-010220 rule. This includes change SLES-15-010370
to SLES-15-010220. SLES-15-010370 was specific to the firewall panic switch.

#### Description:

- Fix SLES-15-010220 
We found out about SuSEfirewall2 to firewalld change after initial SLE15 work.

#### Rationale:

- Use SLE-15 preferred firewall package.

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
