### PR TITLE
Add bash package installated macro

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
@@ -1,10 +1,10 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 
-if rpm -q --quiet chrony ; then
+if {{{ bash_package_installed("chrony") }}} ; then
     if ! /usr/sbin/pidof ntpd ; then
         {{{ bash_service_command("enable", "chronyd") | indent(8) }}}
     fi
-elif rpm -q --quiet ntp ; then
+elif {{{ bash_package_installed("ntp") }}} ; then
     {{{ bash_service_command("enable", "ntpd") | indent(4) }}}
 else
     {{{ bash_package_install("chrony") | indent(4) }}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -644,3 +644,14 @@ if grep -qvzosP $AD_REGEX $SSSD_CONF; then
         fi
 fi
 {{%- endmacro %}}
+
+{{#
+  # Check whether or not a package is installed.
+  #}}
+{{%- macro bash_package_installed(pkgname) -%}}
+{{%- if pkg_manager == "apt_get" -%}}
+dpkg-query --show --showformat='${db:Status-Status}\n' "{{{ pkgname }}}" 2>/dev/null | grep -q installed
+{{%- else -%}}
+rpm --quiet -q "{{{ pkgname }}}"
+{{%- endif -%}}
+{{%- endmacro -%}}


### PR DESCRIPTION
#### Description

This introduces a new macro, `bash_package_installed` that checks (in a platform-dependent way) whether a given package is installed. This macro is then used in `service_chronyd_or_ntpd_enabled`, to ensure the detection happens correctly on Debian/Ubuntu platforms. 

--- 

This macro could also be used in bash fixes for package inventory CPEs, whereby if a package isn't installed, the fix wouldn't be run (when running from a straight-profile hardening script instead of from oscap). This would be instead of the current Python-based code presently used. 

Just a thought for the future, outside the scope of this fix... :-) 
