### PR TITLE
ocp4: Temporarily disable usbguard conf test

### DIFF
--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/ocp4/e2e.yml
@@ -1,3 +1,0 @@
----
-default_result: FAIL
-result_after_remediation: PASS


### PR DESCRIPTION
It's being flaky due to a usbguard bug. Disabling this should redice the
flakiness in the ocp4-rhcos4-moderate test.

This will be re-enabled once the issue is resolved.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>