### PR TITLE
Fix href of added derivative cpe-item

### DIFF
--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -112,7 +112,7 @@ def main():
             )
 
     ssg.build_derivatives.replace_platform(root, oval_ns, derivative)
-    ssg.build_derivatives.add_cpe_item_to_dictionary(root, args[0], args[1], "ssg-%s-cpe-oval.xml" % args[0], options.id_name)
+    ssg.build_derivatives.add_cpe_item_to_dictionary(root, args[0], args[1], options.id_name)
 
     tree.write(options.output)
 

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -44,7 +44,7 @@ def add_cpes(elem, namespace, mapping):
     return affected
 
 
-def add_cpe_item_to_dictionary(tree_root, product_yaml_path, cpe_ref, cpe_oval_filename, id_name):
+def add_cpe_item_to_dictionary(tree_root, product_yaml_path, cpe_ref, id_name):
     cpe_list = tree_root.find(".//{%s}cpe-list" % (PREFIX_TO_NS["cpe-dict"]))
     if cpe_list:
         product_yaml = load_product_yaml(product_yaml_path)
@@ -52,7 +52,7 @@ def add_cpe_item_to_dictionary(tree_root, product_yaml_path, cpe_ref, cpe_oval_f
         cpe_item = product_cpes.get_cpe(cpe_ref)
         translator = IDTranslator(id_name)
         cpe_item.check_id = translator.generate_id("{" + oval_namespace + "}definition", cpe_item.check_id)
-        cpe_list.append(cpe_item.to_xml_element(cpe_oval_filename))
+        cpe_list.append(cpe_item.to_xml_element("ssg-%s-cpe-oval.xml" % product_yaml.get("product")))
 
 
 def add_notice(benchmark, namespace, notice, warning):


### PR DESCRIPTION

#### Description:

- The cpe-item added for the derivative product contained wrong `href`, it pointed to the product.yaml.
- The correct href is the original product cpe oval file, e.g.: `ssg-rhel7-cpe-oval.xml` for rhel7 derivatives.

#### Rationale:

- Fixes scapval validation issues, for [example](https://jenkins.complianceascode.io/view/SCAP%20Security%20Guide/job/scap-security-guide-scapval-scap-1.3/483/console).