### PR TITLE
Fix RHEL8 STIG with GUI stable profile data.

### DIFF
--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -1,6 +1,6 @@
 description: 'This profile contains configuration checks that align to the
 
-    DISA STIG with GUI for Red Hat Enterprise Linux 8.
+    DISA STIG with GUI for Red Hat Enterprise Linux 8 V1R1.
 
 
     In addition to being applicable to Red Hat Enterprise Linux 8, DISA recognizes
@@ -116,7 +116,11 @@ selections:
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages
+- file_groupowner_var_log
+- file_groupowner_var_log_messages
 - file_groupownership_home_directories
+- file_owner_var_log
+- file_owner_var_log_messages
 - file_ownership_binary_dirs
 - file_ownership_library_dirs
 - file_ownership_var_log_audit
@@ -127,7 +131,9 @@ selections:
 - file_permissions_sshd_private_key
 - file_permissions_sshd_pub_key
 - file_permissions_ungroupowned
+- file_permissions_var_log
 - file_permissions_var_log_audit
+- file_permissions_var_log_messages
 - gnome_gdm_disable_automatic_login
 - grub2_admin_username
 - grub2_audit_argument


### PR DESCRIPTION
#### Description:

- Fix RHEL8 STIG with GUI stable profile data.

#### Rationale:

- Hotfix to the current main branch. `stable-profiles` test is failing without this.
