### PR TITLE
Add Rule for SLES-12-010600 and SLES-15-010390

### DIFF
--- a/linux_os/guide/system/apparmor/apparmor_configured/ansible/shared.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/ansible/shared.yml
@@ -1,0 +1,7 @@
+# platform = multi_platform_sle
+
+- name: Start apparmor.service
+  systemd:
+    name: apparmor.service
+    state: started
+    enabled: yes

--- a/linux_os/guide/system/apparmor/apparmor_configured/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/apparmor_configured/bash/shared.sh
@@ -1,0 +1,4 @@
+# platform = multi_platform_sle
+
+# Enable apparmor
+{{{ bash_service_command("enable", "apparmor") }}}

--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -63,7 +63,8 @@ references:
 ocil_clause: 'it is not'
 
 
-ocil: '{{{ describe_service_enable(service="apparmor") }}}'
+ocil: |-
+    {{{ describe_service_enable(service="apparmor") }}}
 
 template:
     name: service_enabled

--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -1,0 +1,74 @@
+documentation_complete: true
+
+prodtype: sle12,sle15
+
+title: 'Ensure AppArmor is Active and Configured'
+
+description: |-
+    Verify that the SUSE operating system Apparmor tool is configured to
+    control whitelisted applications and user home directory access
+    control.<br/><br/>
+
+    Check that <tt>pam_apparmor</tt> is installed on the system with the following
+    command:
+
+    <pre># rpm -q pam_apparmor</pre>
+
+    Check that the "apparmor" daemon is running with the following command:
+
+    <pre># systemctl status apparmor.service | grep -i active
+
+    Active: active (exited) since Fri 2017-01-13 01:01:01 GMT; 1day 1h ago</pre>
+
+    <strong>Note:</strong> <tt>pam_apparmor</tt> must have properly configured
+    profiles. All configurations will be based on the actual system setup and
+    organization.  See the <tt>pam_apparmor</tt> documentation for more
+    information on configuring profiles.
+
+rationale: |-
+    Using a whitelist provides a configuration management method for allowing
+    the execution of only authorized software. Using only authorized software
+    decreases risk by limiting the number of potential vulnerabilities.<br/><br/>
+
+    The organization must identify authorized software programs and permit
+    execution of authorized software by adding each authorized program to the
+    "pam_apparmor" exception policy. The process used to identify software
+    programs that are authorized to execute on organizational information
+    systems is commonly referred to as whitelisting.<br/><br/>
+
+    Verification of whitelisted software occurs prior to execution or at system
+    startup.<br/><br/>
+
+    Users' home directories/folders may contain information of a sensitive
+    nature. Nonprivileged users should coordinate any sharing of information
+    with a System Administrator (SA) through shared resources.<br/><br/>
+
+    Apparmor can confine users to their home directory, not allowing them to
+    make any changes outside of their own home directories. Confining users to
+    their home directory will minimize the risk of sharing information.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83194-1
+    cce@sle15: CCE-85752-4
+
+references:
+    disa: CCI-001764,CCI-001774,CCI-002165,CCI-002233,CCI-002235
+    nist: AC-3(4),AC-6(8),AC-6(10),CM-7(5)(b),CM-7(2),SC-7(21),CM-6(a)
+    srg: SRG-OS-000312-GPOS-00122,SRG-OS-000312-GPOS-00123SRG-OS-000312-GPOS-00124,SRG-OS-000324-GPOS-00125,SRG-OS-000326-GPOS-00126,SRG-OS-000370-GPOS-00155,SRG-OS-000480-GPOS-00230,SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00231,SRG-OS-000480-GPOS-00232
+    stigid@sle12: SLES-12-010600
+    stigid@sle15: SLES-15-010390
+
+ocil_clause: 'it is not'
+
+
+ocil: '{{{ describe_service_enable(service="apparmor") }}}'
+
+template:
+    name: service_enabled
+    vars:
+        servicename: apparmor
+        packagename: apparmor-parser
+
+platform: machine

--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -5,7 +5,7 @@ prodtype: sle12,sle15
 title: 'Ensure AppArmor is Active and Configured'
 
 description: |-
-    Verify that the operating system Apparmor tool is configured to
+    Verify that the Apparmor tool is configured to
     control whitelisted applications and user home directory access
     control.<br/><br/>
     {{{ describe_service_enable(service="apparmor") }}}

--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -5,25 +5,11 @@ prodtype: sle12,sle15
 title: 'Ensure AppArmor is Active and Configured'
 
 description: |-
-    Verify that the SUSE operating system Apparmor tool is configured to
+    Verify that the operating system Apparmor tool is configured to
     control whitelisted applications and user home directory access
     control.<br/><br/>
+    {{{ describe_service_enable(service="apparmor") }}}
 
-    Check that <tt>pam_apparmor</tt> is installed on the system with the following
-    command:
-
-    <pre># rpm -q pam_apparmor</pre>
-
-    Check that the "apparmor" daemon is running with the following command:
-
-    <pre># systemctl status apparmor.service | grep -i active
-
-    Active: active (exited) since Fri 2017-01-13 01:01:01 GMT; 1day 1h ago</pre>
-
-    <strong>Note:</strong> <tt>pam_apparmor</tt> must have properly configured
-    profiles. All configurations will be based on the actual system setup and
-    organization.  See the <tt>pam_apparmor</tt> documentation for more
-    information on configuring profiles.
 
 rationale: |-
     Using a whitelist provides a configuration management method for allowing
@@ -62,9 +48,8 @@ references:
 
 ocil_clause: 'it is not'
 
-
 ocil: |-
-    {{{ describe_service_enable(service="apparmor") }}}
+    {{{ ocil_service_enabled(service="apparmor") }}}
 
 template:
     name: service_enabled

--- a/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_disabled.fail.sh
+++ b/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_disabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle
+# packages = apparmor
+
+
+systemctl disable apparmor.service

--- a/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_enabled.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle
+# packages = apparmor
+
+
+systemctl enable apparmor.service

--- a/linux_os/guide/system/apparmor/group.yml
+++ b/linux_os/guide/system/apparmor/group.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: AppArmor
+
+description: |-
+    Many security vulnerabilities result from bugs in trusted programs. A trusted
+    program runs with privileges that attackers want to possess. The program fails
+    to keep that trust if there is a bug in the program that allows the attacker to
+    acquire said privilege.
+    <br /><br />
+    AppArmor® is an application security solution designed specifically to apply
+    privilege confinement to suspect programs. AppArmor allows the administrator to
+    specify the domain of activities the program can perform by developing a
+    security profile. A security profile is a listing of files that the program may
+    access and the operations the program may perform. AppArmor secures
+    applications by enforcing good application behavior without relying on attack
+    signatures, so it can prevent attacks even if previously unknown
+    vulnerabilities are being exploited.
+    <br /><br />
+    Fore more information on using AppArmor, see
+    {{{ weblink(link="https://www.suse.com/documentation/sles-12/book_security/data/cha_apparmor_intro.html") }}}.

--- a/linux_os/guide/system/apparmor/group.yml
+++ b/linux_os/guide/system/apparmor/group.yml
@@ -17,5 +17,5 @@ description: |-
     signatures, so it can prevent attacks even if previously unknown
     vulnerabilities are being exploited.
     <br /><br />
-    Fore more information on using AppArmor, see
+    For more information on using AppArmor, see
     {{{ weblink(link="https://www.suse.com/documentation/sles-12/book_security/data/cha_apparmor_intro.html") }}}.

--- a/linux_os/guide/system/apparmor/package_pam_apparmor_installed/rule.yml
+++ b/linux_os/guide/system/apparmor/package_pam_apparmor_installed/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: sle12,sle15
+
+title: 'Install the pam_apparmor Package'
+
+description: |-
+    {{{ describe_package_install(package="pam_apparmor") }}}
+rationale: |-
+    Protection of system integrity using AppArmor depends on this package being
+    installed.
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83225-3
+    cce@sle15: CCE-85765-6
+
+references:
+    disa: CCI-001764,CCI-001774,CCI-002165,CCI-002233,CCI-002235
+    nist: AC-3(4),AC-6(8),AC-6(10),CM-7(5)(b),CM-7(2),SC-7(21),CM-6(a)
+    srg: SRG-OS-000312-GPOS-00122,SRG-OS-000312-GPOS-00123SRG-OS-000312-GPOS-00124,SRG-OS-000324-GPOS-00125,SRG-OS-000326-GPOS-00126,SRG-OS-000370-GPOS-00155,SRG-OS-000480-GPOS-00230,SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00231,SRG-OS-000480-GPOS-00232
+    stigid@sle12: SLES-12-010600
+    stigid@sle15: SLES-15-010390
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="pam_apparmor") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: pam_apparmor
+
+platform: machine

--- a/linux_os/guide/system/apparmor/package_pam_apparmor_installed/rule.yml
+++ b/linux_os/guide/system/apparmor/package_pam_apparmor_installed/rule.yml
@@ -6,9 +6,11 @@ title: 'Install the pam_apparmor Package'
 
 description: |-
     {{{ describe_package_install(package="pam_apparmor") }}}
+
 rationale: |-
     Protection of system integrity using AppArmor depends on this package being
     installed.
+
 severity: medium
 
 identifiers:

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -196,6 +196,7 @@ selections:
     - package_audit-audispd-plugins_installed
     - package_audit_installed
     - package_MFEhiplsm_installed
+    - package_pam_apparmor_installed
     - package_SuSEfirewall2_installed
     - package_telnet-server_removed
     - pam_disable_automatic_configuration

--- a/sle12/profiles/stig.profile
+++ b/sle12/profiles/stig.profile
@@ -71,6 +71,7 @@ selections:
     - aide_scan_notification
     - aide_verify_acls
     - aide_verify_ext_attributes
+    - apparmor_configured
     - audit_rules_dac_modification_chmod
     - audit_rules_dac_modification_chown
     - audit_rules_dac_modification_fchmod

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -201,6 +201,7 @@ selections:
     - package_aide_installed
     - package_audit-audispd-plugins_installed
     - package_audit_installed
+    - package_pam_apparmor_installed
     - package_telnet-server_removed
     - package_firewalld_installed
     - package_vsftpd_removed

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -64,6 +64,7 @@ selections:
     - aide_verify_acls
     - aide_verify_ext_attributes
     - aide_periodic_cron_checking
+    - apparmor_configured
     #
     # NOTE: must configure "var_audispd_remote_server" when
     # "auditd_audispd_configure_remote_server" rule is enabled


### PR DESCRIPTION

#### Description:

Add rule for 'Ensure AppArmor is Active and Configured' 

#### Rationale:

- Add rule for 'Ensure AppArmor is Active and Configured' for the sle12 and sle15 platforms
- Add bash and ansible remediation
- Add pass and fail tests
