### PR TITLE
OCP4: Add ocp4-moderate-node profile

### DIFF
--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: '2.7'
+  nist: CM-6,CM-6(1)
 
 platforms:
   - ocp4-master-node

--- a/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
@@ -29,6 +29,7 @@ severity: medium
 
 references:
     cis@ocp4: 4.2.1
+    nist: CM-6,CM-6(1)
 
 identifiers:
       cce@ocp4: CCE-83815-1

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -28,6 +28,7 @@ severity: medium
 
 references:
     cis@ocp4: 4.2.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '<tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>'
 

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
@@ -39,6 +39,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.3
+    nist: CM-6,CM-6(1)
 
 template:
   name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -53,6 +53,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.9
+    nist: CM-6,CM-6(1)
 
 # This check ensures that the option is not left defaulted in the config.  The
 # default of 5 might be sufficient for a deployment; here the point is to check

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -39,6 +39,7 @@ severity: medium
 
 references:
   cis@ocp4: 4.2.13
+  nist: CM-6,CM-6(1)
 
 ocil_clause: "TLS cipher suite configuration is not configured or contains insecure ciphers"
 

--- a/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
@@ -28,3 +28,4 @@ ocil: |-
 
 references:
     cis@ocp4: 4.2.8
+    nist: CM-6,CM-6(1)

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.11
+    nist: CM-6,CM-6(1)
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -33,6 +33,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.11
+    nist: CM-6,CM-6(1)
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
@@ -33,6 +33,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.7
+    nist: CM-6,CM-6(1)
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
@@ -91,6 +91,7 @@ ocil: |-
 
 references:
   cis@ocp4: 4.2.6
+  nist: CM-6,CM-6(1)
 
 template:
   name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -33,6 +33,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.12
+    nist: CM-6,CM-6(1)
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.2.5
+    nist: CM-6,CM-6(1)
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84144-5

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84147-8

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84135-3

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84138-7

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84141-1

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84127-0

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84132-0

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84222-9

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84119-7

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
@@ -52,6 +52,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.3.1
+  nist: CM-6,CM-6(1)
 
 identifiers:
   cce@ocp4: CCE-84123-9

--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.18
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.12
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.12
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/wal/*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.8
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.19
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/cni/networks/openshift-sdn/.*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.4
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.6
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
@@ -24,6 +24,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.14
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.19
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.19
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/run/openshift-sdn/cniserver/config.json", group="root") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '/var/run/openvswitch/ovs-vswitchd.pid has group owner openvswitch or hugetlbfs'
 

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '/run/openvswitch/ovs-vswitchd.pid has group owner openvswitch or hugetlbfs'
 

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '/run/openvswitch/ovsdb-server.pid has group owner openvswitch or hugetlbfs'
 

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.16
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}'
 

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.18
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.12
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.12
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/wal/*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.8
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.19
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.4
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.6
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
@@ -24,6 +24,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.14
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.19
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.19
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openshift-sdn/cniserver/config.json", owner="root") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/conf.db", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.conf.db.~lock~", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/system-id.conf", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovs-vswitchd.pid", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/run/openvswitch/ovsdb-server.pid", owner="openvswitch") }}}'
 

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
   cis@ocp4: 1.1.16
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.17
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.11
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd", perms="drwx------") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.11
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/member/wal/*", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.7
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.20
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-*/secrets/*/*.crt", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/cni/networks/openshift-sdn/*", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.1
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.3
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
@@ -24,6 +24,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.13
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/multus/cni/net.d/*", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.20
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-*/secrets/*/tls.crt", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.21
+  nist: CM-6,CM-6(1)
   nist: IA-5(2)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", perms="-rw-------") }}}'

--- a/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/conf.db", perms="-rw-r-----") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/.conf.db.~lock~", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/system-id.conf", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovsdb-server.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.5
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
@@ -21,6 +21,7 @@ severity: medium
 
 references:
   cis@ocp4: 1.1.15
+  nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 1.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/openshift-sdn/cniserver/config.json", perms="-r--r--r--") }}}'
 

--- a/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
@@ -17,6 +17,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.6
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}'
 

--- a/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.8
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubelet-ca.crt", group="root") }}}'
 

--- a/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/kubelet/kubeconfig", group="root") }}}'
 

--- a/applications/openshift/worker/file_groupowner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_service/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: |-
     {{{ ocil_clause_file_group_owner(file="/etc/systemd/system/kubelet.service", group="root") }}}

--- a/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.6
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}'
 

--- a/applications/openshift/worker/file_owner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_ca/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.8
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubelet-ca.crt", owner="root") }}}'
 

--- a/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.10
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/kubelet/kubeconfig", owner="root") }}}'
 

--- a/applications/openshift/worker/file_owner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_service/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.2
+    nist: CM-6,CM-6(1)
 
 ocil_clause: |-
     {{{ ocil_clause_file_owner(file="/etc/systemd/system/kubelet.service", owner="root") }}}

--- a/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.5
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/kubelet.conf", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/worker/file_permissions_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_ca/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.7
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/kubelet-ca.crt", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.9
+    nist: CM-6,CM-6(1)
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/kubelet/kubeconfig", perms="-rw-------") }}}'
 

--- a/applications/openshift/worker/file_permissions_worker_service/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_service/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis@ocp4: 4.1.1
+    nist: CM-6,CM-6(1)
 
 ocil_clause: |-
   {{{ ocil_clause_file_permissions(file="/etc/systemd/system/kubelet.service", perms="-rw-r--r--") }}}

--- a/ocp4/profiles/moderate-node.profile
+++ b/ocp4/profiles/moderate-node.profile
@@ -1,0 +1,141 @@
+documentation_complete: true
+
+title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level'
+
+platform: ocp4-node
+
+metadata:
+    SMEs:
+        - JAORMX
+        - mrogers950
+        - jhrozek
+
+description: |-
+    This compliance profile reflects the core set of Moderate-Impact Baseline
+    configuration settings for deployment of Red Hat OpenShift Container
+    Platform into U.S. Defense, Intelligence, and Civilian agencies.
+    Development partners and sponsors include the U.S. National Institute
+    of Standards and Technology (NIST), U.S. Department of Defense,
+    the National Security Agency, and Red Hat.
+
+    This baseline implements configuration requirements from the following
+    sources:
+
+    - NIST 800-53 control selections for Moderate-Impact systems (NIST 800-53)
+
+    For any differing configuration requirements, e.g. password lengths, the stricter
+    security setting was chosen. Security Requirement Traceability Guides (RTMs) and
+    sample System Security Configuration Guides are provided via the
+    scap-security-guide-docs package.
+
+    This profile reflects U.S. Government consensus content and is developed through
+    the ComplianceAsCode initiative, championed by the National
+    Security Agency. Except for differences in formatting to accommodate
+    publishing processes, this profile mirrors ComplianceAsCode
+    content as minor divergences, such as bugfixes, work through the
+    consensus and release processes.
+selections:
+
+    # CM-6 CONFIGURATION SETTINGS
+    # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
+    - etcd_unique_ca
+    - file_groupowner_cni_conf
+    - file_groupowner_controller_manager_kubeconfig
+    - file_groupowner_etcd_data_dir
+    - file_groupowner_etcd_data_files
+    - file_groupowner_etcd_member
+    - file_groupowner_etcd_pki_cert_files
+    - file_groupowner_ip_allocations
+    - file_groupowner_kube_apiserver
+    - file_groupowner_kube_controller_manager
+    - file_groupowner_kube_scheduler
+    - file_groupowner_kubelet_conf
+    - file_groupowner_master_admin_kubeconfigs
+    - file_groupowner_multus_conf
+    - file_groupowner_openshift_pki_cert_files
+    - file_groupowner_openshift_pki_key_files
+    - file_groupowner_openshift_sdn_cniserver_config
+    - file_groupowner_ovs_conf_db
+    - file_groupowner_ovs_conf_db_lock
+    - file_groupowner_ovs_pid
+    - file_groupowner_ovs_sys_id_conf
+    - file_groupowner_ovs_vswitchd_pid
+    - file_groupowner_ovsdb_server_pid
+    - file_groupowner_scheduler_kubeconfig
+    - file_groupowner_worker_ca
+    - file_groupowner_worker_kubeconfig
+    - file_groupowner_worker_service
+    - file_owner_cni_conf
+    - file_owner_controller_manager_kubeconfig
+    - file_owner_etcd_data_dir
+    - file_owner_etcd_data_files
+    - file_owner_etcd_member
+    - file_owner_etcd_pki_cert_files
+    - file_owner_ip_allocations
+    - file_owner_kube_apiserver
+    - file_owner_kube_controller_manager
+    - file_owner_kube_scheduler
+    - file_owner_kubelet_conf
+    - file_owner_master_admin_kubeconfigs
+    - file_owner_multus_conf
+    - file_owner_openshift_pki_cert_files
+    - file_owner_openshift_pki_key_files
+    - file_owner_openshift_sdn_cniserver_config
+    - file_owner_ovs_conf_db
+    - file_owner_ovs_conf_db_lock
+    - file_owner_ovs_pid
+    - file_owner_ovs_sys_id_conf
+    - file_owner_ovs_vswitchd_pid
+    - file_owner_ovsdb_server_pid
+    - file_owner_scheduler_kubeconfig
+    - file_owner_worker_ca
+    - file_owner_worker_kubeconfig
+    - file_owner_worker_service
+    - file_permissions_cni_conf
+    - file_permissions_controller_manager_kubeconfig
+    - file_permissions_etcd_data_dir
+    - file_permissions_etcd_data_files
+    - file_permissions_etcd_member
+    - file_permissions_etcd_pki_cert_files
+    - file_permissions_ip_allocations
+    - file_permissions_kube_apiserver
+    - file_permissions_kube_controller_manager
+    - file_permissions_kubelet_conf
+    - file_permissions_master_admin_kubeconfigs
+    - file_permissions_multus_conf
+    - file_permissions_openshift_pki_cert_files
+    - file_permissions_openshift_pki_key_files
+    - file_permissions_ovs_conf_db
+    - file_permissions_ovs_conf_db_lock
+    - file_permissions_ovs_pid
+    - file_permissions_ovs_sys_id_conf
+    - file_permissions_ovs_vswitchd_pid
+    - file_permissions_ovsdb_server_pid
+    - file_permissions_scheduler
+    - file_permissions_scheduler_kubeconfig
+    - file_permissions_worker_ca
+    - file_permissions_worker_kubeconfig
+    - file_permissions_worker_service
+    - file_perms_openshift_sdn_cniserver_config
+    - kubelet_anonymous_auth
+    - kubelet_authorization_mode
+    - kubelet_configure_client_ca
+    - kubelet_configure_event_creation
+    - kubelet_configure_tls_cipher_suites
+    - kubelet_disable_hostname_override
+    - kubelet_enable_cert_rotation
+    - kubelet_enable_client_cert_rotation
+    - kubelet_enable_iptables_util_chains
+    - kubelet_enable_protect_kernel_defaults
+    - kubelet_enable_server_cert_rotation
+    - kubelet_enable_streaming_connections
+    - kubelet_eviction_thresholds_set_hard_imagefs_available
+    - kubelet_eviction_thresholds_set_hard_imagefs_inodesfree
+    - kubelet_eviction_thresholds_set_hard_memory_available
+    - kubelet_eviction_thresholds_set_hard_nodefs_available
+    - kubelet_eviction_thresholds_set_hard_nodefs_inodesfree
+    - kubelet_eviction_thresholds_set_soft_imagefs_available
+    - kubelet_eviction_thresholds_set_soft_imagefs_inodesfree
+    - kubelet_eviction_thresholds_set_soft_memory_available
+    - kubelet_eviction_thresholds_set_soft_nodefs_available
+    - kubelet_eviction_thresholds_set_soft_nodefs_inodesfree

--- a/ocp4/profiles/moderate.profile
+++ b/ocp4/profiles/moderate.profile
@@ -8,7 +8,7 @@ metadata:
 
 reference: https://nvd.nist.gov/800-53/Rev4/impact/moderate
 
-title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift'
+title: 'NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Platform level'
 
 platform: ocp4
 


### PR DESCRIPTION
This profile covers FedRAMP moderate checks that are meant to run on the
node itself. It differs fromt he rhcos4-moderate profile in such a way
that the rules in ocp4-moderate-node check for OCP4-specific
configurations, as opposed to Linux checks.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>