### PR TITLE
ctest - add references check test

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -474,6 +474,18 @@ macro(ssg_build_xccdf_final PRODUCT)
         PROPERTIES
         WILL_FAIL true
     )
+    if("${PRODUCT}" MATCHES "rhel")
+        if("${PRODUCT}" MATCHES "rhel7")
+            set(REFERENCES_CHECK_PROFILE_LIST "cis anssi_nt28_high hipaa")
+        elseif("${PRODUCT}" MATCHES "rhel8")
+            set(REFERENCES_CHECK_PROFILE_LIST "cis anssi_bp28_high hipaa")
+        endif()
+        add_test(
+                NAME "missing-references-ssg-${PRODUCT}-xccdf.xml"
+                COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${CMAKE_SOURCE_DIR}/tests/missing_refs.sh" "${PYTHON_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" ${REFERENCES_CHECK_PROFILE_LIST}
+        )
+        set_tests_properties("missing-references-ssg-${PRODUCT}-xccdf.xml" PROPERTIES LABELS quick)
+    endif()
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"


### PR DESCRIPTION
#### Description:
Extend test suite to check missing references of rules in profiles.

Now, the test will check:
- rhel7 product - `stig cis anssi_nt28_high hipaa` 
- rhel8 product - `cis anssi_bp28_high hipaa`

**Desired state of the test** - check ospp, cui, stig, cis, anssi, and hipaa profiles. However, a lot of rules from ospp, from cui, and from stig (in rhel8) profile miss references. To not block this, those profiles have been excluded and reported - #6842, #6843, and #6844. The profiles will be added to the test when the issues are fixed.

Failure of the test is expected because rules from hipaa and from rhel7 stig miss few references (1, 3, and 11). With this, I want speed up reference completion of those profile and not to create more issues.

**Do not merge until this PR ctest passes**

#### Rationale:
To prevent adding rules without references to profiles.

Blocked by #6849 