### PR TITLE
remove no longer relevant rules from rhel7 stig

### DIFF
--- a/rhel7/profiles/stig.profile
+++ b/rhel7/profiles/stig.profile
@@ -203,7 +203,6 @@ selections:
     - audit_rules_execution_setsebool
     - audit_rules_execution_chcon
     - audit_rules_execution_setfiles
-    - audit_rules_login_events_tallylog
     - audit_rules_login_events_faillock
     - audit_rules_login_events_lastlog
     - audit_rules_privileged_commands_passwd
@@ -216,7 +215,6 @@ selections:
     - audit_rules_sysadmin_actions
     - audit_rules_privileged_commands_newgrp
     - audit_rules_privileged_commands_chsh
-    - audit_rules_privileged_commands_sudoedit
     - audit_rules_media_export
     - audit_rules_privileged_commands_umount
     - audit_rules_privileged_commands_postdrop
@@ -268,7 +266,6 @@ selections:
     - sshd_disable_compression
     - sshd_disable_user_known_hosts
     - chronyd_or_ntpd_set_maxpoll
-    - configure_firewalld_rate_limiting
     - service_firewalld_enabled
     - display_login_attempts
     - no_user_host_based_files


### PR DESCRIPTION
#### Description:

- remove three rules which seem no longer used

#### Rationale:

- reference taken from https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide?version=V3R2
- these rules were discovered when checking for rules without proper stig references

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
