### PR TITLE
Add OCIL to sshd_limit_user_access

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
@@ -16,6 +16,15 @@ rationale: |-
 
 severity: unknown
 
+ocil_clause: 'sshd does not limit the users who can log in'
+
+ocil: |-
+    To ensure sshd limits the users who can log in, run the following:
+    <pre>$ sudo grep AllowUsers /etc/ssh/sshd_config</pre>
+    If properly configured, the output should be a list of usernames allowed to log in
+    to this system.
+
+
 identifiers:
     cce@rhel7: CCE-80219-9
     cce@rhel8: CCE-82422-7


### PR DESCRIPTION
#### Rationale:

OCP4 uses OCIL as instructions for manual checks, so it's prudent to
have OCIL clauses for all rules.