### PR TITLE
Add rule for SLES-15-010354

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/ansible/shared.yml
@@ -1,0 +1,23 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = medium
+# disruption = medium
+- name: "Read list libraries without root ownership"
+  find:
+    paths:
+      - "/usr/lib"
+      - "/usr/lib64"
+      - "/lib"
+      - "/lib64"
+    file_type: "directory"
+  register: library_dirs_not_owned_by_root
+
+- name: "Set ownership of system library dirs to root"
+  file:
+    path: "{{ item.path }}"
+    owner: "root"
+    state: "directory"
+    mode: "{{ item.mode }}"
+  with_items: "{{ library_dirs_not_owned_by_root.files }}"
+  when: library_dirs_not_owned_by_root.matched > 0

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/oval/shared.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="dir_ownership_library_dirs" version="1">
+    {{{ oval_metadata("
+        Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and
+        directories therein, are owned by root.
+      ") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_dir_ownership_lib_dir" />
+    </criteria>
+  </definition>
+
+  <unix:file_test  check="all" check_existence="none_exist" comment="library directories uid root" id="test_dir_ownership_lib_dir" version="1">
+    <unix:object object_ref="object_dir_ownership_lib_dir" />
+  </unix:file_test>
+
+
+  <unix:file_object comment="library directories" id="object_dir_ownership_lib_dir" version="1">
+    <!-- Check that /lib, /lib64, /usr/lib, and /usr/lib64 directories belong to user with uid 0 (root) -->
+    <unix:path operation="pattern match">^\/lib(|64)\/|^\/usr\/lib(|64)\/</unix:path>
+    <unix:filename xsi:nil="true" />
+    <filter action="include">state_owner_library_dirs_not_root</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_owner_library_dirs_not_root" version="1">
+    <unix:user_id datatype="int" operation="not equal">0</unix:user_id>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
@@ -1,0 +1,48 @@
+documentation_complete: true
+
+title: 'Verify that Shared Library Directories Have Root Ownership'
+
+description: |-
+    System-wide shared library files, which are linked to executables
+    during process load time or run time, are stored in the following directories
+    by default:
+    <pre>/lib
+    /lib64
+    /usr/lib
+    /usr/lib64
+    </pre>
+    Kernel modules, which can be added to the kernel during runtime, are also
+    stored in <tt>/lib/modules</tt>. All files in these directories should be
+    owned by the <tt>root</tt> user. If the  directories, is found to be owned
+    by a user other than root correct its
+    ownership with the following command:
+    <pre>$ sudo chown root <i>DIR</i></pre>
+
+rationale: |-
+    Files from shared library directories are loaded into the address
+    space of processes (including privileged ones) or of the kernel itself at
+    runtime. Proper ownership of library directories is necessary to protect
+    the integrity of the system.
+
+severity: medium
+
+identifiers:
+    cce@sle15: CCE-85735-9
+
+references:
+    nist: CM-5(6),CM-5(6).1
+    srg: SRG-OS-000259-GPOS-00100
+    stigid@sle15: SLES-15-010353
+    disa: CCI-001499
+
+ocil_clause: 'any of these directories are not owned by root'
+
+ocil: |-
+    Shared libraries are stored in the following directories:
+    <pre>/lib
+    /lib64
+    /usr/lib
+    /usr/lib64</pre>
+    For each of these directories, run the following command to find files not
+    owned by root:
+    <pre>$ sudo find -L <i>$DIR</i> ! -user root -type d -exec chown root {} \;</pre>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/all_dirs_ok.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/all_dirs_ok.pass.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+DIRS="/lib /lib64 /usr/lib /usr/lib64"
+for dirPath in $DIRS; do
+	find "$dirPath" -type d -exec chown root '{}' \;
+done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/nobody_owned_dir_on_lib.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/nobody_owned_dir_on_lib.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+DIRS="/lib /lib64"
+for dirPath in $DIRS; do
+	mkdir -p "$dirPath/testme" && chown nobody:nogroup "$dirPath/testme"
+done

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -154,6 +154,7 @@ selections:
     - dconf_gnome_login_banner_text
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_mode_blank
+    - dir_ownership_library_dirs
     - dir_permissions_library_dirs
     - dir_perms_world_writable_sticky_bits
     - dir_perms_world_writable_system_owned_group


### PR DESCRIPTION
#### Description:

- Add rule to 'Verify that Shared Library Directories Have Root Ownership'
#### Rationale:

The rule is like a special case of file_ownership_library_dirs, which is checking both files and directories

This one checks only directories.
- Add oval check for directories containing system library files having correct ownership
- Add ansible remediation based on combination of find and file modules in order to avoid lint warnings for file permissions when using find shell command and have no previous knowledge on the directories permission modes
- Add couple of tests to verify pass and fail behaviour
- Add rule for SLES-15-010354 to stig profile