### PR TITLE
Add SCE Support to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ option(SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED "If enabled, Ansible Playbooks for
 option(SSG_BASH_SCRIPTS_ENABLED "If enabled, Bash remediation scripts for each profile will be built and installed." TRUE)
 option(SSG_JINJA2_CACHE_ENABLED "If enabled, the jinja2 templating files will be cached into bytecode. Also see SSG_JINJA2_CACHE_DIR." TRUE)
 option(SSG_BATS_TESTS_ENABLED "If enabled, bats will be used to run unit-tests of bash remediations." TRUE)
+option(SSG_SCE_ENABLED "If enabled, additional SCE audit content will be enabled alongside OVAL-based auditing." FALSE)
 set(SSG_JINJA2_CACHE_DIR "${CMAKE_BINARY_DIR}/jinja2_cache" CACHE PATH "Where the jinja2 cached bytecode should be stored. This speeds up builds at the expense of disk space. You can use one location for multiple SSG builds for performance improvements.")
 
 # SSG_PRODUCT_DEFAULT modifies the behavior of all other options. Products

--- a/build-scripts/build_sce.py
+++ b/build-scripts/build_sce.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import argparse
+
+import ssg.build_sce
+import ssg.environment
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--build-config-yaml", required=True,
+        help="YAML file with information about the build configuration. "
+        "e.g.: ~/scap-security-guide/build/build_config.yml"
+    )
+    p.add_argument(
+        "--product-yaml", required=True,
+        help="YAML file with information about the product we are building. "
+        "e.g.: ~/scap-security-guide/rhel7/product.yml"
+    )
+    p.add_argument(
+        "--output", required=True)
+    p.add_argument(
+        "scedirs", metavar="SCE_DIR", nargs="+",
+        help="SCE definition scripts to build for the specified product.")
+    args = p.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # Create output directory if it doesn't yet exist.
+    if not os.path.exists(args.output):
+        os.makedirs(args.output)
+
+    env_yaml = ssg.environment.open_environment(
+        args.build_config_yaml, args.product_yaml)
+    ssg.build_sce.checks(env_yaml, args.product_yaml, args.scedirs, args.output)

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -44,6 +44,9 @@ def parse_args():
     parser_stats.add_argument("--implemented-ovals", default=False,
                         action="store_true", dest="implemented_ovals",
                         help="Show IDs of implemented OVAL checks.")
+    parser_stats.add_argument("--implemented-sces", default=False,
+                        action="store_true", dest="implemented_sces",
+                        help="Show IDs of implemented SCE checks.")
     parser_stats.add_argument("--missing-stig-ids", default=False,
                         action="store_true", dest="missing_stig_ids",
                         help="Show rules in STIG profiles that don't have STIG IDs.")
@@ -65,6 +68,9 @@ def parse_args():
     parser_stats.add_argument("--missing-ovals", default=False,
                         action="store_true", dest="missing_ovals",
                         help="Show IDs of unimplemented OVAL checks.")
+    parser_stats.add_argument("--missing-sces", default=False,
+                        action="store_true", dest="missing_sces",
+                        help="Show IDs of unimplemented SCE checks.")
     parser_stats.add_argument("--implemented-fixes", default=False,
                         action="store_true", dest="implemented_fixes",
                         help="Show IDs of implemented remediations.")
@@ -138,6 +144,7 @@ def parse_args():
 
         if args.missing:
             args.missing_ovals = True
+            args.missing_sces = True
             args.missing_fixes = True
             args.missing_cces = True
             args.missing_stig_ids = True
@@ -225,6 +232,7 @@ def main():
             'missing_ospp_refs',
             'missing_cui_refs',
             'missing_ovals',
+            'missing_sces',
             'missing_bash_fixes',
             'missing_ansible_fixes',
             'missing_ignition_fixes',

--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -40,6 +40,7 @@ import ssg.xml
 xccdf_ns = ssg.constants.XCCDF11_NS
 oval_ns = ssg.constants.oval_namespace
 ocil_cs = ssg.constants.ocil_cs
+sce_cs = ssg.constants.SCE_SYSTEM
 
 # we use these strings to look for references within the XCCDF rules
 nist_ref_href = "http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf"
@@ -80,6 +81,8 @@ def parse_options():
     parser.add_option("--ovaldefs-unused", default=False,
                       action="store_true", dest="ovaldefs_unused",
                       help="print OVAL definitions which are not used by any XCCDF Rule")
+    parser.add_option("--base-dir", default=False, action="store", dest="base_dir",
+                      help="path to the build directory")
     parser.add_option("--all-checks", default=False, action="store_true",
                       dest="all_checks",
                       help="perform all checks on the given XCCDF file")
@@ -104,7 +107,7 @@ def get_ovalfiles(checks):
             if not checkcontentref_hrefattr.startswith("http://") and \
                not checkcontentref_hrefattr.startswith("https://"):
                 ovalfiles.add(checkcontentref_hrefattr)
-        elif check.get("system") != ocil_cs:
+        elif check.get("system") != ocil_cs and check.get("system") != sce_cs:
             print("ERROR: Non-OVAL checking system found: %s"
                   % (check.get("system")))
             exit_value = 1
@@ -189,10 +192,12 @@ def main():
     # now we can actually do the verification work here
     if options.rules_with_invalid_checks or options.all_checks:
         for check_content_ref in check_content_refs:
-
+            parent = xccdf_parent_map[check_content_ref]
+            rule = xccdf_parent_map[parent]
+            check_system = parent.get("system")
             # Skip those <check-content-ref> elements using OCIL as the checksystem
             # (since we are checking just referenced OVAL definitions)
-            if xccdf_parent_map[check_content_ref].get("system") == ocil_cs:
+            if check_system == ocil_cs:
                 continue
 
             # Obtain the value of the 'href' attribute of particular
@@ -207,14 +212,18 @@ def main():
                check_content_ref_href_attr.startswith("https://"):
                 continue
 
-            refname = check_content_ref.get("name")
-            if refname not in ovaldef_ids:
-                rule = xccdf_parent_map[
-                    xccdf_parent_map[check_content_ref]
-                ]
-                print("ERROR: Invalid OVAL definition referenced by XCCDF Rule: %s"
-                      % (rule.get("id")))
-                exit_value = 1
+            if check_system == sce_cs:
+                check_path = os.path.join(options.base_dir, check_content_ref_href_attr)
+                if not os.path.exists(check_path):
+                    print("ERROR: Invalid or missing SCE definition (%s) referenced by XCCDF Rule: %s"
+                          % (check_path, rule.get("id")))
+                    exit_value = 1
+            else:
+                refname = check_content_ref.get("name")
+                if refname not in ovaldef_ids:
+                    print("ERROR: Invalid OVAL definition referenced by XCCDF Rule: %s"
+                          % (rule.get("id")))
+                    exit_value = 1
 
     if options.rules_without_checks or options.all_checks:
         for rule in rules:

--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -215,8 +215,10 @@ def main():
             if check_system == sce_cs:
                 check_path = os.path.join(options.base_dir, check_content_ref_href_attr)
                 if not os.path.exists(check_path):
-                    print("ERROR: Invalid or missing SCE definition (%s) referenced by XCCDF Rule: %s"
-                          % (check_path, rule.get("id")))
+                    msg = "ERROR: Invalid or missing SCE definition (%s) "
+                    msg += "referenced by XCCDF Rule: %s"
+                    msg = msg % (check_path, rule.get("id"))
+                    print(msg)
                     exit_value = 1
             else:
                 refname = check_content_ref.get("name")

--- a/build-scripts/yaml_to_shorthand.py
+++ b/build-scripts/yaml_to_shorthand.py
@@ -38,6 +38,8 @@ def parse_args():
                         help="To which directory to put processed rule YAMLs.")
     parser.add_argument("--profiles-root",
                         help="Override where to look for profile files.")
+    parser.add_argument("--sce-metadata",
+                        help="Combined SCE metadata to read.")
     return parser.parse_args()
 
 
@@ -65,7 +67,7 @@ def main():
 
     loader = ssg.build_yaml.BuildLoader(
         profiles_root, args.bash_remediation_fns, env_yaml,
-        args.resolved_rules_dir)
+        args.resolved_rules_dir, args.sce_metadata)
     loader.process_directory_tree(benchmark_root, add_content_dirs)
 
     profiles = loader.loaded_group.profiles

--- a/build_config.yml.in
+++ b/build_config.yml.in
@@ -7,3 +7,5 @@ target_oval_version_str: "@SSG_TARGET_OVAL_VERSION@"
 
 jinja2_cache_enabled: @SSG_JINJA2_CACHE_ENABLED_BOOL@
 jinja2_cache_dir: "@SSG_JINJA2_CACHE_DIR@"
+
+sce_enabled: "@SSG_SCE_ENABLED@"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -432,8 +432,6 @@ macro(ssg_build_cpe_dictionary PRODUCT)
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ssg "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-        DEPENDS generate-internal-${PRODUCT}-sce-metadata.json
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/checks/sce/metadata.json"
         DEPENDS generate-internal-${PRODUCT}-oval-unlinked.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         DEPENDS generate-internal-${PRODUCT}-shorthand.xml
@@ -469,8 +467,6 @@ macro(ssg_build_link_xccdf_oval_ocil PRODUCT)
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
         DEPENDS generate-internal-${PRODUCT}-oval-unlinked.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
-        DEPENDS generate-internal-${PRODUCT}-sce-metadata.json
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/checks/sce/metadata.json"
         DEPENDS generate-internal-${PRODUCT}-ocil-unlinked.xml
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/ocil-unlinked.xml"
         DEPENDS "${SSG_BUILD_SCRIPTS}/relabel_ids.py"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -501,7 +501,7 @@ macro(ssg_build_xccdf_final PRODUCT)
     endif()
     add_test(
         NAME "verify-references-ssg-${PRODUCT}-xccdf.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/verify_references.py" --rules-with-invalid-checks --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/verify_references.py" --rules-with-invalid-checks --base-dir "${CMAKE_BINARY_DIR}" --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
     )
     set_tests_properties("verify-references-ssg-${PRODUCT}-xccdf.xml" PROPERTIES LABELS quick)
     add_test(

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -920,6 +920,9 @@ macro(ssg_build_product PRODUCT)
             DESTINATION "${SSG_CONTENT_INSTALL_DIR}")
     endif()
 
+    install(DIRECTORY "${CMAKE_BINARY_DIR}/${PRODUCT}/checks/sce/"
+        DESTINATION "${SSG_CONTENT_INSTALL_DIR}/${PRODUCT}/checks/sce")
+
     install(FILES "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         DESTINATION "${SSG_CONTENT_INSTALL_DIR}")
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Ensure users own their home directories'
+
+description: |-
+    The user home directory is space defined for the particular user to set local
+    environment variables and to store personal files. Since the user is
+    accountable for files stored in the user home directory, the user must be
+    the owner of the directory.
+
+rationale: |-
+    Since the user is accountable for files stored in the user home directory,
+    the user must be the owner of the directory.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 6.2.6
+

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/sce/ubuntu2004.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/sce/ubuntu2004.sh
@@ -1,0 +1,28 @@
+##ssg## platform = multi_platform_ubuntu
+##ssg## check-import = stdout
+#!/bin/bash
+#
+# Contributed by Canonical.
+#
+# Disable job control and run the last command of a pipeline in the current shell environment
+# Require Bash 4.2 and later
+set +m
+shopt -s lastpipe
+
+result=$XCCDF_RESULT_PASS
+
+cat /etc/passwd | egrep -v '^(root|halt|sync|shutdown)' | awk -F: '($7 != "/usr/sbin/nologin" && $7 != "/bin/false") { print $1 " " $6 }'| while read user dir; do
+	if [ ! -d "$dir" ]; then
+		echo "The home directory ($dir) of user $user does not exist."
+		result=$XCCDF_RESULT_FAIL
+		break
+	else
+		owner=$(stat -L -c "%U" "$dir")
+		if [ "$owner" != "$user" ]; then
+			echo "The home directory ($dir) of user $user is owned by $owner."
+			result=$XCCDF_RESULT_FAIL
+			break
+		fi
+	fi
+done
+exit $result

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/sce/ubuntu2004.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/sce/ubuntu2004.sh
@@ -1,11 +1,13 @@
-##ssg## platform = multi_platform_ubuntu
-##ssg## check-import = stdout
 #!/bin/bash
 #
 # Contributed by Canonical.
 #
 # Disable job control and run the last command of a pipeline in the current shell environment
 # Require Bash 4.2 and later
+#
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
 set +m
 shopt -s lastpipe
 

--- a/products/ubuntu2004/profiles/standard.profile
+++ b/products/ubuntu2004/profiles/standard.profile
@@ -6,6 +6,7 @@ description: |-
     This profile contains rules to ensure standard security baseline of an Ubuntu 20.04 system. Regardless of your system's workload all of these checks should pass.
 
 selections:
+    - accounts_users_own_home_directories
     - partition_for_tmp
     - partition_for_var
     - partition_for_var_log

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -38,6 +38,7 @@
 <xsl:variable name="ssg-project-name">SCAP Security Guide Project</xsl:variable>
 
 <!-- misc language URI's -->
+<xsl:variable name="sceuri">http://open-scap.org/page/SCE</xsl:variable>
 <xsl:variable name="ovaluri">http://oval.mitre.org/XMLSchema/oval-definitions-5</xsl:variable>
 
 <xsl:variable name="ociltransitional">ocil-transitional</xsl:variable>

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -197,7 +197,7 @@ class XCCDFBenchmark(object):
                 oval = rule.find("./{%s}check[@system=\"%s\"]" %
                                  (xccdf_ns, oval_ns))
                 sce = rule.find("./{%s}check[@system=\"%s\"]" %
-                                 (xccdf_ns, sce_ns))
+                                (xccdf_ns, sce_ns))
                 bash_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
                                      (xccdf_ns, bash_rem_system))
                 ansible_fix = rule.find("./{%s}fix[@system=\"%s\"]" %

--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -1,0 +1,145 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import os.path
+import json
+
+
+from .build_yaml import Rule, DocumentationNotComplete
+from .constants import MULTI_PLATFORM_LIST
+from .jinja import process_file_with_macros
+from .rule_yaml import parse_prodtype
+from .rules import get_rule_dir_id, get_rule_dir_sces, find_rule_dirs_in_paths
+from . import utils
+
+def load_sce_and_metadata(file_path, local_env_yaml):
+    raw_content = process_file_with_macros(file_path, local_env_yaml)
+
+    metadata = dict()
+    sce_content = []
+
+    for line in raw_content.split("\n"):
+        if line.startswith('##ssg##'):
+            key, value = line[7:].split('=', maxsplit=1)
+            values = value.strip()
+            if ',' in values:
+                values.split(',')
+            metadata[key.strip()] = values
+        else:
+            sce_content.append(line)
+
+    return "\n".join(sce_content), metadata
+
+def _check_is_applicable_for_product(metadata, product):
+    if 'platform' not in metadata:
+        return True
+
+    product, product_version = utils.parse_name(product)
+
+    multi_product = 'multi_platform_{0}'.format(product)
+    if product in ['macos', 'ubuntu']:
+        product_version = product_version[:2] + "." + product_version[2:]
+
+    return ('multi_platform_all' in metadata['platform'] or
+            (multi_product in metadata['platform'] and
+             product in MULTI_PLATFORM_LIST) or
+            (product in metadata['platform'] and
+             product_version in metadata['platform']))
+
+
+def _check_is_loaded(already_loaded, filename):
+    # Right now this check doesn't look at metadata or anything
+    # else. Eventually we might add versions to the entry or
+    # something.
+    return filename in already_loaded
+
+
+def checks(env_yaml, yaml_path, sce_dirs, output):
+    product = utils.required_key(env_yaml, "product")
+    included_checks_count = 0
+    reversed_dirs = sce_dirs[::-1]
+    already_loaded = dict()
+    local_env_yaml = dict()
+    local_env_yaml.update(env_yaml)
+
+    product_dir = os.path.dirname(yaml_path)
+    relative_guide_dir = utils.required_key(env_yaml, "benchmark_root")
+    guide_dir = os.path.abspath(os.path.join(product_dir, relative_guide_dir))
+    additional_content_directories = env_yaml.get("additional_content_directories", [])
+    add_content_dirs = [
+        os.path.abspath(os.path.join(product_dir, rd))
+        for rd in additional_content_directories
+    ]
+
+    for _dir_path in find_rule_dirs_in_paths([guide_dir] + add_content_dirs):
+        rule_id = get_rule_dir_id(_dir_path)
+
+        rule_path = os.path.join(_dir_path, "rule.yml")
+        try:
+            rule = Rule.from_yaml(rule_path, env_yaml)
+        except DocumentationNotComplete:
+            # Happens on non-debug builds when a rule isn't yet completed. We
+            # don't want to build the SCE check for this rule yet so skip it
+            # and move on.
+            continue
+        prodtypes = parse_prodtype(rule.prodtype)
+
+        local_env_yaml['rule_id'] = rule.id_
+        local_env_yaml['rule_title'] = rule.title
+        local_env_yaml['products'] = prodtypes # default is all
+
+        for _path in get_rule_dir_sces(_dir_path, product):
+            # To be compatible with later checks, use the rule_id (i.e., the
+            # value of _dir) to recreate the expected filename if this OVAL
+            # was in a rule directory. However, note that unlike
+            # build_oval.checks(...), we have to get this script's extension
+            # first.
+            _, ext = os.path.splitext(_path)
+            filename = "{0}{1}".format(rule_id, ext)
+
+            sce_content, metadata = load_sce_and_metadata(_path, local_env_yaml)
+            metadata['filename'] = filename
+
+            if not _check_is_applicable_for_product(metadata, product):
+                continue
+            if _check_is_loaded(already_loaded, filename):
+                continue
+
+            output_file = open(os.path.join(output, filename), 'w')
+            print(sce_content, file=output_file)
+
+            included_checks_count += 1
+            already_loaded[rule_id] = metadata
+
+    for sce_dir in reversed_dirs:
+        if not os.path.isdir(sce_dir):
+            continue
+
+        for filename in sorted(os.listdir(sce_dir)):
+            rule_id, _ = os.path.splitext(filename)
+
+            sce_content, metadata = load_sce_and_metadata(filename, env_yaml)
+            metadata['filename'] = filename
+
+            if not _check_is_applicable_for_product(metadata, product):
+                continue
+            if _check_is_loaded(already_loaded, filename):
+                continue
+
+            output_file = open(os.path.join(output, filename), 'w')
+            print(sce_content, file=output_file)
+
+            included_checks_count += 1
+            already_loaded[rule_id] = metadata
+
+    # n.b.: Templated SCE checks don't yet exist.
+    templates_metadata = os.path.join(output, 'templates_metadata.json')
+    if os.path.exists(templates_metadata):
+        templates = json.load(open(templates_metadata, 'r'))
+        templates.update(already_loaded)
+        already_loaded = templates
+    metadata_path = os.path.join(output, 'metadata.json')
+    json.dump(already_loaded, open(metadata_path, 'w'))
+
+    return already_loaded

--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -13,6 +13,7 @@ from .rule_yaml import parse_prodtype
 from .rules import get_rule_dir_id, get_rule_dir_sces, find_rule_dirs_in_paths
 from . import utils
 
+
 def load_sce_and_metadata(file_path, local_env_yaml):
     raw_content = process_file_with_macros(file_path, local_env_yaml)
 
@@ -99,7 +100,7 @@ def checks(env_yaml, yaml_path, sce_dirs, output):
 
         local_env_yaml['rule_id'] = rule.id_
         local_env_yaml['rule_title'] = rule.title
-        local_env_yaml['products'] = prodtypes # default is all
+        local_env_yaml['products'] = prodtypes  # default is all
 
         for _path in get_rule_dir_sces(_dir_path, product):
             # To be compatible with later checks, use the rule_id (i.e., the

--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -20,13 +20,19 @@ def load_sce_and_metadata(file_path, local_env_yaml):
     sce_content = []
 
     for line in raw_content.split("\n"):
-        if line.startswith('##ssg##'):
-            key, value = line[7:].split('=', maxsplit=1)
-            values = value.strip()
-            if ',' in values:
-                values.split(',')
-            metadata[key.strip()] = values
-        else:
+        found_metadata = False
+        keywords = ['platform', 'check-import', 'check-export', 'complex-check']
+        for keyword in keywords:
+            if line.startswith('# ' + keyword + ' = '):
+                # Strip off the initial comment marker
+                _, value = line[2:].split('=', maxsplit=1)
+                values = value.strip()
+                if ',' in values:
+                    values.split(',')
+                metadata[keyword] = values
+                found_metadata = True
+                break
+        if not found_metadata:
             sce_content.append(line)
 
     return "\n".join(sce_content), metadata

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1447,7 +1447,8 @@ class Rule(object):
                     check_export.set('export-name', export)
 
             check_ref = ET.SubElement(check, "check-content-ref")
-            check_ref.set("href", self.current_product + "/checks/sce/" + self.sce_metadata['filename'])
+            href = self.current_product + "/checks/sce/" + self.sce_metadata['filename']
+            check_ref.set("href", href)
 
         if self.ocil or self.ocil_clause:
             ocil = add_sub_element(rule, 'ocil', self.ocil if self.ocil else "")
@@ -1584,7 +1585,8 @@ class DirectoryLoader(object):
 
 
 class BuildLoader(DirectoryLoader):
-    def __init__(self, profiles_dir, bash_remediation_fns, env_yaml, resolved_rules_dir=None, sce_metadata_path=None):
+    def __init__(self, profiles_dir, bash_remediation_fns, env_yaml,
+                 resolved_rules_dir=None, sce_metadata_path=None):
         super(BuildLoader, self).__init__(profiles_dir, bash_remediation_fns, env_yaml)
 
         self.resolved_rules_dir = resolved_rules_dir

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1594,7 +1594,7 @@ class BuildLoader(DirectoryLoader):
             os.mkdir(resolved_rules_dir)
 
         self.sce_metadata = None
-        if sce_metadata_path:
+        if sce_metadata_path and os.path.getsize(sce_metadata_path):
             self.sce_metadata = json.load(open(sce_metadata_path, 'r'))
 
     def _process_values(self):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1436,6 +1436,7 @@ class Rule(object):
                 for entry in self.sce_metadata['check-import']:
                     check_import = ET.SubElement(check, 'check-import')
                     check_import.set('import-name', entry)
+                    check_import.text = None
 
             if 'check-export' in self.sce_metadata:
                 if isinstance(self.sce_metadata['check-export'], str):
@@ -1445,6 +1446,7 @@ class Rule(object):
                     check_export = ET.SubElement(check, 'check-export')
                     check_export.set('value-id', value)
                     check_export.set('export-name', export)
+                    check_export.text = None
 
             check_ref = ET.SubElement(check, "check-content-ref")
             href = self.current_product + "/checks/sce/" + self.sce_metadata['filename']

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import os.path
 from collections import defaultdict
 from copy import deepcopy
 import datetime
+import json
+import os
+import os.path
 import re
 import sys
 from xml.sax.saxutils import escape
@@ -13,7 +14,7 @@ from xml.sax.saxutils import escape
 import yaml
 
 from .build_cpe import CPEDoesNotExist
-from .constants import XCCDF_REFINABLE_PROPERTIES
+from .constants import XCCDF_REFINABLE_PROPERTIES, SCE_SYSTEM
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 from .rule_yaml import parse_prodtype
 from .controls import Control
@@ -1082,11 +1083,13 @@ class Rule(object):
         self.platforms = set()
         self.cpe_names = set()
         self.inherited_platforms = [] # platforms inherited from the group
+        self.sce_metadata = None
         self.template = None
         self.local_env_yaml = None
+        self.current_product = None
 
     @classmethod
-    def from_yaml(cls, yaml_file, env_yaml=None):
+    def from_yaml(cls, yaml_file, env_yaml=None, sce_metadata=None):
         yaml_file = os.path.normpath(yaml_file)
 
         rule_id, ext = os.path.splitext(os.path.basename(yaml_file))
@@ -1145,6 +1148,12 @@ class Rule(object):
 
         if not rule.definition_location:
             rule.definition_location = yaml_file
+
+        if sce_metadata and rule_id in sce_metadata:
+            rule.sce_metadata = sce_metadata[rule_id]
+
+        if env_yaml and 'product' in env_yaml:
+            rule.current_product = env_yaml['product']
 
         rule.validate_prodtype(yaml_file)
         rule.validate_identifiers(yaml_file)
@@ -1411,6 +1420,35 @@ class Rule(object):
             oval_ref = ET.SubElement(rule, "oval")
             oval_ref.set("id", self.id_)
 
+        if self.sce_metadata:
+            # TODO: This is pretty much another hack, just like the previous OVAL
+            # one. However, we avoided the external SCE content as I'm not sure it
+            # is generally useful (unlike say, CVE checking with external OVAL)
+            #
+            # Additionally, we build the content (check subelement) here rather
+            # than in xslt due to the nature of our SCE metadata.
+            check = ET.SubElement(rule, "check")
+            check.set("system", SCE_SYSTEM)
+
+            if 'check-import' in self.sce_metadata:
+                if isinstance(self.sce_metadata['check-import'], str):
+                    self.sce_metadata['check-import'] = [self.sce_metadata['check-import']]
+                for entry in self.sce_metadata['check-import']:
+                    check_import = ET.SubElement(check, 'check-import')
+                    check_import.set('import-name', entry)
+
+            if 'check-export' in self.sce_metadata:
+                if isinstance(self.sce_metadata['check-export'], str):
+                    self.sce_metadata['check-export'] = [self.sce_metadata['check-export']]
+                for entry in self.sce_metadata['check-export']:
+                    value, export = entry.split('=')
+                    check_export = ET.SubElement(check, 'check-export')
+                    check_export.set('value-id', value)
+                    check_export.set('export-name', export)
+
+            check_ref = ET.SubElement(check, "check-content-ref")
+            check_ref.set("href", self.current_product + "/checks/sce/" + self.sce_metadata['filename'])
+
         if self.ocil or self.ocil_clause:
             ocil = add_sub_element(rule, 'ocil', self.ocil if self.ocil else "")
             if self.ocil_clause:
@@ -1546,12 +1584,16 @@ class DirectoryLoader(object):
 
 
 class BuildLoader(DirectoryLoader):
-    def __init__(self, profiles_dir, bash_remediation_fns, env_yaml, resolved_rules_dir=None):
+    def __init__(self, profiles_dir, bash_remediation_fns, env_yaml, resolved_rules_dir=None, sce_metadata_path=None):
         super(BuildLoader, self).__init__(profiles_dir, bash_remediation_fns, env_yaml)
 
         self.resolved_rules_dir = resolved_rules_dir
         if resolved_rules_dir and not os.path.isdir(resolved_rules_dir):
             os.mkdir(resolved_rules_dir)
+
+        self.sce_metadata = None
+        if sce_metadata_path:
+            self.sce_metadata = json.load(open(sce_metadata_path, 'r'))
 
     def _process_values(self):
         for value_yaml in self.value_files:
@@ -1562,7 +1604,7 @@ class BuildLoader(DirectoryLoader):
     def _process_rules(self):
         for rule_yaml in self.rule_files:
             try:
-                rule = Rule.from_yaml(rule_yaml, self.env_yaml)
+                rule = Rule.from_yaml(rule_yaml, self.env_yaml, self.sce_metadata)
             except DocumentationNotComplete:
                 # Happens on non-debug build when a rule is "documentation-incomplete"
                 continue
@@ -1584,8 +1626,11 @@ class BuildLoader(DirectoryLoader):
                     yaml.dump(rule.to_contents_dict(), f)
 
     def _get_new_loader(self):
-        return BuildLoader(
+        loader = BuildLoader(
             self.profiles_dir, self.bash_remediation_fns, self.env_yaml, self.resolved_rules_dir)
+        # Do it this way so we only have to parse the SCE metadata once.
+        loader.sce_metadata = self.sce_metadata
+        return loader
 
     def export_group_to_file(self, filename):
         return self.loaded_group.to_file(filename)

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -90,6 +90,7 @@ standard_profiles = ['standard', 'pci-dss', 'desktop', 'server']
 xslt_ns = "http://www.w3.org/1999/XSL/Transform"
 generic_stig_ns = "https://public.cyber.mil/stigs/downloads/" + \
                   "?_dl_facet_stigs=operating-systems%2Cunix-linux"
+SCE_SYSTEM = "http://open-scap.org/page/SCE"
 
 
 OVAL_SUB_NS = dict(

--- a/ssg/rules.py
+++ b/ssg/rules.py
@@ -109,6 +109,42 @@ def get_rule_dir_ovals(dir_path, product=None):
     return product_results + common_results
 
 
+def get_rule_dir_sces(dir_path, product=None):
+    """
+    Get a list of SCEs contained in a rule directory. If product is None,
+    returns all SCEs. If product is not None, returns applicable SCEs in
+    order of priority:
+
+        {{{ product }}}.{{{ ext }}} -> shared.{{{ ext }}}
+
+    Only returns SCEs which exist.
+    """
+
+    if not is_rule_dir(dir_path):
+        return []
+
+    sce_dir = os.path.join(dir_path, "sce")
+    has_sce_dir = os.path.isdir(sce_dir)
+    if not has_sce_dir:
+        return []
+
+    results = []
+    common_results = []
+    for sce_file in sorted(os.listdir(sce_dir)):
+        file_name, ext = os.path.splitext(sce_file)
+        sce_path = os.path.join(sce_dir, sce_file)
+
+        if applies_to_product(file_name, product):
+            if file_name == 'shared':
+                common_results.append(sce_path)
+            elif file_name != product:
+                common_results.insert(0, sce_path)
+            else:
+                results.append(sce_path)
+
+    return results + common_results
+
+
 def find_rule_dirs(base_dir):
     """
     Generator which yields all rule directories within a given base_dir, recursively


### PR DESCRIPTION
#### Description:

Per today's upstream discussion... :)

This PR adds SCE support into the build system. Currently this does _not_ include template support (as this gets complicated, see below).

This:

 1. Adds a new compilation step prior to generating the shorthand, to build SCE content for all rules which contain it. This also outputs a `metadata.json` file which contains information about all known SCE rules for the product.
 2. Updates shorthand generation to conditionally include SCE content based on whether or not said content actually _exists_.
 3. SCE content is place into `build/${PRODUCT}/checks/sce` -- this is meant to be shipped to end-users ~~(though, install support isn't yet present)~~. (Note that install support was added in the "Add SCE content to installation" commit). 
 4. Updates various utilities to understand the presence of SCE.
 5. Adds a sample rule (from our internal content) using SCE; this rule could be pulled into other CIS profiles like the RHEL one (/cc @alexhaydock).

Note that 2 differs from OVAL: shorthand is built prior to OVAL generation and logic (I _think_ in OpenSCAP or the XSLT layer?) is used to remove any dangling OVAL references. This doesn't work for SCE hence the approach of (1) before (2). Note that as a side effect, it becomes much harder to generate templated content. It would still be possible with some modifications to make sure all information the templated class needs is available while walking the rules. However, as SCEs are meant to be used less than OVAL, I didn't feel it was worth the time (initially) to use templates. 

An example of metadata.json for `ubuntu2004` right now:

```json
{"accounts_users_own_home_directories": {"platform": "multi_platform_ubuntu", "check-import": "stdout", "filename": "accounts_users_own_home_directories.sh"}}
```

And the one SCE rule:

```bash
#!/bin/bash
#
# Contributed by Canonical.
#
# Disable job control and run the last command of a pipeline in the current shell environment
# Require Bash 4.2 and later
#

set +m
shopt -s lastpipe

result=$XCCDF_RESULT_PASS

cat /etc/passwd | egrep -v '^(root|halt|sync|shutdown)' | awk -F: '($7 != "/usr/sbin/nologin" && $7 != "/bin/false") { print $1 " " $6 }'| while read user dir; do
	if [ ! -d "$dir" ]; then
		echo "The home directory ($dir) of user $user does not exist."
		result=$XCCDF_RESULT_FAIL
		break
	else
		owner=$(stat -L -c "%U" "$dir")
		if [ "$owner" != "$user" ]; then
			echo "The home directory ($dir) of user $user is owned by $owner."
			result=$XCCDF_RESULT_FAIL
			break
		fi
	fi
done
exit $result
```

#### Rationale:

Several rules in CIS require features that OVAL doesn't provide. Some of these are "active state" checks (such as loaded auditd rules). Others are features which have been asked for [but haven't yet landed in a released specification](https://github.com/OVAL-Community/OVAL/issues/24) -- SCE is great at returning not applicable directly from a check for e.g., CIS's "choose one" firewall rule.

If there is upstream interest in this code, it would save us from having to maintain it strictly in our downstream fork. Per discussion on the call earlier, it seemed like there were both external users and internal Red Hat members asking about SCE support in CaC, making this a generally useful addition to the community were it to be accepted.

---

If there is general interest in landing this, let me know and I'll iterate on some revisions here. However, if it doesn't seem like there's interest in landing SCE support upstream, I'll likely close the PR without addressing e.g., PEP8 issues. :-) 

Per comments from @jan-cerny on IRC, I'll be cleaning this up and getting it ready for merge.

On a separate internal branch I have templated SCE support figured out, so when this merges I'll propose that as another upstream PR. 