### PR TITLE
CIS: Add OCIL to kubelet_configure_tls_cipher_suites

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -6,6 +6,25 @@ title: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers"
 
 description: |-
   Ensure that the Kubelet is configured to only use strong cryptographic ciphers.
+  To set the cipher suites for the kubelet, create new or modify existing
+  <tt>KubeletConfig</tt> object along these lines, one for every
+  <tt>MachineConfigPool</tt>:
+    <pre>
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: KubeletConfig
+    metadata:
+       name: kubelet-config-$pool
+    spec:
+        machineConfigPoolSelector:
+            matchLabels:
+                pools.operator.machineconfiguration.openshift.io/$pool_name: ""
+        kubeletConfig:
+          tlsCipherSuites:
+          - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+          - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    </pre>
 
 rationale: |-
   TLS ciphers have had a number of known vulnerabilities and weaknesses,
@@ -21,10 +40,18 @@ severity: medium
 references:
   cis@ocp4: 4.2.13
 
-ocil_clause: "TLS cipher suite configuration is not configured"
+ocil_clause: "TLS cipher suite configuration is not configured or contains insecure ciphers"
 
 ocil: |-
-  rule test.
+    Run the following command on the kubelet node(s):
+    <pre>$ sudo grep tlsCipherSuites /etc/kubernetes/kubelet.conf</pre>
+    Verify that the set of ciphers contains only the following:
+    <pre>
+    TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    </pre>
 
 template:
   name: yamlfile_value


### PR DESCRIPTION
#### Description:

Adds an OCIL to kubelet_configure_tls_cipher_suites

#### Rationale:
The rule contained just a placeholder text