### PR TITLE
Updating macros to support idempotency when deduplicating values

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile_d.fail.sh
@@ -2,10 +2,14 @@
 
 # variables = var_accounts_tmout=600
 
+TEST_FILE=/etc/profile.d/tmout.sh
+
 sed -i "/.*TMOUT.*/d" /etc/profile
 
-if grep -q "^TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/^TMOUT.*/# TMOUT=600/" /etc/profile.d/tmout.sh
+test -f $TEST_FILE || touch $TEST_FILE
+
+if grep -q "^TMOUT" $TEST_FILE; then
+	sed -i "s/^TMOUT.*/# TMOUT=600/" $TEST_FILE
 else
-	echo "# TMOUT=600" >> /etc/profile.d/tmout.sh
+	echo "# TMOUT=600" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
@@ -2,10 +2,14 @@
 
 # variables = var_accounts_tmout=700
 
+TEST_FILE=/etc/profile.d/tmout.sh
+
 sed -i "/.*TMOUT.*/d" /etc/profile
 
-if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile.d/tmout.sh
+test -f $TEST_FILE || touch $TEST_FILE
+
+if grep -q "TMOUT" $TEST_FILE; then
+	sed -i "s/.*TMOUT.*/TMOUT=700/" $TEST_FILE
 else
-	echo "TMOUT=700" >> /etc/profile.d/tmout.sh
+	echo "TMOUT=700" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
+if grep -q "TMOUT" /etc/profile; then
+	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile
+	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+else
+	echo "TMOUT=700" >> /etc/profile
+	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
+	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile.d/tmout.sh
+	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+else
+	echo "TMOUT=700" >> /etc/profile.d/tmout.sh
+	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
@@ -2,10 +2,14 @@
 
 # variables = var_accounts_tmout=900
 
+TEST_FILE=/etc/profile.d/tmout.sh
+
 sed -i "/.*TMOUT.*/d" /etc/profile
 
-if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/.*TMOUT.*/TMOUT=950; readonly TMOUT; export TMOUT/" /etc/profile.d/tmout.sh
+test -f $TEST_FILE || touch $TEST_FILE
+
+if grep -q "TMOUT" $TEST_FILE; then
+	sed -i "s/.*TMOUT.*/TMOUT=950; readonly TMOUT; export TMOUT/" $TEST_FILE
 else
-	echo "TMOUT=950; readonly TMOUT; export TMOUT" >> /etc/profile.d/tmout.sh
+	echo "TMOUT=950; readonly TMOUT; export TMOUT" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
@@ -2,8 +2,14 @@
 
 # variables = var_accounts_tmout=700
 
-if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/.*TMOUT.*/TMOUT=700; readonly TMOUT; export TMOUT/" /etc/profile.d/tmout.sh
+TEST_FILE=/etc/profile.d/tmout.sh
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+test -f $TEST_FILE || touch $TEST_FILE
+
+if grep -q "TMOUT" $TEST_FILE; then
+	sed -i "s/.*TMOUT.*/TMOUT=700; readonly TMOUT; export TMOUT/" $TEST_FILE
 else
-	echo "TMOUT=700; readonly TMOUT; export TMOUT" >> /etc/profile.d/tmout.sh
+	echo "TMOUT=700; readonly TMOUT; export TMOUT" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
@@ -2,10 +2,14 @@
 
 # variables = var_accounts_tmout=900
 
+TEST_FILE=/etc/profile.d/tmout.sh
+
 sed -i "/.*TMOUT.*/d" /etc/profile
 
-if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/.*TMOUT.*/TMOUT=800/" /etc/profile.d/tmout.sh
+test -f $TEST_FILE || touch $TEST_FILE
+
+if grep -q "TMOUT" $TEST_FILE; then
+	sed -i "s/.*TMOUT.*/TMOUT=800/" $TEST_FILE
 else
-	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+	echo "TMOUT=800" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_profile_d.fail.sh
@@ -2,10 +2,14 @@
 
 # variables = var_accounts_tmout=900
 
+TEST_FILE=/etc/profile.d/tmout.sh
+
 sed -i "/.*TMOUT.*/d" /etc/profile
 
-if grep -q "^TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/^TMOUT.*/TMOUT=950/" /etc/profile.d/tmout.sh
+test -f $TEST_FILE || touch $TEST_FILE
+
+if grep -q "^TMOUT" $TEST_FILE; then
+	sed -i "s/^TMOUT.*/TMOUT=950/" $TEST_FILE
 else
-	echo "TMOUT=950" >> /etc/profile.d/tmout.sh
+	echo "TMOUT=950" >> $TEST_FILE
 fi

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -361,7 +361,7 @@ The following macro remediates one audit watch rule in /etc/audit/audit.rules.
 The macro requires following parameters:
 - path: path to watch
 - permissions: permissions changes to watch for
-- key: key to use as identifier.
+- key: key to use as identifier
 #}}
 {{% macro ansible_audit_auditctl_add_watch_rule(path='', permissions='', key='') -%}}
 - name: Check if watch rule for {{{ path }}} already exists in /etc/audit/audit.rules

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -107,11 +107,11 @@ value: "Setting={{ varname1 }}"
   block:
     {{{ ansible_lineinfile("Check for duplicate values", path, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True)|indent }}}
     {{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
-    {{{ ansible_lineinfile("Insert correct line to " + path, path, regex=None, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
+    {{{ ansible_lineinfile("Insert correct line to " + path, path, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
 {{%- else %}}
 {{{ ansible_lineinfile("Check for duplicate values", path, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True) }}}
 {{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1') }}}
-{{{ ansible_lineinfile("Insert correct line into " + path, path, regex=None, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
+{{{ ansible_lineinfile("Insert correct line into " + path, path, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
 {{%- endif %}}
 {{%- endmacro %}}
 
@@ -148,7 +148,7 @@ value: "Setting={{ varname1 }}"
     {{{ ansible_stat("Check if " + config_dir + " exists", path=config_dir, register=dir_exists)|indent }}}
     {{{ ansible_find("Check if the parameter " + parameter + " is present in " + config_dir, paths=config_dir, contains=line_regex, register=dir_parameter, when=find_when)|indent }}}
     {{{ ansible_lineinfile("Remove parameter from files in " + config_dir, path="{{ item.path }}", regex=line_regex, state="absent", with_items=lineinfile_items, when=lineinfile_when)|indent }}}
-    {{{ ansible_lineinfile("Insert correct line to " + set_file, set_file, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
+    {{{ ansible_lineinfile("Insert correct line to " + set_file, set_file, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
 {{%- endmacro %}}
 
 {{#

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -19,11 +19,13 @@ value: "Setting={{ varname1 }}"
   only be passed when state is present. with_items will be specified only if
   non-empty, allowing for iterating through a variable of content (with the
   appropriate macro-based path). register will be specified only if non-empty,
-  allowing for saving the output of this lineinfile module.
+  allowing for saving the output of this lineinfile module. check_mode allows
+  an idempotent way to gather output, or run a task without changes. Useful when
+  calling the ansible_only_lineinfile macro to handle deduplication of values.
 
   Note that all string-like parameters are single quoted in the YAML.
 #}}
-{{%- macro ansible_lineinfile(msg='', path='', regex='', new_line='', create='no', state='present', with_items='', register='', when='', validate='', insert_after='', insert_before='') -%}}
+{{%- macro ansible_lineinfile(msg='', path='', regex='', new_line='', create='no', state='present', with_items='', register='', when='', validate='', insert_after='', insert_before='', check_mode=False) -%}}
 - name: "{{{ msg or rule_title }}}"
   lineinfile:
     path: '{{{ path }}}'
@@ -47,6 +49,10 @@ value: "Setting={{ varname1 }}"
     {{%- endif %}}
   {{%- if with_items %}}
   with_items: '{{{ with_items }}}'
+  {{%- endif %}}
+  {{%- if check_mode %}}
+  check_mode: yes
+  changed_when: no
   {{%- endif %}}
   {{%- if register %}}
   register: '{{{ register }}}'
@@ -99,10 +105,12 @@ value: "Setting={{ varname1 }}"
 {{%- if block %}}
 - name: "{{{ msg or rule_title }}}"
   block:
-    {{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, new_line=None, create='no', state='absent')|indent }}}
+    {{{ ansible_lineinfile("Check for duplicate values", path, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True)|indent }}}
+    {{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
     {{{ ansible_lineinfile("Insert correct line to " + path, path, regex=None, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
 {{%- else %}}
-{{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, new_line=None, create='no', state='absent') }}}
+{{{ ansible_lineinfile("Check for duplicate values", path, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True) }}}
+{{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1') }}}
 {{{ ansible_lineinfile("Insert correct line into " + path, path, regex=None, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
 {{%- endif %}}
 {{%- endmacro %}}
@@ -135,7 +143,8 @@ value: "Setting={{ varname1 }}"
 {{%- set new_line = parameter + separator + value -%}}
 - name: '{{{ msg or rule_title }}}'
   block:
-    {{{ ansible_lineinfile("Deduplicate values from " + config_file, config_file, regex=line_regex, create='no', state='absent')|indent }}}
+    {{{ ansible_lineinfile("Check for duplicate values", config_file, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True)|indent }}}
+    {{{ ansible_lineinfile("Deduplicate values from " + config_file, config_file, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
     {{{ ansible_stat("Check if " + config_dir + " exists", path=config_dir, register=dir_exists)|indent }}}
     {{{ ansible_find("Check if the parameter " + parameter + " is present in " + config_dir, paths=config_dir, contains=line_regex, register=dir_parameter, when=find_when)|indent }}}
     {{{ ansible_lineinfile("Remove parameter from files in " + config_dir, path="{{ item.path }}", regex=line_regex, state="absent", with_items=lineinfile_items, when=lineinfile_when)|indent }}}
@@ -352,7 +361,7 @@ The following macro remediates one audit watch rule in /etc/audit/audit.rules.
 The macro requires following parameters:
 - path: path to watch
 - permissions: permissions changes to watch for
-- key: key to use as identifier. 
+- key: key to use as identifier.
 #}}
 {{% macro ansible_audit_auditctl_add_watch_rule(path='', permissions='', key='') -%}}
 - name: Check if watch rule for {{{ path }}} already exists in /etc/audit/audit.rules


### PR DESCRIPTION
#### Description:

- Current ansible lineinfile macros do not support idempotent behavior when invoking the `ansible_only_lineinfile` macro.

#### Rationale:

- If we're using Ansible, might as well use it better. Ensure that the rules that use these macros provide the end-user with a better Ansible experience.
