### PR TITLE
Fix groupowner/permissions for ubuntu2004

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -38,4 +38,5 @@ template:
         filegid@debian10: '42'
         filegid@ubuntu1604: '42'
         filegid@ubuntu1804: '42'
+        filegid@ubuntu2004: '42'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
@@ -39,4 +39,5 @@ template:
         filegid@debian10: '42'
         filegid@ubuntu1604: '42'
         filegid@ubuntu1804: '42'
+        filegid@ubuntu2004: '42'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
@@ -42,4 +42,5 @@ template:
         filemode@debian10: '0640'
         filemode@ubuntu1604: '0640'
         filemode@ubuntu1804: '0640'
+        filemode@ubuntu2004: '0640'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -43,4 +43,5 @@ template:
         filemode@debian10: '0640'
         filemode@ubuntu1604: '0640'
         filemode@ubuntu1804: '0640'
+        filemode@ubuntu2004: '0640'
         missing_file_pass: 'true'


### PR DESCRIPTION
These rules lacked identifiers for Ubuntu 20.04 but were provided for
other releases. These identifiers are still valid, so bring them forward.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

/cc @richardmaciel-canonical