### PR TITLE
OCP4: Disable usbguard rules from RHCOS4 moderate profile

### DIFF
--- a/rhcos4/profiles/moderate.profile
+++ b/rhcos4/profiles/moderate.profile
@@ -191,7 +191,7 @@ selections:
     #- package_openscap-scanner_installed
     #- package_policycoreutils_installed
     - package_sudo_installed
-    - package_usbguard_installed
+    #- package_usbguard_installed
     ####
     # Need to replace with fluentd checks
     #- package_audispd-plugins_installed
@@ -236,9 +236,9 @@ selections:
     #- sssd_run_as_sssd_user
 
     ### Configure USBGuard
-    - service_usbguard_enabled
-    - configure_usbguard_auditbackend
-    - usbguard_allow_hid_and_hub
+    #- service_usbguard_enabled
+    #- configure_usbguard_auditbackend
+    #- usbguard_allow_hid_and_hub
 
     ### Enable / Configure FIPS
     - enable_fips_mode


### PR DESCRIPTION
These rules are very problematic and are the main reason for this job
being flaky... the problem is usbguard crashing which is a bug.

Let's disable these for now as a flaky service brings no value.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>