### PR TITLE
Fix dconf_gnome_login_retries bash remediation

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol
 
 
-{{{ bash_dconf_settings("org/gnome/login-screen", "allowed-failures" "3" "gdm.d", "00-security-settings") }}}
+{{{ bash_dconf_settings("org/gnome/login-screen", "allowed-failures", "3", "gdm.d", "00-security-settings") }}}
 {{{ bash_dconf_lock("org/gnome/login-screen", "allowed-failures", "gdm.d", "00-security-settings-lock") }}}


### PR DESCRIPTION
#### Description:

- Missing commas on call to `bash_dconf_settings` macro resulted in a faulty but executable remediation script, which in turn caused `dconf update` command to fail

#### Rationale:

- This is a bug fix
