### PR TITLE
make sure that rule platforms is a set

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1091,6 +1091,10 @@ class Rule(object):
                    .format(fname=yaml_file, err=str(exc)))
             raise RuntimeError(msg)
 
+        # platforms are read as list from the yaml file
+        # we need them to convert to set again
+        rule.platforms = set(rule.platforms)
+
         for warning_list in rule.warnings:
             if len(warning_list) != 1:
                 raise ValueError("Only one key/value pair should exist for each dictionary")


### PR DESCRIPTION
#### Description:

- convert list of rules read from rule.yml to set

#### Rationale:

I know that this might not seem nice but writing sets into yaml directly looks ugly, you can see it in compiled rules if you build some product with this PR.
But internally we need platforms to be a set to eliminate possible duplicities. So let's do it in the background in this way.