### PR TITLE
Check all rules in profile for required reference

### DIFF
--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import sys
 
+from .build_yaml import ProfileWithInlinePolicies
 from .xml import ElementTree
 from .constants import XCCDF11_NS as xccdf_ns
 from .constants import oval_namespace as oval_ns
@@ -16,6 +17,20 @@ from .constants import cce_uri
 from .constants import ssg_version_uri
 from .constants import stig_ns, cis_ns, hipaa_ns, anssi_ns, ospp_ns, cui_ns
 console_width = 80
+
+
+def make_name_to_profile_mapping(profile_files, env_yaml):
+    name_to_profile = {}
+    for f in profile_files:
+        try:
+            p = ProfileWithInlinePolicies.from_yaml(f, env_yaml)
+            name_to_profile[p.id_] = p
+        except Exception as exc:
+            # The profile is probably doc-incomplete
+            msg = "Not building profile from {fname}: {err}".format(
+                fname=f, err=str(exc))
+            print(msg, file=sys.stderr)
+    return name_to_profile
 
 
 class RuleStats(object):

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import os
 from collections import namedtuple
+from glob import glob
 
 from .build_cpe import ProductCPEs
 from .constants import (product_directories,
@@ -10,7 +11,7 @@ from .constants import (product_directories,
                         PKG_MANAGER_TO_SYSTEM,
                         PKG_MANAGER_TO_CONFIG_FILE,
                         XCCDF_PLATFORM_TO_PACKAGE)
-from .utils import merge_dicts
+from .utils import merge_dicts, required_key
 from .yaml import open_raw
 
 
@@ -94,3 +95,13 @@ def get_all(ssg_root):
 
     products = namedtuple('products', ['linux', 'other'])
     return products(linux_products, other_products)
+
+
+def get_profile_files_from_root(env_yaml, product_yaml):
+    profile_files = []
+    if env_yaml:
+        base_dir = os.path.dirname(product_yaml)
+        profiles_root = required_key(env_yaml, "profiles_root")
+        profile_files = sorted(glob("{base_dir}/{profiles_root}/*.profile"
+                               .format(profiles_root=profiles_root, base_dir=base_dir)))
+    return profile_files

--- a/utils/refchecker.py
+++ b/utils/refchecker.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import argparse
+import json
+
+import ssg.build_yaml
+import ssg.products
+import ssg.rules
+import ssg.yaml
+import ssg.utils
+import ssg.rule_yaml
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Check all rule.yml referenced in a given"
+                                     "profile for a required reference identifier")
+    parser.add_argument("-j", "--json", type=str, action="store",
+                        default="build/rule_dirs.json", help="File to read "
+                        "json output of rule_dir_json from (defaults to "
+                        "build/rule_dirs.json")
+    parser.add_argument("-c", "--build-config-yaml", default="build/build_config.yml",
+                        help="YAML file with information about the build configuration. "
+                        "Defaults to build/build_config.yml")
+    parser.add_argument("-p", "--profiles-root",
+                        help="Override where to look for profile files.")
+    parser.add_argument("product", type=str, help="Product to check has required references")
+    parser.add_argument("profile", type=str, help="Profile to iterate over")
+    parser.add_argument("reference", type=str, help="Required reference system to check for")
+
+    return parser.parse_args()
+
+
+def load(rule_obj, env_yaml=None):
+    """
+    From the given rule_dir object, load the build_yaml.Rule associated with
+    it.
+    """
+
+    yaml_file = ssg.rules.get_rule_dir_yaml(rule_obj['dir'])
+    return ssg.build_yaml.Rule.from_yaml(yaml_file, env_yaml=env_yaml)
+
+
+def load_for_product(rule_obj, product, env_yaml=None):
+    """
+    From the given rule_dir object, load the build_yaml.Rule associated with
+    it, normalizing for the given product.
+    """
+
+    rule = load(rule_obj, env_yaml=env_yaml)
+    rule.normalize(product)
+    return rule
+
+
+def reference_check(env_yaml, rule_dirs, profile_path, product, reference):
+    profile = ssg.build_yaml.ProfileWithInlinePolicies.from_yaml(profile_path, env_yaml)
+
+    ok = True
+    for rule_id in profile.selected + profile.unselected:
+        if rule_id not in rule_dirs:
+            msg = "Unable to find rule in rule_dirs.json: {0}"
+            msg = msg.format(rule_id)
+            raise ValueError(msg)
+
+        rule = load_for_product(rule_dirs[rule_id], product, env_yaml=env_yaml)
+
+        if reference not in rule.references:
+            ok = False
+            msg = "Rule {0} lacks required reference {1} or {1}@{2}"
+            msg = msg.format(rule_id, reference, product)
+            print(msg, file=sys.stderr)
+
+    return ok
+
+
+def main():
+    args = parse_args()
+
+    json_file = open(args.json, 'r')
+    all_rules = json.load(json_file)
+
+    linux_products, other_products = ssg.products.get_all(SSG_ROOT)
+    all_products = linux_products.union(other_products)
+    if args.product not in all_products:
+        msg = "Unknown product {0}: check SSG_ROOT and try again"
+        msg = msg.format(args.product)
+        raise ValueError(msg)
+
+    product_base = os.path.join(SSG_ROOT, args.product)
+    product_yaml = os.path.join(product_base, "product.yml")
+    env_yaml = ssg.yaml.open_environment(args.build_config_yaml, product_yaml)
+
+    profiles_root = os.path.join(product_base, "profiles")
+    if args.profiles_root:
+        profiles_root = args.profiles_root
+
+    profile_filename = args.profile + ".profile"
+    profile_path = os.path.join(profiles_root, profile_filename)
+    if not os.path.exists(profile_path):
+        msg = "Unknown profile {0}: check profile, --profiles-root, and try again. "
+        msg = "Note that the '.profile' suffix shouldn't be included."
+        msg = msg.format(args.profile)
+        raise ValueError(msg)
+
+    ok = reference_check(env_yaml, all_rules, profile_path, args.product, args.reference)
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Description

The new `refchecker.py` utility automatically checks all rules in a given
profile for a required reference field. This is most commonly useful
when creating benchmarks for a specified system, such as CIS or STIG,
where it is expected that all rules in a given benchmark have references
related to them.

Unlike `tests/missing_refs.sh` (and its helper tool,
`build-scripts/profile_tool.py`), this operates on the YAML level and
should have fewer false-positives in the content for non-RHEL
identifiers. Additionally, this parses the present values of the rules,
meaning that it can be used between builds.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

#### Rationale

I found `build-scripts/profile_tool.py` not to work for Ubuntu CIS references, what this was originally meant to help with. I also don't really like waiting for even the Ubuntu product to build, so it nice to have a much quicker utility for checking some things (like missing references). 

I also didn't want to write the next utility when I first wrote this one. But I eventually ended up doing it anyways... :-)

See also: #6906