### PR TITLE
OCP4: Add missing NIST audit references

### DIFF
--- a/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
@@ -17,11 +17,10 @@ rationale: |-
 
 references:
   cis@ocp4: 1.2.23
-  nist: AC-2(12),AU-9(2)
+  nist: AC-2(12),AU-6,AU-6(1),AU-6(3),AU-9(2),SI-4(16)
 
 identifiers:
   cce@ocp4: CCE-84076-9
-
 
 severity: medium
 

--- a/applications/openshift/logging/audit_profile_set/rule.yml
+++ b/applications/openshift/logging/audit_profile_set/rule.yml
@@ -55,6 +55,7 @@ identifiers:
 
 references:
   cis@ocp4: 3.2.1,3.2.2
+  nist: AU-3,AU-3(1),AU-6,AU-6(1),AU-6(3),AU-7,AU-8,AU-8(1)
 
 ocil_clause: 'The proper audit profile is not set'
 

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -44,6 +44,9 @@ selections:
     - ocp_allowed_registries_for_import
     - ocp_allowed_registries
 
+    # AU
+    - audit_profile_set
+
     # AU-9
     - audit_log_forwarding_enabled
 


### PR DESCRIPTION
These were missing from the relevant rules. This also adds the audit_profile_set
to the moderate profile.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>