### PR TITLE
Enable SELinux rules for RHEL9

### DIFF
--- a/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
+++ b/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9
+prodtype: rhel7
 
 title: 'Ensure SELinux support is enabled in Docker'
 

--- a/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
+++ b/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Ensure SELinux support is enabled in Docker'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Record Any Attempts to Run setsebool'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Ensure SELinux Not Disabled in zIPL'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_enable_selinux/rule.yml
@@ -19,7 +19,7 @@ severity: medium
 ocil_clause: 'SELinux is disabled at boot time'
 
 ocil: |-
-    To check that selinux is not disabled at boot time;
+    To check that SELinux is not disabled at boot time;
     Check that no boot entry disables selinux:
     <pre>sudo grep -L "^options\s+.*\bselinux=0\b" /boot/loader/entries/*.conf</pre>
     No line should be returned, each line returned is a boot entry that disables SELinux.

--- a/linux_os/guide/system/selinux/coreos_enable_selinux_kernel_argument/rule.yml
+++ b/linux_os/guide/system/selinux/coreos_enable_selinux_kernel_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure SELinux Not Disabled in the kernel arguments'
 

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure SELinux Not Disabled in /etc/default/grub'
 

--- a/linux_os/guide/system/selinux/package_libselinux_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,rhcos4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Install libselinux Package'
 

--- a/linux_os/guide/system/selinux/package_policycoreutils_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils_installed/rule.yml
@@ -19,8 +19,7 @@ rationale: |-
     <tt>policycoreutils</tt> contains the policy core utilities that are required for
     basic operation of an SELinux-enabled system. These utilities include <tt>load_policy</tt>
     to load SELinux policies, <tt>setfiles</tt> to label filesystems, <tt>newrole</tt> to
-    switch roles, and <tt>run_init</tt> to run <tt>/etc/init.d</tt> scripts in the proper
-    context.
+    switch roles, and so on.
 
 severity: high
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the abrt_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_handle_event/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_handle_event/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the abrt_handle_event SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_upload_watch_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_upload_watch_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the abrt_upload_watch_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_antivirus_can_scan_system/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_antivirus_can_scan_system/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the antivirus_can_scan_system SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_antivirus_use_jit/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_antivirus_use_jit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the antivirus_use_jit SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_auditadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_auditadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the auditadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_authlogin_nsswitch_use_ldap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_authlogin_nsswitch_use_ldap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the authlogin_nsswitch_use_ldap SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_authlogin_radius/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_authlogin_radius/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the authlogin_radius SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_authlogin_yubikey/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_authlogin_yubikey/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the authlogin_yubikey SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_awstats_purge_apache_log_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_awstats_purge_apache_log_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the awstats_purge_apache_log_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_boinc_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_boinc_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the boinc_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cdrecord_read_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cdrecord_read_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cdrecord_read_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cluster_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cluster_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cluster_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cluster_manage_all_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cluster_manage_all_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cluster_manage_all_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cluster_use_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cluster_use_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cluster_use_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cobbler_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cobbler_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cobbler_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cobbler_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cobbler_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_collectd_tcp_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_collectd_tcp_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the collectd_tcp_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_condor_tcp_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_condor_tcp_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the condor_tcp_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_conman_can_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_conman_can_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the conman_can_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_container_connect_any/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_container_connect_any/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the container_connect_any SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_can_relabel/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_can_relabel/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the cron_can_relabel SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_system_cronjob_use_shares/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_system_cronjob_use_shares/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the cron_system_cronjob_use_shares SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_userdomain_transition/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_userdomain_transition/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the cron_userdomain_transition SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cups_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cups_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cups_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cvs_read_shadow/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cvs_read_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the cvs_read_shadow SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_dump_core/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_dump_core/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the daemons_dump_core SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_enable_cluster_mode/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_enable_cluster_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the daemons_enable_cluster_mode SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tcp_wrapper/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tcp_wrapper/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the daemons_use_tcp_wrapper SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tty/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tty/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the daemons_use_tty SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_dbadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_dbadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the dbadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_dbadm_manage_user_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_dbadm_manage_user_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the dbadm_manage_user_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_dbadm_read_user_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_dbadm_read_user_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the dbadm_read_user_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the deny_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_ptrace/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_ptrace/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the deny_ptrace SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_dhcpc_exec_iptables/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_dhcpc_exec_iptables/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the dhcpc_exec_iptables SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_dhcpd_use_ldap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_dhcpd_use_ldap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the dhcpd_use_ldap SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_fd_use/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_fd_use/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the domain_fd_use SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_kernel_load_modules/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_kernel_load_modules/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the domain_kernel_load_modules SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_entropyd_use_audio/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_entropyd_use_audio/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the entropyd_use_audio SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_exim_can_connect_db/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_exim_can_connect_db/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the exim_can_connect_db SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_exim_manage_user_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_exim_manage_user_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the exim_manage_user_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_exim_read_user_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_exim_read_user_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the exim_read_user_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_fcron_crond/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_fcron_crond/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the fcron_crond SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_fenced_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_fenced_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the fenced_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_fenced_can_ssh/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_fenced_can_ssh/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the fenced_can_ssh SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_fips_mode/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_fips_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the fips_mode SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_connect_all_unreserved/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_connect_all_unreserved/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_connect_all_unreserved SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_connect_db/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_connect_db/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_connect_db SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_full_access/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_full_access/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_full_access SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_fusefs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_fusefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_use_fusefs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_passive_mode/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ftpd_use_passive_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ftpd_use_passive_mode SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_cgi_enable_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_cgi_enable_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_cgi_enable_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_cgi_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_cgi_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_cgi_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_cgi_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_cgi_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_cgi_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_session_bind_all_unreserved_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_session_bind_all_unreserved_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_session_bind_all_unreserved_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_session_users/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_session_users/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_session_users SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_system_enable_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_system_enable_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_system_enable_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_system_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_system_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_system_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_git_system_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_git_system_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the git_system_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_gitosis_can_sendmail/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_gitosis_can_sendmail/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the gitosis_can_sendmail SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_glance_api_can_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_glance_api_can_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the glance_api_can_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_glance_use_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_glance_use_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the glance_use_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_glance_use_fusefs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_glance_use_fusefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the glance_use_fusefs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_global_ssp/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_global_ssp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the global_ssp SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_gluster_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_gluster_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the gluster_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_gluster_export_all_ro/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_gluster_export_all_ro/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the gluster_export_all_ro SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_gluster_export_all_rw/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_gluster_export_all_rw/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Configure the gluster_export_all_rw SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_gpg_web_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_gpg_web_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the gpg_web_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_gssd_read_tmp/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_gssd_read_tmp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the gssd_read_tmp SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_guest_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_guest_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the guest_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_haproxy_connect_any/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_haproxy_connect_any/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the haproxy_connect_any SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_builtin_scripting/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_builtin_scripting/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Configure the httpd_builtin_scripting SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_check_spam/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_check_spam/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_check_spam SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_ftp/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_ftp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_connect_ftp SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_ldap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_ldap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_connect_ldap SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_mythtv/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_mythtv/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_connect_mythtv SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_zabbix/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_connect_zabbix/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_connect_zabbix SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_connect_cobbler/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_connect_cobbler/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_network_connect_cobbler SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_connect_db/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_connect_db/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_network_connect_db SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_memcache/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_memcache/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_network_memcache SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_relay/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_network_relay/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_network_relay SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_sendmail/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_can_sendmail/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_can_sendmail SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_dbus_avahi/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_dbus_avahi/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_dbus_avahi SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_dbus_sssd/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_dbus_sssd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_dbus_sssd SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_dontaudit_search_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_dontaudit_search_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_dontaudit_search_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_enable_cgi/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_enable_cgi/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Configure the httpd_enable_cgi SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_enable_ftp_server/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_enable_ftp_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_enable_ftp_server SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_enable_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_enable_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_enable_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_graceful_shutdown/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_graceful_shutdown/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the httpd_graceful_shutdown SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_manage_ipa/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_manage_ipa/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_manage_ipa SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_mod_auth_ntlm_winbind/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_mod_auth_ntlm_winbind/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_mod_auth_ntlm_winbind SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_mod_auth_pam/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_mod_auth_pam/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_mod_auth_pam SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_read_user_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_read_user_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_read_user_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_run_ipa/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_run_ipa/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_run_ipa SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_run_preupgrade/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_run_preupgrade/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_run_preupgrade SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_run_stickshift/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_run_stickshift/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_run_stickshift SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_serve_cobbler_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_serve_cobbler_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_serve_cobbler_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_setrlimit/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_setrlimit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_setrlimit SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_ssi_exec/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_ssi_exec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_ssi_exec SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_sys_script_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_sys_script_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_sys_script_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_tmp_exec/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_tmp_exec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_tmp_exec SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_tty_comm/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_tty_comm/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_tty_comm SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_unified/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_unified/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_unified SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_fusefs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_fusefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_use_fusefs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_gpg/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_gpg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_use_gpg SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_openstack/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_openstack/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_use_openstack SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_sasl/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_use_sasl/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_use_sasl SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_verify_dns/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_verify_dns/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the httpd_verify_dns SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_icecast_use_any_tcp_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_icecast_use_any_tcp_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the icecast_use_any_tcp_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_irc_use_any_tcp_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_irc_use_any_tcp_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the irc_use_any_tcp_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_irssi_use_full_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_irssi_use_full_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the irssi_use_full_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_kdumpgui_run_bootloader/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_kdumpgui_run_bootloader/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the kdumpgui_run_bootloader SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_kerberos_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_kerberos_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the kerberos_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ksmtuned_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ksmtuned_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ksmtuned_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ksmtuned_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ksmtuned_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the ksmtuned_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the logadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_can_sendmail/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_can_sendmail/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the logging_syslogd_can_sendmail SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_run_nagios_plugins/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_run_nagios_plugins/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the logging_syslogd_run_nagios_plugins SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_use_tty/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_use_tty/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the logging_syslogd_use_tty SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_login_console_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_login_console_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the login_console_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logrotate_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logrotate_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the logrotate_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logwatch_can_network_connect_mail/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logwatch_can_network_connect_mail/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the logwatch_can_network_connect_mail SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_lsmd_plugin_connect_any/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_lsmd_plugin_connect_any/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the lsmd_plugin_connect_any SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mailman_use_fusefs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mailman_use_fusefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mailman_use_fusefs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_client/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_client/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mcelog_client SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_exec_scripts/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_exec_scripts/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the mcelog_exec_scripts SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_foreground/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_foreground/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mcelog_foreground SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_server/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mcelog_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mcelog_server SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_minidlna_read_generic_user_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_minidlna_read_generic_user_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the minidlna_read_generic_user_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mmap_low_allowed/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mmap_low_allowed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the mmap_low_allowed SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mock_enable_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mock_enable_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the mock_enable_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mount_anyfile/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mount_anyfile/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the mount_anyfile SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_bind_unreserved_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_bind_unreserved_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mozilla_plugin_bind_unreserved_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mozilla_plugin_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_use_bluejeans/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_use_bluejeans/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mozilla_plugin_use_bluejeans SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_use_gps/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_use_gps/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mozilla_plugin_use_gps SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_use_spice/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_plugin_use_spice/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mozilla_plugin_use_spice SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_read_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mozilla_read_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mozilla_read_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mpd_enable_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mpd_enable_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mpd_enable_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mpd_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mpd_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mpd_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mpd_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mpd_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mpd_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mplayer_execstack/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mplayer_execstack/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mplayer_execstack SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mysql_connect_any/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mysql_connect_any/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the mysql_connect_any SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_nagios_run_pnp4nagios/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_nagios_run_pnp4nagios/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the nagios_run_pnp4nagios SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_nagios_run_sudo/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_nagios_run_sudo/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the nagios_run_sudo SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_named_tcp_bind_http_port/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_named_tcp_bind_http_port/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the named_tcp_bind_http_port SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_named_write_master_zones/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_named_write_master_zones/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the named_write_master_zones SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_neutron_can_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_neutron_can_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the neutron_can_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_nfs_export_all_ro/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_nfs_export_all_ro/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the nfs_export_all_ro SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_nfs_export_all_rw/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_nfs_export_all_rw/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the nfs_export_all_rw SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_nfsd_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_nfsd_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the nfsd_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_nis_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_nis_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the nis_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_nscd_use_shm/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_nscd_use_shm/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the nscd_use_shm SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_openshift_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_openshift_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the openshift_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_openvpn_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_openvpn_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the openvpn_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_openvpn_enable_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_openvpn_enable_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the openvpn_enable_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_openvpn_run_unconfined/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_openvpn_run_unconfined/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the openvpn_run_unconfined SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_pcp_bind_all_unreserved_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_pcp_bind_all_unreserved_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the pcp_bind_all_unreserved_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_pcp_read_generic_logs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_pcp_read_generic_logs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the pcp_read_generic_logs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_piranha_lvs_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_piranha_lvs_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the piranha_lvs_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_connect_all_unreserved/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_connect_all_unreserved/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the polipo_connect_all_unreserved SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_session_bind_all_unreserved_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_session_bind_all_unreserved_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the polipo_session_bind_all_unreserved_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_session_users/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_session_users/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the polipo_session_users SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_use_cifs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_use_cifs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the polipo_use_cifs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polipo_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the polipo_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polyinstantiation_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polyinstantiation_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the polyinstantiation_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_postfix_local_write_mail_spool/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_postfix_local_write_mail_spool/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the postfix_local_write_mail_spool SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_can_rsync/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_can_rsync/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the postgresql_can_rsync SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_selinux_transmit_client_label/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_selinux_transmit_client_label/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the postgresql_selinux_transmit_client_label SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_selinux_unconfined_dbadm/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_selinux_unconfined_dbadm/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the postgresql_selinux_unconfined_dbadm SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_selinux_users_ddl/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_postgresql_selinux_users_ddl/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the postgresql_selinux_users_ddl SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_pppd_can_insmod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_pppd_can_insmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the pppd_can_insmod SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_pppd_for_user/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_pppd_for_user/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the pppd_for_user SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_privoxy_connect_any/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_privoxy_connect_any/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the privoxy_connect_any SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_prosody_bind_http_port/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_prosody_bind_http_port/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the prosody_bind_http_port SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_puppetagent_manage_all_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_puppetagent_manage_all_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the puppetagent_manage_all_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_puppetmaster_use_db/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_puppetmaster_use_db/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the puppetmaster_use_db SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_racoon_read_shadow/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_racoon_read_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the racoon_read_shadow SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the rsync_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_client/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_client/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the rsync_client SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_export_all_ro/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_export_all_ro/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the rsync_export_all_ro SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_full_access/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_rsync_full_access/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the rsync_full_access SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_create_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_create_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_create_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_domain_controller/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_domain_controller/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_domain_controller SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_enable_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_enable_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_enable_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_export_all_ro/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_export_all_ro/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_export_all_ro SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_export_all_rw/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_export_all_rw/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_export_all_rw SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_load_libgfapi/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_load_libgfapi/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_load_libgfapi SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_portmapper/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_portmapper/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_portmapper SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_run_unconfined/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_run_unconfined/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_run_unconfined SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_share_fusefs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_share_fusefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_share_fusefs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_share_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_samba_share_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the samba_share_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_sanlock_use_fusefs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_sanlock_use_fusefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the sanlock_use_fusefs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_sanlock_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_sanlock_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the sanlock_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_sanlock_use_samba/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_sanlock_use_samba/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the sanlock_use_samba SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_saslauthd_read_shadow/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_saslauthd_read_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the saslauthd_read_shadow SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the secadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the secure_mode SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the secure_mode_insmod SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_policyload/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_policyload/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the secure_mode_policyload SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_direct_dri_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_direct_dri_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Configure the selinuxuser_direct_dri_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_execheap SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execmod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the selinuxuser_execmod SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'disable the selinuxuser_execstack SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_mysql_connect_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_mysql_connect_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_mysql_connect_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_ping/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_ping/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the selinuxuser_ping SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_postgresql_connect_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_postgresql_connect_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_postgresql_connect_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_rw_noexattrfile/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_rw_noexattrfile/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_rw_noexattrfile SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_share_music/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_share_music/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_share_music SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_tcp_server/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_tcp_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_tcp_server SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_udp_server/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_udp_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_udp_server SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_use_ssh_chroot/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_use_ssh_chroot/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_use_ssh_chroot SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_sge_domain_can_network_connect/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_sge_domain_can_network_connect/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the sge_domain_can_network_connect SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_sge_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_sge_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the sge_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_smartmon_3ware/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_smartmon_3ware/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the smartmon_3ware SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_smbd_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_smbd_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the smbd_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_spamassassin_can_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_spamassassin_can_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the spamassassin_can_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_spamd_enable_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_spamd_enable_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the spamd_enable_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_squid_connect_any/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_squid_connect_any/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the squid_connect_any SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_squid_use_tproxy/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_squid_use_tproxy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the squid_use_tproxy SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_chroot_rw_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_chroot_rw_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the ssh_chroot_rw_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_keysign/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the ssh_keysign SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_sysadm_login/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_sysadm_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the ssh_sysadm_login SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_staff_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_staff_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the staff_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_staff_use_svirt/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_staff_use_svirt/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the staff_use_svirt SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_swift_can_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_swift_can_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the swift_can_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_sysadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_sysadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the sysadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_telepathy_connect_all_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_telepathy_connect_all_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the telepathy_connect_all_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_telepathy_tcp_connect_generic_network_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_telepathy_tcp_connect_generic_network_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the telepathy_tcp_connect_generic_network_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_tftp_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_tftp_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the tftp_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_tftp_home_dir/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_tftp_home_dir/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the tftp_home_dir SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_tmpreaper_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_tmpreaper_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the tmpreaper_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_tmpreaper_use_samba/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_tmpreaper_use_samba/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the tmpreaper_use_samba SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_tor_bind_all_unreserved_ports/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_tor_bind_all_unreserved_ports/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the tor_bind_all_unreserved_ports SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_tor_can_network_relay/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_tor_can_network_relay/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the tor_can_network_relay SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_chrome_sandbox_transition/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_chrome_sandbox_transition/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the unconfined_chrome_sandbox_transition SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_login/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the unconfined_login SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_mozilla_plugin_transition/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_mozilla_plugin_transition/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the unconfined_mozilla_plugin_transition SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_unprivuser_use_svirt/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_unprivuser_use_svirt/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the unprivuser_use_svirt SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_use_ecryptfs_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_use_ecryptfs_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the use_ecryptfs_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_use_fusefs_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_use_fusefs_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the use_fusefs_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_use_lpd_server/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_use_lpd_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the use_lpd_server SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_use_nfs_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_use_nfs_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the use_nfs_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_use_samba_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_use_samba_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the use_samba_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_user_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_user_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the user_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_varnishd_connect_any/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_varnishd_connect_any/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the varnishd_connect_any SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_read_qemu_ga_data/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_read_qemu_ga_data/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_read_qemu_ga_data SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_rw_qemu_ga_data/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_rw_qemu_ga_data/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_rw_qemu_ga_data SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_all_caps/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_all_caps/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_sandbox_use_all_caps SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_audit/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the virt_sandbox_use_audit SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_mknod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_mknod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_sandbox_use_mknod SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_netlink/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_netlink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_sandbox_use_netlink SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_sys_admin/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_sandbox_use_sys_admin/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_sandbox_use_sys_admin SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_transition_userdomain/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_transition_userdomain/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_transition_userdomain SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_comm/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_comm/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_comm SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_fusefs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_fusefs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_fusefs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_rawip/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_rawip/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_rawip SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_samba/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_samba/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_samba SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_sanlock/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_sanlock/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_sanlock SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_usb/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_usb/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_usb SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_xserver/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_virt_use_xserver/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the virt_use_xserver SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_webadm_manage_user_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_webadm_manage_user_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the webadm_manage_user_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_webadm_read_user_files/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_webadm_read_user_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the webadm_read_user_files SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_wine_mmap_zero_ignore/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_wine_mmap_zero_ignore/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the wine_mmap_zero_ignore SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_bind_vnc_tcp_port/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_bind_vnc_tcp_port/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_bind_vnc_tcp_port SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_exec_bootloader/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_exec_bootloader/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_exec_bootloader SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_sysadm_login/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_sysadm_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_sysadm_login SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_write_home/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_write_home/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_write_home SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xen_use_nfs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xen_use_nfs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the xen_use_nfs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xend_run_blktap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xend_run_blktap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the xend_run_blktap SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xend_run_qemu/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xend_run_qemu/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Enable the xend_run_qemu SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_connect_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_connect_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_connect_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_mount_media/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_mount_media/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_mount_media SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_use_bluetooth/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_use_bluetooth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_use_bluetooth SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_clients_write_xshm/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_clients_write_xshm/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xserver_clients_write_xshm SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xserver_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_object_manager/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_object_manager/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xserver_object_manager SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_zabbix_can_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_zabbix_can_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the zabbix_can_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_zarafa_setrlimit/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_zarafa_setrlimit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the zarafa_setrlimit SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_zebra_write_config/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_zebra_write_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the zebra_write_config SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_zoneminder_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_zoneminder_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the zoneminder_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_zoneminder_run_sudo/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_zoneminder_run_sudo/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8
+prodtype: rhel7,rhel8,rhel9
 
 title: 'Disable the zoneminder_run_sudo SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure No Device Files are Unlabeled by SELinux'
 

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure No Daemons are Unconfined by SELinux'
 

--- a/linux_os/guide/system/selinux/selinux_policytype/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_policytype/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Configure SELinux Policy'
 

--- a/linux_os/guide/system/selinux/selinux_user_login_roles/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_user_login_roles/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Map System Users To The Appropriate SELinux Role'
 


### PR DESCRIPTION
There were no changes in SELinux that would affect our rules, and SELinux booleans also remain the same.

There were just small fixes in the rule description.