### PR TITLE
Notate that Ubuntu is a FIPS-certified OS

### DIFF
--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
@@ -10,6 +10,9 @@
       <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7_family" />
       <extend_definition comment="Installed OS is SLE12" definition_ref="installed_OS_is_sle12" />
       <extend_definition comment="Installed OS is SLE15" definition_ref="installed_OS_is_sle15" />
+      <extend_definition comment="Installed OS is Ubuntu 16.04" definition_ref="installed_OS_is_ubuntu1604" />
+      <extend_definition comment="Installed OS is Ubuntu 18.04" definition_ref="installed_OS_is_ubuntu1804" />
+      <extend_definition comment="Installed OS is Ubuntu 20.04" definition_ref="installed_OS_is_ubuntu2004" />
       <!-- DO NOT add operating systems here unless they adhere to government certifications
            and the vendor provides professional security updates and support -->
     </criteria>

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux8,wrlinux1019
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux8,ubuntu1604,ubuntu1804,ubuntu2004,wrlinux1019
 
 title: 'The Installed Operating System Is FIPS 140-2 Certified'
 
@@ -15,6 +15,13 @@ description: |-
     SUSE Enterprise Linux is supported by SUSE Software Solutions Germany GmbH. As the SUSE Enterprise
     Linux vendor, SUSE Software Solutions Germany GmbH is responsible for maintaining government
     certifications and standards.
+{{% elif product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
+    Ubuntu Linux is supported by Canonical Ltd. As the Ubuntu Linux Vendor, Canonical Ltd. is
+    responsible for government certifications and standards.
+
+    Users of Ubuntu Linux either need an Ubuntu Advantage subscription or need
+    to be using Ubuntu Pro from a sponsored vendor in order to have access to
+    FIPS content supported by Canonical.
 {{% endif %}}
 
 rationale: |-
@@ -74,6 +81,8 @@ ocil: |-
     <pre>$ grep -i "oracle" /etc/oracle-release</pre>
 {{% elif product in ["sle12", "sle15"] %}}
     <pre>$ grep -i "suse" /etc/os-release</pre>
+{{% elif product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
+    <pre>$ grep -i "ubuntu" /etc/os-release</pre>
 {{% endif %}}
     The output should contain something similar to:
     <pre>{{{ full_name }}}</pre>


### PR DESCRIPTION
Ubuntu undergoes FIPS certification using paid libraries not shipped in
the base distribution. Users of Ubuntu can either attach a Ubuntu
Advantage (https://ubuntu.com/advantage) subscription or use a Ubuntu
Pro image (https://ubuntu.com/aws/pro or https://ubuntu.com/azure/pro)
from a third-party marketplace.

Note that many 20.04 certificates are presently in-flight at NIST.

See also: https://ubuntu.com/security/certifications

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`