### PR TITLE
Remove sshd_allow_only_protocol2 from RHEL8 STIG.

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
@@ -41,7 +41,6 @@ references:
     iso27001-2013: A.11.2.6,A.13.1.1,A.13.2.1,A.14.1.3,A.18.1.4,A.6.2.1,A.6.2.2,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     cis-csc: 1,12,15,16,5,8
     ism: 0487,1449,1506
-    stigid@rhel8: RHEL-08-040060
 
 ocil_clause: 'it is commented out or is not set correctly to Protocol 2'
 

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -332,7 +332,6 @@ selections:
     # - audit_rules_sysadmin_actions
     - package_audit_installed
     - service_auditd_enabled
-    - sshd_allow_only_protocol2
     - package_fapolicyd_installed
     - service_fapolicyd_enabled
     - package_usbguard_installed

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -223,7 +223,6 @@ selections:
 - set_password_hashing_algorithm_logindefs
 - set_password_hashing_algorithm_systemauth
 - ssh_client_rekey_limit
-- sshd_allow_only_protocol2
 - sshd_disable_compression
 - sshd_disable_empty_passwords
 - sshd_disable_gssapi_auth


### PR DESCRIPTION


#### Description:
- Remove sshd_allow_only_protocol2 from RHEL8 STIG.

#### Rationale:
- This item is to be removed from the next STIG revision since it's not
applicable anymore.
