### PR TITLE
Add rule for SLES-15-010340

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/ansible/shared.yml
@@ -1,0 +1,27 @@
+# platform = multi_platform_sle
+# reboot = false
+# complexity = low
+# strategy = configure
+# disruption = low
+
+- name: "Find log files"
+  find:
+    paths: '/var/log/'
+    recurse: yes
+    patterns: '*'
+  register: log_files
+
+- name: "Configure permission for /var/log/"
+  lineinfile:
+    path: "/etc/permissions.local"
+    regexp: '^{{ item.path }}\s+\w+\:\w+\d+\s*$'
+    line: "{{ item.path }}\t\t\t\t{{ item.pw_name }}:{{ item.gr_name }}\t640"
+    state: present
+  when: (item.mode | int) > 640
+  with_items: "{{ log_files.files }}"
+  register: update_permissions_local_logs_result
+
+- name: "Correct file permissions for /var/log"
+  shell: >
+    chkstat --set --system
+  when: update_permissions_local_logs_result.changed

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/oval/shared.xml
@@ -1,0 +1,36 @@
+<def-group>
+  <definition class="compliance" id="permissions_local_var_log" version="1">
+    {{{ oval_metadata("
+        Checks that files in /var/log have permission at least 0640
+      ") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_mode_log_files" />
+    </criteria>
+  </definition>
+
+  <unix:file_test  check="all" check_existence="none_exist" comment="log file with less restrictive permission than 0640" id="test_mode_log_files" version="1">
+    <unix:object object_ref="object_file_mode_log_files" />
+  </unix:file_test>
+
+  <unix:file_object comment="log files" id="object_file_mode_log_files" version="1">
+    <unix:path operation="pattern match">^\/var\/log\/</unix:path>
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <filter action="include">log_files_permission_more_0640</filter>
+    <filter action="exclude">var_log_symlinks</filter>
+  </unix:file_object>
+
+  <unix:file_state id="log_files_permission_more_0640" version="1" operator="OR">
+     <!-- if any one of these is true then mode is NOT 0640 (hence the OR operator) -->
+    <unix:uexec datatype="boolean">true</unix:uexec>
+    <unix:gwrite datatype="boolean">true</unix:gwrite>
+    <unix:gexec datatype="boolean">true</unix:gexec>
+    <unix:oread datatype="boolean">true</unix:oread>
+    <unix:owrite datatype="boolean">true</unix:owrite>
+    <unix:oexec datatype="boolean">true</unix:oexec>
+  </unix:file_state>
+
+  <unix:file_state id="var_log_symlinks" version="1">
+    <unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -1,0 +1,51 @@
+documentation_complete: true
+
+prodtype: sle15
+
+title: 'Verify permissions of log files'
+
+description: |-
+    Any operating system providing too much information in error messages
+    risks compromising the data and security of the structure, and content
+    of error messages needs to be carefully considered by the organization.
+
+    Organizations carefully consider the structure/content of error messages.
+    The extent to which information systems are able to identify and handle
+    error conditions is guided by organizational policy and operational
+    requirements. Information that could be exploited by adversaries includes,
+    for example, erroneous logon attempts with passwords entered by mistake
+    as the username, mission/business information that can be derived from
+    (if not stated explicitly by) information recorded, and personal
+    information, such as account numbers, social security numbers, and credit
+    card numbers.
+
+rationale: |-
+    The {{{ full_name }}} must generate error messages that provide information
+    necessary for corrective actions without revealing information that could
+    be exploited by adversaries.
+
+severity: medium
+
+identifiers:
+    cce@sle15: CCE-85755-7
+
+references:
+    disa@sle15: CCI-001312
+    nist: SI-11(a),SI-11(b),SI-11.1(iii)
+    nist-csf: PR.AC-4,PR.DS-5
+    stigid@sle15: SLES-15-010340
+    srg@sle15: SRG-OS-000205-GPOS-00083
+
+ocil_clause: 'all log files are with permission at least 640'
+
+ocil: |-
+    All files in
+    <pre>/var/log/
+    </pre>
+    directory should be with permissions
+    <tt>640</tt> or more restrictive. If any of the log files under
+    <pre>/var/log</pre> directory does not match the criteria, this should be
+    fixed by using the following command:
+    <pre>
+    > sudo find /var/log -perm /137 -type f -exec chmod 640 '{}' \;
+    </pre>

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -34,7 +34,7 @@ references:
     nist: SI-11(a),SI-11(b),SI-11.1(iii)
     nist-csf: PR.AC-4,PR.DS-5
     stigid@sle15: SLES-15-010340
-    srg@sle15: SRG-OS-000205-GPOS-00083
+    srg: SRG-OS-000205-GPOS-00083
 
 ocil_clause: 'all log files are with permission at least 640'
 

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -39,13 +39,9 @@ references:
 ocil_clause: 'not all log files have permission 640 or stricter'
 
 ocil: |-
-    All files in
-    <pre>/var/log/
-    </pre>
-    directory should be with permissions
-    <tt>640</tt> or more restrictive. If any of the log files under
-    <pre>/var/log</pre> directory does not match the criteria, this should be
-    fixed by using the following command:
+    Verify the operating system has all system log files under the
+    <pre>/var/log</pre> directory with a permission set to 640,
+    by using the following command:
     <pre>
-    > sudo find /var/log -perm /137 -type f -exec chmod 640 '{}' \;
+    > sudo find /var/log -perm /137 -type f -exec stat -c "%n %a" {} \;
     </pre>

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -30,7 +30,7 @@ identifiers:
     cce@sle15: CCE-85755-7
 
 references:
-    disa@sle15: CCI-001312
+    disa: CCI-001312
     nist: SI-11(a),SI-11(b),SI-11.1(iii)
     nist-csf: PR.AC-4,PR.DS-5
     stigid@sle15: SLES-15-010340

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -36,7 +36,7 @@ references:
     stigid@sle15: SLES-15-010340
     srg: SRG-OS-000205-GPOS-00083
 
-ocil_clause: 'all log files are with permission at least 640'
+ocil_clause: 'not all log files have permission 640 or stricter'
 
 ocil: |-
     All files in

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -43,5 +43,5 @@ ocil: |-
     <pre>/var/log</pre> directory with a permission set to 640,
     by using the following command:
     <pre>
-    > sudo find /var/log -perm /137 -type f -exec stat -c "%n %a" {} \;
+    sudo find /var/log -perm /137 -type f -exec stat -c "%n %a" {} \;
     </pre>

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/group_writable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/group_writable_logfile.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+touch /var/log/testme/test_world_read.log
+chmod 660 /var/log/testme/test_world_read.log

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/var_logfile_correct_mode.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/var_logfile_correct_mode.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+touch /var/log/testme/test.log
+chmod 640 /var/log/testme/test.log

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/world_readable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/world_readable_logfile.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+touch /var/log/testme/test_world_read.log
+chmod a+r /var/log/testme/test_world_read.log

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/world_writable_dir.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/world_writable_dir.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+chmod 777 /var/log/testme

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/world_writable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/world_writable_logfile.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+touch /var/log/testme/test_world_read.log
+chmod o+w /var/log/testme/test_world_read.log

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -201,6 +201,7 @@ selections:
     - partition_for_var_log_audit
     - permissions_local_audit_binaries
     - permissions_local_var_log_audit
+    - permissions_local_var_log
     - postfix_client_configure_mail_alias
     - rsyslog_remote_loghost
     - security_patches_up_to_date


### PR DESCRIPTION

#### Description:

- Verify permissions of log files

#### Rationale:

- Add rule for correct permissions in /var/log together with ansible remediation, based on /etc/permissions and chkstat approach
- Add permissions_local_var_log to SLE15 stig profile
- Add tests for permissions_local_var_log rule
- Set CCE id to CCE-85755-7