### PR TITLE
Enable the RHEL9 prodtype for rules that are expected to work the same on that system

### DIFF
--- a/linux_os/guide/services/base/package_abrt_removed/rule.yml
+++ b/linux_os/guide/services/base/package_abrt_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall Automatic Bug Reporting Tool (abrt)'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4,sle15
+prodtype: rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify Permissions on cron.d'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4,sle15
+prodtype: rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify Permissions on cron.daily'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4,sle15
+prodtype: rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify Permissions on cron.hourly'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4,sle15
+prodtype: rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify Permissions on cron.monthly'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4,sle15
+prodtype: rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify Permissions on cron.weekly'
 

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4,sle15
+prodtype: rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify Permissions on crontab'
 

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall DHCP Server Package'
 

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Uninstall bind Package'
 

--- a/linux_os/guide/services/fapolicyd/package_fapolicyd_installed/rule.yml
+++ b/linux_os/guide/services/fapolicyd/package_fapolicyd_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Install fapolicyd Package'
 

--- a/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/rule.yml
+++ b/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol8,rhel8
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Enable the File Access Policy Service'
 

--- a/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/rule.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Uninstall vsftpd Package'
 

--- a/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,sle15
+prodtype: rhel7,rhel8,rhel9,sle15
 
 title: 'Uninstall httpd Package'
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_d_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Set Permissions on All Configuration Files Inside /etc/httpd/conf.d/'
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_conf_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Set Permissions on All Configuration Files Inside /etc/httpd/conf/'
 

--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_restrict_file_dir_access/file_permissions_httpd_server_modules_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Set Permissions on All Configuration Files Inside /etc/httpd/conf.modules.d/'
 

--- a/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Uninstall dovecot Package'
 

--- a/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
+++ b/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Remove the Kerberos Server Package'
 

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure LDAP client is not installed'
 

--- a/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,sle15
+prodtype: rhel7,rhel8,rhel9,sle15
 
 title: 'Uninstall openldap-servers Package'
 

--- a/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
+++ b/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Uninstall Sendmail Package'
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,wrlinux1019
 
 title: 'Mount Remote Filesystems with Kerberos Security'
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Mount Remote Filesystems with nodev'
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Mount Remote Filesystems with noexec'
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Mount Remote Filesystems with nosuid'
 

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall nfs-utils Package'
 

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Uninstall xinetd Package'
 

--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Remove NIS Client'
 

--- a/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Uninstall ypserv Package'
 

--- a/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Uninstall rsh-server Package'
 

--- a/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Uninstall rsh Package'
 

--- a/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Uninstall talk-server Package'
 

--- a/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Uninstall talk Package'
 

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Uninstall telnet-server Package'
 

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Remove telnet Clients'
 

--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Uninstall tftp-server Package'
 

--- a/linux_os/guide/services/obsolete/tftp/package_tftp_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Remove tftp Daemon'
 

--- a/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/rule.yml
+++ b/linux_os/guide/services/proxy/disabling_squid/package_squid_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall squid Package'
 

--- a/linux_os/guide/services/radius/package_freeradius_removed/rule.yml
+++ b/linux_os/guide/services/radius/package_freeradius_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Remove the FreeRadius Server Package'
 

--- a/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/rule.yml
+++ b/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall quagga Package'
 

--- a/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing/rule.yml
+++ b/linux_os/guide/services/smb/configuring_samba/mount_option_smb_client_signing/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Require Client SMB Packet Signing, if using mount.cifs'
 

--- a/linux_os/guide/services/smb/configuring_samba/package_samba-common_installed/rule.yml
+++ b/linux_os/guide/services/smb/configuring_samba/package_samba-common_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,rhel7,rhel8,rhv4,sle15
+prodtype: rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Install the Samba Common Package'
 

--- a/linux_os/guide/services/smb/disabling_samba/package_samba_removed/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/package_samba_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Uninstall Samba Package'
 

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian9,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Uninstall net-snmp Package'
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4,sle15,rhcos4
+prodtype: rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify Permissions on SSH Server config file'
 

--- a/linux_os/guide/services/ssh/package_openssh-clients_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-clients_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8
+prodtype: ol8,rhel8,rhel9
 
 title: 'Install OpenSSH client software'
 

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Log USBGuard daemon audit events using Linux Audit'
 

--- a/linux_os/guide/services/usbguard/package_usbguard_installed/rule.yml
+++ b/linux_os/guide/services/usbguard/package_usbguard_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install usbguard Package'
 

--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Enable the USBGuard Service'
 

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Authorize Human Interface Devices in USBGuard daemon'
 

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Authorize Human Interface Devices and USB hubs in USBGuard daemon'
 

--- a/linux_os/guide/services/usbguard/usbguard_allow_hub/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hub/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Authorize USB hubs in USBGuard daemon'
 

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Remove the X Windows Package Group'
 

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Verify permissions on System Login Banner'
 

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Verify permissions on Message of the Day Banner'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Limit Password Reuse'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Set Deny For Failed Password Attempts'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Configure the root Account for Failed Password Attempts'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8
+prodtype: fedora,rhel8,rhel9
 
 title: 'Enforce pam_faillock for Local Accounts Only'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Set Interval For Counting Failed Password Attempts'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Set Lockout Time for Failed Password Attempts'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Digit Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Different Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_local/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_local/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8
+prodtype: fedora,rhel8,rhel9
 
 title: 'Ensure PAM Enforces Password Requirements - Enforce for Local Accounts Only'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_root/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8
+prodtype: fedora,rhel8,rhel9
 
 title: 'Ensure PAM Enforces Password Requirements - Enforce for root User'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Lowercase Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Maximum Consecutive Repeating Characters from Same Character Class'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Set Password Maximum Consecutive Repeating Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Different Categories'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Length'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Special Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Authentication Retry Prompts Permitted Per-Session'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Uppercase Characters'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8,rhv4,rhcos4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: 'Install the tmux Package'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Set number of Password Hashing Rounds - password-auth'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Set number of Password Hashing Rounds - system-auth'
 

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure All User Initialization Files Have Mode 0740 Or Less Permissive'
 

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'All Interactive User Home Directories Must Have mode 0750 Or Less Permissive'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Any Attempts to Run chcon'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Any Attempts to Run restorecon'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Record Any Attempts to Run semanage'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Any Attempts to Run setfiles'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Record Any Attempts to Run setsebool'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Any Attempts to Run seunshare'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects File Deletion Events by User'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Record Successful Permission Changes to Files - chmod'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Ownership Changes to Files - chown'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Access Attempts to Files - creat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - fchmod'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchmodat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - fchmodat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Ownership Changes to Files - fchown'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fchownat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Ownership Changes to Files - fchownat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fremovexattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - fremovexattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_fsetxattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - fsetxattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_ftruncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Access Attempts to Files - ftruncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lchown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Ownership Changes to Files - lchown'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lremovexattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - lremovexattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lsetxattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - lsetxattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Access Attempts to Files - open'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Access Attempts to Files - open_by_handle_at'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Record Successful Creation Attempts to Files - open_by_handle_at O_CREAT'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Record Successful Creation Attempts to Files - open_by_handle_at O_TRUNC_WRITE'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Record Successful Creation Attempts to Files - open O_CREAT'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open_o_trunc_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Record Successful Creation Attempts to Files - open O_TRUNC_WRITE'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Access Attempts to Files - openat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Record Successful Creation Attempts to Files - openat O_CREAT'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_openat_o_trunc_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Record Successful Creation Attempts to Files - openat O_TRUNC_WRITE'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_removexattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - removexattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_rename/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Delete Attempts to Files - rename'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_renameat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Delete Attempts to Files - renameat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_setxattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Permission Changes to Files - setxattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_truncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Access Attempts to Files - truncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Delete Attempts to Files - unlink'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlinkat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Record Successful Delete Attempts to Files - unlinkat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful)'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - chmod'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Ownership Changes to Files - chown'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - creat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - fchmod'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmodat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - fchmodat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Ownership Changes to Files - fchown'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Ownership Changes to Files - fchownat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fremovexattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - fremovexattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fsetxattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - fsetxattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - ftruncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Ownership Changes to Files - lchown'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lremovexattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - lremovexattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lsetxattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - lsetxattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - open'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - open_by_handle_at'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessful Creation Attempts to Files - open_by_handle_at O_CREAT'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessful Modification Attempts to Files - open_by_handle_at O_TRUNC_WRITE'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Unauthorized Access Attempts To open_by_handle_at Are Ordered Correctly'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessful Creation Attempts to Files - open O_CREAT'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessful Modification Attempts to Files - open O_TRUNC_WRITE'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Rules For Unauthorized Attempts To open Are Ordered Correctly'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - openat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessful Creation Attempts to Files - openat O_CREAT'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessful Modification Attempts to Files - openat O_TRUNC_WRITE'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Rules For Unauthorized Attempts To openat Are Ordered Correctly'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_removexattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - removexattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - rename'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - renameat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_setxattr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Unsuccessul Permission Changes to Files - setxattr'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - truncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - unlink'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - unlinkat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Unloading - delete_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading - init_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - faillock'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - lastlog'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - tallylog'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - at'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chage'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chsh'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - crontab'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - gpasswd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - mount'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newgidmap'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newgrp'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newuidmap'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pam_timestamp_check'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - passwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postdrop'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postqueue'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pt_chown'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - ssh-keysign'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - su'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudo'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudoedit'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - umount'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,wrlinux1019
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix_chkpwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - userhelper'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - usernetctl'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open syscall - /etc/group'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/group'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via openat syscall - /etc/group'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open syscall - /etc/gshadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/gshadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via openat syscall - /etc/gshadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open syscall - /etc/passwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/passwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via openat syscall - /etc/passwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open syscall - /etc/shadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via open_by_handle_at syscall - /etc/shadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Record Events that Modify User/Group Information via openat syscall - /etc/shadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Shutdown System When Auditing Failures Occur'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/group'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/gshadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/security/opasswd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/passwd'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/shadow'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'System Audit Logs Must Have Mode 0640 or Less Permissive'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Configure audispd Plugin To Send Logs To Remote Server'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Configure audispd''s Plugin disk_full_action When Disk Is Full'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Encrypt Audit Records Sent With audispd Plugin'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Configure audispd''s Plugin network_failure_action On Network Failure'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Configure auditd flush priority'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Configure auditd space_left on Low Disk Space'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Configure audit according to OSPP requirements'
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify /boot/grub2/grub.cfg Permissions'
 

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Verify the UEFI Boot Loader grub.cfg Permissions'
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure cron Is Logging To Rsyslog'
 

--- a/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Ensure rsyslog-gnutls is installed'
 

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure rsyslog Does Not Accept Remote Messages Unless Acting As Log Server'
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Configure TLS for rsyslog remote logging'
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Configure CA certificate for rsyslog remote logging'
 

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
 
 title: 'Install firewalld Package'
 

--- a/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install libreswan Package'
 

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Ensure All SGID Executables Are Authorized'
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,wrlinux1019,sle15,wrlinux8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle15,wrlinux1019,wrlinux8
 
 description: |-
     The SGID (set group id) bit should be set only on files that were

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Ensure All SUID Executables Are Authorized'
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15,wrlinux1019,wrlinux8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle15,wrlinux1019,wrlinux8
 
 description: |-
     The SUID (set user id) bit should be set only on files that were

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure All Files Are Owned by a Group'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Add noauto Option to /boot'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nodev Option to /boot'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Add noexec Option to /boot'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nosuid Option to /boot'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4,sle15,ubuntu1804
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Add noexec Option to /dev/shm'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhcos4,sle15,ubuntu1804
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Add nodev Option to /home'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Add noexec Option to /home'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,rhcos4,sle12,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Add nosuid Option to /home'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nodev Option to Non-Root Local Partitions'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,rhcos4,sle15,ubuntu1804
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804
 
 title: 'Add nodev Option to Removable Media Partitions'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,rhcos4,sle15,ubuntu1804
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804
 
 title: 'Add noexec Option to Removable Media Partitions'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019,rhcos4,ubuntu1804
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu1804,wrlinux1019
 
 title: 'Add nosuid Option to Removable Media Partitions'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Add nosuid Option to /opt'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Add nosuid Option to /srv'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15,ubuntu1804,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Add nodev Option to /tmp'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
 
 title: 'Add noexec Option to /tmp'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15,ubuntu1804,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Add nosuid Option to /tmp'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nodev Option to /var/log/audit'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add noexec Option to /var/log/audit'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nosuid Option to /var/log/audit'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nodev Option to /var/log'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add noexec Option to /var/log'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nosuid Option to /var/log'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nodev Option to /var'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Add noexec Option to /var'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhcos4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Add nosuid Option to /var'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Bind Mount /var/tmp To /tmp'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhcos4,sle15,ubuntu1804
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Add nodev Option to /var/tmp'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhcos4,sle15,ubuntu1804
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Add noexec Option to /var/tmp'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhcos4,sle15,ubuntu1804
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Add nosuid Option to /var/tmp'
 

--- a/linux_os/guide/system/selinux/package_libselinux_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,rhcos4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Install libselinux Package'
 

--- a/linux_os/guide/system/selinux/package_mcstrans_removed/rule.yml
+++ b/linux_os/guide/system/selinux/package_mcstrans_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,sle15
+prodtype: fedora,rhel7,rhel8,rhel9,sle15
 
 title: 'Uninstall mcstrans Package'
 

--- a/linux_os/guide/system/selinux/package_setroubleshoot_removed/rule.yml
+++ b/linux_os/guide/system/selinux/package_setroubleshoot_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle15
 
 title: 'Uninstall setroubleshoot Package'
 

--- a/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhv4
+prodtype: fedora,rhel7,rhel8,rhel9,rhv4
 
 title: 'Remove the GDM Package Group'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8,rhv4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: 'Configure BIND to use System Crypto Policy'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8,rhv4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: 'Configure System Cryptography Policy'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8,rhv4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: 'Configure Kerberos to use System Crypto Policy'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8,rhv4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: 'Configure Libreswan to use System Crypto Policy'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8,rhv4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: 'Configure OpenSSL library to use System Crypto Policy'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8,rhv4,rhcos4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: 'Configure SSH to use System Crypto Policy'
 

--- a/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8
+prodtype: ol8,rhel8,rhel9
 
 title: 'Install crypto-policies package'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Install AIDE'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Verify File Hashes with RPM'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_ownership/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Verify and Correct Ownership with RPM'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Verify and Correct File Permissions with RPM'
 

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Install sudo Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-ccpp_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-ccpp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall abrt-addon-ccpp Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall abrt-addon-kerneloops Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-python_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-python_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall abrt-addon-python Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-cli_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-cli_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall abrt-cli Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall abrt-plugin-logger Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall abrt-plugin-rhtsupport Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall abrt-plugin-sosreport Package'
 

--- a/linux_os/guide/system/software/system-tools/package_geolite2-city_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_geolite2-city_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall geolite2-city Package'
 

--- a/linux_os/guide/system/software/system-tools/package_geolite2-country_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_geolite2-country_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall geolite2-country Package'
 

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall gssproxy Package'
 

--- a/linux_os/guide/system/software/system-tools/package_iprutils_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_iprutils_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall iprutils Package'
 

--- a/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall krb5-workstation Package'
 

--- a/linux_os/guide/system/software/system-tools/package_openscap-scanner_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_openscap-scanner_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install openscap-scanner Package'
 

--- a/linux_os/guide/system/software/system-tools/package_scap-security-guide_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_scap-security-guide_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install scap-security-guide Package'
 

--- a/linux_os/guide/system/software/system-tools/package_subscription-manager_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_subscription-manager_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Install subscription-manager Package'
 

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Uninstall tuned Package'
 

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: Configure dnf-automatic to Install Only Security Updates
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Ensure gpgcheck Enabled In Main {{{ pkg_manager }}} Configuration'
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure gpgcheck Enabled for Local Packages'
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Ensure gpgcheck Enabled for All {{{ pkg_manager }}} Package Repositories'
 


### PR DESCRIPTION
The `utils/mod_prodtype.py` has been used to insert the RHEL9 prodtype, and it reorders the list by the lexicographical order.

Individual commits contain additional information regarding why a set of rules got enabled.