### PR TITLE
Fix usbguard match-all syntax for HID rule

### DIFF
--- a/linux_os/guide/services/usbguard/usbguard_allow_hid/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid/rule.yml
@@ -8,7 +8,7 @@ description: |-
     To allow authorization of Human Interface Devices (keyboard, mouse)
     by USBGuard daemon,
     add the line
-    <tt>allow with-interface match_all { 03:*:* }</tt>
+    <tt>allow with-interface match-all { 03:*:* }</tt>
     to <tt>/etc/usbguard/rules.conf</tt>.
 
 rationale: |-

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/kubernetes/shared.yml
@@ -1,6 +1,6 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos 
 {{% macro usbguard_hid_and_hub_config_source() %}}
-allow with-interface match_all { 03:*:* 09:00:* }
+allow with-interface match-all { 03:*:* 09:00:* }
 {{%- endmacro -%}}
 
 {{{ kubernetes_machine_config_file_with_dependencies(path='/etc/usbguard/rules.d/75-hid-and-hub.conf', file_permissions_mode='0600', source=usbguard_hid_and_hub_config_source(), deps=["xccdf_org.ssgproject.content_rule_package_usbguard_installed"]) }}}

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
@@ -8,7 +8,7 @@ description: |-
     To allow authorization of USB devices combining human interface device and hub capabilities
     by USBGuard daemon,
     add the line
-    <tt>allow with-interface match_all { 03:*:* 09:00:* }</tt>
+    <tt>allow with-interface match-all { 03:*:* 09:00:* }</tt>
     to <tt>/etc/usbguard/rules.conf</tt>.
 
 rationale: |-


### PR DESCRIPTION
#### Description:

The description for the usbguard HID rule had a suggested fix with incorrect configuration syntax. 
Specifically it suggested a fix of: 
```
allow with-interface match_all { 03:*:* 09:00:* }`
```

Unfortunately `match_all` is incorrect syntax, instead it should be `match-all`, full example:
```
allow with-interface match-all { 03:*:* 09:00:* }
```

The `shared.sh` fix script has the correct syntax and matches the syntax adjusted in this PR for the descriptions.

#### Rationale:

Ensures that description has proper syntax and matches the `shared.sh` fix script.
