### PR TITLE
Remove harden_sshd_crypto_policy from RHEL8 STIG profile

### DIFF
--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -164,7 +164,6 @@ selections:
     # RHEL-08-010290 && RHEL-08-010291
     ### NOTE: This will get split out in future STIG releases, as well as we will break
     ### these rules up to be more flexible in meeting the requirements.
-    - harden_sshd_crypto_policy
     - configure_ssh_crypto_policy
 
     # RHEL-08-010292

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -128,7 +128,6 @@ selections:
 - grub2_uefi_admin_username
 - grub2_uefi_password
 - grub2_vsyscall_argument
-- harden_sshd_crypto_policy
 - install_smartcard_packages
 - installed_OS_is_vendor_supported
 - kerberos_disable_no_keytab


### PR DESCRIPTION
#### Description:

- Remove harden_sshd_crypto_policy from RHEL8 STIG profile.

#### Rationale:

- Follow up from https://github.com/ComplianceAsCode/content/pull/6856#discussion_r615735419
