### PR TITLE
Update VSEL references to remove qualifier from global references

### DIFF
--- a/vsel/guide/vsel/general_settings/dats_auto_update/rule.yml
+++ b/vsel/guide/vsel/general_settings/dats_auto_update/rule.yml
@@ -19,9 +19,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-002
 
 ocil_clause: |-

--- a/vsel/guide/vsel/general_settings/dats_updated/rule.yml
+++ b/vsel/guide/vsel/general_settings/dats_updated/rule.yml
@@ -18,9 +18,9 @@ rationale: |-
 severity: high
 
 references:
-    disa@vsel: CCI-001240
+    disa: CCI-001240
     nist: SI-3
-    srg@vsel: SRG-APP-000276
+    srg: SRG-APP-000276
     stigid@vsel: DTAVSEL-001
 
 ocil_clause: |-

--- a/vsel/guide/vsel/general_settings/restricted_user/rule.yml
+++ b/vsel/guide/vsel/general_settings/restricted_user/rule.yml
@@ -38,7 +38,7 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-002235
+    disa: CCI-002235
     nist: AC-6(10)
-    srg@vsel: SRG-APP-000340
+    srg: SRG-APP-000340
     stigid@vsel: DTAVSEL-202

--- a/vsel/guide/vsel/general_settings/scanned_media/rule.yml
+++ b/vsel/guide/vsel/general_settings/scanned_media/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-000870
+    disa: CCI-000870
     nist: MA-3(2)
-    srg@vsel: SRG-APP-000073
+    srg: SRG-APP-000073
     stigid@vsel: DTAVSEL-200

--- a/vsel/guide/vsel/general_settings/updates_source/rule.yml
+++ b/vsel/guide/vsel/general_settings/updates_source/rule.yml
@@ -26,8 +26,8 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001749
+    disa: CCI-001749
     nist: CM-5
-    srg@vsel: SRG-APP-000131
+    srg: SRG-APP-000131
     stigid@vsel: DTAVSEL-201
 

--- a/vsel/guide/vsel/general_settings/virus_notification/rule.yml
+++ b/vsel/guide/vsel/general_settings/virus_notification/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001240
+    disa: CCI-001240
     nist: SI-3
-    srg@vsel: SRG-APP-000276
+    srg: SRG-APP-000276
     stigid@vsel: DTAVSEL-205
 
 ocil_clause: |-

--- a/vsel/guide/vsel/general_settings/web_client_disabled/rule.yml
+++ b/vsel/guide/vsel/general_settings/web_client_disabled/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001813
+    disa: CCI-001813
     nist: CM-5(1)
-    srg@vsel: SRG-APP-000380
+    srg: SRG-APP-000380
     stigid@vsel: DTAVSEL-000
 
 ocil_clause: |-

--- a/vsel/guide/vsel/general_settings/web_client_firewalled/rule.yml
+++ b/vsel/guide/vsel/general_settings/web_client_firewalled/rule.yml
@@ -14,7 +14,7 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001813
+    disa: CCI-001813
     nist: CM-5
-    srg@vsel: SRG-APP-000380
+    srg: SRG-APP-000380
     stigid@vsel: DTAVSEL-301

--- a/vsel/guide/vsel/on_access_settings/oas_action_app_primary/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_action_app_primary/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-013
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_action_app_secondary/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_action_app_secondary/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-014
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_action_default_primary/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_action_default_primary/rule.yml
@@ -19,9 +19,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-015
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_action_default_secondary/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_action_default_secondary/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-016
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_action_error/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_action_error/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-017
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_action_timeout/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_action_timeout/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-018
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_allFiles/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_allFiles/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-010
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_decompArchive/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_decompArchive/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-004
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_enabled/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_enabled/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: high
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-003
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_exclusions/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_exclusions/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-012
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_heuristicAnalysis/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_heuristicAnalysis/rule.yml
@@ -18,9 +18,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-005
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_macroAnalysis/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_macroAnalysis/rule.yml
@@ -19,9 +19,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-006
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_program/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_program/rule.yml
@@ -19,9 +19,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-007
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_scanMaxTmo/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_scanMaxTmo/rule.yml
@@ -21,9 +21,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-010
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_scanNWFiles/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_scanNWFiles/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001242
+    disa: CCI-001242
     nist: SI-3
-    srg@vsel: SRG-APP-000278
+    srg: SRG-APP-000278
     stigid@vsel: DTAVSEL-019
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_scanOnRead/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_scanOnRead/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-009
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_access_settings/oas_scanOnWrite/rule.yml
+++ b/vsel/guide/vsel/on_access_settings/oas_scanOnWrite/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001243
+    disa: CCI-001243
     nist: SI-3
-    srg@vsel: SRG-APP-000279
+    srg: SRG-APP-000279
     stigid@vsel: DTAVSEL-008
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_action_app_primary/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_action_app_primary/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-106
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_action_app_secondary/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_action_app_secondary/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-107
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_action_default_primary/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_action_default_primary/rule.yml
@@ -19,9 +19,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-110
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_action_default_secondary/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_action_default_secondary/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-111
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_allFiles/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_allFiles/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-105
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_decompArchive/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_decompArchive/rule.yml
@@ -17,9 +17,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-101
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_enabled/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_enabled/rule.yml
@@ -28,7 +28,7 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-100

--- a/vsel/guide/vsel/on_demand_settings/ods_exclusions/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_exclusions/rule.yml
@@ -33,7 +33,7 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-108

--- a/vsel/guide/vsel/on_demand_settings/ods_extensions/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_extensions/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-113
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_heuristicAnalysis/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_heuristicAnalysis/rule.yml
@@ -18,9 +18,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-102
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_macroAnalysis/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_macroAnalysis/rule.yml
@@ -19,9 +19,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-103
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_mime/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_mime/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-112
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_program/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_program/rule.yml
@@ -19,9 +19,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001241
+    disa: CCI-001241
     nist: SI-3
-    srg@vsel: SRG-APP-000277
+    srg: SRG-APP-000277
     stigid@vsel: DTAVSEL-104
 
 ocil_clause: |-

--- a/vsel/guide/vsel/on_demand_settings/ods_scanNWFiles_local/rule.yml
+++ b/vsel/guide/vsel/on_demand_settings/ods_scanNWFiles_local/rule.yml
@@ -16,9 +16,9 @@ rationale: |-
 severity: medium
 
 references:
-    disa@vsel: CCI-001242
+    disa: CCI-001242
     nist: SI-3
-    srg@vsel: SRG-APP-000278
+    srg: SRG-APP-000278
     stigid@vsel: DTAVSEL-019
 
 ocil_clause: |-


### PR DESCRIPTION
#### Description:

- Update VSEL references to remove qualifier from global references.

#### Rationale:

- Since we introduced this build condition #6896, some of the references cannot have product qualifier as they are so called global references.
- We missed these references because those rules belong only to VSEL product and our PR gating doesn't build that product ;(

