### PR TITLE
Fix oval check in uefi_no_removeable_media

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_uefi_no_removeable_media" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^['|\(](?!fd)(?!cd)(?!usb).*['|\)].*'$</ind:subexpression>
+    <ind:subexpression datatype="string" operation="pattern match">^['|\(](?!fd)(?!cd)(?!usb).*['|\)]$</ind:subexpression>
   </ind:textfilecontent54_state>
 
   {{{ oval_file_absent(grub_cfg_prefix + "/grub.cfg") }}}


### PR DESCRIPTION
#### Description:

- The group `['|\(]` already matches the closing `'`, so the extra `.*'` at the end of the regex was causing false negatives

#### Rationale:

- This fixes false negatives
