### PR TITLE
Remove support statement from the manual page

### DIFF
--- a/docs/man_page_template.jinja
+++ b/docs/man_page_template.jinja
@@ -93,27 +93,6 @@ Contains Ansible Playbooks for SSG profiles.
 Contains Bash remediation scripts for SSG profiles.
 .RE
 
-.SH STATEMENT OF SUPPORT
-The SCAP Security Guide, an open source project jointly maintained by Red Hat
-and the NSA, provides XCCDF and OVAL content for Red Hat technologies. As an open
-source project, community participation extends into U.S. Department of Defense
-agencies, civilian agencies, academia, and other industrial partners.
-
-SCAP Security Guide is provided to consumers through Red Hat's Extended
-Packages for Enterprise Linux (EPEL) repository. As such, SCAP Security Guide
-content is considered "vendor provided."
-
-Note that while Red Hat hosts the infrastructure for this project and
-Red Hat engineers are involved as maintainers and leaders, there is no
-commercial support contracts or service level agreements provided by Red Hat.
-
-Support, for both users and developers, is provided through the SCAP Security
-Guide community.
-
-Homepage: https://www.open-scap.org/security-policies/scap-security-guide
-.PP
-Mailing List: https://lists.fedorahosted.org/mailman/listinfo/scap-security-guide
-
 
 .SH DEPLOYMENT TO U.S. CIVILIAN GOVERNMENT SYSTEMS
 SCAP Security Guide content is considered vendor (Red Hat) provided content.


### PR DESCRIPTION
This statement is outdated. It says that SSG is shipped in EPEL and that
it isn't supported by Red Hat. We don't ship it EPEL for many years.
When the man page is shipped in RHEL it isn't true that it isn't
supported by Red Hat. When the man page is packaged in other
distributions, the information about support by Red Hat is redundant.
The package usually follows the distro's support policy.  Other packages
also don't claim their support level in their manual page. People should
refer to the distribution support documentation instead.
