### PR TITLE
Show which OVAL fails during parsing

### DIFF
--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -118,7 +118,12 @@ def applicable_platforms(oval_file, oval_version_string=None):
 
     body = process_file_with_macros(oval_file, subst_dict)
 
-    oval_tree = ET.fromstring(header + body + footer)
+    try:
+        oval_tree = ET.fromstring(header + body + footer)
+    except Exception as e:
+        msg = "Error while loading " + oval_file
+        print(msg, file=sys.stderr)
+        raise e
 
     element_path = "./{%s}def-group/{%s}definition/{%s}metadata/{%s}affected/{%s}platform"
     element_ns_path = element_path % (ovalns, ovalns, ovalns, ovalns, ovalns)


### PR DESCRIPTION
#### Description:

When `rule_dir_json.py` runs as part of the build process (and invalid
OVALs are present), the build will fail with an error like:

    product has multiple remediations of the same type: sle12 - sle12.yml,sle15.yml
    product has multiple remediations of the same type: sle15 - sle12.yml,sle15.yml
    Traceback (most recent call last):
      File "/home/cipherboy/GitHub/cipherboy/ComplianceAsCode-content/utils/rule_dir_json.py", line 203, in <module>
        main()
      File "/home/cipherboy/GitHub/cipherboy/ComplianceAsCode-content/utils/rule_dir_json.py", line 173, in main
        rule_obj['ovals'], oval_products = handle_ovals(product_list, product_yamls, rule_obj)
      File "/home/cipherboy/GitHub/cipherboy/ComplianceAsCode-content/utils/rule_dir_json.py", line 98, in handle_ovals
        platforms = ssg.oval.applicable_platforms(oval_path)
      File "/home/cipherboy/GitHub/cipherboy/ComplianceAsCode-content/ssg/oval.py", line 126, in applicable_platforms
        raise e
      File "/home/cipherboy/GitHub/cipherboy/ComplianceAsCode-content/ssg/oval.py", line 122, in applicable_platforms
        oval_tree = ET.fromstring(header + body + footer)
      File "/usr/lib/python3.9/xml/etree/ElementTree.py", line 1347, in XML
        parser.feed(text)
    xml.etree.ElementTree.ParseError: mismatched tag: line 111, column 21

This makes it hard to find which OVAL actually caused the failure.

Add a line indicating such information to the user.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

#### Rationale:

If #6911 gets merged, builds will fail with this error rather than a more obvious one. This is because `rule_dir_json.py` is independent of all other tasks and usually gets executed fairly early in the build. Even if it doesn't get merged and someone is actively developing content, it makes sense to show this exception either way.

I think it might affect other code paths as well, so at worst we'll end up with a duplicated message showing which file is bad.


Thoughts?