### PR TITLE
Broaden sshd_use_approved_* to non-FIPS use cases

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
@@ -1,8 +1,7 @@
 <def-group>
   <definition class="compliance" id="sshd_use_approved_ciphers" version="1">
-    {{{ oval_metadata("Limit the ciphers to those which are FIPS-approved.") }}}
+    {{{ oval_metadata("Limit the ciphers to those which are approved.") }}}
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criteria comment="SSH is configured correctly or is not installed"
       operator="OR">
         <criteria comment="sshd is not installed" operator="AND">
@@ -56,5 +55,5 @@
     </split>
   </local_variable>
 
-  <external_variable comment="SSH Approved Ciphers by FIPS" datatype="string" id="sshd_approved_ciphers" version="1" />
+  <external_variable comment="SSH Approved Ciphers" datatype="string" id="sshd_approved_ciphers" version="1" />
 </def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: ol7,ol8,rhel7,rhel8,wrlinux1019,wrlinux8,sle12
 
-title: 'Use Only FIPS 140-2 Validated Ciphers'
+title: 'Use Only Approved Ciphers'
 
 description: |-
-    Limit the ciphers to those algorithms which are FIPS-approved.
+    Limit the ciphers to those algorithms which are approved.
     Counter (CTR) mode is also preferred over cipher-block chaining (CBC) mode.
     The following line in <tt>/etc/ssh/sshd_config</tt>
-    demonstrates use of FIPS-approved ciphers:
+    demonstrates use of approved ciphers:
     <pre>Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc</pre>
     The man page <tt>sshd_config(5)</tt> contains a list of supported ciphers.
 {{% if product in ["rhel7","ol7"] %}}
@@ -37,7 +37,7 @@ rationale: |-
     Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore
     cannot be relied upon to provide confidentiality or integrity, and system data may be compromised.
     <br />
-    Operating systems utilizing encryption are required to use FIPS-compliant mechanisms for authenticating to
+    Operating systems utilizing encryption are required to use approved mechanisms for authenticating to
     cryptographic modules.
     <br />
     FIPS 140-2 is the current standard for validating that mechanisms used to access cryptographic modules
@@ -67,20 +67,20 @@ references:
     iso27001-2013: A.11.2.6,A.12.1.2,A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.5.1,A.12.6.2,A.12.7.1,A.13.1.1,A.13.2.1,A.14.1.3,A.14.2.2,A.14.2.3,A.14.2.4,A.18.1.4,A.6.1.2,A.6.2.1,A.6.2.2,A.7.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
     cis-csc: 1,11,12,14,15,16,18,3,5,6,8,9
 
-ocil_clause: 'FIPS ciphers are not configured or the enabled ciphers are not FIPS-approved'
+ocil_clause: 'ciphers are not configured or the enabled ciphers are not approved'
 
 ocil: |-
-    Only FIPS ciphers should be used. To verify that only FIPS-approved
+    Only approved ciphers should be used. To verify that only approved
     ciphers are in use, run the following command:
     <pre>$ sudo grep Ciphers /etc/ssh/sshd_config</pre>
-    The output should contain only those ciphers which are FIPS-approved.
+    The output should contain only those ciphers which are approved.
 
 warnings:
     - general: |-
         The system needs to be rebooted for these changes to take effect.
     - regulatory: |-
-        System Crypto Modules must be provided by a vendor that undergoes
-        FIPS-140 certifications.
+        To achieve FIPS compliance, System Crypto Modules must be provided by
+        a vendor that undergoes FIPS-140 certifications.
         FIPS-140 is applicable to all Federal agencies that use
         cryptographic-based security systems to protect sensitive information
         in computer and telecommunication systems (including voice systems) as

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -1,8 +1,7 @@
 <def-group>
   <definition class="compliance" id="sshd_use_approved_macs" version="1">
-    {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.") }}}
+    {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are approved.") }}}
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criteria comment="SSH is configured correctly or is not installed"
       operator="OR">
         <criteria comment="sshd is not installed" operator="AND">
@@ -66,6 +65,6 @@
     </split>
   </local_variable>
 
-  <external_variable comment="SSH Approved MACs by FIPS" datatype="string" id="sshd_approved_macs" version="1" />
+  <external_variable comment="SSH Approved MACs" datatype="string" id="sshd_approved_macs" version="1" />
 
 </def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -2,12 +2,12 @@ documentation_complete: true
 
 prodtype: ol7,ol8,rhel7,rhel8,sle12,wrlinux1019
 
-title: 'Use Only FIPS 140-2 Validated MACs'
+title: 'Use Only Approved MACs'
 
 description: |-
-    Limit the MACs to those hash algorithms which are FIPS-approved.
+    Limit the MACs to those hash algorithms which are approved.
     The following line in <tt>/etc/ssh/sshd_config</tt>
-    demonstrates use of FIPS-approved MACs:
+    demonstrates use of approved MACs:
 {{% if product in ["sle12", "sle15"] %}}
     <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
 {{% else %}}
@@ -35,7 +35,7 @@ description: |-
     The rule is parametrized to use the following MACs: <code>{{{ xccdf_value("sshd_approved_macs") }}}</code>.
 
 rationale: |-
-    DoD Information Systems are required to use FIPS-approved cryptographic hash
+    DoD Information Systems are required to use approved cryptographic hash
     functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
 
 severity: medium
@@ -61,22 +61,22 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.11.2.6,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.6.2.1,A.6.2.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
     cis-csc: 1,12,13,15,16,5,8
 
-ocil_clause: 'MACs option is commented out or not using FIPS-approved hash algorithms'
+ocil_clause: 'MACs option is commented out or not using approved hash algorithms'
 
 ocil: |-
-    Only FIPS-approved MACs should be used. To verify that only FIPS-approved
+    Only approved MACs should be used. To verify that only approved
     MACs are in use, run the following command:
     <pre>$ sudo grep -i macs /etc/ssh/sshd_config</pre>
-    The output should contain only those MACs which are FIPS-approved. Any use of other
-    ciphers or algorithms will result in the module entering the non-FIPS mode of
-    operation.
+    The output should contain only those MACs which are approved. Any use of other
+    ciphers or algorithms will result in the module entering a non-compliant mode
+    of operation.
 
 warnings:
     - general: |-
         The system needs to be rebooted for these changes to take effect.
     - regulatory: |-
-        System Crypto Modules must be provided by a vendor that undergoes
-        FIPS-140 certifications.
+        To achieve FIPS compliance, System Crypto Modules must be provided by
+        a vendor that undergoes FIPS-140 certifications.
         FIPS-140 is applicable to all Federal agencies that use
         cryptographic-based security systems to protect sensitive information
         in computer and telecommunication systems (including voice systems) as


### PR DESCRIPTION
#### Description

Allow `sshd_use_approved_ciphers` to satisfy both FIPS and non-FIPS use
cases with the same rule. Benchmarks like CIS encourage the usage of
approved cipher suites as well (and do mention FIPS), but don't strictly
limit the caller to FIPS. For DISA STIG, other rules are more applicable
like sshd_use_approved_ciphers_ordered_stig so this change should be
safe.

Remove the dependency on the installed_OS_is_FIPS_certified OVAL as
well.

Also apply to sshd_use_approved_macs.

Resolves: #6901

```
Co-Authored-By: Richard Maciel Costa <richard.maciel.costa@canonical.com>
Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>
```

#### Rationale

As mentioned in #6901, we have duplicate rules for strictly DISA-STIG systems (`sshd_use_approved_ciphers_ordered_stig` and `sshd_use_approved_macs_ordered_stig`). Benchmarks like CIS can use but don't strictly require FIPS mode. But all benchmarks have the notion of an "approved" list of ciphers. So replace most instances of FIPS with Approved.

Note that I left the list of FIPS ciphers in place (along with the FIPS warning message) as the CIS benchmark does include FIPS-approved cipher listings. 