### PR TITLE
Add HIPAA rules references

### DIFF
--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
@@ -26,6 +26,7 @@ references:
     cis@rhel7: 1.7.2
     cis@rhel8: 1.8.2
     srg: SRG-OS-000480-GPOS-00227
+    hipaa: 164.308(a)(1)(ii)(B),164.308(a)(5)(ii)(A)
 
 ocil_clause: 'The system-wide dconf databases are up-to-date with regards to respective keyfiles'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
@@ -63,6 +63,7 @@ references:
     srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
     cis@rhel8: 1.10,1.11
     ism: "1446"
+    hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.312(e)(1),164.312(e)(2)(ii)
 
 ocil_clause: 'cryptographic policy is not configured or is configured incorrectly'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -25,6 +25,7 @@ references:
     nist: AC-17(a),AC-17(2),CM-6(a),MA-4(6),SC-13
     cis@rhel8: 5.2.20
     srg: SRG-OS-000250-GPOS-00093
+    hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.312(e)(1),164.312(e)(2)(ii)
 
 ocil_clause: 'the CRYPTO_POLICY variable is not set or is commented in the /etc/sysconfig/sshd'
 


### PR DESCRIPTION
#### Description:
Add HIPAA references to `configure_ssh_crypto_policy`, `configure_crypto_policy`, and `dconf_db_up_to_date` based on https://www.govinfo.gov/content/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf

#### Rationale:
HIPAA references completion.
