### PR TITLE
install_vm.py: add possibility to install GUI system

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -115,7 +115,7 @@ def main():
 
     if not data.url:
         if data.distro == "fedora":
-            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os"
+            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/os"
         elif data.distro == "centos7":
             data.url = "http://mirror.centos.org/centos/7/os/x86_64"
     if not data.url:

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -83,11 +83,11 @@ volgroup VolGroup --pesize=4096 pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5512 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
 logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition
-logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /home Located On Separate Partition
 logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -12,8 +12,6 @@
 
 # Install a fresh new system (optional)
 install
-skipx
-text
 
 # To enable custom repositories for the machine after installation use:
 #repo --name=myrepo --baseurl=http://...
@@ -86,21 +84,21 @@ part pv.01 --grow --size=1
 volgroup VolGroup --pesize=4096 pv.01
 
 # Create particular logical volumes (optional)
-logvol / --fstype=xfs --name=root --vgname=VolGroup --size=6144 --grow
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
+# Ensure /usr Located On Separate Partition
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+# Ensure /opt Located On Separate Partition
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /srv Located On Separate Partition
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
 # Ensure /home Located On Separate Partition
 logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
-# Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=4096 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
-# Ensure /opt Located On Separate Partition
-logvol /opt --fstype=xfs --name=opt --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
-# Ensure /srv Located On Separate Partition
-logvol /srv --fstype=xfs --name=srv --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /var/tmp Located On Separate Partition
 logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /var Located On Separate Partition
-logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048 --fsoptions="nodev"
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
 # Ensure /var/log Located On Separate Partition
 logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /var/log/audit Located On Separate Partition

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -10,9 +10,6 @@
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
-# Install a fresh new system (optional)
-install
-
 # To enable custom repositories for the machine after installation use:
 #repo --name=myrepo --baseurl=http://...
 &&YUM_EXTRA_REPO&&


### PR DESCRIPTION
This PR introduces `--install-gui` option into the `install_vm.py` script so it is easy to test also installations with GUI.

Additional changes:
* updated default Fedora compose in the `install_vm.py` script to Fedora 34
* updated SSGTS kickstart file as `install` command has been deprecated in Fedora 34 - https://docs.fedoraproject.org/my/fedora/f34/release-notes/sysadmin/Installation/#sect-kickstart-deprecated-removed
* updated SSGTS kickstart file to contain additional partitions (`/usr`, `/opt`, `/srv`) so the kickstart is compatible with all Fedora/RHEL profiles (`/usr` partition has increased size to be able to install Fedora 34 with GUI)

I have tested both installations, with and without GUI, for the following:
* RHEL7
* RHEL8
* Fedora 34