### PR TITLE
templates/yamlfile_value: Add 'check_existence_yamlpath' argument to the template

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1887,6 +1887,15 @@ The selected value can be changed in the profile (consult the actual variable fo
     -   **embedded_data** - if set to `"true"` and used combined with `xccdf_variable`, the data retrieved by `yamlpath`
         is considered as a blob and the field `value` has to contain a capture regex.
 
+    -   **check_existence_yamlpath** - optional YAML Path that could be set to ensure that the target sequence from `yamlpath` has all
+        required sub-elements. It is helpful when the `yamlpath` is targeting a map inside a sequence, and the document could be
+        missing a key in that map (i.e. `$.seq[:].obj.item.key_that_might_be_missing`). When `check_existence_yamlpath` is set to a path
+        like `$.seq[:].obj.item.key_that_always_exists` (or `$.seq[:].obj.key_that_always_exists`) the template will create a check,
+        that will count elements in both paths and would fail if amounts are not equal.
+
+        This check has a limitation: both `check_existence_yamlpath` and `yamlpath` have to point to a scalar value for it to work
+        correctly (that is, the path `$.seq[:].obj.item` won't work).
+
     -   **values** - a list of dictionaries with values to check, where:
 
         -   **key** - the yaml key to check, optional. Used when the

--- a/shared/templates/yamlfile_value/oval.template
+++ b/shared/templates/yamlfile_value/oval.template
@@ -8,30 +8,34 @@
       {{%- endfor -%}}
     {{%- endcall -%}}
     <criteria>
-        <criterion {{{ {'comment': "In the YAML/JSON file '" + FILEPATH + "' at path '" + YAMLPATH + "' " + (ENTITY_CHECK if ENTITY_CHECK else "all")}|xmlattr }}} test_ref="test_{{{ rule_id }}}"/>
-        {{% if OCP_DATA %}}
-        <criterion comment="Make sure that the file '{{{ FILEPATH }}}' exists." test_ref="test_file_for_{{{ rule_id }}}"/>
-        {{% endif %}}
+      <criterion {{{ {'comment': "In the YAML/JSON file '" + FILEPATH + "' at path '" + YAMLPATH + "' " + (ENTITY_CHECK if ENTITY_CHECK else "all")}|xmlattr }}} test_ref="test_{{{ rule_id }}}"/>
+      {{% if OCP_DATA %}}
+      <criterion comment="Make sure that the file '{{{ FILEPATH }}}' exists." test_ref="test_file_for_{{{ rule_id }}}"/>
+      {{% endif %}}
+      {{% if CHECK_EXISTENCE_YAMLPATH %}}
+      <criterion {{{ {'comment': "Make sure that all target elements exists for elements at path '" + CHECK_EXISTENCE_YAMLPATH + "'"}|xmlattr }}} test_ref="test_elements_count_for_{{{ rule_id }}}"/>
+      {{% endif %}}
     </criteria>
   </definition>
 
   <local_variable id="{{{ rule_id }}}_file_location" datatype="string" comment="The actual path of the file to scan." version="1">
-      {{% if OCP_DATA %}}
-      <concat>
-        <variable_component var_ref="ocp_data_root"/>
-        <literal_component>{{{ FILEPATH }}}</literal_component>
-      </concat>
-      {{% else %}}
+    {{% if OCP_DATA %}}
+    <concat>
+      <variable_component var_ref="ocp_data_root"/>
       <literal_component>{{{ FILEPATH }}}</literal_component>
-      {{% endif %}}
+    </concat>
+    {{% else %}}
+    <literal_component>{{{ FILEPATH }}}</literal_component>
+    {{% endif %}}
   </local_variable>
-{{% if not XCCDF_VARIABLE or (XCCDF_VARIABLE and not EMBEDDED_DATA) %}}
+
+  {{% if not XCCDF_VARIABLE or (XCCDF_VARIABLE and not EMBEDDED_DATA) %}}
   <ind:yamlfilecontent_test id="test_{{{ rule_id }}}" check="all" check_existence="{{{ CHECK_EXISTENCE|default("only_one_exists") }}}"
     {{{ {'comment': "In the file '" + FILEPATH + "' find only one object at path '" + YAMLPATH + "'."}|xmlattr }}} version="1">
     <ind:object object_ref="object_{{{ rule_id }}}"/>
     <ind:state state_ref="state_{{{ rule_id }}}"/>
   </ind:yamlfilecontent_test>
-{{% else %}}
+  {{% else %}}
   <ind:variable_test id="test_{{{ rule_id }}}" check="all" check_existence="all_exist" comment="Variable test to check XCCDF variable" version="1">
     <ind:object object_ref="variable_object_{{{ rule_id }}}" />
     <ind:state state_ref="variable_state_{{{ rule_id }}}" />
@@ -50,12 +54,19 @@
        <object_component item_field="value" record_field="{{{ (VALUES|first).key|default('#') }}}" object_ref="object_{{{ rule_id }}}" />
     </regex_capture>
   </local_variable>
+  {{% endif %}}
 
-{{% endif %}}
+  {{% if CHECK_EXISTENCE_YAMLPATH %}}
+  <ind:variable_test version="1" id="test_elements_count_for_{{{ rule_id }}}" check="all"
+    comment="Count elements at both paths and compare">
+    <ind:object object_ref="object_elements_count_for_{{{ rule_id }}}"/>
+    <ind:state state_ref="state_elements_count_for_{{{ rule_id }}}"/>
+  </ind:variable_test>
+  {{% endif %}}
 
-{{% if XCCDF_VARIABLE %}}
+  {{% if XCCDF_VARIABLE %}}
   <external_variable comment="variable" datatype="string" id="{{{ XCCDF_VARIABLE }}}" version="1" />
-{{% endif %}}
+  {{% endif %}}
 
   {{% if OCP_DATA %}}
   <unix:file_test id="test_file_for_{{{ rule_id }}}" check="all" check_existence="only_one_exists"
@@ -72,6 +83,27 @@
     <ind:filepath var_ref="{{{ rule_id }}}_file_location"/>
     <ind:yamlpath>{{{ YAMLPATH }}}</ind:yamlpath>
   </ind:yamlfilecontent_object>
+
+  {{% if CHECK_EXISTENCE_YAMLPATH %}}
+  <ind:yamlfilecontent_object id="object_exists_counter_{{{ rule_id }}}" version="1">
+    <ind:filepath var_ref="{{{ rule_id }}}_file_location"/>
+    <ind:yamlpath>{{{ CHECK_EXISTENCE_YAMLPATH }}}</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+  <ind:variable_object id="object_elements_count_for_{{{ rule_id }}}" version="1">
+    <ind:var_ref>local_variable_counter_{{{ rule_id }}}</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable comment="Items counter" datatype="int" id="local_variable_counter_{{{ rule_id }}}" version="1">
+    <count><object_component object_ref="object_{{{ rule_id }}}" item_field="value" record_field="#"/></count>
+  </local_variable>
+  <local_variable comment="Items counter control" datatype="int" id="local_variable_counter_control_{{{ rule_id }}}" version="1">
+    <count><object_component object_ref="object_exists_counter_{{{ rule_id }}}" item_field="value" record_field="#"/></count>
+  </local_variable>
+
+  <ind:variable_state id="state_elements_count_for_{{{ rule_id }}}" version="1">
+    <ind:value var_ref="local_variable_counter_control_{{{ rule_id }}}"/>
+  </ind:variable_state>
+  {{% endif %}}
 
   {{% if not XCCDF_VARIABLE or (XCCDF_VARIABLE and not EMBEDDED_DATA) %}}
   <ind:yamlfilecontent_state id="state_{{{ rule_id }}}" version="1">


### PR DESCRIPTION
This argument is supposed to receive a YAML path and would work as a control group element collection. It will make sure that there are no missing values at the target YAML Path.

This is a hackish workaround until the probe will support nil values for missing elements.

It should help in cased like #6971.