### PR TITLE
display_login_attempts - DISA STIG compliance

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
@@ -1,34 +1,39 @@
-# platform = multi_platform_sle,multi_platform_ol
+{{% if product in ["sle12", "sle15"] %}}
+{{% set pam_lastlog_filename = "login" %}}
+{{% else %}}
+{{% set pam_lastlog_filename = "postlogin" %}}
+{{% endif %}}
+
+# platform = multi_platform_sle,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
 # reboot = false
 # strategy = configure
 # complexity = low
 # disruption = low
 
+- name: "Check if pam_lastlog.so is set"
+  find:
+    path: /etc/pam.d/
+    pattern: '{{{ pam_lastlog_filename }}}'
+    contains: '^\s*(session)(\s+)[^\s]+(\s+)(pam_lastlog\.so)(\s+)(.*)'
+  register: pam_lastlog_exists
+
 - name: Make sure pam_lastlog.so control is required
   replace:
-    {{% if product in ['ol7', 'ol8'] -%}}
-    path: /etc/pam.d/postlogin
-    {{%- else -%}}
-    path: /etc/pam.d/login
-    {{%- endif %}}
+    path: /etc/pam.d/{{{ pam_lastlog_filename }}}
     regexp: ^\s*(session)(\s+)[^\s]+(\s+)(pam_lastlog\.so)(\s+)(.*)
     replace: '\1\2required\3\4\5\6'
   register: control_update_result
 
 - name: Add control for pam_lastlog.so module
   lineinfile:
-    {{% if product in ['ol7', 'ol8'] -%}}
-    path: /etc/pam.d/postlogin
-    {{%- else -%}}
-    path: /etc/pam.d/login
-    {{%- endif %}}
+    path: /etc/pam.d/{{{ pam_lastlog_filename }}}
     line: 'session required pam_lastlog.so showfailed'
-  when: not control_update_result.changed
+  when: pam_lastlog_exists.matched == 0
   register: add_new_pam_lastlog_control_result
 
 - name: Add 'showfailed' arg to pam_lastlog.so module
   pamd:
-    name: login
+    name: {{{ pam_lastlog_filename }}}
     type: session
     control: required
     module_path: pam_lastlog.so
@@ -38,7 +43,7 @@
 
 - name: Remove 'silent' arg for pam_lastlog.so module
   pamd:
-    name: login
+    name: {{{ pam_lastlog_filename }}}
     type: session
     control: required
     module_path: pam_lastlog.so

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ol
 # reboot = false
 # strategy = configure
 # complexity = low
@@ -6,14 +6,22 @@
 
 - name: Make sure pam_lastlog.so control is required
   replace:
+    {{% if product in ['ol7', 'ol8'] -%}}
+    path: /etc/pam.d/postlogin
+    {{%- else -%}}
     path: /etc/pam.d/login
+    {{%- endif %}}
     regexp: ^\s*(session)(\s+)[^\s]+(\s+)(pam_lastlog\.so)(\s+)(.*)
     replace: '\1\2required\3\4\5\6'
   register: control_update_result
 
 - name: Add control for pam_lastlog.so module
   lineinfile:
+    {{% if product in ['ol7', 'ol8'] -%}}
+    path: /etc/pam.d/postlogin
+    {{%- else -%}}
     path: /etc/pam.d/login
+    {{%- endif %}}
     line: 'session required pam_lastlog.so showfailed'
   when: not control_update_result.changed
   register: add_new_pam_lastlog_control_result

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -1,7 +1,12 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
+{{% if product in ["sle12", "sle15"] %}}
+{{% set pam_lastlog_path = "/etc/pam.d/login" %}}
+{{% else %}}
+{{% set pam_lastlog_path = "/etc/pam.d/postlogin" %}}
+{{% endif %}}
+# platform = multi_platform_sle,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
+. /usr/share/scap-security-guide/remediation_functions
 
-if grep -q "^session.*pam_lastlog.so" /etc/pam.d/postlogin; then
-	sed -i --follow-symlinks "/pam_lastlog.so/d" /etc/pam.d/postlogin
-fi
+ensure_pam_module_options '{{{ pam_lastlog_path }}}' 'session' 'required' 'pam_lastlog.so' 'showfailed' "" ""
 
-echo "session     required      pam_lastlog.so showfailed" >> /etc/pam.d/postlogin
+# remove 'silent' option
+sed -i --follow-symlinks -E -e 's/^([^#]+pam_lastlog\.so[^#]*)\ssilent/\1/' '{{{ pam_lastlog_path }}}'

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -4,5 +4,4 @@ if grep -q "^session.*pam_lastlog.so" /etc/pam.d/postlogin; then
 	sed -i --follow-symlinks "/pam_lastlog.so/d" /etc/pam.d/postlogin
 fi
 
-echo "session     [default=1]   pam_lastlog.so nowtmp showfailed" >> /etc/pam.d/postlogin
-echo "session     optional      pam_lastlog.so silent noupdate showfailed" >> /etc/pam.d/postlogin
+echo "session     required      pam_lastlog.so showfailed" >> /etc/pam.d/postlogin

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/sle12.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/sle12.sh
@@ -1,7 +1,0 @@
-# platform = SUSE Linux Enterprise 12
-. /usr/share/scap-security-guide/remediation_functions
-
-ensure_pam_module_options '/etc/pam.d/login' 'session' 'required' 'pam_lastlog.so' 'showfailed' "" ""
-
-# remove 'silent' option
-sed -i --follow-symlinks -E -e 's/^([^#]+pam_lastlog\.so[^#]*)\ssilent/\1/' '/etc/pam.d/login'

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
@@ -3,8 +3,8 @@
     {{{ oval_metadata("Configure the system to notify users of last login/access using pam_lastlog.") }}}
     <criteria operator="AND">
       <criterion comment="Conditions for pam_lastlog are satisfied" test_ref="test_display_login_attempts" />
-      {{% if product in ['sle12', 'sle15'] %}}
-      <criterion comment="silent option for pam_lastlog is set" test_ref="test_display_login_attempts_silent" />
+      {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] %}}
+      <criterion comment="silent option for pam_lastlog is not set" test_ref="test_display_login_attempts_silent" />
       {{% endif %}}
     </criteria>
   </definition>
@@ -13,10 +13,28 @@
     <ind:object object_ref="obj_display_login_attempts" />
   </ind:textfilecontent54_test>
 
-  {{% if product in ['sle12', 'sle15'] %}}
+  {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] %}}
   <ind:textfilecontent54_object id="obj_display_login_attempts" version="1">
+    {{% if product in ['sle12', 'sle15'] %}}
     <ind:filepath>/etc/pam.d/login</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*session\s+(required|requisite)?\s+pam_lastlog.so[\s\w\d\=]+showfailed(\s|$)</ind:pattern>
+    {{% else %}}
+    <ind:filepath>/etc/pam.d/postlogin</ind:filepath>
+    {{% endif %}}
+    <ind:pattern operation="pattern match">^\s*session\s+required\s+pam_lastlog.so[\s\w\d\=]+showfailed(\s|$)</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- DISA STIG forbids the 'silent' option for SLE12/SLE15, OL7, RHEL7/RHEL8 -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="Forbid 'silent' option for pam_lastlog" id="test_display_login_attempts_silent" version="1">
+    <ind:object object_ref="obj_display_login_attempts_silent" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_display_login_attempts_silent" version="1">
+    {{% if product in ['sle12', 'sle15'] %}}
+    <ind:filepath>/etc/pam.d/login</ind:filepath>
+    {{% else %}}
+    <ind:filepath>/etc/pam.d/postlogin</ind:filepath>
+    {{% endif %}}
+    <ind:pattern operation="pattern match">^\s*session\s+required\s+pam_lastlog.so[\s\w\d\=]+silent(\s|$)</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% else %}}
@@ -29,14 +47,4 @@
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endif %}}
-
-  <!-- on SLE12/SLE15, the STIG forbids the 'silent' option -->
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="Forbid 'silent' option for pam_lastlog" id="test_display_login_attempts_silent" version="1">
-    <ind:object object_ref="obj_display_login_attempts_silent" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_display_login_attempts_silent" version="1">
-    <ind:filepath>/etc/pam.d/login</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*session\s+(required|requisite)?\s+pam_lastlog.so[\s\w\d\=]+silent(\s|$)</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
@@ -1,11 +1,14 @@
+{{% if product in ["sle12", "sle15"] %}}
+{{% set pam_lastlog_path = "/etc/pam.d/login" %}}
+{{% else %}}
+{{% set pam_lastlog_path = "/etc/pam.d/postlogin" %}}
+{{% endif %}}
 <def-group>
   <definition class="compliance" id="display_login_attempts" version="1">
     {{{ oval_metadata("Configure the system to notify users of last login/access using pam_lastlog.") }}}
     <criteria operator="AND">
       <criterion comment="Conditions for pam_lastlog are satisfied" test_ref="test_display_login_attempts" />
-      {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] %}}
       <criterion comment="silent option for pam_lastlog is not set" test_ref="test_display_login_attempts_silent" />
-      {{% endif %}}
     </criteria>
   </definition>
 
@@ -13,13 +16,8 @@
     <ind:object object_ref="obj_display_login_attempts" />
   </ind:textfilecontent54_test>
 
-  {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] %}}
   <ind:textfilecontent54_object id="obj_display_login_attempts" version="1">
-    {{% if product in ['sle12', 'sle15'] %}}
-    <ind:filepath>/etc/pam.d/login</ind:filepath>
-    {{% else %}}
-    <ind:filepath>/etc/pam.d/postlogin</ind:filepath>
-    {{% endif %}}
+    <ind:filepath>{{{ pam_lastlog_path }}}</ind:filepath>
     <ind:pattern operation="pattern match">^\s*session\s+required\s+pam_lastlog.so[\s\w\d\=]+showfailed(\s|$)</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -29,22 +27,8 @@
     <ind:object object_ref="obj_display_login_attempts_silent" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_display_login_attempts_silent" version="1">
-    {{% if product in ['sle12', 'sle15'] %}}
-    <ind:filepath>/etc/pam.d/login</ind:filepath>
-    {{% else %}}
-    <ind:filepath>/etc/pam.d/postlogin</ind:filepath>
-    {{% endif %}}
+    <ind:filepath>{{{ pam_lastlog_path }}}</ind:filepath>
     <ind:pattern operation="pattern match">^\s*session\s+required\s+pam_lastlog.so[\s\w\d\=]+silent(\s|$)</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
-  {{% else %}}
-  <ind:textfilecontent54_object id="obj_display_login_attempts" version="1">
-    <!-- Read whole /etc/pam.d/postlogin as single line so we can verify form
-         of both pam_lastlog.so rows and their order -->
-    <ind:behaviors singleline="true" />
-    <ind:filepath>/etc/pam.d/postlogin</ind:filepath>
-    <ind:pattern operation="pattern match">[\n][\s]*session[\s]+\[default=1\][\s]+pam_lastlog.so[\s\w\d\=]+showfailed[\s\w\d\=]*\n[\s]*session[\s]+optional[\s]+pam_lastlog.so[\s\w\d\=]+showfailed[\s\w\d\=]*[\n]</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
@@ -6,7 +6,7 @@ description: |-
     To configure the system to notify users of last logon/access
     using <tt>pam_lastlog</tt>, add or correct the <tt>pam_lastlog</tt>
     settings in
-    {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
+    {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] or 'ubuntu' in product %}}
     <tt>/etc/pam.d/login</tt> to read as follows:
     <pre>session     required pam_lastlog.so showfailed</pre>
     And make sure that the <tt>silent</tt> option is not set.
@@ -57,7 +57,7 @@ ocil_clause: 'that is not the case'
 ocil: |-
     To ensure that last logon/access notification is configured correctly, run
     the following command:
-    {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
+    {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] or 'ubuntu' in product %}}
     <pre>$ grep pam_lastlog.so /etc/pam.d/login</pre>
     The output should show output <tt>showfailed</tt> and must not contain
     <tt>silent</tt>.

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
@@ -1,3 +1,9 @@
+{{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
+{{% set pam_lastlog_path = "/etc/pam.d/login" %}}
+{{% else %}}
+{{% set pam_lastlog_path = "/etc/pam.d/postlogin" %}}
+{{% endif %}}
+
 documentation_complete: true
 
 title: 'Ensure PAM Displays Last Logon/Access Notification'
@@ -6,16 +12,9 @@ description: |-
     To configure the system to notify users of last logon/access
     using <tt>pam_lastlog</tt>, add or correct the <tt>pam_lastlog</tt>
     settings in
-    {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] or 'ubuntu' in product %}}
-    <tt>/etc/pam.d/login</tt> to read as follows:
+    <tt>{{{ pam_lastlog_path }}}</tt> to read as follows:
     <pre>session     required pam_lastlog.so showfailed</pre>
     And make sure that the <tt>silent</tt> option is not set.
-    {{% else %}}
-    <tt>/etc/pam.d/postlogin</tt> to read as follows:
-    <pre>session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet
-    session     [default=1]   pam_lastlog.so nowtmp showfailed
-    session     optional      pam_lastlog.so silent noupdate showfailed</pre>
-    {{% endif %}}
 
 rationale: |-
     Users need to be aware of activity that occurs regarding
@@ -57,13 +56,8 @@ ocil_clause: 'that is not the case'
 ocil: |-
     To ensure that last logon/access notification is configured correctly, run
     the following command:
-    {{% if product in ['sle12', 'sle15', 'ol7', 'ol8', 'rhel7', 'rhel8'] or 'ubuntu' in product %}}
-    <pre>$ grep pam_lastlog.so /etc/pam.d/login</pre>
+    <pre>$ grep pam_lastlog.so {{{ pam_lastlog_path }}}</pre>
     The output should show output <tt>showfailed</tt> and must not contain
     <tt>silent</tt>.
-    {{% else %}}
-    <pre>$ grep pam_lastlog.so /etc/pam.d/postlogin</pre>
-    The output should show output <tt>showfailed</tt>.
-    {{% endif %}}
 
 platform: pam

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/correct_value.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_ol
+
+rm -f /etc/pam.d/postlogin
+echo "session required pam_lastlog.so showfailed" >> /etc/pam.d/postlogin

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_ol
+
+rm -f /etc/pam.d/postlogin
+# pamd ansible module has a bug that if there is only one line in the file it raises an Out of Index exception
+# so let's add more lines there
+echo "session     optional                   pam_umask.so silent" >> /etc/pam.d/postlogin
+echo "session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet" >> /etc/pam.d/postlogin
+echo "session required pam_lastlog.so wrong_value" >> /etc/pam.d/postlogin

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value_silent.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value_silent.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_ol
+
+rm -f /etc/pam.d/postlogin
+# pamd ansible module has a bug that if there is only one line in the file it raises an Out of Index exception
+# so let's add more lines there
+echo "session     optional                   pam_umask.so silent" >> /etc/pam.d/postlogin
+echo "session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet" >> /etc/pam.d/postlogin
+echo "session required pam_lastlog.so silent showfailed" >> /etc/pam.d/postlogin


### PR DESCRIPTION
#### Description:

- update oval to:
    - check there is no 'silent' option for pam_lastlog
    - check for 'required' control value

#### Rationale:

- As per DISA STIG, following line should be added to PAM's postlogin config file:
```
session required pam_lastlog.so showfailed
```
- Also check content states: _If "pam_lastlog" is missing from "/etc/pam.d/postlogin" file, or the **silent** option is present, this is a finding._
- [RHEL7 DISA STIG implementation guide reference](https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-204605)