### PR TITLE
Flip more rules to RHEL9

### DIFF
--- a/linux_os/guide/services/base/service_kdump_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_kdump_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Disable KDump Kernel Crash Analyzer (kdump)'
 

--- a/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
+++ b/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Enable the Hardware RNG Entropy Gatherer Service'
 

--- a/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Enable the OpenSSH Service'
 

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable graphical user interface'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -8,7 +8,7 @@
 
 documentation_complete: true
 
-prodtype: fedora,ol7,rhel7,rhel8,sle12,sle15
+prodtype: fedora,ol7,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Install Smart Card Packages For Multifactor Authentication'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install the opensc Package For Multifactor Authentication'
 

--- a/linux_os/guide/system/auditing/package_audispd-plugins_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audispd-plugins_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install audispd-plugins Package'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of unsuccessful file accesses'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of successful file accesses'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure basic parameters of Audit system'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of unsuccessful file creations'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of successful file creations'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of unsuccessful file deletions'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of successful file deletions'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure immutable Audit login UIDs'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of unsuccessful file modifications'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of successful file modifications'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of loading and unloading of kernel modules'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Perform general configuration of Audit for OSPP'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of unsuccessful ownership changes'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of successful ownership changes'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of unsuccessful permission changes'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure auditing of successful permission changes'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8
+prodtype: ol8,rhel8,rhel9
 
 title: 'Configure kernel to trust the CPU random number generator'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Enable Kernel Page-Table Isolation (KPTI)'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable vsyscalls'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Enable Auditing to Start Prior to the Audit Daemon in zIPL'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_audit_backlog_limit_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Extend Audit Backlog Limit for the Audit Daemon in zIPL'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_bls_entries_only/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bls_entries_only/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Ensure all zIPL boot entries are BLS compliant'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Ensure zIPL bootmap is up to date'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_page_poison_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Enable page allocator poisoning in zIPL'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_slub_debug_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Enable SLUB/SLAB allocator poisoning in zIPL'
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_vsyscall_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8,rhel9
 
 title: 'Disable vsyscalls in zIPL'
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Ensure All World-Writable Directories Are Owned by root user'
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8,rhel9
 
 title: 'Disable acquiring, saving, and processing core dumps'
 

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Enable page allocator poisoning'
 

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Enable SLUB/SLAB allocator poisoning'
 

--- a/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8
+prodtype: ol8,rhel8,rhel9
 
 title: 'Install policycoreutils-python-utils package'
 

--- a/linux_os/guide/system/selinux/package_policycoreutils_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install policycoreutils Package'
 

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Encrypt Partitions'
 
@@ -37,8 +37,10 @@ description: |-
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/install/ol8-install-basic.html#install-storage-network") }}}.
     {{% elif product in ["sle12", "sle15"] %}}
         {{{ weblink(link="https://www.suse.com/documentation/sled-12/book_security/data/sec_security_cryptofs_y2.html") }}}
-    {{% else %}}
+    {{% elif product == "rhel7" %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html") }}}.
+    {{% else %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/encrypting-block-devices-using-luks_security-hardening") }}}.
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux8,ubuntu1604,ubuntu1804,ubuntu2004,wrlinux1019
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux8,ubuntu1604,ubuntu1804,ubuntu2004,wrlinux1019
 
 title: 'The Installed Operating System Is FIPS 140-2 Certified'
 

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'The Installed Operating System Is Vendor Supported'
 
@@ -56,7 +56,7 @@ ocil_clause: 'the installed operating system is not supported'
 ocil: |-
     To verify that the installed operating system is supported, run
     the following command:
-{{% if product in ["rhel7", "rhel8"] %}}
+{{% if product.startswith("rhel") %}}
     <pre>$ grep -i "red hat" /etc/redhat-release</pre>
 {{% elif product in ["ol7", "ol8"] %}}
     <pre>$ grep -i "oracle" /etc/oracle-release</pre>

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: rhel8,rhel9
 
 title: 'Configure OpenSSL library to use TLS Encryption'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian9,debian10,fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Build and Test AIDE Database'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,wrlinux1019
 
 title: 'Configure Notification of Post-AIDE Scan Details'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Configure AIDE to Use FIPS 140-2 for Validating Hashes'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Configure AIDE to Verify Access Control Lists (ACLs)'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Configure AIDE to Verify Extended Attributes'
 

--- a/linux_os/guide/system/software/sudo/sudo_restrict_privilege_elevation_to_authorized/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_restrict_privilege_elevation_to_authorized/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'The operating system must restrict privilege elevation to authorized personnel'
 
-prodtype: ol7,ol8,rhel7,rhel8,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,sle15
 
 description: |-
     The sudo command allows a user to execute programs with elevated

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Ensure invoking users password for privilege escalation when using sudo'
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle15
 
 description: |-
     The sudoers security policy requires that users authenticate themselves before they can use sudo.

--- a/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install rng-tools Package'
 

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Ensure {{{ pkg_manager }}} Removes Previous Package Versions'
 

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: Configure dnf-automatic to Install Available Updates Automatically
 

--- a/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Install dnf-automatic Package'
 

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: Enable dnf-automatic Timer
 


### PR DESCRIPTION
Enable more rules - it is not about large groups that are enabled for one single reason, but it is rather about small "packs" of rules.

Those "packs" are grouped in individual commits, and the common rationale is that there are no notable changes in behavior in related components.