### PR TITLE
Make profile-tool product-aware

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -93,6 +93,9 @@ def parse_args():
     parser_stats.add_argument("--all", default=False,
                         action="store_true", dest="all",
                         help="Show all available statistics.")
+    parser_stats.add_argument("--product", action="store", dest="product",
+                              help="Product directory to evaluate XCCDF under "
+                              "(e.g., ~/scap-security-guide/rhel8)")
     parser_stats.add_argument("--skip-stats", default=False,
                               action="store_true", dest="skip_overall_stats",
                               help="Do not show overall statistics.")
@@ -186,7 +189,7 @@ def main():
             print("Subtraction would produce an empty profile. No new profile was generated")
         exit(0)
 
-    benchmark = ssg.build_profile.XCCDFBenchmark(args.benchmark)
+    benchmark = ssg.build_profile.XCCDFBenchmark(args.benchmark, args.product)
     ret = []
     if args.profile:
         ret.append(benchmark.show_profile_stats(args.profile, args))

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import os
 import sys
 
 from .xml import ElementTree
@@ -14,7 +15,8 @@ from .constants import puppet_system as puppet_rem_system
 from .constants import anaconda_system as anaconda_rem_system
 from .constants import cce_uri
 from .constants import ssg_version_uri
-from .constants import stig_ns, cis_ns, hipaa_ns, anssi_ns, ospp_ns, cui_ns
+from .constants import stig_ns, cis_ns, generic_stig_ns, hipaa_ns, anssi_ns
+from .constants import ospp_ns, cui_ns, xslt_ns
 console_width = 80
 
 
@@ -54,7 +56,7 @@ class XCCDFBenchmark(object):
     statistics about the profiles contained within it.
     """
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, product=""):
         self.tree = None
         try:
             with open(filepath, 'r') as xccdf_file:
@@ -75,6 +77,24 @@ class XCCDFBenchmark(object):
                 raise RuntimeError("Multiple rules exist with same id attribute: %s!" % rule_id)
 
             self.indexed_rules[rule_id] = rule
+
+        self.cis_ns = cis_ns
+        self.stig_ns = stig_ns
+        if product:
+            constants_path = os.path.join(product, "transforms/constants.xslt")
+            if os.path.exists(constants_path):
+                root = ElementTree.parse(constants_path)
+                cis_var = root.find('./{%s}variable[@name="cisuri"]' % (xslt_ns))
+                if cis_var is not None and cis_var.text:
+                    self.cis_ns = cis_var.text
+
+                stig_var = root.find('./{%s}variable[@name="disa-stigs-uri"]' % (xslt_ns))
+                if stig_var is not None and stig_var.text:
+                    self.stig_ns = stig_var.text
+                elif (stig_var and 'select' in stig_var.attrib and
+                      stig_var.attrib['select'] == '$disa-stigs-os-unix-linux-uri'):
+                    self.stig_ns = generic_stig_ns
+
 
     def get_profile_stats(self, profile):
         """Obtain statistics for the profile"""
@@ -171,9 +191,9 @@ class XCCDFBenchmark(object):
                 cce = rule.find("./{%s}ident[@system=\"%s\"]" %
                                 (xccdf_ns, cce_uri))
                 stig_id = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, stig_ns))
+                                    (xccdf_ns, self.stig_ns))
                 cis_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, cis_ns))
+                                    (xccdf_ns, self.cis_ns))
                 hipaa_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
                                     (xccdf_ns, hipaa_ns))
                 anssi_ref = rule.find("./{%s}reference[@href=\"%s\"]" %

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -86,6 +86,9 @@ min_ansible_version = "2.5"
 ansible_version_requirement_pre_task_name = \
     "Verify Ansible meets SCAP-Security-Guide version requirements."
 standard_profiles = ['standard', 'pci-dss', 'desktop', 'server']
+xslt_ns = "http://www.w3.org/1999/XSL/Transform"
+generic_stig_ns = "https://public.cyber.mil/stigs/downloads/" + \
+                  "?_dl_facet_stigs=operating-systems%2Cunix-linux"
 
 
 OVAL_SUB_NS = dict(


### PR DESCRIPTION
#### Description:

This introduces a product-specific form of `profile_tool.py`, taking the
optional `--product` argument (without a default). When the product
directory exists and there's a `templates/constants.xslt` under it, we'll
load that and attempt to influence our STIG and CIS benchmark namespaces
appropriately.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

See also discussion on https://github.com/ComplianceAsCode/content/pull/6907 