### PR TITLE
RHEL8 STIG - add missing SRGs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 
 references:
   anssi: BP28(R32)
+  srg: SRG-OS-000073-GPOS-00041
 
 ocil_clause: 'it does not set the appropriate number of hashing rounds'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 
 references:
   anssi: BP28(R32)
+  srg: SRG-OS-000073-GPOS-00041
 
 ocil_clause: 'it does not set the appropriate number of hashing rounds'
 


### PR DESCRIPTION
#### Description:
Add SRGs to `accounts_password_pam_unix_rounds_system_auth` and `accounts_password_pam_unix_rounds_password_auth`.

Both rules are under `RHEL-08-010130` in the rhel8 stig profile. SRGs are taken from https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_8_security_technical_implementation_guide/V-230233
