### PR TITLE
Add anaconda remediation for xwindows_remove_packages

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/anaconda/shared.anaconda
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/anaconda/shared.anaconda
@@ -1,0 +1,3 @@
+# platform = multi_platform_all
+
+package --remove=xorg-x11-server-Xorg --remove=xorg-x11-server-common --remove=xorg-x11-server-utils {{{ "--remove=xorg-x11-server-Xwayland" if product not in ["rhel7", "ol7"] }}}


### PR DESCRIPTION
#### Description:

- Add anaconda remediation for xwindows_remove_packages

#### Rationale:

- This is required so oscap anaconda addon can preprocess the list of packages being removed and decide whether to prevent users from continue installation or not. In case they select Server with Gui and default STIG profile (which removes xorg packages and cause conflict in the installation)


It's not possible to add the agent switch the same as [bash](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/bash/shared.sh#L17
) and ansible remediation are doing. But this does not pose a problem since the bash remediation will also get executed later in the installation phase.