### PR TITLE
RHCOS4: Use RHEL8 OVAL feed and allow usage of `security_patches_up_to_date` rule

### DIFF
--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu1604,ubuntu1804
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu1604,ubuntu1804
 
 title: 'Ensure Software Patches Installed'
 

--- a/rhcos4/product.yml
+++ b/rhcos4/product.yml
@@ -26,3 +26,5 @@ pkg_release: "4ae0493b"
 pkg_version: "fd431d51"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
+
+oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml"


### PR DESCRIPTION
RHCOS4 bases its packages on RHEL 8, so it may use RHEL 8's OVAL feed
for checking that the security patches are up to date.

This also adds rhcos4 to that rule's platforms so we may enable it if
needed.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>