### PR TITLE
Revert STIG id for require_emergency_target_auth.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
@@ -27,7 +27,6 @@ references:
     stigid@rhel7: RHEL-07-010481
     stigid@rhel8: RHEL-08-010151
     stigid@ol7: OL07-00-010481
-    stigid@rhel8: RHEL-08-010152
     cis@rhel7: 1.4.3
     cis@rhel8: 1.5.3
     cui: 3.1.1,3.4.5

--- a/rhel8/profiles/stig.profile
+++ b/rhel8/profiles/stig.profile
@@ -123,9 +123,11 @@ selections:
 
     # RHEL-08-010151
     - require_singleuser_auth
+    - require_emergency_target_auth
 
     # RHEL-08-010152
-    - require_emergency_target_auth
+    # To be released in V1R3
+    # - require_emergency_target_auth
 
     # RHEL-08-010160
     - set_password_hashing_algorithm_systemauth


### PR DESCRIPTION
#### Description:

- Revert STIG id for require_emergency_target_auth.

#### Rationale:

- Keep the STIG id that is currently released. This new STIG id will be released in V1R3.

Fixes: #6925
