### PR TITLE
Extend profile_tool.py with option to check for missing OSPP and CUI references

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -56,6 +56,9 @@ def parse_args():
     parser_stats.add_argument("--missing-anssi-refs", default=False,
                         action="store_true", dest="missing_anssi_refs",
                         help="Show rules in ANSSI profiles that don't have ANSSI references.")
+    parser_stats.add_argument("--missing-ospp-refs", default=False,
+                        action="store_true", dest="missing_ospp_refs",
+                        help="Show rules in OSPP profiles that don't have OSPP references.")
     parser_stats.add_argument("--missing-ovals", default=False,
                         action="store_true", dest="missing_ovals",
                         help="Show IDs of unimplemented OVAL checks.")
@@ -132,6 +135,7 @@ def parse_args():
             args.missing_cis_refs = True
             args.missing_hipaa_refs = True
             args.missing_anssi_refs = True
+            args.missing_ospp_refs = True
 
     return args
 
@@ -208,6 +212,7 @@ def main():
             'missing_cis_refs',
             'missing_hipaa_refs',
             'missing_anssi_refs',
+            'missing_ospp_refs',
             'missing_ovals',
             'missing_bash_fixes',
             'missing_ansible_fixes',

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -57,8 +57,8 @@ def parse_args():
                         action="store_true", dest="missing_anssi_refs",
                         help="Show rules in ANSSI profiles that don't have ANSSI references.")
     parser_stats.add_argument("--missing-ospp-refs", default=False,
-                        action="store_true", dest="missing_ospp_refs",
-                        help="Show rules in OSPP profiles that don't have OSPP references.")
+                              action="store_true", dest="missing_ospp_refs",
+                              help="Show rules in OSPP profiles that don't have OSPP references.")
     parser_stats.add_argument("--missing-cui-refs", default=False,
                               action="store_true", dest="missing_cui_refs",
                               help="Show rules in CUI profiles that don't have CUI references.")

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -59,6 +59,9 @@ def parse_args():
     parser_stats.add_argument("--missing-ospp-refs", default=False,
                         action="store_true", dest="missing_ospp_refs",
                         help="Show rules in OSPP profiles that don't have OSPP references.")
+    parser_stats.add_argument("--missing-cui-refs", default=False,
+                              action="store_true", dest="missing_cui_refs",
+                              help="Show rules in CUI profiles that don't have CUI references.")
     parser_stats.add_argument("--missing-ovals", default=False,
                         action="store_true", dest="missing_ovals",
                         help="Show IDs of unimplemented OVAL checks.")
@@ -136,6 +139,7 @@ def parse_args():
             args.missing_hipaa_refs = True
             args.missing_anssi_refs = True
             args.missing_ospp_refs = True
+            args.missing_cui_refs = True
 
     return args
 
@@ -213,6 +217,7 @@ def main():
             'missing_hipaa_refs',
             'missing_anssi_refs',
             'missing_ospp_refs',
+            'missing_cui_refs',
             'missing_ovals',
             'missing_bash_fixes',
             'missing_ansible_fixes',

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -14,7 +14,7 @@ from .constants import puppet_system as puppet_rem_system
 from .constants import anaconda_system as anaconda_rem_system
 from .constants import cce_uri
 from .constants import ssg_version_uri
-from .constants import stig_ns, cis_ns, hipaa_ns, anssi_ns, ospp_ns
+from .constants import stig_ns, cis_ns, hipaa_ns, anssi_ns, ospp_ns, cui_ns
 console_width = 80
 
 
@@ -28,7 +28,7 @@ class RuleStats(object):
                  rignition_fix=None, rkubernetes_fix=None,
                  rpuppet_fix=None, ranaconda_fix=None, rcce=None,
                  stig_id=None, cis_ref=None, hipaa_ref=None,
-                 anssi_ref=None, ospp_ref=None):
+                 anssi_ref=None, ospp_ref=None, cui_ref=None):
         self.dict = {
             'id': rid,
             'oval': roval,
@@ -44,6 +44,7 @@ class RuleStats(object):
             'hipaa_ref': hipaa_ref,
             'anssi_ref': anssi_ref,
             'ospp_ref': ospp_ref,
+            'cui_ref': cui_ref,
         }
 
 
@@ -113,6 +114,7 @@ class XCCDFBenchmark(object):
             'missing_hipaa_refs': [],
             'missing_anssi_refs': [],
             'missing_ospp_refs': [],
+            'missing_cui_refs': [],
             'ansible_parity': [],
         }
 
@@ -178,13 +180,15 @@ class XCCDFBenchmark(object):
                                     (xccdf_ns, anssi_ns))
                 ospp_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
                                     (xccdf_ns, ospp_ns))
+                cui_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
+                                    (xccdf_ns, cui_ns))
 
                 rule_stats.append(
                     RuleStats(rule.get("id"), oval,
                               bash_fix, ansible_fix, ignition_fix,
                               kubernetes_fix, puppet_fix, anaconda_fix,
                               cce, stig_id, cis_ref, hipaa_ref, anssi_ref,
-                              ospp_ref)
+                              ospp_ref, cui_ref)
                 )
 
         if not rule_stats:
@@ -277,6 +281,11 @@ class XCCDFBenchmark(object):
             profile_stats['missing_ospp_refs'] = \
                 [x.dict['id'] for x in rule_stats if x.dict['ospp_ref'] is None]
 
+        profile_stats['missing_cui_refs'] = []
+        if 'cui' in profile_stats['profile_id']:
+            profile_stats['missing_cui_refs'] = \
+                [x.dict['id'] for x in rule_stats if x.dict['cui_ref'] is None]
+
         profile_stats['implemented_anaconda_fixes_pct'] = \
             float(len(profile_stats['implemented_anaconda_fixes'])) / \
             profile_stats['rules_count'] * 100
@@ -319,6 +328,7 @@ class XCCDFBenchmark(object):
         missing_hipaa_refs_count = len(profile_stats['missing_hipaa_refs'])
         missing_anssi_refs_count = len(profile_stats['missing_anssi_refs'])
         missing_ospp_refs_count = len(profile_stats['missing_ospp_refs'])
+        missing_cui_refs_count = len(profile_stats['missing_cui_refs'])
         impl_cces_count = len(profile_stats['assigned_cces'])
 
         if options.format == "plain":
@@ -531,6 +541,15 @@ class XCCDFBenchmark(object):
                 self.console_print(profile_stats['missing_ospp_refs'],
                                    console_width)
 
+            if options.missing_cui_refs and profile_stats['missing_cui_refs']:
+                print("*** rules of '%s' profile missing "
+                      "CUI Refs: %d of %d have them [%d%% missing]"
+                      % (profile, rules_count - missing_cui_refs_count,
+                         rules_count,
+                         (100.0 * missing_cui_refs_count / rules_count)))
+                self.console_print(profile_stats['missing_cui_refs'],
+                                   console_width)
+
             if options.missing_cces and profile_stats['missing_cces']:
                 print("***Rules of '%s' " % profile + "profile missing " +
                       "CCE identifier: %d of %d [%d%% complete]" %
@@ -563,6 +582,7 @@ class XCCDFBenchmark(object):
             profile_stats['missing_hipaa_refs_count'] = missing_hipaa_refs_count
             profile_stats['missing_anssi_refs_count'] = missing_anssi_refs_count
             profile_stats['missing_ospp_refs_count'] = missing_ospp_refs_count
+            profile_stats['missing_cui_refs_count'] = missing_cui_refs_count
             profile_stats['missing_ovals_count'] = len(profile_stats['missing_ovals'])
             profile_stats['missing_bash_fixes_count'] = len(profile_stats['missing_bash_fixes'])
             profile_stats['missing_ansible_fixes_count'] = len(profile_stats['missing_ansible_fixes'])
@@ -601,6 +621,7 @@ class XCCDFBenchmark(object):
                 del profile_stats['missing_hipaa_refs']
                 del profile_stats['missing_anssi_refs']
                 del profile_stats['missing_ospp_refs']
+                del profile_stats['missing_cui_refs']
             if not options.missing_cces:
                 del profile_stats['missing_cces']
             if not options.implemented_ovals:

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -179,7 +179,7 @@ class XCCDFBenchmark(object):
                 anssi_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
                                     (xccdf_ns, anssi_ns))
                 ospp_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, ospp_ns))
+                                     (xccdf_ns, ospp_ns))
                 cui_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
                                     (xccdf_ns, cui_ns))
 

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -65,6 +65,7 @@ cis_ns = "https://www.cisecurity.org/benchmark/red_hat_linux/"
 hipaa_ns = "https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf"
 anssi_ns = "http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
 ospp_ns = "https://www.niap-ccevs.org/Profile/PP.cfm"
+cui_ns = 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf'
 stig_refs = 'https://public.cyber.mil/stigs/'
 disa_cciuri = "https://public.cyber.mil/stigs/cci/"
 ssg_version_uri = \

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -64,6 +64,7 @@ stig_ns = "https://public.cyber.mil/stigs/srg-stig-tools/"
 cis_ns = "https://www.cisecurity.org/benchmark/red_hat_linux/"
 hipaa_ns = "https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf"
 anssi_ns = "http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
+ospp_ns = "https://www.niap-ccevs.org/Profile/PP.cfm"
 stig_refs = 'https://public.cyber.mil/stigs/'
 disa_cciuri = "https://public.cyber.mil/stigs/cci/"
 ssg_version_uri = \


### PR DESCRIPTION
#### Description:
`profile_tool.py` already has options to check missing references for ANSSI, CIS, STIG, and HIPAA references. This extends the script with OSPP and CUI missing references check.

#### Rationale:
We want to have test that will check for missing references in rules. The `profile_tool.py` script will be used in the test and thus to be able to check OSPP and CUI missing references, the script needs to have option to check those references.