### PR TITLE
OCP4: Link ocp_idp_no_htpasswd with IA-5(4)

### DIFF
--- a/applications/openshift/authentication/ocp_idp_no_htpasswd/rule.yml
+++ b/applications/openshift/authentication/ocp_idp_no_htpasswd/rule.yml
@@ -54,7 +54,7 @@ rationale: |-
   </p>
 
 references:
-  nist: AC-2(1),AC-2(2),AC-2(3),AC-2(4),AC-2(7),AC-2(8),AC-7,IA-2,IA-2(1),IA-2(2),IA-2(3),IA-2(5),IA-2(12)
+  nist: AC-2(1),AC-2(2),AC-2(3),AC-2(4),AC-2(7),AC-2(8),AC-7,IA-2,IA-2(1),IA-2(2),IA-2(3),IA-2(5),IA-2(12),IA-5(4)
 
 identifiers:
     cce@ocp4: CCE-84209-6

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.21
+  nist: IA-5(2)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", perms="-rw-------") }}}'
 


### PR DESCRIPTION
The control is mostly an IDP-side control with the exception that htpasswd
must not be used so that the password policy can be set and controlled
centrally.