### PR TITLE
OCP: Fix description of kubelet TLS cipher suites

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -23,7 +23,7 @@ description: |-
           - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
           - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
           - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-          - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+          - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     </pre>
 
 rationale: |-


### PR DESCRIPTION
#### Description:

Removes a trailing comma from the cipher list

#### Rationale:

The trailing comma would have produced an invalid kubelet config:

   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"
  ],

note the comma in the string