### PR TITLE
OCP: Fix description and OCIL in proxy-kubeconfig rules

### DIFF
--- a/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
@@ -4,7 +4,16 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The Worker Proxy Kubeconfig File'
 
-description: '{{{ describe_file_group_owner(file="/config/kube-proxy-config.yaml", group="root") }}}'
+description: |-
+  To ensure the Kubernetes ConfigMap is mounted into the sdn daemonset pods with the
+  correct ownership, make sure that the <tt>sdn-config</tt> ConfigMap is mounted using
+  a ConfigMap at the <tt>/config</tt> mount point and that the <tt>sdn</tt> container
+  points to that configuration using the <tt>--proxy-config</tt> command line option.
+  Run:
+  <pre> oc get -nopenshift-sdn ds sdn -ojson | jq -r '.spec.template.spec.containers[] | select(.name == "sdn")'</pre>
+  and ensure the <tt>--proxy-config</tt> parameter points to 
+  <tt>/config/kube-proxy-config.yaml</tt> and that the <tt>config</tt> mount point is
+  mounted from the <tt>sdn-config</tt> ConfigMap.
 
 rationale: |-
   The kubeconfig file for kube-proxy provides permissions to the kube-proxy service.
@@ -23,7 +32,14 @@ severity: medium
 references:
   cis@ocp4: 4.1.4
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/config/kube-proxy-config.yaml", group="root") }}}'
+ocil_clause: 'The kube-proxy configuration ConfigMap mount is mounted with wrong group ownership'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/config/kube-proxy-config.yaml", group="root") }}}
+  Run the following command:
+  <pre>
+   $ for i in $(oc get pods -n openshift-sdn -l app=sdn -oname)
+     do
+        oc exec -n openshift-sdn $i -- stat -Lc %U:%G /config/kube-proxy-config.yaml
+     done
+  </pre>
+  The output should be <tt>root:root</tt>

--- a/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
@@ -4,7 +4,16 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Worker Proxy Kubeconfig File'
 
-description: '{{{ describe_file_owner(file="/config/kube-proxy-config.yaml", owner="root") }}}'
+description: |-
+  To ensure the Kubernetes ConfigMap is mounted into the sdn daemonset pods with the
+  correct ownership, make sure that the <tt>sdn-config</tt> ConfigMap is mounted using
+  a ConfigMap at the <tt>/config</tt> mount point and that the <tt>sdn</tt> container
+  points to that configuration using the <tt>--proxy-config</tt> command line option.
+  Run:
+  <pre> oc get -nopenshift-sdn ds sdn -ojson | jq -r '.spec.template.spec.containers[] | select(.name == "sdn")'</pre>
+  and ensure the <tt>--proxy-config</tt> parameter points to 
+  <tt>/config/kube-proxy-config.yaml</tt> and that the <tt>config</tt> mount point is
+  mounted from the <tt>sdn-config</tt> ConfigMap.
 
 rationale: |-
   The kubeconfig file for kube-proxy provides permissions to the kube-proxy service.
@@ -23,7 +32,14 @@ severity: medium
 references:
   cis@ocp4: 4.1.4
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/config/kube-proxy-config.yaml", owner="root") }}}'
+ocil_clause: 'The kube-proxy configuration ConfigMap mount is mounted with wrong ownership'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/config/kube-proxy-config.yaml", owner="root") }}}
+  Run the following command:
+  <pre>
+   $ for i in $(oc get pods -n openshift-sdn -l app=sdn -oname)
+     do
+        oc exec -n openshift-sdn $i -- stat -Lc %U:%G /config/kube-proxy-config.yaml
+     done
+  </pre>
+  The output should be <tt>root:root</tt>

--- a/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
@@ -5,7 +5,19 @@ prodtype: ocp4
 title: 'Verify Permissions on the Worker Proxy Kubeconfig File'
 
 description: |-
-  {{{ describe_file_permissions(file="/config/kube-proxy-config.yaml", perms="0644") }}}
+  To ensure the Kubernetes ConfigMap is mounted into the sdn daemonset pods with the
+  correct permissions, make sure that the <tt>sdn-config</tt> ConfigMap is mounted using
+  restrictive permissions. Check that the <tt>config</tt> VolumeMount mounts the
+  <tt>sdn-config</tt> configMap with permissions set to 420:
+  <pre>
+  {
+  "configMap": {
+    "defaultMode": 420,
+    "name": "sdn-config"
+    },
+  "name": "config"
+  }
+  </pre>
 
 rationale: |-
   The kube-proxy kubeconfig file controls various parameters of the kube-proxy
@@ -27,10 +39,12 @@ identifiers:
 references:
   cis@ocp4: 4.1.3
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/config/kube-proxy-config.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: 'The kube-proxy configuration ConfigMap mount is mounted using wrong permissions'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/config/kube-proxy-config.yaml", perms="-rw-r--r--") }}}
+    Run the following command:
+    <pre>$ oc get -nopenshift-sdn ds sdn -ojson | jq -r '.spec.template.spec.volumes[] | select(.configMap.name == "sdn-config") | .configMap.defaultMode'</pre>
+    The output should return a value of <pre>420</pre>.
 
 warnings:
 - general: |-


### PR DESCRIPTION
The proxy-kubeconfig rules were sort of a special case as they don't
check ownership or file permissions of files on the hosts, but mounted
inside a pod. The rules used autogenerated description and OCIL which
didn't make sense to check files inside a pod, let's use hand-crafted
instructions instead.

Resolves: rhbz#1954572