### PR TITLE
Add platform check for RHEL minor version.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -55,4 +55,11 @@ ocil: |-
     <pre>$ grep even_deny_root /etc/pam.d/system-auth</pre>
     The output should show <tt>even_deny_root</tt>.
 
+{{% if product == "rhel8" %}}
+platforms:
+    - pam
+    - rhel8_0
+    - rhel8_1
+{{% else %}}
 platform: pam
+{{% endif %}}

--- a/rhel8/product.yml
+++ b/rhel8/product.yml
@@ -26,6 +26,14 @@ cpes:
       name: "cpe:/o:redhat:enterprise_linux:8"
       title: "Red Hat Enterprise Linux 8"
       check_id: installed_OS_is_rhel8
+  - rhel8_0:
+      name: "cpe:/o:redhat:enterprise_linux:8.0"
+      title: "Red Hat Enterprise Linux 8.0"
+      check_id: installed_OS_is_rhel8_0
+  - rhel8_1:
+      name: "cpe:/o:redhat:enterprise_linux:8.1"
+      title: "Red Hat Enterprise Linux 8.1"
+      check_id: installed_OS_is_rhel8_1
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/shared/checks/oval/installed_OS_is_rhel8_0.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8_0.xml
@@ -1,0 +1,42 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_rhel8_0" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.0</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.0"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      Red Hat Enterprise Linux 8.0</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_rhel8_0_unix_family" />
+      <criteria operator="OR">
+        <criterion comment="RHEL 8.0 is installed" test_ref="test_rhel8_0" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_rhel8_0_unix_family" version="1">
+    <ind:object object_ref="obj_rhel8_0_unix_family" />
+    <ind:state state_ref="state_rhel8_0_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_rhel8_0_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_rhel8_0_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8" id="test_rhel8_0" version="1">
+    <linux:object object_ref="obj_rhel8_0" />
+    <linux:state state_ref="state_rhel8_0" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_0" version="1">
+    <linux:version operation="pattern match">^8.0*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_0" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/shared/checks/oval/installed_OS_is_rhel8_1.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8_1.xml
@@ -1,0 +1,42 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_rhel8_1" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.1</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.1"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      Red Hat Enterprise Linux 8.1</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_rhel8_1_unix_family" />
+      <criteria operator="OR">
+        <criterion comment="RHEL 8.1 is installed" test_ref="test_rhel8_1" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_rhel8_1_unix_family" version="1">
+    <ind:object object_ref="obj_rhel8_1_unix_family" />
+    <ind:state state_ref="state_rhel8_1_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_rhel8_1_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_rhel8_1_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8" id="test_rhel8_1" version="1">
+    <linux:object object_ref="obj_rhel8_1" />
+    <linux:state state_ref="state_rhel8_1" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_1" version="1">
+    <linux:version operation="pattern match">^8.1*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_1" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+</def-group>


### PR DESCRIPTION
#### Description:

- Add platform check for RHEL minor version.

#### Rationale:

- This rule should be applicable to RHEL 8.0 and 8.1 only (RHEL-08-020022)

#### Problems

- The current way our `platform` implementation works does not allow me to combine the RHEL platform check with `pam` check using AND operator, so ultimately this does not solve the problem. But I'm starting here to ask for more opinions on how to tackle this problem of applicability only to certain minor versions of RHEL (which is one of the problems to be solved with minor version agnostic content)

#### Disclaimer

- This is a very simplistic implementation. ;)