### PR TITLE
SLES-15-020102 new STIG rule

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("'Ensure sudo timestamp_timeout is appropriate - sudo timestamp_timeout") }}}
+    <criteria comment="The timestamp_timeout should be configured" >
+      <criterion comment="check configuration in /etc/sudoers" test_ref="test_sudo_timestamp_timeout" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check correct configuration in /etc/sudoers" id="test_sudo_timestamp_timeout" version="1">
+    <ind:object object_ref="obj_sudo_timestamp_timeout"/>
+    <ind:state state_ref="state_sudo_timestamp_timeout" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_sudo_timestamp_timeout" version="1">
+    <ind:filepath>/etc/sudoers</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*Defaults[\s]+timestamp_timeout=([\d]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_sudo_timestamp_timeout"
+  version="1">
+    <ind:subexpression datatype="int" operation="greater than or equal">0</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -1,0 +1,42 @@
+documentation_complete: true
+
+prodtype: sle15
+
+title: 'The operating system must require Re-Authentication when using the sudo command.
+ Ensure sudo timestamp_timeout is appropriate - sudo timestamp_timeout'
+
+description: |-
+    The sudo <tt>timestamp_timeout</tt> tag sets the amount of time sudo password prompt waits.
+    The default <tt>timestamp_timeout</tt> value is 5 minutes.
+    The timestamp_timeout should be configured by making sure that the
+    <tt>timestamp_timeout</tt> tag exists in
+    <tt>/etc/sudoers</tt> configuration file or any sudo configuration snippets
+    in <tt>/etc/sudoers.d/</tt>.
+    If the value is set to an integer less than 0, the user's time stamp will not expire 
+    and the user will not have to re-authenticate for privileged actions until the user's session is terminated.
+
+rationale: |-
+    Without re-authentication, users may access resources or perform tasks for which they
+    do not have authorization.
+    <br /><br />
+    When operating systems provide the capability to escalate a functional capability, it
+    is critical that the user re-authenticate.
+
+severity: medium
+
+identifiers:
+    cce@sle15: CCE-85764-9
+
+references:
+    disa: CCI-002038
+    stigid@sle15: SLES-15-020102
+    srgid: SRG-OS-000373-GPOS-00156
+
+ocil_clause: 'timestamp_timeout is not set with the appropriate value for sudo.'
+
+ocil: |-
+    Verify the operating system requires re-authentication 
+    when using the "sudo" command to elevate privileges, run the following command:
+    <pre>sudo grep -ri '^Defaults.*timestamp_timeout' /etc/sudoers /etc/sudoers.d</pre>
+    The output should be:
+    <pre>/etc/sudoers:Defaults timestamp_timout=0</pre> or "timestamp_timout" is set to a positive number.

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -48,3 +48,4 @@ template:
         variable_name: "var_sudo_timestamp_timeout"
     backends:
         oval: "off"
+        

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -39,7 +39,7 @@ ocil: |-
     when using the "sudo" command to elevate privileges, run the following command:
     <pre>sudo grep -ri '^Defaults.*timestamp_timeout' /etc/sudoers /etc/sudoers.d</pre>
     The output should be:
-    <pre>/etc/sudoers:Defaults timestamp_timout=0</pre> or "timestamp_timout" is set to a positive number.
+    <pre>/etc/sudoers:Defaults timestamp_timeout=0</pre> or "timestamp_timeout" is set to a positive number.
 
 template:
     name: sudo_defaults_option

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -40,3 +40,11 @@ ocil: |-
     <pre>sudo grep -ri '^Defaults.*timestamp_timeout' /etc/sudoers /etc/sudoers.d</pre>
     The output should be:
     <pre>/etc/sudoers:Defaults timestamp_timout=0</pre> or "timestamp_timout" is set to a positive number.
+
+template:
+    name: sudo_defaults_option
+    vars:
+        option: timestamp_timeout
+        variable_name: "var_sudo_timestamp_timeout"
+    backends:
+        oval: "off"

--- a/linux_os/guide/system/software/sudo/var_sudo_timestamp_timeout.var
+++ b/linux_os/guide/system/software/sudo/var_sudo_timestamp_timeout.var
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Sudo - passwd_timeout value'
+
+description: |-
+    Defines the number of minutes before the <tt>sudo</tt> password prompt times out.
+    Defining negative number means no timeout. Defining 0 means always prompt for a 
+    password. The default timeout value is 5 minutes.
+
+interactive: false
+
+type: string
+
+operator: equals
+
+options:
+    default: "5"
+    always_prompt: "0"
+    1_minute: "1"
+    2_minutes: "2"
+    3_minutes: "3"
+    5_minutes: "5"

--- a/linux_os/guide/system/software/sudo/var_sudo_timestamp_timeout.var
+++ b/linux_os/guide/system/software/sudo/var_sudo_timestamp_timeout.var
@@ -1,10 +1,10 @@
 documentation_complete: true
 
-title: 'Sudo - passwd_timeout value'
+title: 'Sudo - timestamp_timeout value'
 
 description: |-
-    Defines the number of minutes before the <tt>sudo</tt> password prompt times out.
-    Defining negative number means no timeout. Defining 0 means always prompt for a 
+    Defines the number of minutes that can elapse before <tt>sudo</tt> will ask for a passwd again.
+    If set to a value less than 0 the user's time stamp will never expire. Defining 0 means always prompt for a 
     password. The default timeout value is 5 minutes.
 
 interactive: false

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -250,6 +250,7 @@ selections:
     - sudo_remove_nopasswd
     - sudo_restrict_privilege_elevation_to_authorized
     - sudo_require_authentication
+    - sudo_require_reauthentication
     - sudoers_validate_passwd
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_randomize_va_space

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -19,6 +19,7 @@ selections:
     - var_accounts_fail_delay=4
     - var_accounts_tmout=15_min
     - inactivity_timeout_value=15_minutes
+    - var_sudo_timestamp_timeout=1_minute
     #
     # Note: must configure "var_accounts_authorized_local_users_regex" when
     # "accounts_authorized_local_users" rule is enabled

--- a/sle15/profiles/stig.profile
+++ b/sle15/profiles/stig.profile
@@ -19,7 +19,7 @@ selections:
     - var_accounts_fail_delay=4
     - var_accounts_tmout=15_min
     - inactivity_timeout_value=15_minutes
-    - var_sudo_timestamp_timeout=1_minute
+    - var_sudo_timestamp_timeout=always_prompt
     #
     # Note: must configure "var_accounts_authorized_local_users_regex" when
     # "accounts_authorized_local_users" rule is enabled


### PR DESCRIPTION
#### Description:

Add rule for sudo Re-Authentication when using the sudo command

#### Rationale:

Add rule concerning sudo Re-Authentication timestamp_timeout to SLE15 stig profile
