### PR TITLE
Show which rule failed during template builds

### DIFF
--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -217,7 +217,7 @@ class Builder(object):
                 self.build_lang(
                     rule_id, template_name, template_vars, lang, local_env_yaml)
             except Exception as e:
-                print("Error building rule {0}".format(rule_id), file=sys.stderr)
+                print("Error building templated {0} content for rule {1}".format(lang, rule_id), file=sys.stderr)
                 raise e
 
     def build_extra_ovals(self):

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -213,8 +213,12 @@ class Builder(object):
         local_env_yaml["rule_title"] = rule_title
         local_env_yaml["products"] = self.env_yaml["product"]
         for lang in langs_to_generate:
-            self.build_lang(
-                rule_id, template_name, template_vars, lang, local_env_yaml)
+            try:
+                self.build_lang(
+                    rule_id, template_name, template_vars, lang, local_env_yaml)
+            except Exception as e:
+                print("Error building rule {0}".format(rule_id), file=sys.stderr)
+                raise e
 
     def build_extra_ovals(self):
         declaration_path = os.path.join(self.templates_dir, "extra_ovals.yml")


### PR DESCRIPTION
#### Description

Previously, when a rule failed to build when applying the template
(e.g., using a glob in a package removal template), we wouldn't
necessarily know which rule failed to build. Print an error message
showing which rule this was and then re-throw the error so that the
builder can see which rule caused the build failure.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`