### PR TITLE
ocp4: Enhance group ownership checks openvswitch processes pid files

### DIFF
--- a/applications/openshift/master/file_groupowner_ovs_pid/oval/shared.xml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="file_groupowner_ovs_pid" version="1">
+    {{{ oval_metadata("This test makes sure that /run/openvswitch/ovs-vswitchd.pid is group owned by 800 or 801.") }}}
+    <criteria operator="OR">
+      <criterion comment="Check file group ownership of /run/openvswitch/ovs-vswitchd.pid belongs to group 800" test_ref="test_file_groupowner_run_ovs_vswitchd_pid_800" />
+      <criterion comment="Check file group ownership of /run/openvswitch/ovs-vswitchd.pid belongs to group 801" test_ref="test_file_groupowner_run_ovs_vswitchd_pid_801" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /run/openvswitch/ovs-vswitchd.pid" id="test_file_groupowner_run_ovs_vswitchd_pid_800" version="1">
+    <unix:object object_ref="object_file_groupowner_run_ovs_vswitchd_pid" />
+    <unix:state state_ref="state_file_groupowner_run_ovs_vswitchd_pid_gid_800" />
+  </unix:file_test>
+
+  <unix:file_state id="state_file_groupowner_run_ovs_vswitchd_pid_gid_800" version="1">
+    <unix:group_id datatype="int">800</unix:group_id>
+  </unix:file_state>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /run/openvswitch/ovs-vswitchd.pid" id="test_file_groupowner_run_ovs_vswitchd_pid_801" version="1">
+    <unix:object object_ref="object_file_groupowner_run_ovs_vswitchd_pid" />
+    <unix:state state_ref="state_file_groupowner_run_ovs_vswitchd_pid_gid_801" />
+  </unix:file_test>
+
+  <unix:file_state id="state_file_groupowner_run_ovs_vswitchd_pid_gid_801" version="1">
+    <unix:group_id datatype="int">801</unix:group_id>
+  </unix:file_state>
+
+  <unix:file_object comment="/run/openvswitch/ovs-vswitchd.pid" id="object_file_groupowner_run_ovs_vswitchd_pid" version="1">
+      <unix:filepath>/run/openvswitch/ovs-vswitchd.pid</unix:filepath>
+  </unix:file_object>
+</def-group>

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -5,7 +5,9 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Process ID File'
 
 description: |-
-    {{{ describe_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
+    Ensure that the file <pre>/var/run/openvswitch/ovs-vswitchd.pid</pre>,
+    is owned by the group <pre>openvswitch</pre> or <pre>hugetlbfs</pre>,
+    depending on your settings and Open vSwitch version.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,13 +23,26 @@ identifiers:
 references:
     cis@ocp4: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}'
+ocil_clause: '/var/run/openvswitch/ovs-vswitchd.pid has group owner openvswitch or hugetlbfs'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
+    To check the group ownership of <pre>/var/run/openvswitch/ovs-vswitchd.pid</pre>,
+    you'll need to log into a node in the cluster.
+    As a user with administrator privileges, log into a node in the relevant pool:
 
-template:
-    name: file_groupowner
-    vars:
-        filepath: /var/run/openvswitch/ovs-vswitchd.pid
-        filegid: '800'
+    <pre>
+    $ oc debug node/$NODE_NAME
+    </pre>
+
+    At the <tt>sh-4.4#</tt> prompt, run:
+
+    <pre>
+    # chroot /host
+    </pre>
+
+    Then,run the command:
+    <pre>
+    $ ls -l /var/run/openvswitch/ovs-vswitchd.pid
+    </pre>
+    If properly configured, the output should indicate one of the following group-owners:
+    openvswitch or hugetlbfs

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/oval/shared.xml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="file_groupowner_ovs_vswitchd_pid" version="1">
+    {{{ oval_metadata("This test makes sure that /var/run/openvswitch/ovs-vswitchd.pid is group owned by 800 or 801.") }}}
+    <criteria operator="OR">
+      <criterion comment="Check file group ownership of /var/run/openvswitch/ovs-vswitchd.pid belongs to group 800" test_ref="test_file_groupowner_var_run_ovs_vswitchd_pid_800" />
+      <criterion comment="Check file group ownership of /var/run/openvswitch/ovs-vswitchd.pid belongs to group 801" test_ref="test_file_groupowner_var_run_ovs_vswitchd_pid_801" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /var/run/openvswitch/ovs-vswitchd.pid" id="test_file_groupowner_var_run_ovs_vswitchd_pid_800" version="1">
+    <unix:object object_ref="object_file_groupowner_var_run_ovs_vswitchd_pid" />
+    <unix:state state_ref="state_file_groupowner_var_run_ovs_vswitchd_pid_gid_800" />
+  </unix:file_test>
+
+  <unix:file_state id="state_file_groupowner_var_run_ovs_vswitchd_pid_gid_800" version="1">
+    <unix:group_id datatype="int">800</unix:group_id>
+  </unix:file_state>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /var/run/openvswitch/ovs-vswitchd.pid" id="test_file_groupowner_var_run_ovs_vswitchd_pid_801" version="1">
+    <unix:object object_ref="object_file_groupowner_var_run_ovs_vswitchd_pid" />
+    <unix:state state_ref="state_file_groupowner_var_run_ovs_vswitchd_pid_gid_801" />
+  </unix:file_test>
+
+  <unix:file_state id="state_file_groupowner_var_run_ovs_vswitchd_pid_gid_801" version="1">
+    <unix:group_id datatype="int">801</unix:group_id>
+  </unix:file_state>
+
+  <unix:file_object comment="/var/run/openvswitch/ovs-vswitchd.pid" id="object_file_groupowner_var_run_ovs_vswitchd_pid" version="1">
+      <unix:filepath>/var/run/openvswitch/ovs-vswitchd.pid</unix:filepath>
+  </unix:file_object>
+</def-group>

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -5,7 +5,9 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Daemon PID File'
 
 description: |-
-    {{{ describe_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
+    Ensure that the file <pre>/run/openvswitch/ovs-vswitchd.pid</pre>,
+    is owned by the group <pre>openvswitch</pre> or <pre>hugetlbfs</pre>,
+    depending on your settings and Open vSwitch version.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,13 +23,26 @@ identifiers:
 references:
     cis@ocp4: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}'
+ocil_clause: '/run/openvswitch/ovs-vswitchd.pid has group owner openvswitch or hugetlbfs'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/run/openvswitch/ovs-vswitchd.pid", group="openvswitch") }}}
+    To check the group ownership of <pre>/run/openvswitch/ovs-vswitchd.pid</pre>,
+    you'll need to log into a node in the cluster.
+    As a user with administrator privileges, log into a node in the relevant pool:
 
-template:
-    name: file_groupowner
-    vars:
-        filepath: /run/openvswitch/ovs-vswitchd.pid
-        filegid: '800'
+    <pre>
+    $ oc debug node/$NODE_NAME
+    </pre>
+
+    At the <tt>sh-4.4#</tt> prompt, run:
+
+    <pre>
+    # chroot /host
+    </pre>
+
+    Then,run the command:
+    <pre>
+    $ ls -l /run/openvswitch/ovs-vswitchd.pid
+    </pre>
+    If properly configured, the output should indicate one of the following group-owners:
+    openvswitch or hugetlbfs

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/oval/shared.xml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="file_groupowner_ovsdb_server_pid" version="1">
+    {{{ oval_metadata("This test makes sure that /run/openvswitch/ovsdb-server.pid is group owned by 800 or 801.") }}}
+    <criteria operator="OR">
+      <criterion comment="Check file group ownership of /run/openvswitch/ovsdb-server.pid belongs to group 800" test_ref="test_file_groupowner_ovsdb_server_pid_800" />
+      <criterion comment="Check file group ownership of /run/openvswitch/ovsdb-server.pid belongs to group 801" test_ref="test_file_groupowner_ovsdb_server_pid_801" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /run/openvswitch/ovsdb-server.pid" id="test_file_groupowner_ovsdb_server_pid_800" version="1">
+    <unix:object object_ref="object_file_groupowner_ovsdb_server_pid" />
+    <unix:state state_ref="state_file_file_groupowner_ovsdb_server_pid_gid_800" />
+  </unix:file_test>
+
+  <unix:file_state id="state_file_file_groupowner_ovsdb_server_pid_gid_800" version="1">
+    <unix:group_id datatype="int">800</unix:group_id>
+  </unix:file_state>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Testing group ownership of /run/openvswitch/ovsdb-server.pid" id="test_file_groupowner_ovsdb_server_pid_801" version="1">
+    <unix:object object_ref="object_file_groupowner_ovsdb_server_pid" />
+    <unix:state state_ref="state_file_file_groupowner_ovsdb_server_pid_gid_801" />
+  </unix:file_test>
+
+  <unix:file_state id="state_file_file_groupowner_ovsdb_server_pid_gid_801" version="1">
+    <unix:group_id datatype="int">801</unix:group_id>
+  </unix:file_state>
+
+  <unix:file_object comment="/run/openvswitch/ovsdb-server.pid" id="object_file_groupowner_ovsdb_server_pid" version="1">
+      <unix:filepath>/run/openvswitch/ovsdb-server.pid</unix:filepath>
+  </unix:file_object>
+</def-group>

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -5,7 +5,9 @@ prodtype: ocp4
 title: 'Verify Group Who Owns The Open vSwitch Database Server PID'
 
 description: |-
-    {{{ describe_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="openvswitch") }}}
+    Ensure that the file <pre>/run/openvswitch/ovsdb-server.pid</pre>,
+    is owned by the group <pre>openvswitch</pre> or <pre>hugetlbfs</pre>,
+    depending on your settings and Open vSwitch version.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -21,13 +23,26 @@ identifiers:
 references:
     cis@ocp4: 1.1.9
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="openvswitch") }}}'
+ocil_clause: '/run/openvswitch/ovsdb-server.pid has group owner openvswitch or hugetlbfs'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/run/openvswitch/ovsdb-server.pid", group="openvswitch") }}}
+    To check the group ownership of <pre>/run/openvswitch/ovsdb-server.pid</pre>,
+    you'll need to log into a node in the cluster.
+    As a user with administrator privileges, log into a node in the relevant pool:
 
-template:
-    name: file_groupowner
-    vars:
-        filepath: /run/openvswitch/ovsdb-server.pid
-        filegid: '800'
+    <pre>
+    $ oc debug node/$NODE_NAME
+    </pre>
+
+    At the <tt>sh-4.4#</tt> prompt, run:
+
+    <pre>
+    # chroot /host
+    </pre>
+
+    Then,run the command:
+    <pre>
+    $ ls -l /run/openvswitch/ovsdb-server.pid
+    </pre>
+    If properly configured, the output should indicate one of the following group-owners:
+    openvswitch or hugetlbfs


### PR DESCRIPTION
In a more recent version of Open vSwitch, the process pid files changed
ownership from "openvswitch" to "hugetlbfs". OCP 4.6 will stay in an
older version of OvS, so to keep this working with newer versions (e.g.
the one included in OCP 4.8), this fixes the content to check for both
groups. This way the content keeps being valid accross releases.

Closes https://github.com/ComplianceAsCode/content/issues/6913

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>