### PR TITLE
Add CCI reference to package_gssproxy_removed

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 references:
     srg: SRG-OS-000095-GPOS-00049
     stigid@rhel8: RHEL-08-040370
+    disa: CCI-000381
 
 {{{ complete_ocil_entry_package(package="gssproxy") }}}
 


### PR DESCRIPTION
#### Description:

- Add CCI reference to package_gssproxy_removed.

#### Rationale:

- Reference is going to be changed in V1R2

CCI: ~~CCI-000366~~**CCI-000381**

