### PR TITLE
Fix grub2's /boot location for Debian, Ubuntu

### DIFF
--- a/debian10/product.yml
+++ b/debian10/product.yml
@@ -10,6 +10,8 @@ pkg_manager: "apt_get"
 
 init_system: "systemd"
 
+grub2_boot_path: "/boot/grub"
+
 cpes_root: "../shared/applicability"
 cpes:
   - debian10:

--- a/debian9/product.yml
+++ b/debian9/product.yml
@@ -10,6 +10,8 @@ pkg_manager: "apt_get"
 
 init_system: "systemd"
 
+grub2_boot_path: "/boot/grub"
+
 cpes_root: "../shared/applicability"
 cpes:
   - debian9:

--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -13,7 +13,7 @@ description: |-
     <pre>GRUB_CMDLINE_LINUX="... audit=1 ..."</pre>
     In case the <tt>GRUB_DISABLE_RECOVERY</tt> is set to true, then the parameter should be added to the <tt>GRUB_CMDLINE_LINUX_DEFAULT</tt> instead.
 {{% else %}}
-    <tt>/boot/grub2/grubenv</tt>, in the manner below:
+    <tt>{{{ grub2_boot_path }}}/grubenv</tt>, in the manner below:
     <pre># grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) audit=1"</pre>
 {{% endif %}}
 
@@ -62,9 +62,9 @@ ocil: |-
     If the recovery is disabled, check the line with
     <pre>$ grep 'GRUB_CMDLINE_LINUX.*audit=1.*' /etc/default/grub</pre>.
     Moreover, current Grub2 config file in <tt>/etc/grub2/grub.cfg</tt> must be checked.
-    <pre># grep vmlinuz /boot/grub2/grub.cfg | grep -v 'audit=1'</pre>
+    <pre># grep vmlinuz {{{ grub2_boot_path }}}/grub.cfg | grep -v 'audit=1'</pre>
     This command should not return any output. If it does, update the configuration with
-    <pre># grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre># grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
     <br /><br />
     Alternatively, to ensure <tt>audit=1</tt> is configured on all installed kernels, the
     following command may be used:
@@ -73,9 +73,9 @@ ocil: |-
     <br />
 {{% else %}}
     Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/boot/grub2/grubenv</tt>. If they include <tt>audit=1</tt>, then auditing
+    in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. If they include <tt>audit=1</tt>, then auditing
     is enabled at boot time.
-    <pre># grep 'kernelopts.*audit=1.*' /boot/grub2/grubenv</pre>
+    <pre># grep 'kernelopts.*audit=1.*' {{{ grub2_boot_path }}}/grubenv</pre>
     <br /><br />
     To ensure <tt>audit=1</tt> is configured on all installed kernels, the
     following command may be used:
@@ -94,7 +94,7 @@ warnings:
         <pre>grub2-mkconfig -o</pre> command as follows:
         <ul>
         <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
 {{% if product in ["rhel7", "ol7", "rhel8", "ol8"] %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -52,7 +52,7 @@ warnings:
         <pre>grub2-mkconfig -o</pre> command as follows:
         <ul>
         <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
 {{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
@@ -30,7 +30,7 @@
   </ind:textfilecontent54_object>
 
 <ind:textfilecontent54_test id="test_trust_cpu_rng_boot_param_off"
-  comment="check forkernel command line parameters random.trust_cpu=off in /boot/grub2/grubenv for all kernels"
+  comment="check forkernel command line parameters random.trust_cpu=off in {{{ grub2_boot_path }}}/grubenv for all kernels"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_trust_cpu_rng_boot_param" />
     <ind:state state_ref="state_trust_cpu_rng_boot_param_off" />
@@ -38,7 +38,7 @@
 
 
   <ind:textfilecontent54_test id="test_trust_cpu_rng_boot_param_on"
-  comment="check forkernel command line parameters random.trust_cpu=on in /boot/grub2/grubenv for all kernels"
+  comment="check forkernel command line parameters random.trust_cpu=on in {{{ grub2_boot_path }}}/grubenv for all kernels"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_trust_cpu_rng_boot_param" />
     <ind:state state_ref="state_trust_cpu_rng_boot_param_on" />
@@ -46,7 +46,7 @@
 
   <ind:textfilecontent54_object id="object_trust_cpu_rng_boot_param"
   version="1">
-    <ind:filepath>/boot/grub2/grubenv</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grubenv</ind:filepath>
     <ind:pattern operation="pattern match">^kernelopts=(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
@@ -41,11 +41,11 @@ ocil: |-
     <pre>CONFIG_RANDOM_TRUST_CPU=y</pre>,
     it means that the option is compiled into the kernel. Make sure that the
     option is not overridden through a boot parameter:
-    <pre>sudo grep 'kernelopts.*random\.trust_cpu=off.*' /boot/grub2/grubenv</pre>
+    <pre>sudo grep 'kernelopts.*random\.trust_cpu=off.*' {{{ grub2_boot_path }}}/grubenv</pre>
     The command should not return any output. If the option is not compiled into
     the kernel, check that the option is configured through boot parameter with
     the following command:
-    <pre>sudo grep 'kernelopts.*random\.trust_cpu=on.*' /boot/grub2/grubenv</pre>
+    <pre>sudo grep 'kernelopts.*random\.trust_cpu=on.*' {{{ grub2_boot_path }}}/grubenv</pre>
     If the command does not return any output, then the boot parameter is
     missing.
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -50,7 +50,7 @@ warnings:
         <pre>grub2-mkconfig -o</pre> command as follows:
         <ul>
         <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
 {{% if product in ["rhel8", "ol8"] %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -49,7 +49,7 @@ warnings:
         <pre>grub2-mkconfig -o</pre> command as follows:
         <ul>
         <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
 {{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15
 
-title: 'Verify /boot/grub2/grub.cfg Group Ownership'
+title: 'Verify {{{ grub2_boot_path }}}/grub.cfg Group Ownership'
 
 description: |-
-    The file <tt>/boot/grub2/grub.cfg</tt> should
+    The file <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> should
     be group-owned by the <tt>root</tt> group to prevent
     destruction or modification of the file.
-    {{{ describe_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}
+    {{{ describe_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}
 
 rationale: |-
     The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
@@ -36,15 +36,15 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 12,13,14,15,16,18,3,5
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/boot/grub2/grub.cfg", group="root") }}}
+    {{{ ocil_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}
 
 platform: machine
 
 template:
     name: file_groupowner
     vars:
-        filepath: /boot/grub2/grub.cfg
+        filepath: {{{ grub2_boot_path }}}/grub.cfg
         filegid: '0'

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15
 
-title: 'Verify /boot/grub2/grub.cfg User Ownership'
+title: 'Verify {{{ grub2_boot_path }}}/grub.cfg User Ownership'
 
 description: |-
-    The file <tt>/boot/grub2/grub.cfg</tt> should
+    The file <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> should
     be owned by the <tt>root</tt> user to prevent destruction
     or modification of the file.
-    {{{ describe_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}
+    {{{ describe_file_owner(file="{{{ grub2_boot_path }}}/grub.cfg", owner="root") }}}
 
 rationale: 'Only root should be able to modify important boot parameters.'
 
@@ -34,15 +34,15 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 12,13,14,15,16,18,3,5
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="{{{ grub2_boot_path }}}/grub.cfg", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/boot/grub2/grub.cfg", owner="root") }}}
+    {{{ ocil_file_owner(file="{{{ grub2_boot_path }}}/grub.cfg", owner="root") }}}
 
 platform: machine
 
 template:
     name: file_owner
     vars:
-        filepath: /boot/grub2/grub.cfg
+        filepath: {{{ grub2_boot_path }}}/grub.cfg
         fileuid: '0'

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -2,11 +2,11 @@ documentation_complete: true
 
 prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
-title: 'Verify /boot/grub2/grub.cfg Permissions'
+title: 'Verify {{{ grub2_boot_path }}}/grub.cfg Permissions'
 
 description: |-
-    File permissions for <tt>/boot/grub2/grub.cfg</tt> should be set to 600.
-    {{{ describe_file_permissions(file="/boot/grub2/grub.cfg", perms="600") }}}
+    File permissions for <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> should be set to 600.
+    {{{ describe_file_permissions(file="{{{ grub2_boot_path }}}/grub.cfg", perms="600") }}}
 
 rationale: |-
     Proper permissions ensure that only the root user can modify important boot
@@ -35,8 +35,8 @@ references:
 ocil_clause: 'it does not'
 
 ocil: |-
-    To check the permissions of /boot/grub2/grub.cfg, run the command:
-    <pre>$ sudo ls -lL /boot/grub2/grub.cfg</pre>
+    To check the permissions of {{{ grub2_boot_path }}}/grub.cfg, run the command:
+    <pre>$ sudo ls -lL {{{ grub2_boot_path }}}/grub.cfg</pre>
     If properly configured, the output should indicate the following
     permissions: <tt>-rw-------</tt>
 
@@ -45,5 +45,5 @@ platform: machine
 template:
     name: file_permissions
     vars:
-        filepath: /boot/grub2/grub.cfg
+        filepath: {{{ grub2_boot_path }}}/grub.cfg
         filemode: '0600'

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
@@ -3,18 +3,18 @@
     {{{ oval_metadata("The grub2 boot loader superuser should have a username that is hard to guess.") }}}
 
     <criteria operator="OR">
-      {{{ oval_file_absent_criterion("/boot/grub2/grub.cfg") }}}
-      <criterion comment="Superuser is defined in /boot/grub2/grub.cfg and it isn't root, admin, or administrator." test_ref="test_bootloader_unique_superuser"/>
+      {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
+      <criterion comment="Superuser is defined in {{{ grub2_boot_path }}}/grub.cfg and it isn't root, admin, or administrator." test_ref="test_bootloader_unique_superuser"/>
     </criteria>
   </definition>
 
-  {{{ oval_file_absent("/boot/grub2/grub.cfg") }}}
+  {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /boot/grub2/grub.cfg files. Superuser is not root, admin, or administrator" id="test_bootloader_unique_superuser" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_boot_path }}}/grub.cfg files. Superuser is not root, admin, or administrator" id="test_bootloader_unique_superuser" version="1">
     <ind:object object_ref="object_bootloader_unique_superuser" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_unique_superuser" version="1">
-    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers="(?i)(?!root|admin|administrator)(?-i).*"$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
@@ -20,7 +20,7 @@ description: |-
     Once the superuser account has been added,
     update the
     <tt>grub.cfg</tt> file by running:
-    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
 
 rationale: |-
     Having a non-default grub superuser username makes password-guessing attacks less effective.

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/oval/shared.xml
@@ -1,1 +1,1 @@
-{{{ oval_check_config_file(path='/boot/grub2/grub.cfg', prefix_regex='^[ \\t]*', parameter='set root', separator_regex='=', value="['|\(](?!fd)(?!cd)(?!usb).*['|\)]", missing_parameter_pass=false, missing_config_file_fail=true) }}}
+{{{ oval_check_config_file(path=grub2_boot_path + '/grub.cfg', prefix_regex='^[ \\t]*', parameter='set root', separator_regex='=', value="['|\(](?!fd)(?!cd)(?!usb).*['|\)]", missing_parameter_pass=false, missing_config_file_fail=true) }}}

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/rule.yml
@@ -31,7 +31,7 @@ ocil_clause: 'it is not'
 ocil: |-
     To verify the system is not configured to use a boot loader on removable media,
     run the following command:
-    <pre>$ sudo grep "set root='hd0" /boot/grub2/grub.cfg</pre>
+    <pre>$ sudo grep "set root='hd0" {{{ grub2_boot_path }}}/grub.cfg</pre>
     The output should return something similar to:
     <pre>set root='hd0,msdos1'</pre>
     <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
@@ -1,45 +1,44 @@
-{{% set grub_cfg_prefix = "/boot/grub2" %}}
 <def-group>
   <definition class="compliance" id="grub2_password" version="1">
     {{{ oval_metadata("The grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
-      {{{ oval_file_absent_criterion(grub_cfg_prefix + "/grub.cfg") }}}
+      {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
       <criteria operator="AND">
         <criteria comment="check both files to account for procedure change in documenation" operator="OR">
-          <criterion comment="make sure a password is defined in /boot/grub2/user.cfg" test_ref="test_grub2_password_usercfg" />
-          <criterion comment="make sure a password is defined in /boot/grub2/grub.cfg" test_ref="test_grub2_password_grubcfg" />
+          <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
+          <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/grub.cfg" test_ref="test_grub2_password_grubcfg" />
         </criteria>
-        <criterion comment="make sure a superuser is defined in /boot/grub2/grub.cfg" test_ref="test_bootloader_superuser"/>
+        <criterion comment="make sure a superuser is defined in {{{ grub2_boot_path }}}/grub.cfg" test_ref="test_bootloader_superuser"/>
       </criteria>
     </criteria>
   </definition>
 
-  {{{ oval_file_absent(grub_cfg_prefix + "/grub.cfg") }}}
+  {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in /boot/grub2/grub.cfg files." id="test_bootloader_superuser" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_boot_path }}}/grub.cfg files." id="test_bootloader_superuser" version="2">
     <ind:object object_ref="object_bootloader_superuser" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_superuser" version="2">
-    <ind:filepath>{{{ grub_cfg_prefix }}}/grub.cfg</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/user.cfg" id="test_grub2_password_usercfg" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" id="test_grub2_password_usercfg" version="1">
     <ind:object object_ref="object_grub2_password_usercfg" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_grub2_password_usercfg" version="1">
-    <ind:filepath>{{{ grub_cfg_prefix }}}/user.cfg</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/user.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*GRUB2_PASSWORD=grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/grub2/grub.cfg" id="test_grub2_password_grubcfg" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_boot_path }}}/grub.cfg" id="test_grub2_password_grubcfg" version="1">
     <ind:object object_ref="object_grub2_password_grubcfg" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_grub2_password_grubcfg" version="1">
-    <ind:filepath>{{{ grub_cfg_prefix }}}/grub.cfg</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -30,7 +30,7 @@ description: |-
     Once the superuser password has been added,
     update the
     <tt>grub.cfg</tt> file by running:
-    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
 
 rationale: |-
     Password protection on the boot loader configuration ensures
@@ -74,7 +74,7 @@ ocil: |-
     To verify the boot loader superuser password has been set, run the following
     command:
     {{% if product in ["sle12", "sle15"] %}}
-    <pre>sudo grep "boot" /boot/grub2/grub.cfg</pre>
+    <pre>sudo grep "boot" {{{ grub2_boot_path }}}/grub.cfg</pre>
     {{% else %}}
     <pre>sudo grep "superusers" /etc/grub2.cfg</pre>
     {{% endif %}}
@@ -88,7 +88,7 @@ ocil: |-
     <pre>set superusers="boot"
     password_pbkdf2 boot grub.pbkdf2.sha512.10000.5DE5DF6E01A52E17A8C2FEDF585A3916B345F654C9D19C9ECD0BC958DF8C8A5E1AB15862D9C0B6DCE1F3209D8E8B46101DB3AE7146BB9D7D6C1D379E1854AF9E.CD75F981FE5223C583FB7887544C3A4C96431B5C089801D26855B93A1CB0BC0A508D189F1799A1CC40036B069C36EAD51DAE6A2EE6C0732353B2B5B4F5C49088</pre>
     {{% else %}}
-    <pre>sudo cat /boot/grub2/user.cfg</pre>
+    <pre>sudo cat {{{ grub2_boot_path }}}/user.cfg</pre>
     The output should be similar to:
     <pre>GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
     2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
@@ -13,11 +13,11 @@ description: |-
     <pre>GRUB_CMDLINE_LINUX="... ipv6.disable=1 ..."</pre>
     In case the <tt>GRUB_DISABLE_RECOVERY</tt> is set to true, then the parameter should be added to the <tt>GRUB_CMDLINE_LINUX_DEFAULT</tt> instead.
     Run one of following command to ensure that the configuration is applied when booting currently installed kernels:
-    <pre>sudo grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>sudo grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
     or
     <pre>sudo /sbin/grubby --update-kernel=ALL --args="ipv6.disable=1"</pre>
 {{% else %}}
-    <tt>/boot/grub2/grubenv</tt>, in the manner below:
+    <tt>{{{ grub2_boot_path }}}/grubenv</tt>, in the manner below:
     <pre>sudo  grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) ipv6.disable=1"</pre>
 {{% endif %}}
 
@@ -50,16 +50,16 @@ ocil: |-
     If the recovery is disabled, check the line with
     <pre>grep 'GRUB_CMDLINE_LINUX.*ipv6.disable=1.*' /etc/default/grub</pre>.
     Moreover, current GRUB2 config file in <tt>/etc/grub2/grub.cfg</tt> must be checked.
-    <pre>sudo grep vmlinuz /boot/grub2/grub.cfg | grep -v 'ipv6.disable=1'</pre>
+    <pre>sudo grep vmlinuz {{{ grub2_boot_path }}}/grub.cfg | grep -v 'ipv6.disable=1'</pre>
     This command should not return any output. If it does, update the configuration with one of following commands:
-    <pre>sudo grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>sudo grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
     or
     <pre>sudo /sbin/grubby --update-kernel=ALL --args="ipv6.disable=1"</pre>
     <br />
 {{% else %}}
     Inspect the form of default GRUB2 command line for the Linux operating system
-    in <tt>/boot/grub2/grubenv</tt>. Check if it includes <tt>ipv6.disable=1</tt>.
-    <pre>sudo grep 'kernelopts.*ipv6.disable=1.*' /boot/grub2/grubenv</pre>
+    in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. Check if it includes <tt>ipv6.disable=1</tt>.
+    <pre>sudo grep 'kernelopts.*ipv6.disable=1.*' {{{ grub2_boot_path }}}/grubenv</pre>
     <br /><br />
     To ensure <tt>ipv6.disable=1</tt> is configured on all installed kernels, the
     following command may be used:
@@ -78,7 +78,7 @@ warnings:
         <pre>grub2-mkconfig -o</pre> command as follows:
         <ul>
         <li>On BIOS-based machines, issue the following command:
-        <pre>sudo grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <pre>sudo grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command:
 {{% if product in ["rhel7", "ol7", "rhel8", "ol8"] %}}
         <pre>sudo grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -16,10 +16,10 @@ if [ "$(getconf LONG_BIT)" = "32" ] ; then
 fi
 
 if [ "$(getconf LONG_BIT)" = "64" ] ; then
-  if grep --silent noexec /boot/grub2/grub*.cfg ; then 
+  if grep --silent noexec {{{ grub2_boot_path }}}/grub*.cfg ; then
         sed -i "s/noexec.*//g" /etc/default/grub
         sed -i "s/noexec.*//g" /etc/grub.d/*
-        GRUBCFG=/boot/grub2/*.cfg
+        GRUBCFG={{{ grub2_boot_path }}}/*.cfg
         grub2-mkconfig -o "$GRUBCFG"
   fi
 fi

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -51,7 +51,7 @@ ocil: |-
     The output should not contain <tt>'disabled by kernel command line option'</tt>.
     To verify that ExecShield has not been disabled in the kernel configuration,
     run the following command:
-    <pre>$ sudo grep noexec /boot/grub2/grub.cfg</pre>
+    <pre>$ sudo grep noexec {{{ grub2_boot_path }}}/grub.cfg</pre>
     The output should not return <tt>noexec=off</tt>.
     For 32-bit Red Hat Enterprise Linux 7 systems, run the following command:
     <pre>$ sysctl kernel.exec-shield</pre>

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
@@ -52,7 +52,7 @@ warnings:
         <pre>grub2-mkconfig -o</pre> command as follows:
         <ul>
         <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
 {{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -52,7 +52,7 @@ warnings:
         <pre>grub2-mkconfig -o</pre> command as follows:
         <ul>
         <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
         <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
 {{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
         <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -16,7 +16,7 @@ description: |-
     <pre>grub2-mkconfig -o</pre> command as follows:
     <ul>
     <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-    <pre>~]# grub2-mkconfig -o /boot/grub2/grub.cfg</pre></li>
+    <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
     <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
     <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
     </ul>

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -4,7 +4,7 @@
     <criteria operator="AND">
       {{% if product in ["rhel7", "ol7"] %}}
         <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the /boot/grub2/grub.cfg for all kernels" />
+        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
         <criteria operator="OR">
           <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
           comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX" />
@@ -17,7 +17,7 @@
         </criteria>
       {{% else %}}
         <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in /boot/grub2/grubenv" />
+        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the GRUB2 environment variable block in {{{ grub2_boot_path }}}/grubenv" />
       {{% endif %}}
     </criteria>
   </definition>
@@ -51,7 +51,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
-  comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} in /boot/grub2/grub.cfg for all kernels"
+  comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} in {{{ grub2_boot_path }}}/grub.cfg for all kernels"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
@@ -59,7 +59,7 @@
 
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
   version="1">
-    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     {{% if product == "rhel7" %}}
       <ind:pattern operation="pattern match">^.*/vmlinuz.*(root=.*)$</ind:pattern>
     {{% else %}}
@@ -71,7 +71,7 @@
 {{% else %}}
 
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env"
-  comment="check forkernel command line parameters {{{ ARG_NAME_VALUE }}} in /boot/grub2/grubenv for all kernels"
+  comment="check forkernel command line parameters {{{ ARG_NAME_VALUE }}} in {{{ grub2_boot_path }}}/grubenv for all kernels"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
@@ -79,7 +79,7 @@
 
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_env"
   version="1">
-    <ind:filepath>/boot/grub2/grubenv</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grubenv</ind:filepath>
     <ind:pattern operation="pattern match">^kernelopts=(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -380,3 +380,4 @@ MAKEFILE_ID_TO_PRODUCT_MAP = {
 
 # Application constants
 DEFAULT_UID_MIN = 1000
+DEFAULT_GRUB2_BOOT_PATH = '/boot/grub2'

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -8,6 +8,7 @@ from glob import glob
 from .build_cpe import ProductCPEs
 from .constants import (product_directories,
                         DEFAULT_UID_MIN,
+                        DEFAULT_GRUB2_BOOT_PATH,
                         PKG_MANAGER_TO_SYSTEM,
                         PKG_MANAGER_TO_CONFIG_FILE,
                         XCCDF_PLATFORM_TO_PACKAGE)
@@ -42,6 +43,9 @@ def _get_implied_properties(existing_properties):
 
     if "auid" not in existing_properties:
         result["auid"] = existing_properties.get("uid_min", DEFAULT_UID_MIN)
+
+    if "grub2_boot_path" not in existing_properties:
+        result["grub2_boot_path"] = DEFAULT_GRUB2_BOOT_PATH
 
     return result
 

--- a/ubuntu1604/product.yml
+++ b/ubuntu1604/product.yml
@@ -11,6 +11,8 @@ pkg_manager: "apt_get"
 init_system: "systemd"
 oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml"
 
+grub2_boot_path: "/boot/grub"
+
 cpes_root: "../shared/applicability"
 cpes:
   - ubuntu1604:

--- a/ubuntu1804/product.yml
+++ b/ubuntu1804/product.yml
@@ -10,6 +10,8 @@ pkg_manager: "apt_get"
 
 init_system: "systemd"
 
+grub2_boot_path: "/boot/grub"
+
 cpes_root: "../shared/applicability"
 cpes:
   - ubuntu1804:

--- a/ubuntu2004/product.yml
+++ b/ubuntu2004/product.yml
@@ -10,6 +10,8 @@ pkg_manager: "apt_get"
 
 init_system: "systemd"
 
+grub2_boot_path: "/boot/grub"
+
 cpes_root: "../shared/applicability"
 cpes:
   - ubuntu2004:


### PR DESCRIPTION
#### Description:

Ubuntu and Debian use a different grub2 path than RHEL-like systems do: we use `/boot/grub` instead of `/boot/grub2`. Turn this into an implied property and add overrides into Debian's and Ubuntu's product files. Update all Rules, OVALs, and fixes to use the correct path.

```
commit ffc36463fe81c3f64948cb900153a25e79b25881 (HEAD -> fix-grub2-boot-grub-debian, origin/fix-grub2-boot-grub-debian)
Author: Alexander Scheel <alex.scheel@canonical.com>
Date:   Mon May 10 10:28:18 2021 -0400

    Update grub2_bootloader_argument to use grub2_boot_path
    
    This updates the shared template to use the implied property, rather
    than assuming /boot/grub2 is the path everywhere.
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

commit 82c3139458071cc813ac78791c00600084a747d6
Author: Alexander Scheel <alex.scheel@canonical.com>
Date:   Mon May 10 10:25:12 2021 -0400

    Update shared bash script to fix grub2 path
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

commit 81e8b87115567412846af5ee89c5f2644b1d28d6
Author: Alexander Scheel <alex.scheel@canonical.com>
Date:   Mon May 10 10:24:13 2021 -0400

    Update shared ovals to use grub2_boot_path
    
    Note that grub2_password already partially used it via the (internal)
    parameter grub_cfg_prefix. This highlights that lifting it up into a
    global (platform) implied property is probably a good idea.
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

commit db2d3e80b26147322285745b788f3b72288da8b9
Author: Alexander Scheel <alex.scheel@canonical.com>
Date:   Mon May 10 10:21:58 2021 -0400

    Update rule text to use grub2_boot_path
    
    This updates all linux_os/guide rules which explicitly name /boot/grub2
    to instead use the implied property grub2_boot_path.
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

commit 8e08eb430b63a25d93120a162860c281a12a5dfa
Author: Alexander Scheel <alex.scheel@canonical.com>
Date:   Mon May 10 10:12:31 2021 -0400

    Add overridden grub2_boot_path for Debian-likes
    
    Debian-like distributions use /boot/grub for grub2's configuration path,
    instead of /boot/grub2 like most RHEL-like distributions do. Add
    overrides for these products so we can use the correct paths in the
    grub2_* rules.
    
    See also: https://wiki.debian.org/Grub2
    See also: https://help.ubuntu.com/community/Grub2
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

commit 9cf540224f4fa421ae4884c0e447f5ebbb182ec7
Author: Alexander Scheel <alex.scheel@canonical.com>
Date:   Mon May 10 10:10:00 2021 -0400

    Add grub2_boot_path as an implied property
    
    This defaults to /boot/grub2.
    
    Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>

```

#### Rationale:

Either we need to add an implied property, or we need to significantly duplicate grub2 rules between distros. This is probably the easier way. :-) 

I left this as a top-level implied property for the time being. Things like `auid` and `uid_min` are also top-level properties, so I think this is fine for now. At some point, we might come back and clean this up, I dunno. 