### PR TITLE
Revert "Remove `package_gssproxy_removed` from STIG GUI profile"

### DIFF
--- a/rhel8/profiles/stig_gui.profile
+++ b/rhel8/profiles/stig_gui.profile
@@ -34,7 +34,3 @@ extends: stig
 selections:
     # RHEL-08-040320
     - '!xwindows_remove_packages'
-
-    # RHEL-08-040370
-    # conflicts with nfs-utils package required by GUI installations
-    - '!package_gssproxy_removed'

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -200,6 +200,7 @@ selections:
 - package_audit_installed
 - package_fapolicyd_installed
 - package_firewalld_installed
+- package_gssproxy_removed
 - package_iprutils_removed
 - package_krb5-workstation_removed
 - package_opensc_installed


### PR DESCRIPTION
Reverts ComplianceAsCode/content#6967

We need additional testing before merging this in.