### PR TITLE
configure_opensc_nss_db remediation fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/bash/shared.sh
@@ -4,8 +4,9 @@
 # complexity = low
 # disruption = low
 
+yum install -y opensc
 PKCSSW=$(/usr/bin/pkcs11-switch)
 
-if [ ${PKCSSW} != "opensc" ] ; then
-    ${PKCSSW} opensc
+if [ "${PKCSSW}" != "opensc" ] ; then
+    /usr/bin/pkcs11-switch opensc
 fi


### PR DESCRIPTION
#### Description:
The remediation needs to ensure that `opensc` is installed because it uses the `pkcs11-switch` script from the package and it also needs `opensc` for NSS db.

`/usr/bin/pkcs11-switch` is the script for switching db. Not the `$(/usr/bin/pkcs11-switch)` output (the script outputs current NSS db - "opensc", "coolkey", or empty string).

Unfortunately, the remediation still might not work as expected on rhel7, because the database switch might require user interaction, see https://bugzilla.redhat.com/show_bug.cgi?id=1719753. It works when no database is set (no user interaction needed). However, when e.g. coolkey is used, then user is propted with:
> WARNING: Performing this operation while the browser is running could cause
corruption of your security databases. If the browser is currently running,
you should exit browser before continuing this operation. Type 
'q <enter>' to abort, or <enter> to continue: 