### PR TITLE
Relax version checks for Oracle JRE only

### DIFF
--- a/jre/checks/oval/installed_app_is_java.xml
+++ b/jre/checks/oval/installed_app_is_java.xml
@@ -20,7 +20,8 @@
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="Oracle JRE is installed" id="test_oracle_java" version="1">
     <linux:object object_ref="obj_oracle_java" />
-    <linux:state state_ref="state_java_version" />
+    <linux:state state_ref="state_java_version_minimum" />
+    <linux:state state_ref="state_java_version_maximum" />
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_oracle_java" version="1">
     <linux:name datatype="string" operation="pattern match">^jre.*$</linux:name>
@@ -68,5 +69,11 @@
 
   <linux:rpminfo_state id="state_java_version" version="1">
     <linux:version datatype="version" operation="equals">1.8.0</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_state id="state_java_version_minimum" version="1">
+    <linux:version datatype="version" operation="greater than or equal">1.8.0</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_state id="state_java_version_maximum" version="1">
+    <linux:version datatype="version" operation="less than">1.9.0</linux:version>
   </linux:rpminfo_state>
 </def-group>


### PR DESCRIPTION
#### Description:
- Bounds the version check to be 1.8.0 <= x < 1.9.0 instead of strictly 1.8.0

#### Rationale:

- Oracle Java RPM package reports the update version number as "1.8.0_xxx" for update versions (so 1.8 u281 -> 1.8.0_281), which fails a check.
- Fixes #6885
