### PR TITLE
Fix ansible remediation applicability

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -488,7 +488,8 @@ class AnsibleRemediation(Remediation):
             additional_when.append(" or ".join(rule_specific_conditionals))
 
         to_update.setdefault("when", "")
-        new_when = ssg.yaml.update_yaml_list_or_string(to_update["when"], additional_when, prepend=True)
+        new_when = ssg.yaml.update_yaml_list_or_string(to_update["when"], additional_when,
+                                                       prepend=True)
         if not new_when:
             to_update.pop("when")
         else:

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -488,7 +488,7 @@ class AnsibleRemediation(Remediation):
             additional_when.append(" or ".join(rule_specific_conditionals))
 
         to_update.setdefault("when", "")
-        new_when = ssg.yaml.update_yaml_list_or_string(to_update["when"], additional_when)
+        new_when = ssg.yaml.update_yaml_list_or_string(to_update["when"], additional_when, prepend=True)
         if not new_when:
             to_update.pop("when")
         else:

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -225,12 +225,15 @@ def _strings_to_list(one_or_more_strings):
         return list(one_or_more_strings)
 
 
-def update_yaml_list_or_string(current_contents, new_contents):
+def update_yaml_list_or_string(current_contents, new_contents, prepend=False):
     result = []
     if current_contents:
         result += _strings_to_list(current_contents)
     if new_contents:
-        result += _strings_to_list(new_contents)
+        if prepend:
+            result = _strings_to_list(new_contents) + result
+        else:
+            result += _strings_to_list(new_contents)
     if not result:
         result = ""
     if len(result) == 1:


### PR DESCRIPTION
#### Description:

- Fix ansible remediation applicability.
  - When clauses for applicability must come first in the list. Otherwise it
can produce unexpected results when multiple tasks have to interact with
each other but they have different or none additional when clauses.

#### Rationale:

- Fixes #6857
