### PR TITLE
Address NIST SP 800-32 control CM-8(3) with usbguard

### DIFF
--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
@@ -25,8 +25,8 @@ references:
     srg: SRG-OS-000378-GPOS-00163
     ism: "1418"
     stigid@rhel8: RHEL-08-040140
-    disa: CCI-001958
-    nist: CM-8(3)
+    disa: CCI-000416,CCI-001958
+    nist: CM-8(3)(a),IA-3
 
 ocil_clause: 'the service is not enabled'
 

--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
@@ -26,6 +26,7 @@ references:
     ism: "1418"
     stigid@rhel8: RHEL-08-040140
     disa: CCI-001958
+    nist: CM-8(3)
 
 ocil_clause: 'the service is not enabled'
 


### PR DESCRIPTION
The control states the following:

> The organization:
>  (a)   Employs automated mechanisms [Assignment: organization-defined frequency] to detect the presence of unauthorized hardware, software, and firmware components within the information system; and
>  (b)   Takes the following actions when unauthorized components are detected: [Selection (one or more): disables network access by such components; isolates the components; notifies [Assignment: organization-defined personnel or roles]].
>
> Supplemental Guidance:  This control enhancement is applied in addition to the monitoring for unauthorized remote connections and mobile devices. Monitoring for unauthorized system components may be accomplished on an ongoing basis or by the periodic scanning of systems for that purpose. Automated mechanisms can be implemented within information systems or in other separate devices. Isolation can be achieved, for example, by placing unauthorized information system components in separate domains or subnets or otherwise quarantining such components. This type of component isolation is commonly referred to as sandboxing. Related controls: AC-17, AC-18, AC-19, CA-7, SI-3, SI-4, SI-7, RA-5.

With that reasoning, usbguard helps address CM-8(3)(a).

So, let's mark it as such in the content.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>