### PR TITLE
Fix ansible lint issue in ensure_rtc_utc_configuration.

### DIFF
--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/ansible/shared.yml
@@ -1,6 +1,8 @@
 # platform = multi_platform_sle
 - name: Check 'UTC' timezone is set
-  shell: timedatectl status | grep -i 'Time zone'| grep -iv 'UTC\|GMT'
+  shell: |
+    set -o pipefail
+    timedatectl status | grep -i 'Time zone'| grep -iv 'UTC\|GMT' || true
   register: check_tz
   failed_when: "check_tz.rc not in [ 0 , 1 ]"
  


### PR DESCRIPTION
#### Description:

- Fix ansible lint issue in ensure_rtc_utc_configuration.

#### Rationale:

- Based on #6779
- Should fix ansible lint job: https://jenkins.complianceascode.io/job/scap-security-guide-lint-check/587/console

```
43/50 Test #353: ansible-playbook-ansible-lint-check-sle15 .........***Failed  156.98 sec
all/ensure_rtc_utc_configuration.yml:13: [E306] Shells that use pipes should set the pipefail option
stig/ensure_rtc_utc_configuration.yml:13: [E306] Shells that use pipes should set the pipefail option
```

@brett060102
