### PR TITLE
Fix configure_opensc_nss_db bash remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
@@ -4,8 +4,11 @@
 # complexity = low
 # disruption = low
 
-PKCSSW=$(/usr/bin/pkcs11-switch)
+PKCSSW="/usr/bin/pkcs11-switch"
+MODULE=$(${PKCSSW})
 
-if [ ${PKCSSW} != "opensc" ] ; then
-    ${PKCSSW} opensc
+if [ "$MODULE" != "opensc" ] ; then
+    echo | ${PKCSSW} opensc
 fi
+
+modutil -force -add opensc -dbdir sql:/etc/pki/nssdb -libfile opensc-pkcs11.so


### PR DESCRIPTION
#### Description:

- Fix remediation script to compare the output value of `pkcs11-switch` and to run `pkcs11-switch opensc` inside of `if` statement
- Added call to `modutil` since `pkcs11-switch opensc` does not update `/etc/pki/nssdb/pkcs11.txt`. Without this update rule results in `fail` even after successfully running the remediation

#### Rationale:

- This is a bug fix