### PR TITLE
Improve the test suite wrapper

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -290,7 +290,16 @@ class ContainerTestEnv(TestEnv):
 
     def get_ssh_port(self):
         if self.domain_ip == 'localhost':
-            ports = self._get_container_ports(self.current_container)
+            try:
+                ports = self._get_container_ports(self.current_container)
+            except Exception as exc:
+                msg = (
+                    "Unable to extract SSH ports from the container. "
+                    "This usually means that the container backend reported its configuration "
+                    "in an unexpected format."
+                )
+                raise RuntimeError(msg)
+
             if self.internal_ssh_port in ports:
                 ssh_port = ports[self.internal_ssh_port]
             else:

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -130,7 +130,7 @@ def get_oscap_supported_cpes():
     """
     result = []
     proc = subprocess.Popen(
-            ("oscap", "--version"), text=True,
+            ("oscap", "--version"),
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
         outs, errs = proc.communicate(timeout=3)
@@ -144,7 +144,7 @@ def get_oscap_supported_cpes():
         logging.warn("Error getting CPEs from the scanner: {msg}".format(msg=first_error_line))
 
     cpe_regex = re.compile(r'\bcpe:\S+$')
-    for line in outs.split("\n"):
+    for line in outs.decode().split("\n"):
         match = cpe_regex.search(line)
         if match:
             result.append(match.group(0))

--- a/tests/test_rule_in_container.sh
+++ b/tests/test_rule_in_container.sh
@@ -185,7 +185,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || { echo "Couldn't d
 # [ <-- needed because of Argbash
 
 podman images | grep -q "$_arg_name" || die "Couldn't find the podman image '$_arg_name'"
-test_image_cpe_product=$(podman run --rm "$_arg_name" cat /etc/os-release | grep cpe | cut -d : -f 4)
+test_image_cpe_product=$(podman run --rm "$_arg_name" sh -c '. /etc/os-release && echo "$CPE_NAME"')
 test -n "$test_image_cpe_product" || die "Unable to deduce the product CPE from the container's /etc/os-release file."
 
 additional_args=()


### PR DESCRIPTION
It now uses a whole, literal CPE for the purpose of CPE injection into the datastream.

The previous way that used part of the CPE stopped working for some reason.