### PR TITLE
update accounts_tmout

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -5,4 +5,4 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_tmout") }}}
 
-{{{ ansible_etc_profile_set(parameter='TMOUT', value='{{ var_accounts_tmout }}') }}}
+{{{ ansible_set_config_file(file='/etc/profile.d/tmout.sh', parameter='TMOUT', separator='=', separator_regex='=', value='{{ var_accounts_tmout }}', create='yes') }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -2,9 +2,17 @@
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("var_accounts_tmout") }}}
 
-if grep --silent '^\s*TMOUT' /etc/profile ; then
-        sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/\1TMOUT=$var_accounts_tmout\3/g" /etc/profile
-else
-        echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile
-        echo "TMOUT=$var_accounts_tmout" >> /etc/profile
+# if 0, no occurence of tmout found, if 1, occurence found
+tmout_found=0
+
+for f in /etc/profile /etc/profile.d/*.sh; do
+    if grep --silent '^\s*TMOUT' $f; then
+        sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/\1TMOUT=$var_accounts_tmout\3/g" $f
+        $tmout_found=1
+    fi
+done
+
+if [ $tmout_found -eq 0 ]; then
+        echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile.d/tmout.sh
+        echo "TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -13,7 +13,8 @@ description: |-
     readonly TMOUT
     export TMOUT
     {{% else %}}
-    setting in <tt>/etc/profile</tt> should read as follows:
+    setting in a file loaded by <tt>/etc/profile</tt>, e.g.
+    <tt>/etc/profile.d/tmout.sh</tt> should read as follows:
     <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
     {{% endif %}}
 
@@ -62,7 +63,7 @@ ocil: |-
     {{% if product in ["sle12", "sle15"] %}}
     <pre>$ sudo grep TMOUT /etc/profile.d/autologout.sh</pre>
     {{% else %}}
-    <pre>$ sudo grep TMOUT /etc/profile</pre>
+    <pre>$ sudo grep TMOUT /etc/profile /etc/profile.d/*.sh</pre>
     {{% endif %}}
     The output should return the following:
     <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile.fail.sh
@@ -2,6 +2,8 @@
 
 # variables = var_accounts_tmout=600
 
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
 if grep -q "^TMOUT" /etc/profile; then
 	sed -i "s/^TMOUT.*/# TMOUT=600/" /etc/profile
 else

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile_d.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=600
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+if grep -q "^TMOUT" /etc/profile.d/tmout.sh; then
+	sed -i "s/^TMOUT.*/# TMOUT=600/" /etc/profile.d/tmout.sh
+else
+	echo "# TMOUT=600" >> /etc/profile.d/tmout.sh
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
@@ -2,6 +2,8 @@
 
 # variables = var_accounts_tmout=700
 
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
 if grep -q "TMOUT" /etc/profile; then
 	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile
 else

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
+	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile.d/tmout.sh
+else
+	echo "TMOUT=700" >> /etc/profile.d/tmout.sh
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/line_not_there.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 sed -i "/^TMOUT.*/d" /etc/profile
+sed -i "/^TMOUT.*/d" /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile.fail.sh
@@ -2,6 +2,8 @@
 
 # variables = var_accounts_tmout=900
 
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
 if grep -q "TMOUT" /etc/profile; then
 	sed -i "s/.*TMOUT.*/TMOUT=950; readonly TMOUT; export TMOUT/" /etc/profile
 else

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=900
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
+	sed -i "s/.*TMOUT.*/TMOUT=950; readonly TMOUT; export TMOUT/" /etc/profile.d/tmout.sh
+else
+	echo "TMOUT=950; readonly TMOUT; export TMOUT" >> /etc/profile.d/tmout.sh
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
+	sed -i "s/.*TMOUT.*/TMOUT=700; readonly TMOUT; export TMOUT/" /etc/profile.d/tmout.sh
+else
+	echo "TMOUT=700; readonly TMOUT; export TMOUT" >> /etc/profile.d/tmout.sh
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
@@ -2,6 +2,8 @@
 
 # variables = var_accounts_tmout=900
 
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
 if grep -q "TMOUT" /etc/profile; then
 	sed -i "s/.*TMOUT.*/TMOUT=800/" /etc/profile
 else

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=900
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
+	sed -i "s/.*TMOUT.*/TMOUT=800/" /etc/profile.d/tmout.sh
+else
+	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_profile.fail.sh
@@ -2,6 +2,8 @@
 
 # variables = var_accounts_tmout=900
 
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
 if grep -q "^TMOUT" /etc/profile; then
 	sed -i "s/^TMOUT.*/TMOUT=950/" /etc/profile
 else

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_profile_d.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=900
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+if grep -q "^TMOUT" /etc/profile.d/tmout.sh; then
+	sed -i "s/^TMOUT.*/TMOUT=950/" /etc/profile.d/tmout.sh
+else
+	echo "TMOUT=950" >> /etc/profile.d/tmout.sh
+fi


### PR DESCRIPTION
#### Description:

- rename existing tests to clearly distinguish that they test for /etc/profile
- add another bunch of tests which test the case of a file within /etc/profile.d directory
- update remediations to remediate through /etc/profile.d/tmout.sh
- update description and ocil to mention both /etc/profile and also /etc/profile.d/tmout.sh


#### Rationale:

Until now the rule was focused mainly on /etc/profile. However, editing /etc/profile directly is not a good practice anymore. We should rather modify some file within /etc/profile.d/ directory.
This PR also extends tests to cover all capabilities of check and remediations. Before we were testing only for correct check / remediation of /etc/profile, although /etc/profile.d/*.sh was covered too.
This PR addresses main concerns of #6746 . I am hesitant to remove references to /etc/profile entirely.