### PR TITLE
Remove deprecated install command from RHEL8 kickstarts

### DIFF
--- a/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
@@ -6,9 +6,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
@@ -4,9 +4,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
@@ -6,9 +6,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
@@ -6,9 +6,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
@@ -4,9 +4,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
@@ -4,9 +4,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
@@ -4,9 +4,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
+++ b/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
@@ -4,9 +4,6 @@
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
 
-# Install a fresh new system (optional)
-install
-
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
 # the selected choice with proper options & un-comment it

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -43,7 +43,7 @@ def parse_args():
     parser.add_argument(
         "--ram",
         dest="ram",
-        default=2048,
+        default=3072,
         type=int,
         help="Amount of RAM configured for the VM."
     )


### PR DESCRIPTION
#### Description:

* Remove deprecated install command from RHEL8 kickstarts, Anaconda prints the following warning when installing RHEL8:
```   
    The install command has been deprecated and no longer has any effect.
    It may be removed from future releases, which will result in a fatal
    error from kickstart.  Please modify your kickstart file to remove
    this command.
```
* Increased default memory in `install_vm.py` as for RHEL8 min. memory is 1.5 GB per logical CPU core: https://access.redhat.com/articles/rhel-limits

There is one more warning from Anaconda about authconfig:
```
org.fedoraproject.Anaconda.Modules.Security[1733]: INFO:program:IMPORTANT: authconfig is replaced by authselect, please update your scripts.
```
but I am not sure if we can just replace `authconfig` with `authselect` as there might be also some rules in profiles
which would need the similar update. This needs more investigation (outside of this PR).
