### PR TITLE
Fix autoprodtyper's open_environment call

### DIFF
--- a/utils/autoprodtyper.py
+++ b/utils/autoprodtyper.py
@@ -6,6 +6,7 @@ import argparse
 import json
 
 import ssg.build_yaml
+import ssg.environment
 import ssg.products
 import ssg.rules
 import ssg.yaml
@@ -63,7 +64,7 @@ def main():
 
     product_base = os.path.join(SSG_ROOT, args.product)
     product_yaml = os.path.join(product_base, "product.yml")
-    env_yaml = ssg.yaml.open_environment(args.build_config_yaml, product_yaml)
+    env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml)
 
     profiles_root = os.path.join(product_base, "profiles")
     if args.profiles_root:


### PR DESCRIPTION
#### Description:

Since #6754 was merged before #6906's last update (and before #6906 was
merged), it missed the move of `ssg.yaml.open_environment` into
`ssg.environment.open_environment`.

This fixes `autoprodtyper.py` to understand the new location of this
function.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`