### PR TITLE
configure_gnutls_crypto_policy update

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
@@ -15,9 +15,8 @@
   register: gnutls
 
 - name: "{{{ rule_title }}}"
-  copy:
-    dest: /etc/crypto-policies/back-ends/gnutls.config
-    content: |
-      SYSTEM=NONE:+MAC-ALL:-MD5:+GROUP-ALL:+SIGN-ALL:-SIGN-RSA-MD5:-SIGN-DSA-SHA1:-SIGN-DSA-SHA224:-SIGN-DSA-SHA256:-SIGN-DSA-SHA384:-SIGN-DSA-SHA512:+SIGN-RSA-SHA1:%VERIFY_ALLOW_SIGN_WITH_SHA1:+CIPHER-ALL:-CAMELLIA-256-GCM:-CAMELLIA-128-GCM:-CAMELLIA-256-CBC:-CAMELLIA-128-CBC:-3DES-CBC:-ARCFOUR-128:+ECDHE-RSA:+ECDHE-ECDSA:+RSA:+DHE-RSA:+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0:+COMP-NULL:%PROFILE_MEDIUM
-    follow: yes
+  replace:
+    path: /etc/crypto-policies/back-ends/gnutls.config
+    regexp: (\+VERS-ALL(?::-VERS-[A-Z]+\d\.\d)+)
+    replace: +VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0
   when: (gnutls.found is defined and gnutls.found != 1) or gnutls.msg == "file not present"

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
@@ -3,20 +3,43 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-
-- name: "{{{ rule_title }}}: Existing value check"
-  lineinfile:
+- name: "{{{ rule_title }}}: set_fact"
+  set_fact:
     path: /etc/crypto-policies/back-ends/gnutls.config
-    create: false
-    regexp: '\+VERS-ALL:-VERS-DTLS0\.9:-VERS-SSL3\.0:-VERS-TLS1\.0:-VERS-TLS1\.1:-VERS-DTLS1\.0'
-    state: absent
-  check_mode: true
-  changed_when: false
-  register: gnutls
+    correct_value: '+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0'
+    lineinfile_reg: \+VERS-ALL:-VERS-DTLS0\.9:-VERS-SSL3\.0:-VERS-TLS1\.0:-VERS-TLS1\.1:-VERS-DTLS1\.0
+
+- name: "{{{ rule_title }}}: stat"
+  stat:
+    path: "{{ path }}"
+    follow: yes
+  register: gnutls_file
+
+- name: "{{{ rule_title }}}: Add"
+  lineinfile:
+    path: "{{ path }}"
+    regexp: "{{ lineinfile_reg }}"
+    line: "{{ correct_value }}"
+    create: yes
+  when: not gnutls_file.stat.exists or gnutls_file.stat.size <= correct_value|length
 
 - name: "{{{ rule_title }}}"
-  replace:
-    path: /etc/crypto-policies/back-ends/gnutls.config
-    regexp: (\+VERS-ALL(?::-VERS-[A-Z]+\d\.\d)+)
-    replace: +VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0
-  when: (gnutls.found is defined and gnutls.found != 1) or gnutls.msg == "file not present"
+  block:
+    - name: "{{{ rule_title }}}: Existing value check"
+      lineinfile:
+        path: "{{ path }}"
+        create: false
+        regexp: "{{ lineinfile_reg }}"
+        state: absent
+      check_mode: true
+      changed_when: false
+      register: gnutls
+
+    - name: "{{{ rule_title }}}: Update"
+      replace:
+        path: "{{ path }}"
+        regexp: (\+VERS-ALL(?::-VERS-[A-Z]+\d\.\d)+)
+        replace: "{{ correct_value }}"
+      when: gnutls.found is defined and gnutls.found != 1
+
+  when: gnutls_file.stat.exists and gnutls_file.stat.size > correct_value|length

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/bash/shared.sh
@@ -4,17 +4,10 @@
 # complexity = low
 # disruption = low
 
-RULE_LINE='+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0'
 CONF_FILE=/etc/crypto-policies/back-ends/gnutls.config
 correct_value='+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0'
 
-# Make sure file is present
-if [[ -f ${CONF_FILE} ]]; then
-    echo "Aborting remediation as '${CONF_FILE}' was not even found." >&2
-    exit 1
-fi
-
-grep -q ${RULE_LINE} ${CONF_FILE}
+grep -q ${correct_value} ${CONF_FILE}
 
 if [[ $? -ne 0 ]]; then
     # We need to get the existing value, using PCRE to maintain same regex

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/bash/shared.sh
@@ -6,6 +6,29 @@
 
 RULE_LINE='+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0'
 CONF_FILE=/etc/crypto-policies/back-ends/gnutls.config
-CP='SYSTEM=NONE:+MAC-ALL:-MD5:+GROUP-ALL:+SIGN-ALL:-SIGN-RSA-MD5:-SIGN-DSA-SHA1:-SIGN-DSA-SHA224:-SIGN-DSA-SHA256:-SIGN-DSA-SHA384:-SIGN-DSA-SHA512:+SIGN-RSA-SHA1:%VERIFY_ALLOW_SIGN_WITH_SHA1:+CIPHER-ALL:-CAMELLIA-256-GCM:-CAMELLIA-128-GCM:-CAMELLIA-256-CBC:-CAMELLIA-128-CBC:-3DES-CBC:-ARCFOUR-128:+ECDHE-RSA:+ECDHE-ECDSA:+RSA:+DHE-RSA:+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0:+COMP-NULL:%PROFILE_MEDIUM'
+correct_value='+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0'
 
-grep -q ${RULE_LINE} ${CONF_FILE} || echo ${CP} > ${CONF_FILE}
+# Make sure file is present
+if [[ -f ${CONF_FILE} ]]; then
+    echo "Aborting remediation as '${CONF_FILE}' was not even found." >&2
+    exit 1
+fi
+
+grep -q ${RULE_LINE} ${CONF_FILE}
+
+if [[ $? -ne 0 ]]; then
+    # We need to get the existing value, using PCRE to maintain same regex
+    existing_value=$(grep -Po '(\+VERS-ALL(?::-VERS-[A-Z]+\d\.\d)+)' ${CONF_FILE})
+
+    if [[ ! -z ${existing_value} ]]; then
+        # replace existing_value with correct_value
+        sed -i "s/${existing_value}/${correct_value}/g" ${CONF_FILE}
+    else
+        # ***NOTE*** #
+        # This probably means this file is not here or it's been modified
+        # unintentionally.
+        # ********** #
+        # echo correct_value to end
+        echo ${correct_value} >> ${CONF_FILE}
+    fi
+fi

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/oval/shared.xml
@@ -1,4 +1,27 @@
-{{{ oval_file_contents(
-    filepath="/etc/crypto-policies/back-ends/gnutls.config",
-    contents="SYSTEM=NONE:+MAC-ALL:-MD5:+GROUP-ALL:+SIGN-ALL:-SIGN-RSA-MD5:-SIGN-DSA-SHA1:-SIGN-DSA-SHA224:-SIGN-DSA-SHA256:-SIGN-DSA-SHA384:-SIGN-DSA-SHA512:+SIGN-RSA-SHA1:%VERIFY_ALLOW_SIGN_WITH_SHA1:+CIPHER-ALL:-CAMELLIA-256-GCM:-CAMELLIA-128-GCM:-CAMELLIA-256-CBC:-CAMELLIA-128-CBC:-3DES-CBC:-ARCFOUR-128:+ECDHE-RSA:+ECDHE-ECDSA:+RSA:+DHE-RSA:+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0:+COMP-NULL:%PROFILE_MEDIUM",
-    ) }}}
+{{%- set regex = "\+VERS-ALL:-VERS-DTLS0\.9:-VERS-SSL3\.0:-VERS-TLS1\.0:-VERS-TLS1\.1:-VERS-DTLS1\.0" -%}}
+{{%- set TEXT = "+VERS-ALL:-VERS-DTLS0.9:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS1.0" -%}}
+{{%- set PATH = "/etc/crypto-policies/back-ends/gnutls.config" -%}}
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Check presence of " + TEXT + " in " + PATH) }}}
+    <criteria operator="AND" comment="Test conditions - presence of the file plus {{{ OVAL_EXTEND_DEFINITIONS | length }}} extra definitions.">
+      {{%- for def in OVAL_EXTEND_DEFINITIONS %}}
+     <extend_definition comment="extend_definition added explicitly" definition_ref="{{{ def }}}" />
+      {{%- endfor %}}
+      <criterion comment="Check that {{{ PATH }}} contains a line with certain text" test_ref="test_{{{ rule_id }}}" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all"
+  comment="tests the presence of '{{{ TEXT }}}' setting in the {{{ PATH }}} file"
+  id="test_{{{ rule_id }}}" version="1">
+  <ind:object object_ref="obj_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath>{{{ PATH }}}</ind:filepath>
+    <ind:pattern operation="pattern match">{{{ regex }}}</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>
+

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/oval/shared.xml
@@ -6,7 +6,7 @@
     {{{ oval_metadata("Check presence of " + TEXT + " in " + PATH) }}}
    <criteria>
       <criterion comment="Check that {{{ PATH }}} contains a line with certain text" test_ref="test_{{{ rule_id }}}" />
-   <criteria/>
+   </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all"

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/oval/shared.xml
@@ -4,12 +4,9 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Check presence of " + TEXT + " in " + PATH) }}}
-    <criteria operator="AND" comment="Test conditions - presence of the file plus {{{ OVAL_EXTEND_DEFINITIONS | length }}} extra definitions.">
-      {{%- for def in OVAL_EXTEND_DEFINITIONS %}}
-     <extend_definition comment="extend_definition added explicitly" definition_ref="{{{ def }}}" />
-      {{%- endfor %}}
+   <criteria>
       <criterion comment="Check that {{{ PATH }}} contains a line with certain text" test_ref="test_{{{ rule_id }}}" />
-    </criteria>
+   <criteria/>
   </definition>
 
   <ind:textfilecontent54_test check="all"
@@ -24,4 +21,3 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>
-


### PR DESCRIPTION
#### Description:

- The original OVAL did not do a regex check for the appropriate value. It was simply ensuring that the content of the file was correct. However, with newer versions of the crypto-policies rpm, the contents have changed, thus making this an ineffective way to check state.

#### Rationale:

- Update OVAL to ensure the string is in the file
- Update Ansible to use replace module with appropriate regexp
- Update Bash to replace (sed) incorrect entry (if found) with appropriate value
- Fixes #7038 
