### PR TITLE
Enable RHEL9 for kernel-related rules

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Configure Accepting Router Advertisements on All IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_defrtr/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_defrtr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Accepting Default Router in Router Advertisements on All IPv6 Interfaces
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_pinfo/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_pinfo/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Accepting Prefix Information in Router Advertisements on All IPv6 Interfaces
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_rtr_pref/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_rtr_pref/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Accepting Router Preference in Router Advertisements on All IPv6 Interfaces
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable Accepting ICMP Redirects for All IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_autoconf/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_autoconf/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Auto Configuration on All IPv6 Interfaces
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable Kernel Parameter for IPv6 Forwarding'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_max_addresses/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_max_addresses/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Maximum Number of Autoconfigured Addresses on All IPv6 Interfaces
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_router_solicitations/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_router_solicitations/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Configure Denying Router Solicitations on All IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable Accepting Router Advertisements on all IPv6 Interfaces by Default'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_defrtr/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_defrtr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Accepting Default Router in Router Advertisements on All IPv6 Interfaces By Default
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_pinfo/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_pinfo/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Accepting Prefix Information in Router Advertisements on All IPv6 Interfaces By Default
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_rtr_pref/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_rtr_pref/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Accepting Router Preference in Router Advertisements on All IPv6 Interfaces By Default
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv6 Interfaces'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on IPv6 Interfaces by Default'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_autoconf/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_autoconf/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Auto Configuration on All IPv6 Interfaces By Default
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_max_addresses/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_max_addresses/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: Configure Maximum Number of Autoconfigured Addresses on All IPv6 Interfaces By Default
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_router_solicitations/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_router_solicitations/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Configure Denying Router Solicitations on All IPv6 Interfaces By Default'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Accepting ICMP Redirects for All IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable Kernel Parameter to Log Martian Packets on all IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable Kernel Parameter for Accepting Secure ICMP Redirects on all IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on IPv4 Interfaces by Default'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable Kernel Paremeter to Log Martian Packets on all IPv4 Interfaces by Default'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces by Default'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Configure Kernel Parameter for Accepting Secure Redirects By Default'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Enable Kernel Parameter to Ignore ICMP Broadcast Echo Requests on IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable Kernel Parameter to Ignore Bogus ICMP Error Responses on IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Set Kernel Parameter to Increase Local Port Range'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,sle15,wrlinux1019
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,wrlinux1019
 
 title: 'Configure Kernel to Rate Limit Sending of Duplicate TCP Acknowledgments'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_rfc1337/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_rfc1337/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Enable Kernel Parameter to Use TCP RFC 1337 on IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Enable Kernel Parameter to Use TCP Syncookies on IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces by Default'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019,rhcos4,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Kernel Parameter for IP Forwarding on IPv4 Interfaces'
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel7,rhel8
+prodtype: fedora,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Disable ATM Support'
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel7,rhel8
+prodtype: fedora,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Disable CAN Support'
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Disable DCCP Support'
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel7,rhel8
+prodtype: fedora,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Disable IEEE 1394 (FireWire) Support'
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable SCTP Support'
 

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable Bluetooth Kernel Module'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15,ubuntu1804
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of cramfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhv4,sle15,ubuntu1804
+prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of freevxfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhv4,sle15,ubuntu1804
+prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of hfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhv4,sle15,ubuntu1804
+prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of hfsplus'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhv4,sle15,ubuntu1804
+prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804
 
 title: 'Disable Mounting of jffs2'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,sle15
+prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable Mounting of squashfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,sle15,ubuntu1804
+prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,sle15,ubuntu1804
 
 title: 'Disable Mounting of udf'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable Modprobe Loading of USB Storage Driver'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable Mounting of vFAT filesystems'
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhv4
+prodtype: fedora,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable ExecShield via sysctl'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Disable storing core dumps'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Restrict Access to Kernel Message Buffer'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Disable Kernel Image Loading'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable loading and unloading of kernel modules'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Limit CPU consumption of the Perf system'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Limit sampling frequency of the Perf system'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Disallow kernel profiling by unprivileged users'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Configure maximum number of process identifiers'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_sysrq/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_sysrq/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disallow magic SysRq key'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Disable Access to Network bpf() Syscall From Unprivileged Processes'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
 
 title: 'Restrict usage of ptrace to descendant processes'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Harden the operation of the BPF just-in-time compiler'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Disable the use of user namespaces'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_vm_mmap_min_addr/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_vm_mmap_min_addr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Prevent applications from mapping low portion of virtual memory'
 

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8,rhv4
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9,rhv4
 
 title: "Set kernel parameter 'crypto.fips_enabled' to 1"
 


### PR DESCRIPTION
No sysctl variables were deprecated.
Rules for kernel modules are about disabling them, so there is little reason not to enable them for RHEL9 as well. Besides that, all modules are relevant, except the `dccp` and `freevxfs` ones.