### PR TITLE
Select rule for RHEL8 CIS 1.3.2 (fixes #5220)

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
@@ -20,10 +20,9 @@ identifiers:
     cce@rhel8: CCE-83798-9
 
 references:
-    cis@rhel8: 1.3.2
-
-references:
     anssi: BP28(R58)
+    cis@rhel7: 5.2.2
+    cis@rhel8: 1.3.2
 
 ocil_clause: 'use_pty is not enabled in sudo'
 

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
@@ -18,6 +18,8 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-83797-1
     cce@rhel8: CCE-83798-9
+
+references:
     cis@rhel8: 1.3.2
 
 references:

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
@@ -18,6 +18,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-83797-1
     cce@rhel8: CCE-83798-9
+    cis@rhel8: 1.3.2
 
 references:
     anssi: BP28(R58)

--- a/rhel8/profiles/cis.profile
+++ b/rhel8/profiles/cis.profile
@@ -129,7 +129,7 @@ selections:
     - package_sudo_installed
 
     ### 1.3.2 Ensure sudo commands use pty (Scored)
-    # NEEDS RULE - https://github.com/ComplianceAsCode/content/issues/5220
+    - sudo_add_use_pty
 
     ### 1.3.3 Ensure sudo log file exists (Scored)
     # NEEDS RULE - https://github.com/ComplianceAsCode/content/issues/5221


### PR DESCRIPTION
#### Description:

- Add rule for RHEL 8 CIS control 1.3.2

#### Rationale:

- There is already a rule for ensuring that sudo commands only work when using a PTY. We just need to enable it.

- Fixes #5220 
