### PR TITLE
Add RHEL OS profiles to the rule/check to look for silent option in pam_lastlog

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("Configure the system to notify users of last login/access using pam_lastlog.") }}}
     <criteria operator="AND">
       <criterion comment="Conditions for pam_lastlog are satisfied" test_ref="test_display_login_attempts" />
-      {{% if product in ['sle12', 'sle15'] %}}
+      {{% if product in ['sle12', 'sle15', 'rhel7', 'rhel8', 'rhel9'] %}}
       <criterion comment="silent option for pam_lastlog is set" test_ref="test_display_login_attempts_silent" />
       {{% endif %}}
     </criteria>

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
@@ -6,7 +6,7 @@ description: |-
     To configure the system to notify users of last logon/access
     using <tt>pam_lastlog</tt>, add or correct the <tt>pam_lastlog</tt>
     settings in
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if product in ["sle12", "sle15", "rhel7", "rhel8", "rhel9"] %}}
     <tt>/etc/pam.d/login</tt> to read as follows:
     <pre>session     required pam_lastlog.so showfailed</pre>
     And make sure that the <tt>silent</tt> option is not set.
@@ -56,7 +56,7 @@ ocil_clause: 'that is not the case'
 ocil: |-
     To ensure that last logon/access notification is configured correctly, run
     the following command:
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if product in ["sle12", "sle15", "rhel7", "rhel8", "rhel9"] %}}
     <pre>$ grep pam_lastlog.so /etc/pam.d/login</pre>
     The output should show output <tt>showfailed</tt> and must not contain
     <tt>silent</tt>.


### PR DESCRIPTION

#### Description:

- Added the check for `silent` in `display_login_attempts` to the OVAL when building for RHEL7/8/9, which was already present for SLE.

#### Rationale:
- [DISA STIG](https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2017-12-14/finding/V-72275) requires that silent not be present.
- NIST (ncp) [AC-7](https://www.stigviewer.com/controls/800-53/AC-9) indicates that it should also not be silenced.
- PCI DSS 10.2.4 is silent on the matter, so altering the behavior should be fine. 
- Fixes #6902
