### PR TITLE
Prevent global references to use product-qualifiers

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -252,10 +252,10 @@ A rule may contain those reference-type attributes:
     `srg`, `nist`, etc., whose keys may be modified with a product
     (e.g., `stigid@rhel7`) to restrict what products a reference
     identifier applies to. Depending on the type of reference (e.g.
-    catalog, rulei, etc.) will depend on how many can be added to a
+    catalog, ruleid, etc.) will depend on how many can be added to a
     single rule. In addition, certain references in a rule such as
-    `stigid` only apply to a certain product and product version; they
-    cannot be used for multiple products and versions
+    `stigid` or `cis` only apply to a certain product and product version; they
+    cannot be used for multiple products and versions.
 
     <table>
     <colgroup>
@@ -274,7 +274,7 @@ A rule may contain those reference-type attributes:
     </thead>
     <tbody>
     <tr class="odd">
-    <td><p>cis</p></td>
+    <td><p>cis@&lt;product&gt;&lt;product_version&gt;</p></td>
     <td><p>Center for Internet Security (catalog identifier)</p></td>
     <td><p>0-to-many, 0-to-1 is preferred</p></td>
     <td><p>5.2.5</p></td>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/rule.yml
@@ -38,8 +38,8 @@ identifiers:
 references:
     disa: CCI-000803
     nist: IA-7,IA-7.1
-    srg@sle15: SRG-OS-000120-GPOS-00061
-    vmmsrg@sle15: SRG-OS-000480-VMM-002000
+    srg: SRG-OS-000120-GPOS-00061
+    vmmsrg: SRG-OS-000480-VMM-002000
     stigid@sle15: SLES-15-010250
 
 ocil_clause: 'it does not'

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1044,6 +1044,7 @@ class Rule(object):
     }
 
     PRODUCT_REFERENCES = ("stigid", "cis",)
+    GLOBAL_REFERENCES = ("srg", "disa", "cis-csc",)
 
     def __init__(self, id_):
         self.id_ = id_
@@ -1229,6 +1230,12 @@ class Rule(object):
                 continue
 
             label = full_label.split("@")[0]
+
+            if label in Rule.GLOBAL_REFERENCES:
+                raise ValueError(
+                    "You cannot use product-qualified for '{item_u}' reference. Please remove the product-qualifier and merge values with existing reference. Original line: {item_q}: {value_q}"
+                    .format(item_u=label, item_q=full_label, value_q=value))
+
             if label in items_dict and not allow_overwrites and value != items_dict[label]:
                 msg = (
                     "There is a product-qualified '{item_q}' item, "

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1226,19 +1226,22 @@ class Rule(object):
                 new_items[full_label] = value
                 continue
 
-            if not full_label.endswith(product_suffix):
-                continue
-
             label = full_label.split("@")[0]
 
+            # this test should occur before matching product_suffix with the product qualifier
+            # present in the reference, so it catches problems even for products that are not
+            # being built at the moment
             if label in Rule.GLOBAL_REFERENCES:
                 msg = (
                     "You cannot use product-qualified for the '{item_u}' reference. "
-                    "Please remove the product-qualifier and merge values with "
-                    "the existing reference. Original line: {item_q}: {value_q}"
+                    "Please remove the product-qualifier and merge values with the "
+                    "existing reference if there is any. Original line: {item_q}: {value_q}"
                     .format(item_u=label, item_q=full_label, value_q=value)
                 )
                 raise ValueError(msg)
+
+            if not full_label.endswith(product_suffix):
+                continue
 
             if label in items_dict and not allow_overwrites and value != items_dict[label]:
                 msg = (

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1044,7 +1044,7 @@ class Rule(object):
     }
 
     PRODUCT_REFERENCES = ("stigid", "cis",)
-    GLOBAL_REFERENCES = ("srg", "disa", "cis-csc",)
+    GLOBAL_REFERENCES = ("srg", "vmmsrg", "disa", "cis-csc",)
 
     def __init__(self, id_):
         self.id_ = id_

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1232,9 +1232,13 @@ class Rule(object):
             label = full_label.split("@")[0]
 
             if label in Rule.GLOBAL_REFERENCES:
-                raise ValueError(
-                    "You cannot use product-qualified for '{item_u}' reference. Please remove the product-qualifier and merge values with existing reference. Original line: {item_q}: {value_q}"
-                    .format(item_u=label, item_q=full_label, value_q=value))
+                msg = (
+                    "You cannot use product-qualified for the '{item_u}' reference. "
+                    "Please remove the product-qualifier and merge values with "
+                    "the existing reference. Original line: {item_q}: {value_q}"
+                    .format(item_u=label, item_q=full_label, value_q=value)
+                )
+                raise ValueError(msg)
 
             if label in items_dict and not allow_overwrites and value != items_dict[label]:
                 msg = (


### PR DESCRIPTION

#### Description:

- Prevent global references to use product-qualifiers.
  - Starts with srg and disa references.

This will definitely fail during the build because we have many of these instances.

Relates to: #6895
