### PR TITLE
Automatically prodtype rules in a profile

### DIFF
--- a/utils/autoprodtyper.py
+++ b/utils/autoprodtyper.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import argparse
+import json
+
+import ssg.build_yaml
+import ssg.products
+import ssg.rules
+import ssg.yaml
+import ssg.utils
+import ssg.rule_yaml
+
+from mod_prodtype import add_products
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Automatically add a missing product "
+                                     "reference to the prodtype key of a rule.yml based "
+                                     "on inclusion in a specified profile")
+    parser.add_argument("-j", "--json", type=str, action="store",
+                        default="build/rule_dirs.json", help="File to read "
+                        "json output of rule_dir_json from (defaults to "
+                        "build/rule_dirs.json")
+    parser.add_argument("-c", "--build-config-yaml", default="build/build_config.yml",
+                        help="YAML file with information about the build configuration. "
+                        "Defaults to build/build_config.yml")
+    parser.add_argument("-p", "--profiles-root",
+                        help="Override where to look for profile files.")
+    parser.add_argument("product", type=str, help="Product to add prod types for")
+    parser.add_argument("profile", type=str, help="Profile to iterate over")
+
+    return parser.parse_args()
+
+
+def autoprodtype(env_yaml, rule_dirs, profile_path, product):
+    profile = ssg.build_yaml.ProfileWithInlinePolicies.from_yaml(profile_path, env_yaml)
+
+    for rule_id in profile.selected + profile.unselected:
+        if rule_id not in rule_dirs:
+            msg = "Unable to find rule in rule_dirs.json: {0}"
+            msg = msg.format(rule_id)
+            raise ValueError(msg)
+
+        add_products(rule_dirs[rule_id], [product], silent=True)
+
+
+def main():
+    args = parse_args()
+
+    json_file = open(args.json, 'r')
+    all_rules = json.load(json_file)
+
+    linux_products, other_products = ssg.products.get_all(SSG_ROOT)
+    all_products = linux_products.union(other_products)
+    if args.product not in all_products:
+        msg = "Unknown product {0}: check SSG_ROOT and try again"
+        msg = msg.format(args.product)
+        raise ValueError(msg)
+
+    product_base = os.path.join(SSG_ROOT, args.product)
+    product_yaml = os.path.join(product_base, "product.yml")
+    env_yaml = ssg.yaml.open_environment(args.build_config_yaml, product_yaml)
+
+    profiles_root = os.path.join(product_base, "profiles")
+    if args.profiles_root:
+        profiles_root = args.profiles_root
+
+    profile_filename = args.profile + ".profile"
+    profile_path = os.path.join(profiles_root, profile_filename)
+    if not os.path.exists(profile_path):
+        msg = "Unknown profile {0}: check profile, --profiles-root, and try again. "
+        msg += "Note that profiles should not include '.profile' suffix."
+        msg = msg.format(args.profile)
+        raise ValueError(msg)
+
+    autoprodtype(env_yaml, all_rules, profile_path, args.product)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/mod_prodtype.py
+++ b/utils/mod_prodtype.py
@@ -49,7 +49,7 @@ def list_products(rule_obj):
         print("Empty listed prodtype in the file")
 
 
-def add_products(rule_obj, products):
+def add_products(rule_obj, products, silent=False):
     yaml_file, yaml_contents = ssg.rule_yaml.get_yaml_contents(rule_obj)
     prodtype_section = ssg.rule_yaml.get_section_lines(yaml_file, yaml_contents, 'prodtype')
 
@@ -66,7 +66,8 @@ def add_products(rule_obj, products):
 
         start_line = doc_complete_section[1]+1
 
-        print("Current prodtype is empty, not adding the new prodtype.")
+        if not silent:
+            print("Current prodtype is empty, not adding the new prodtype.")
     else:
         prodtype_contents = ssg.rule_yaml.parse_from_yaml(yaml_contents, prodtype_section)
         prodtype = prodtype_contents['prodtype']
@@ -75,8 +76,9 @@ def add_products(rule_obj, products):
         new_prodtype.update(products)
         new_prodtype_str = ','.join(sorted(new_prodtype))
 
-        print("Current prodtype: %s" % prodtype)
-        print("New prodtype: %s" % new_prodtype_str)
+        print("Modifying %s:" % yaml_file)
+        print("  Current prodtype: %s" % prodtype)
+        print("  New prodtype: %s" % new_prodtype_str)
 
         yaml_contents = ssg.rule_yaml.update_key_value(yaml_contents, 'prodtype',
                                                        prodtype, new_prodtype_str)


### PR DESCRIPTION
#### Description

The new `autoprodtyper.py` utility automatically prodtypes all rules in
a given profile, adding the specified product. This leverages the work
previously done in `utils/mod_protype.py` to seamlessly edit prodtypes
with minimal diff (modifying only the prodtype line). If we assume a
profile for a product was created with intent (and that the rules in it
were intended to work for the product the profile is in), then
automatically adding this prodtype to the rules saves a bit of effort.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

#### Rationale:

Per discussion with Jan and Matej on `#openscap`, I'd like to share what I've been working on, and eventually work together with upstream to improve the controls format.

This is one step in our work to begin officially maintaining Ubuntu content in CaC. Nobody likes adding prodtypes and this utility helps with that. 