### PR TITLE
Don't mistake ':' in variable selector for control

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -514,7 +514,8 @@ class ProfileWithInlinePolicies(ResolvableProfile):
         self.controls_by_policy = defaultdict(list)
 
     def apply_selection(self, item):
-        if ":" in item:
+        # ":" is the delimiter for controls but not when the item is a variable
+        if ":" in item and "=" not in item:
             policy_id, control_id = item.split(":", 1)
             self.controls_by_policy[policy_id].append(control_id)
         else:


### PR DESCRIPTION
#### Description:

- Check if the item is not a variable selection before assuming it is a control selection.

#### Rationale:

- This allows variable to use ":" in the selector.