### PR TITLE
RHEL-08-020100 updating existing rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -7,12 +7,30 @@
 
 - name: "Set Password Retry Prompts Permitted Per-Session - system-auth (change)"
   replace:
+    {{% if product == "rhel8" -%}}
+    dest: "{{ item }}"
+    {{%- else -%}}
     dest: /etc/pam.d/system-auth
+    {{%- endif %}}
     regexp: '(^.*\spam_pwquality.so\s.*retry\s*=\s*)(\S+)(.*$)'
     replace: '\g<1>{{ var_password_pam_retry }}\g<3>'
+  {{% if product == "rhel8" -%}}
+  loop:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  {{%- endif %}}
 
 - name: "Set Password Retry Prompts Permitted Per-Session - system-auth (add)"
   replace:
+    {{% if product == "rhel8" -%}}
+    dest: "{{ item }}"
+    {{%- else -%}}
     dest: /etc/pam.d/system-auth
+    {{%- endif %}}
     regexp: '^.*\spam_pwquality.so\s(?!.*retry\s*=\s*).*$'
     replace: '\g<0> retry={{ var_password_pam_retry }}'
+  {{% if product == "rhel8" -%}}
+  loop:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  {{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -7,3 +7,11 @@ if grep -q "retry=" /etc/pam.d/system-auth ; then
 else
 	sed -i --follow-symlinks "/pam_pwquality.so/ s/$/ retry=$var_password_pam_retry/" /etc/pam.d/system-auth
 fi
+
+{{% if product == "rhel8" -%}}
+if grep -q "retry=" /etc/pam.d/password-auth ; then
+	sed -i --follow-symlinks "s/\(retry *= *\).*/\1$var_password_pam_retry/" /etc/pam.d/password-auth
+else
+	sed -i --follow-symlinks "/pam_pwquality.so/ s/$/ retry=$var_password_pam_retry/" /etc/pam.d/password-auth
+fi
+{{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -2,20 +2,37 @@
   <definition class="compliance" id="accounts_password_pam_retry" version="1">
     {{{ oval_metadata("The password retry should meet minimum requirements") }}}
     <criteria operator="AND" comment="Conditions for retry are satisfied">
-      <criterion comment="pam_pwquality" test_ref="test_password_pam_pwquality_retry" />
+      <criterion comment="pam_pwquality system-auth" test_ref="test_password_pam_pwquality_retry_system_auth" />
+      {{% if product == "rhel8" -%}}
+      <criterion comment="pam_pwquality password-auth" test_ref="test_password_pam_pwquality_retry_password_auth" />
+      {{%- endif %}}
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="check the configuration of /etc/pam.d/system-auth" id="test_password_pam_pwquality_retry" version="1">
-    <ind:object object_ref="obj_password_pam_pwquality_retry" />
+  {{% macro test_pwquality_retry(path, test_ref) %}}
+  <ind:textfilecontent54_test check="all" comment="check the configuration of {{{ path }}}" id="test_{{{ test_ref }}}" version="1">
+    <ind:object object_ref="obj_{{{ test_ref }}}" />
     <ind:state state_ref="state_password_pam_retry" />
   </ind:textfilecontent54_test>
+  {{% endmacro %}}
 
-  <ind:textfilecontent54_object id="obj_password_pam_pwquality_retry" version="1">
-    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+  {{{ test_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_system_auth") }}}
+  {{% if product == "rhel8" -%}}
+  {{{ test_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
+  {{%- endif %}}
+
+  {{% macro object_pwquality_retry(path, test_ref) %}}
+  <ind:textfilecontent54_object id="obj_{{{ test_ref }}}" version="1">
+    <ind:filepath>{{{ path }}}</ind:filepath>
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_pwquality\.so.*retry=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endmacro %}}
+
+  {{{ object_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_system_auth") }}}
+  {{% if product == "rhel8" -%}}
+  {{{ object_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
+  {{%- endif %}}
 
   <ind:textfilecontent54_state id="state_password_pam_retry" version="1">
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_retry" />

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -12,7 +12,8 @@
   {{% macro test_pwquality_retry(path, test_ref) %}}
   <ind:textfilecontent54_test check="all" comment="check the configuration of {{{ path }}}" id="test_{{{ test_ref }}}" version="1">
     <ind:object object_ref="obj_{{{ test_ref }}}" />
-    <ind:state state_ref="state_password_pam_retry" />
+    <ind:state state_ref="state_password_pam_retry_upper_bound" />
+    <ind:state state_ref="state_password_pam_retry_lower_bound" />
   </ind:textfilecontent54_test>
   {{% endmacro %}}
 
@@ -34,8 +35,12 @@
   {{{ object_pwquality_retry( path="/etc/pam.d/password-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
   {{%- endif %}}
 
-  <ind:textfilecontent54_state id="state_password_pam_retry" version="1">
+  <ind:textfilecontent54_state comment="upper bound of password_pam_retry" id="state_password_pam_retry_upper_bound" version="1">
     <ind:subexpression datatype="int" operation="less than or equal" var_ref="var_password_pam_retry" />
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state comment="lower bound of password_pam_retry" id="state_password_pam_retry_lower_bound" version="1">
+    <ind:subexpression datatype="int" operation="greater than">0</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <external_variable comment="External variable for pam_pwquality retry" datatype="int" id="var_password_pam_retry" version="1" />

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -18,7 +18,7 @@
 
   {{{ test_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_system_auth") }}}
   {{% if product == "rhel8" -%}}
-  {{{ test_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
+  {{{ test_pwquality_retry( path="/etc/pam.d/password-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
   {{%- endif %}}
 
   {{% macro object_pwquality_retry(path, test_ref) %}}
@@ -31,7 +31,7 @@
 
   {{{ object_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_system_auth") }}}
   {{% if product == "rhel8" -%}}
-  {{{ object_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
+  {{{ object_pwquality_retry( path="/etc/pam.d/password-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
   {{%- endif %}}
 
   <ind:textfilecontent54_state id="state_password_pam_retry" version="1">

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -6,10 +6,12 @@ title: 'Ensure PAM Enforces Password Requirements - Authentication Retry Prompts
 
 description: |-
     To configure the number of retry prompts that are permitted per-session:
-    Edit the <tt>pam_pwquality.so</tt> statement in <tt>/etc/pam.d/system-auth</tt> to
-    show <tt>retry={{{ xccdf_value("var_password_pam_retry") }}}</tt>, or a lower value if
-    site policy is more restrictive.
-    The DoD requirement is a maximum of 3 prompts per session.
+    Edit the <tt>pam_pwquality.so</tt> statement in
+    <tt>/etc/pam.d/system-auth</tt> {{% if product == "rhel8" %}} and
+    <tt>/etc/pam.d/password-auth</tt> {{% endif %}} to show
+    <tt>retry={{{xccdf_value("var_password_pam_retry") }}}</tt>, or a lower value if site
+    policy is more restrictive. The DoD requirement is a maximum of 3 prompts
+    per session.
 
 rationale: |-
     Setting the password retry prompts that are permitted on a per-session basis to a low value
@@ -45,7 +47,7 @@ ocil_clause: 'it is not the required value'
 
 ocil: |-
     To check how many retry attempts are permitted on a per-session basis, run the following command:
-    <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre>
+    <pre>$ grep pam_pwquality /etc/pam.d/system-auth {{% if product == "rhel8" %}}/etc/pam.d/password-auth{{% endif %}}</pre>
     The <tt>retry</tt> parameter will indicate how many attempts are permitted.
     The DoD required value is less than or equal to 3.
     This would appear as <tt>retry=3</tt>, or a lower value.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/argument_missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
 
 config_file="/etc/pam.d/system-auth"
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
 
 retry_cnt=3
 config_file="/etc/pam.d/system-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/rhel8_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/rhel8_argument_missing.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+for auth_file in system-auth password-auth
+do
+    config_file=/etc/pam.d/${auth_file}
+
+    if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
+        sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*//" $config_file
+    fi
+done

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/rhel8_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/rhel8_correct_value.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+retry_cnt=3
+for auth_file in system-auth password-auth
+do
+    config_file=/etc/pam.d/${auth_file}
+
+	if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
+		sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*/\1$retry_cnt/" $config_file
+	else
+		sed -i --follow-symlinks "/pam_pwquality\.so/ s/$/ retry=$retry_cnt/" $config_file
+	fi
+done

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/rhel8_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/rhel8_wrong_value.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+retry_cnt=7
+for auth_file in system-auth password-auth
+do
+    config_file=/etc/pam.d/${auth_file}
+
+	if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
+		sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*/\1$retry_cnt/" $config_file
+	else
+		sed -i --follow-symlinks "/pam_pwquality\.so/ s/$/ retry=$retry_cnt/" $config_file
+	fi
+done

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
 
 retry_cnt=7
 config_file="/etc/pam.d/system-auth"


### PR DESCRIPTION
#### Description:

- Retry=3 pam_pwquality module does not check/remediate the password-auth file in RHEL 8.

#### Rationale:

- The RHEL 8 STIG currently expects the retry=3 option to be in both system-auth and password-auth files

- Fixes #6954 

- ***NOTES*** I will be requesting a change for this rule with DISA to follow the same format for all the other pwquality rules. That is, to use the `/etc/security/pwquality.conf` file to set this rule.
