### PR TITLE
Introduce @ form in all template fields

### DIFF
--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -42,7 +42,9 @@ service_sssd_disabled:
   name: service_disabled
   vars:
     servicename: sssd
-    packagename: "{{% if product in ['sle12', 'sle15'] %}}sssd{{% else %}}sssd-common{{% endif %}}"
+    packagename: sssd-common
+    packagename@sle12: sssd
+    packagename@sle15: sssd
 
 service_syslog_disabled:
   name: service_disabled

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -167,6 +167,21 @@ class Builder(object):
         else:
             return languages
 
+    def process_product_vars(self, all_variables):
+        """
+        Given a dictionary with the format key[@<product>]=value, filter out
+        and only take keys that apply to this product (unqualified or qualified
+        to exactly this product). Returns a new dict.
+        """
+        processed = dict(filter(lambda item: '@' not in item[0], all_variables.items()))
+        suffix = '@' + self.env_yaml['product']
+        for variable in filter(lambda key: key.endswith(suffix), all_variables):
+            new_variable = variable[:-len(suffix)]
+            value = all_variables[variable]
+            processed[new_variable] = value
+
+        return processed
+
     def build_rule(self, rule_id, rule_title, template, langs_to_generate):
         """
         Builds templated content for a given rule for selected languages,
@@ -183,7 +198,7 @@ class Builder(object):
                 "Rule {0} uses template {1} which does not exist.".format(
                     rule_id, template_name))
         try:
-            template_vars = template["vars"]
+            template_vars = self.process_product_vars(template["vars"])
         except KeyError:
             raise ValueError(
                 "Rule {0} does not contain mandatory 'vars:' key under "


### PR DESCRIPTION
#### Description & Rationale

As noted by @ggbecker in #6659, templates apparently lack the ability to
process @-formed variables in the extra_ovals.yml format. Because of the
way a Rule's yaml gets processed in build_yaml.py, we do not have that
issue due to its preprocessing, though this fix does get applied in both
places.

This allows us to avoid the need to use Jinja processing on
extra_ovals.yml for determining package name, making it look nicer and
be a little more friendly for contributors.

Resolves: #6659

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

RHEL7:

```
        <linux:rpminfo_object id="oval:ssg-obj_test_service_sssd_package_sssd-common_removed:obj:1" version="1">
          <linux:name>sssd-common</linux:name>
        </linux:rpminfo_object>
```

SLES15:

```
        <linux:rpminfo_object id="oval:ssg-obj_env_has_sssd-common_installed:obj:1" version="1">
          <linux:name>sssd</linux:name>
        </linux:rpminfo_object>
```

(Note that SLES currently uses Jinja macro to achieve this anyways).

----

Do we want to support `@<product>` without a version suffix in all rules/templates? So e.g., `@rhel` or `@ubuntu` or `@sle`? Thoughts? 