### PR TITLE
Fix CIS-CSC URI

### DIFF
--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -29,7 +29,7 @@
 <xsl:variable name="isa-62443-2013uri">https://www.isa.org/templates/one-column.aspx?pageid=111294&amp;productId=116785</xsl:variable>
 <xsl:variable name="isa-62443-2009uri">https://www.isa.org/templates/one-column.aspx?pageid=111294&amp;productId=116731</xsl:variable>
 <xsl:variable name="cobit5uri">https://www.isaca.org/resources/cobit</xsl:variable>
-<xsl:variable name="cis-cscuri">https://www.cisecurity.org/wp-content/uploads/2017/03/Poster_Winter2016_CSCs.pdf</xsl:variable>
+<xsl:variable name="cis-cscuri">https://www.cisecurity.org/controls/</xsl:variable>
 <xsl:variable name="osppuri">https://www.niap-ccevs.org/Profile/PP.cfm</xsl:variable>
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf</xsl:variable>
 <xsl:variable name="ssg-benchmark-latest-uri">https://github.com/OpenSCAP/scap-security-guide/releases/latest</xsl:variable>


### PR DESCRIPTION
#### Description:

CIS-CSC: Center for Internet Security Critical Security Controls
for Effective Cyber Defense -- appears to have been renamed to
just CIS Controls and is now present at a new URL:

    https://www.cisecurity.org/controls/

Update ours to match rather than linking to a (now dated) poster.

Resolves: #6791

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`
