### PR TITLE
Fix typo in rule description

### DIFF
--- a/applications/openshift/accounts/accounts_unique_service_account/rule.yml
+++ b/applications/openshift/accounts/accounts_unique_service_account/rule.yml
@@ -8,8 +8,8 @@ description: |-
     Using the <tt>default</tt> service account prevents accurate application
     rights review and audit tracing. Instead of <tt>default</tt>, create
     a new and unique service account with the following command:
-    <pre>$ oc create sa <i>service_account_name></i></pre>
-    where <i>service_account_name></i> is the name of a service account
+    <pre>$ oc create sa <i>service_account_name</i></pre>
+    where <i>service_account_name</i> is the name of a service account
     that is needed in the project namespace.
 
 rationale: |-


### PR DESCRIPTION
I was formatting the rules in the Compliance Operator a nicer way and
this one looked odd.