### PR TITLE
RHCOS/OCP: Add more detailed instructions for more OCIL instances

### DIFF
--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -24,7 +24,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -23,7 +23,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_groupowner_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_kubeconfig/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubeconfig", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/kubeconfig", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/kubeconfig", group="root") }}}
 
 #template:
 #    name: file_groupowner

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_groupowner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_groupowner_openvswitch/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.*", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/origin/openvswitch/.*", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/origin/openvswitch/.*", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/cni/net.d/*", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -24,7 +24,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_owner_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_kubeconfig/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubeconfig", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/kubeconfig", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/kubernetes/kubeconfig", owner="root") }}}
 
 #template:
 #    name: file_owner

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_owner_openvswitch/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.*", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/openvswitch/.*", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/openvswitch/.*", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/master/file_owner_var_lib_etcd/rule.yml
+++ b/applications/openshift/master/file_owner_var_lib_etcd/rule.yml
@@ -18,7 +18,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/var/lib/etcd", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/var/lib/etcd", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
@@ -20,7 +20,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
@@ -25,4 +25,5 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/config/kube-proxy-config.yaml", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/config/kube-proxy-config.yaml", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/config/kube-proxy-config.yaml", group="root") }}}

--- a/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubelet-ca.crt", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/kubernetes/kubelet-ca.crt", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/kubelet-ca.crt", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/kubelet/kubeconfig", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/var/lib/kubelet/kubeconfig", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/lib/kubelet/kubeconfig", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/worker/file_groupowner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_service/rule.yml
@@ -22,10 +22,10 @@ references:
     cis@ocp4: 4.1.2
 
 ocil_clause: |-
-  '{{{ ocil_clause_file_group_owner(file="/etc/systemd/system/kubelet.service", group="root") }}}'
+    {{{ ocil_clause_file_group_owner(file="/etc/systemd/system/kubelet.service", group="root") }}}
 
-ocil:
-  '{{{ ocil_file_group_owner(file="/etc/systemd/system/kubelet.service", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/systemd/system/kubelet.service", group="root") }}}
 
 template:
     name: file_groupowner

--- a/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
@@ -25,4 +25,5 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/config/kube-proxy-config.yaml", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/config/kube-proxy-config.yaml", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/config/kube-proxy-config.yaml", owner="root") }}}

--- a/applications/openshift/worker/file_owner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_ca/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubelet-ca.crt", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/kubernetes/kubelet-ca.crt", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/kubernetes/kubelet-ca.crt", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/kubelet/kubeconfig", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/var/lib/kubelet/kubeconfig", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/var/lib/kubelet/kubeconfig", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openshift/worker/file_owner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_service/rule.yml
@@ -22,10 +22,10 @@ references:
     cis@ocp4: 4.1.2
 
 ocil_clause: |-
-  '{{{ ocil_clause_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}'
+    {{{ ocil_clause_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}
 
-ocil:
-  '{{{ ocil_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}
 
 template:
     name: file_owner

--- a/applications/openstack/cinder/cinder_conf_file_perms/rule.yml
+++ b/applications/openstack/cinder/cinder_conf_file_perms/rule.yml
@@ -16,7 +16,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cinder/*.conf", perms="-rw-r-----") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/cinder/*.conf", perms="-rw-r-----") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cinder/*.conf", perms="-rw-r-----") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.d", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cron.d", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/cron.d", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.daily", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cron.daily", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/cron.daily", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.hourly", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cron.hourly", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/cron.hourly", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.monthly", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cron.monthly", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/cron.monthly", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.weekly", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cron.weekly", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/cron.weekly", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/crontab", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/crontab", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/crontab", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_d/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.d", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cron.d", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/cron.d", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_daily/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.daily", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cron.daily", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/cron.daily", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.hourly", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cron.hourly", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/cron.hourly", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.monthly", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cron.monthly", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/cron.monthly", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.weekly", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cron.weekly", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/cron.weekly", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/cron_and_at/file_owner_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_crontab/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/crontab", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/crontab", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/crontab", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.d", perms="-rwx------") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/cron.d", perms="-rwx------") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cron.d", perms="-rwx------") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.daily", perms="-rwx------") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/cron.daily", perms="-rwx------") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cron.daily", perms="-rwx------") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.hourly", perms="-rwx------") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/cron.hourly", perms="-rwx------") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cron.hourly", perms="-rwx------") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.monthly", perms="-rwx------") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/cron.monthly", perms="-rwx------") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cron.monthly", perms="-rwx------") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.weekly", perms="-rwx------") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/cron.weekly", perms="-rwx------") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cron.weekly", perms="-rwx------") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/crontab", perms="-rw-------") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/crontab", perms="-rw-------") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/crontab", perms="-rw-------") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.allow", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/cron.allow", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/cron.allow", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
@@ -32,7 +32,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cron.allow", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/cron.allow", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/cron.allow", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/dir_perms_etc_httpd_conf/rule.yml
@@ -15,4 +15,5 @@ severity: unknown
 identifiers:
     cce@rhel7: CCE-80323-9
 
-ocil: '{{{ ocil_file_permissions(file="/etc/http/conf", perms="-rwxr-x---") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/http/conf", perms="-rwxr-x---") }}}

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/http/conf.d/*", perms="-rw-r-----") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/http/conf/*", perms="-rw-r-----") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/rule.yml
@@ -26,4 +26,5 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/http/conf.modules.d/*", perms="-rw-r-----") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/http/conf.modules.d/*", perms="-rw-r-----") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/http/conf.modules.d/*", perms="-rw-r-----") }}}

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
@@ -33,7 +33,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/ssh/sshd_config", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/ssh/sshd_config", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/ssh/sshd_config", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
@@ -33,7 +33,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/ssh/sshd_config", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/ssh/sshd_config", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/ssh/sshd_config", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
@@ -33,7 +33,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/sshd_config", perms="-rw-------") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/ssh/sshd_config", perms="-rw-------") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/ssh/sshd_config", perms="-rw-------") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -42,7 +42,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -36,7 +36,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/ssh/*.pub", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/issue", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/issue", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/issue", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/motd", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/motd", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/motd", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/issue", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/issue", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/issue", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/motd", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/motd", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/motd", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/issue", perms="-rw-r--r--") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/issue", perms="-rw-r--r--") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/issue", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/motd", perms="-rw-r--r--") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/etc/motd", perms="-rw-r--r--") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/motd", perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -38,7 +38,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -36,7 +36,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}
 
 platform: machine
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/rule.yml
@@ -27,6 +27,7 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/security/opasswd", owner="root") }}} and {{{ ocil_clause_file_group_owner(file="/etc/security/opasswd", group="root") }}} and {{{ ocil_clause_file_permissions(file="/etc/security/opasswd", perms="0600") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/security/opasswd", owner="root") }}}
-{{{ ocil_file_group_owner(file="/etc/security/opasswd", group="root") }}}
-{{{ ocil_file_permissions(file="/etc/security/opasswd", perms="0600") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/security/opasswd", owner="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/security/opasswd", group="root") }}}
+    {{{ ocil_file_permissions(file="/etc/security/opasswd", perms="0600") }}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group-", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/group", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/group", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -26,7 +26,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow-", group=target_group) }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/gshadow-", group=target_group) }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/gshadow-", group=target_group) }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd-", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/passwd-", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/passwd-", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
@@ -27,7 +27,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow-", group=target_group) }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/shadow-", group=target_group) }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/shadow-", group=target_group) }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
@@ -30,7 +30,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/group", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/group", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
@@ -34,7 +34,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow", group=target_group) }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/gshadow", group=target_group) }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/gshadow", group=target_group) }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
@@ -30,7 +30,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd", group="root") }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -36,7 +36,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow", group=target_group) }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/etc/shadow", group=target_group) }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/shadow", group=target_group) }}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group-", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/group-", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/group-", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
@@ -20,7 +20,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow-", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/gshadow-", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/gshadow-", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd-", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/passwd-", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/passwd-", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
@@ -21,7 +21,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow-", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/shadow-", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/shadow-", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
@@ -31,7 +31,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/group", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/group", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
@@ -28,7 +28,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
@@ -30,7 +30,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
@@ -34,7 +34,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow", owner="root") }}}'
 
-ocil: '{{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/software/sudo/sudo_dedicated_group/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_dedicated_group/rule.yml
@@ -30,4 +30,5 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/usr/bin/sudo", group=sub_var_value("var_sudo_dedicated_group")) }}}'
 
-ocil: '{{{ ocil_file_group_owner(file="/usr/bin/sudo", group=sub_var_value("var_sudo_dedicated_group")) }}}'
+ocil: |-
+    {{{ ocil_file_group_owner(file="/usr/bin/sudo", group=sub_var_value("var_sudo_dedicated_group")) }}}

--- a/linux_os/guide/system/software/sudo/sudo_restrict_others_executable_permission/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_restrict_others_executable_permission/rule.yml
@@ -22,7 +22,8 @@ references:
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/usr/bin/sudo", perms="---s--x---") }}}'
 
-ocil: '{{{ ocil_file_permissions(file="/usr/bin/sudo", perms="---s--x---") }}}'
+ocil: |-
+    {{{ ocil_file_permissions(file="/usr/bin/sudo", perms="---s--x---") }}}
 
 template:
     name: file_permissions

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -596,7 +596,13 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 
 
 {{%- macro ocil_file_permissions(file, perms) -%}}
-    To check the permissions of <code>{{{ file }}}</code>, run the command:
+    To check the permissions of <code>{{{ file }}}</code>,
+    {{% if product == "rhcos4" or product == "ocp4" -%}}
+    you'll need to log into a node in the cluster.
+    {{{ rhcos_node_login_instructions() }}}
+    Then,
+    {{%- endif -%}}
+    run the command:
     <pre>$ ls -l {{{ file }}}</pre>
     If properly configured, the output should indicate the following permissions:
     <code>{{{ perms }}}</code>
@@ -604,7 +610,13 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 
 
 {{%- macro ocil_file_owner(file, owner) -%}}
-    To check the ownership of <code>{{{ file }}}</code>, run the command:
+    To check the ownership of <code>{{{ file }}}</code>,
+    {{% if product == "rhcos4" or product == "ocp4" -%}}
+    you'll need to log into a node in the cluster.
+    {{{ rhcos_node_login_instructions() }}}
+    Then,
+    {{%- endif -%}}
+    run the command:
     <pre>$ ls -lL {{{ file }}}</pre>
     If properly configured, the output should indicate the following owner:
     <code>{{{ owner }}}</code>
@@ -612,7 +624,13 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 
 
 {{%- macro ocil_file_group_owner(file, group) -%}}
-    To check the group ownership of <code>{{{ file }}}</code>, run the command:
+    To check the group ownership of <code>{{{ file }}}</code>,
+    {{% if product == "rhcos4" or product == "ocp4" -%}}
+    you'll need to log into a node in the cluster.
+    {{{ rhcos_node_login_instructions() }}}
+    Then,
+    {{%- endif -%}}
+    run the command:
     <pre>$ ls -lL {{{ file }}}</pre>
     If properly configured, the output should indicate the following group-owner:
     <code>{{{ group }}}</code>


### PR DESCRIPTION
This covers better instructions in RHCOS4 and OCP4 content.

The following macros were modified:

* ocil_file_permissions
* ocil_file_group_owner
* ocil_file_owner

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>