### PR TITLE
OCP4: Port ocp4-cis rules to moderate profile

### DIFF
--- a/applications/openshift/accounts/accounts_restrict_service_account_tokens/rule.yml
+++ b/applications/openshift/accounts/accounts_restrict_service_account_tokens/rule.yml
@@ -19,6 +19,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.1.6
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'service account token usage needs review'
 

--- a/applications/openshift/accounts/accounts_unique_service_account/rule.yml
+++ b/applications/openshift/accounts/accounts_unique_service_account/rule.yml
@@ -25,6 +25,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.1.5
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'default service account usage needs review'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.11
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>AlwaysAdmit</tt> admission control plugin is not set'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -37,6 +37,7 @@ severity: high
 
 references:
     cis@ocp4: 1.2.12
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>AlwaysPullImages</tt> is included in <tt>admissionConfig</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.15
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'API server config contains <tt>NamespaceLifecycle</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -25,6 +25,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.17
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>enable-admission-plugins</tt> does not contain <tt>NodeRestriction</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
@@ -25,6 +25,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.16
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'the list of enabled admission plugins contains <tt>SecurityContextConstraint</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -29,6 +29,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.13
+    nist: CM-6,CM-6(1)
 
 ocil_clause: |-
     '<tt>enable-admission-plugins</tt>does not contain <tt>SecurityContextDeny</tt>'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -25,6 +25,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.14
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'API server configuration contains <tt>ServiceAccount</tt>'
 

--- a/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_anonymous_auth/rule.yml
@@ -36,6 +36,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.1
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'anonymous requests are not authorized'
 

--- a/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
@@ -35,6 +35,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.2.10
+  nist: CM-6,CM-6(1)
 
 ocil_clause: 'A FlowSchema object <tt>catch-all</tt> exists'
 

--- a/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.2.10
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>.apiServerArguments["feature-gates"]</tt> does not include <tt>APIPriorityAndFairness</tt>'
 

--- a/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
@@ -35,6 +35,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.2.10
+  nist: CM-6,CM-6(1)
 
 ocil_clause: 'A FlowSchema object <tt>catch-all</tt> exists'
 

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -31,6 +31,7 @@ severity: low
 
 references:
     cis@ocp4: 1.2.24
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
 

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.25
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
 

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -30,6 +30,7 @@ severity: high
 
 references:
     cis@ocp4: 1.2.22
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>audit-log-path</tt> does not contain a valid audit file path'
 

--- a/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
@@ -15,6 +15,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.7
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'The Node authorization-mode is configured and enabled'
 

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -17,6 +17,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.8
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'The Node authorization-mode is configured and enabled'
 

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'The RBAC authorization mode is enabled'
 

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -35,6 +35,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'basic-auth-file is configured and enabled for the API server'
 

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -20,6 +20,7 @@ severity: low
 
 references:
     cis@ocp4: 1.2.20
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>bindAddress</tt> allows unsecure connections'
 

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -33,6 +33,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.29
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>etcd-certfile</tt> does not exist or is not configured to valid certificates'
 

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -33,6 +33,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.29
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>keyFile</tt> does not exist or is not configured to valid certificates'
 

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -19,6 +19,7 @@ severity: medium
 
 references:
     cis: 1.2.4
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>kubelet-https</tt> is set to false'
 

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.18
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'insecure-bind-address is exists and has not been removed</tt>'
 

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -35,6 +35,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.19
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>insecure-port</tt> setting exists'
 

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -34,6 +34,7 @@ severity: high
 
 references:
     cis@ocp4: 1.2.6
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>kubelet-certificate-authority</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -31,6 +31,7 @@ severity: high
 
 references:
     cis@ocp4: 1.2.5
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>kubelet-client-certificate</tt> is not set as appropriate in <tt>apiServerArguments:</tt>'
 

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -31,6 +31,7 @@ severity: high
 
 references:
     cis@ocp4: 1.2.5
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>kubelet-client-key</tt> is not set as appropriate in <tt>apiServerArguments:</tt>'
 

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -22,12 +22,8 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.13
-    cis@ocp4: 1.2.14
-    cis@ocp4: 1.2.14
-    cis@ocp4: 1.2.15
-    cis@ocp4: 1.2.16
-    cis@ocp4: 1.2.17
+    cis@ocp4: 1.2.13,1.2.14,1.2.14,1.2.15,1.2.16,1.2.17
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'No admission plugins are disabled'
 

--- a/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.4
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: |-
     The openshift-apiserver serving-cert is not set to type

--- a/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.4
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: |-
     The openshift-apiserver serving-cert is not set to type

--- a/applications/openshift/api-server/api_server_profiling_protected_by_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_profiling_protected_by_rbac/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
   cis@ocp4: 1.2.21
+  nist: CM-6,CM-6(1)
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.26
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>min-request-timeout</tt> is not set or is not set to an appropriate value'
 

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.2.27
+  nist: CM-6,CM-6(1)
 
 ocil_clause: 'API server argument <tt>--service-account-lookup</tt> contains <tt>true</tt>'
 

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -33,6 +33,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.28
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'serviceAccountPublicKeyFiles is not configured correctly'
 

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -33,6 +33,7 @@ severity: high
 
 references:
     cis@ocp4: 1.2.3
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>token-auth-file</tt> argument is configured'
 

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
@@ -31,6 +31,7 @@ severity: low
 
 references:
     cis@ocp4: 1.2.24
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
 

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.2.25
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
 

--- a/applications/openshift/authentication/idp_is_configured/rule.yml
+++ b/applications/openshift/authentication/idp_is_configured/rule.yml
@@ -57,6 +57,7 @@ identifiers:
 
 references:
   cis@ocp4: 3.1.1
+  nist: AC-2,AC-2(1),AC-2(2),AC-2(3),AC-2(4),AC-2(5),AC-2(6),AC-2(7),AC-2(8),AC-7
 
 ocil_clause: 'identity provider is not configured'
 

--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -39,6 +39,7 @@ ocil: |-
 
 references:
     cis@ocp4: 1.3.7
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 warnings:
 - general: |-

--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -52,6 +52,7 @@ warnings:
 
 references:
     cis@ocp4: 1.3.6
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 template:
   name: yamlfile_value

--- a/applications/openshift/controller/controller_secure_port/rule.yml
+++ b/applications/openshift/controller/controller_secure_port/rule.yml
@@ -39,6 +39,7 @@ ocil: |-
 
 references:
     cis@ocp4: 1.3.7
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 warnings:
 - general: |-

--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.3.5
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>root-ca-file</tt> is not configured</tt>'
 

--- a/applications/openshift/controller/controller_service_account_private_key/rule.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/rule.yml
@@ -33,6 +33,7 @@ severity: medium
 
 references:
     cis@ocp4: 1.3.4
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: '<tt>service-account-private-key-file</tt> does not exist or is configured properly'
 

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -36,6 +36,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.3.3
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>use-service-account-credentials</tt> is set to <tt>false</tt>'
 

--- a/applications/openshift/etcd/etcd_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis@ocp4: '2.3'
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: 'the etcd is using self-signed certificates'
 

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis@ocp4: '2.1'
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: 'the etcd client certificate is not configured'
 

--- a/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis@ocp4: '2.2'
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: 'the etcd client certificate authentication is not configured'
 

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis@ocp4: '2.1'
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: 'the etcd client key file is not configured'
 

--- a/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis@ocp4: '2.6'
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: 'the etcd is using peer self-signed certificates'
 

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
@@ -22,7 +22,8 @@ identifiers:
     cce@ocp4: CCE-83465-5
 
 references:
-   cis@ocp4: '2.5'
+    cis@ocp4: '2.5'
+    nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 ocil_clause: 'the etcd peer client certificate authentication is not configured'
 

--- a/applications/openshift/general/general_apply_scc/rule.yml
+++ b/applications/openshift/general/general_apply_scc/rule.yml
@@ -29,3 +29,4 @@ ocil: |-
 
 references:
     cis@ocp4: 5.6.3
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/general/general_configure_imagepolicywebhook/rule.yml
+++ b/applications/openshift/general/general_configure_imagepolicywebhook/rule.yml
@@ -31,3 +31,4 @@ ocil: |-
 
 references:
     cis@ocp4: 5.5.1
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/general/general_default_namespace_use/rule.yml
+++ b/applications/openshift/general/general_default_namespace_use/rule.yml
@@ -26,3 +26,4 @@ ocil: |-
 
 references:
     cis@ocp4: 5.6.4
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/general/general_default_seccomp_profile/rule.yml
+++ b/applications/openshift/general/general_default_seccomp_profile/rule.yml
@@ -32,3 +32,4 @@ ocil: |-
 
 references:
     cis@ocp4: 5.6.2
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/general/general_namespaces_in_use/rule.yml
+++ b/applications/openshift/general/general_namespaces_in_use/rule.yml
@@ -29,3 +29,4 @@ ocil: |-
 
 references:
     cis@ocp4: 5.6.1
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.4
+    nist: CM-6,CM-6(1)
 
 warnings:
     - general: |-

--- a/applications/openshift/networking/configure_network_policies/rule.yml
+++ b/applications/openshift/networking/configure_network_policies/rule.yml
@@ -26,3 +26,4 @@ ocil: |-
 
 references:
     cis@ocp4: 5.3.1
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -26,3 +26,4 @@ ocil: |-
 
 references:
     cis@ocp4: 5.3.2
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
+++ b/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
@@ -30,6 +30,7 @@ severity: high
 
 references:
     cis@ocp4: 1.2.22
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>audit-log-path</tt> does not contain a valid audit file path'
 

--- a/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
+++ b/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
   cis@ocp4: 1.3.2,1.4.1
+  nist: CM-6,CM-6(1)
 
 severity: medium
 

--- a/applications/openshift/rbac/rbac_limit_cluster_admin/rule.yml
+++ b/applications/openshift/rbac/rbac_limit_cluster_admin/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.1.1
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'cluster-admin clusterrolebindings need review'
 

--- a/applications/openshift/rbac/rbac_limit_secrets_access/rule.yml
+++ b/applications/openshift/rbac/rbac_limit_secrets_access/rule.yml
@@ -23,6 +23,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.1.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'Access to secrets needs review'
 

--- a/applications/openshift/rbac/rbac_pod_creation_access/rule.yml
+++ b/applications/openshift/rbac/rbac_pod_creation_access/rule.yml
@@ -18,6 +18,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.1.4
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'pod creation privileges in roles needs review'
 

--- a/applications/openshift/rbac/rbac_wildcard_use/rule.yml
+++ b/applications/openshift/rbac/rbac_wildcard_use/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.1.3
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'wildcard usage in roles needs review'
 

--- a/applications/openshift/scc/scc_drop_container_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_drop_container_capabilities/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.2.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'requiredDropCapabilities use in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.2.8
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'allowed capabilities listings in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_ipc_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_ipc_namespace/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis@ocp4: 5.2.3
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'allowHostIPC usage in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
+++ b/applications/openshift/scc/scc_limit_net_raw_capability/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.2.7
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'NET_RAW use in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_network_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_network_namespace/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis@ocp4: 5.2.4
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'allowHostNetwork usage in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_privilege_escalation/rule.yml
+++ b/applications/openshift/scc/scc_limit_privilege_escalation/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis@ocp4: 5.2.5
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'allowPrivilegeEscalation usage in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.2.1
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'allowPrivilegedContainer usage in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
+++ b/applications/openshift/scc/scc_limit_process_id_namespace/rule.yml
@@ -19,6 +19,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.2.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'allowHostPID usage in SCCs needs review'
 

--- a/applications/openshift/scc/scc_limit_root_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_root_containers/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.2.6
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'allowPrivilegedContainer usage in SCCs needs review'
 

--- a/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
+++ b/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
@@ -20,6 +20,7 @@ rationale: |-
 
 references:
   cis@ocp4: 1.4.2
+  nist: CM-6,CM-6(1),SC-8,SC-8(1)
 
 identifiers:
   cce@ocp4: CCE-83674-2

--- a/applications/openshift/secrets/secrets_consider_external_storage/rule.yml
+++ b/applications/openshift/secrets/secrets_consider_external_storage/rule.yml
@@ -22,6 +22,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.4.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'review the need for external secrets storage'
 

--- a/applications/openshift/secrets/secrets_no_environment_variables/rule.yml
+++ b/applications/openshift/secrets/secrets_no_environment_variables/rule.yml
@@ -17,6 +17,7 @@ severity: medium
 
 references:
     cis@ocp4: 5.4.1
+    nist: CM-6,CM-6(1)
 
 ocil_clause: 'secrets mounted as environment variables need review'
 

--- a/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
   cis@ocp4: 4.1.4
+  nist: CM-6,CM-6(1)
 
 ocil_clause: 'The kube-proxy configuration ConfigMap mount is mounted with wrong group ownership'
 

--- a/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
@@ -31,6 +31,7 @@ severity: medium
 
 references:
   cis@ocp4: 4.1.4
+  nist: CM-6,CM-6(1)
 
 ocil_clause: 'The kube-proxy configuration ConfigMap mount is mounted with wrong ownership'
 

--- a/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
@@ -38,6 +38,7 @@ identifiers:
 
 references:
   cis@ocp4: 4.1.3
+  nist: CM-6,CM-6(1)
 
 ocil_clause: 'The kube-proxy configuration ConfigMap mount is mounted using wrong permissions'
 

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -50,6 +50,72 @@ selections:
     # AU-9
     - audit_log_forwarding_enabled
 
+    # CM-6 CONFIGURATION SETTINGS
+    # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
+    - api_server_anonymous_auth
+    - api_server_basic_auth
+    - api_server_token_auth
+    - api_server_kubelet_client_cert
+    - api_server_kubelet_client_key
+    - api_server_kubelet_certificate_authority
+    - api_server_auth_mode_no_aa
+    - api_server_auth_mode_node
+    - api_server_auth_mode_rbac
+    - api_server_api_priority_gate_enabled
+    - api_server_api_priority_flowschema_catch_all
+    - api_server_api_priority_v1alpha1_flowschema_catch_all
+    - api_server_admission_control_plugin_AlwaysAdmit
+    - api_server_admission_control_plugin_AlwaysPullImages
+    - api_server_admission_control_plugin_SecurityContextDeny
+    - api_server_admission_control_plugin_ServiceAccount
+    - api_server_no_adm_ctrl_plugins_disabled
+    - api_server_admission_control_plugin_NamespaceLifecycle
+    - api_server_admission_control_plugin_Scc
+    - api_server_admission_control_plugin_NodeRestriction
+    - api_server_insecure_bind_address
+    - api_server_insecure_port
+    - api_server_bind_address
+    - api_server_profiling_protected_by_rbac
+    - api_server_audit_log_path
+    - openshift_api_server_audit_log_path
+    - api_server_audit_log_maxbackup
+    - ocp_api_server_audit_log_maxbackup
+    - api_server_audit_log_maxsize
+    - ocp_api_server_audit_log_maxsize
+    - api_server_request_timeout
+    - api_server_service_account_lookup
+    - api_server_service_account_public_key
+    - rbac_debug_role_protects_pprof
+    - controller_use_service_account
+    - file_permissions_proxy_kubeconfig
+    - file_owner_proxy_kubeconfig
+    - file_groupowner_proxy_kubeconfig
+    - kubelet_disable_readonly_port
+    - rbac_limit_cluster_admin
+    - rbac_limit_secrets_access
+    - rbac_wildcard_use
+    - rbac_pod_creation_access
+    - accounts_unique_service_account
+    - accounts_restrict_service_account_tokens
+    - scc_limit_privileged_containers
+    - scc_limit_process_id_namespace
+    - scc_limit_ipc_namespace
+    - scc_limit_network_namespace
+    - scc_limit_privilege_escalation
+    - scc_limit_root_containers
+    - scc_limit_net_raw_capability
+    - scc_limit_container_allowed_capabilities
+    - scc_drop_container_capabilities
+    - configure_network_policies
+    - configure_network_policies_namespaces
+    - secrets_no_environment_variables
+    - secrets_consider_external_storage
+    - general_configure_imagepolicywebhook
+    - general_namespaces_in_use
+    - general_default_seccomp_profile
+    - general_apply_scc
+    - general_default_namespace_use
+
     # RA-5 VULNERABILITY SCANNING
     - compliancesuite_exists
 
@@ -63,13 +129,30 @@ selections:
     # SC-8(1): TRANSMISSION CONFIDENTIALITY AND INTEGRITY | CRYPTOGRAPHIC OR ALTERNATE PHYSICAL PROTECTION
     - api_server_client_ca
     - api_server_etcd_ca
+    - api_server_etcd_cert
+    - api_server_etcd_key
+    - api_server_https_for_kubelet_conn
+    - api_server_oauth_https_serving_cert
+    - api_server_openshift_https_serving_cert
     - api_server_tls_cert
     - api_server_tls_private_key
+    - controller_insecure_port_disabled
+    - controller_rotate_kubelet_server_certs
+    - controller_secure_port
+    - controller_service_account_ca
+    - controller_service_account_private_key
+    - etcd_auto_tls
+    - etcd_cert_file
+    - etcd_client_cert_auth
+    - etcd_key_file
+    - etcd_peer_auto_tls
     - etcd_peer_cert_file
+    - etcd_peer_client_cert_auth
     - etcd_peer_key_file
     - kubelet_configure_tls_cert
     - kubelet_configure_tls_key
     - routes_protected_by_tls
+    - scheduler_no_bind_address
 
     # SC-13: CRYPTOGRAPHIC PROTECTION
     - fips_mode_enabled


### PR DESCRIPTION
They are relevant since they address the CM-6 control. This also adds
the needed references.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>