### PR TITLE
Check libpam-runtime on Ubuntu

### DIFF
--- a/debian10/product.yml
+++ b/debian10/product.yml
@@ -20,3 +20,4 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   net-snmp: "snmp"
+  pam: libpam-runtime

--- a/debian9/product.yml
+++ b/debian9/product.yml
@@ -20,3 +20,4 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   net-snmp: "snmp"
+  pam: libpam-runtime

--- a/shared/checks/oval/installed_env_has_pam_package.xml
+++ b/shared/checks/oval/installed_env_has_pam_package.xml
@@ -31,7 +31,7 @@
     <linux:object object_ref="obj_env_has_pam_installed" />
   </linux:dpkginfo_test>
   <linux:dpkginfo_object id="obj_env_has_pam_installed" version="1">
-    <linux:name>pam</linux:name>
+    <linux:name>libpam-runtime</linux:name>
   </linux:dpkginfo_object>
 {{% endif %}}
 

--- a/ubuntu1604/product.yml
+++ b/ubuntu1604/product.yml
@@ -17,3 +17,6 @@ cpes:
       name: "cpe:/o:canonical:ubuntu_linux:16.04::~~lts~~~"
       title: "Ubuntu release 16.04 (Xenial)"
       check_id: installed_OS_is_ubuntu1604
+
+platform_package_overrides:
+  pam: libpam-runtime

--- a/ubuntu1804/product.yml
+++ b/ubuntu1804/product.yml
@@ -16,3 +16,6 @@ cpes:
       name: "cpe:/o:canonical:ubuntu_linux:18.04::~~lts~~~"
       title: "Ubuntu release 18.04 (Bionic Beaver)"
       check_id: installed_OS_is_ubuntu1804
+
+platform_package_overrides:
+  pam: libpam-runtime

--- a/ubuntu2004/product.yml
+++ b/ubuntu2004/product.yml
@@ -16,3 +16,6 @@ cpes:
       name: "cpe:/o:canonical:ubuntu_linux:20.04::~~lts~~~"
       title: "Ubuntu release 20.04 (Focal Fossa)"
       check_id: installed_OS_is_ubuntu2004
+
+platform_package_overrides:
+  pam: libpam-runtime


### PR DESCRIPTION
On Debian-based systems, the `pam` package doesn't exist as a binary
package. `libpam-runtime` is the equivalent, depending on `libpam0g` which
provides the actual binaries. Many packages depend on `libpam-runtime`,
making it the preferred package to check for.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

/cc @richardmaciel-canonical