### PR TITLE
Remove `package_gssproxy_removed` from STIG GUI profile

### DIFF
--- a/rhel8/profiles/stig_gui.profile
+++ b/rhel8/profiles/stig_gui.profile
@@ -34,3 +34,7 @@ extends: stig
 selections:
     # RHEL-08-040320
     - '!xwindows_remove_packages'
+
+    # RHEL-08-040370
+    # conflicts with nfs-utils package required by GUI installations
+    - '!package_gssproxy_removed'

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -1,6 +1,6 @@
 description: 'This profile contains configuration checks that align to the
 
-    DISA STIG with GUI for Red Hat Enterprise Linux 8 V1R1.
+    DISA STIG with GUI for Red Hat Enterprise Linux 8 V1R2.
 
 
     In addition to being applicable to Red Hat Enterprise Linux 8, DISA recognizes
@@ -199,7 +199,6 @@ selections:
 - package_audit_installed
 - package_fapolicyd_installed
 - package_firewalld_installed
-- package_gssproxy_removed
 - package_iprutils_removed
 - package_krb5-workstation_removed
 - package_opensc_installed


### PR DESCRIPTION
#### Description:
- Remove `package_gssproxy_removed` from STIG GUI profile.


#### Rationale:

- It conflicts with nfs-utils which is included in GUI installations.
- Fixes #6899
