### PR TITLE
Improve test suite documentation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -172,7 +172,10 @@ The header consists of comments (starting by `#`). Possible keys are:
   intended for casual use.
 - `remediation` is a string specifying one of the allowed remediation types (eg.
   `bash`, `ansible`, `none`). The `none` value means that the tested rule has no
-  implemented remediation.
+  implemented remediation. The `none` value can also be used in case that
+  remediation breaks test environment (for example unmounting /tmp in a test
+  scenario would break test suite because OpenSCAP generates reports into the
+  /tmp directory).
 - `templates` has no effect at the moment.
 - `variables` is a comma-separated list of XCCDF values that sets a different
   default value for XCCDF variables in a form `<variable name>=<value>`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,6 +42,9 @@ To use Libvirt backend, you need to have:
   - Package `openscap` version 1.2.15 or higher installed
   - `root` can login via ssh (it is recommended to setup key-based authentication)
   - `root` can install packages (for RHEL7, it means subscription enabled).
+  - `CPE_NAME` is present in `/etc/os-release`. Currently, Ubuntu doesn't ship
+    it in the stock image. See [this Ubuntu
+    bug](https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/1472288).
 
 An easy way to install your VM is via `install_vm.py` script. It will setup a VM according to the requirements, including configuration of a key for SSH login.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -403,8 +403,14 @@ Note that `profile-id` is matched by the suffix, so it works the same as in `osc
 
 ### Unselecting problematic rules
 
-Sometimes you would like to skip a rule in the profile because they are too slow to test,\
-or you know a rule doesn't have a remediation and you get less value by testing it.
+Sometimes you would like to skip a rule in the profile because they are too slow
+to test, or you know a rule doesn't have a remediation and you get less value by
+testing it.
+
+Also, some rules need to be skipped in the profile mode because they might break
+the test backend. For example, the rule `sshd_disable_root_login` which disables
+root login to the tested VM will prevent the test suite from execution because
+the test suite uses root user in all underlying SSH commands.
 
 For these situations, use `ds_unselect_rules.sh` to unselect these rules in all profiles of the data stream.
 It will copy your data stream to `/tmp` and unselect rules listed in `rules_list`


### PR DESCRIPTION
1. reorganize into a new structure. There are 3 main sections now:
- Preparing backends
- Test scenarios
- Running tests

2. add more information about the profiles key in test scenario
headers

3. explain more the combined and rule mode and usage of profiles in
   these modes

4. typo and grammar fixes

5. consistent usage of data stream

It's mostly reshuffling the text, there is only a little new text.


