### PR TITLE
Update dpkg package installed command

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -28,7 +28,8 @@ REMEDIATION_TO_EXT_MAP = {
 }
 
 PKG_MANAGER_TO_PACKAGE_CHECK_COMMAND = {
-    'apt_get': 'dpkg-query -s {0} &>/dev/null',
+    'apt_get': "dpkg-query --show --showformat='${{db:Status-Status}}\\n' '{0}' 2>/dev/null " +
+               "| grep -q installed",
     'dnf': 'rpm --quiet -q {0}',
     'yum': 'rpm --quiet -q {0}',
     'zypper': 'rpm --quiet -q {0}',


### PR DESCRIPTION
#### Description:

Previously the command was:

    dpkg-query -s {0} &>/dev/null

This was replaced with:

    dpkg-query --show --showformat='${db:Status-Status}\n' '{0}' 2>/dev/null | grep -q installed

The rationale for this change is `dpkg-query` alone isn't sufficient for
detecting whether or not a package is installed. In particular, if the
package used to be installed but was removed, dpkg-query will still exit
with a status code of 0 (thus, succeeding), but will display output similar
to:

    Status: deinstall ok config-files

Outputting just the field we want (`${db:Status-Status}`) and then
quietly grepping for the status we want (`installed`) gives us the final
result we want.

```
Co-Authored-By: Richard Maciel Costa <richard.maciel.costa@canonical.com>
Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>
```

---

/cc @richardmaciel-canonical