### PR TITLE
ocp4: Temporarily disable usbguard tests

### DIFF
--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/ocp4/e2e.yml
@@ -1,3 +1,0 @@
----
-default_result: FAIL
-result_after_remediation: PASS

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/ocp4/e2e.yml
@@ -1,3 +1,0 @@
----
-default_result: FAIL
-result_after_remediation: PASS


### PR DESCRIPTION
They're flaky cause of a bug.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>