### PR TITLE
Use noninteractive front-end to apt

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -114,7 +114,7 @@ if ! rpm -q --quiet "{{{ package }}}" ; then
     {{{ pkg_manager }}} install -y "{{{ package }}}"
 fi
 {{%- elif pkg_manager == "apt_get" -%}}
-apt-get install -y "{{{ package }}}"
+DEBIAN_FRONTEND=noninteractive apt-get install -y "{{{ package }}}"
 {{%- elif pkg_manager == "zypper" -%}}
 zypper install -y "{{{ package }}}"
 {{%- else -%}}
@@ -140,7 +140,7 @@ if rpm -q --quiet "{{{ package }}}" ; then
     {{{ pkg_manager }}} remove -y "{{{ package }}}"
 fi
 {{%- elif pkg_manager == "apt_get" -%}}
-apt-get remove -y "{{{ package }}}"
+DEBIAN_FRONTEND=noninteractive apt-get remove -y "{{{ package }}}"
 {{%- elif pkg_manager == "zypper" -%}}
 zypper remove -y "{{{ package }}}"
 {{%- else -%}}


### PR DESCRIPTION
This allows APT to run non-interactively. Some package installations
will prompt for user interaction by default (e.g., mail servers) on
Debian-like installations. However, because apt doesn't natively do any
detection of terminal input, when running from `scap-workbench`,
remediation will hang due to waiting for input during these installs.

Thus, running non-interactively seems like the best option.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

As mentioned by Richard, an administrator could run `debconf-set-selections` prior to hardening to set options that aren't the default. `DEBIAN_FRONTEND=noninteractive` will respect these selections. Any settings not specified will then take their defaults.

This prevents a bug with running any Ubuntu/Debian profiles with package installations from `scap-workbench`.

/cc @richardmaciel-canonical 