### PR TITLE
Minor updates packages for Ubuntu

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -42,3 +42,6 @@ template:
     vars:
         servicename: avahi-daemon
         packagename: avahi
+        packagename@ubuntu1604: avahi-daemon
+        packagename@ubuntu1804: avahi-daemon
+        packagename@ubuntu2004: avahi-daemon

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -7,7 +7,13 @@ title: 'Uninstall DHCP Server Package'
 description: |-
     If the system does not need to act as a DHCP server,
     the dhcp package can be uninstalled.
+    {{% if 'ubuntu' in product %}}
+    {{{ describe_package_remove(package="isc-dhcp-server") }}}
+    {{% elif product == 'rhel8' %}}
+    {{{ describe_package_remove(package="dhcp-server") }}}
+    {{% else %}}
     {{{ describe_package_remove(package="dhcp") }}}
+    {{% endif %}}
 
 rationale: |-
     Removing the DHCP server ensures that it cannot be easily or
@@ -30,10 +36,19 @@ references:
     cis-csc: 11,14,3,9
     anssi: BP28(R1)
 
+{{% if 'ubuntu' in product %}}
+{{{ complete_ocil_entry_package(package="isc-dhcp-server") }}}
+{{% elif product == 'rhel8' %}}
+{{{ complete_ocil_entry_package(package="dhcp-server") }}}
+{{% else %}}
 {{{ complete_ocil_entry_package(package="dhcp") }}}
+{{% endif %}}
 
 template:
     name: package_removed
     vars:
         pkgname: dhcp
         pkgname@rhel8: dhcp-server
+        pkgname@ubuntu1604: isc-dhcp-server
+        pkgname@ubuntu1804: isc-dhcp-server
+        pkgname@ubuntu2004: isc-dhcp-server

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -34,3 +34,6 @@ template:
     name: package_removed
     vars:
         pkgname: bind
+        pkgname@ubuntu1604: bind9
+        pkgname@ubuntu1804: bind9
+        pkgname@ubuntu2004: bind9

--- a/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
@@ -4,7 +4,12 @@ prodtype: rhel7,rhel8,rhel9,sle15
 
 title: 'Uninstall httpd Package'
 
-description: '{{{ describe_package_remove(package="httpd") }}}'
+description: |-
+  {{% if 'ubuntu' not in product %}}
+  {{{ describe_package_remove(package="httpd") }}}
+  {{% else %}}
+  {{{ describe_package_remove(package="apache2") }}}
+  {{% endif %}}
 
 rationale: |-
     If there is no need to make the web server software available,
@@ -24,9 +29,16 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4,A.9.1.2
     cis-csc: 11,14,3,9
 
+{{% if 'ubuntu' not in product %}}
 {{{ complete_ocil_entry_package(package="httpd") }}}
+{{% else %}}
+{{{ complete_ocil_entry_package(package="apache2") }}}
+{{% endif %}}
 
 template:
     name: package_removed
     vars:
         pkgname: httpd
+        pkgname@ubuntu1604: apache2
+        pkgname@ubuntu1804: apache2
+        pkgname@ubuntu2004: apache2

--- a/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
@@ -5,7 +5,11 @@ prodtype: rhel7,rhel8,rhel9
 title: 'Uninstall dovecot Package'
 
 description: |-
+    {{% if 'ubuntu' not in product %}}
     {{{ describe_package_remove(package="dovecot") }}}
+    {{% else %}}
+    {{{ describe_package_remove(package="dovecot-core") }}}
+    {{% endif %}}
 
 rationale: |-
     If there is no need to make the Dovecot software available,
@@ -16,9 +20,16 @@ severity: unknown
 identifiers:
     cce@rhel7: CCE-80295-9
 
+{{% if 'ubuntu' not in product %}}
 {{{ complete_ocil_entry_package(package="dovecot") }}}
+{{% else %}}
+{{{ complete_ocil_entry_package(package="dovecot-core") }}}
+{{% endif %}}
 
 template:
     name: package_removed
     vars:
         pkgname: dovecot
+        pkgname@ubuntu1604: dovecot-core
+        pkgname@ubuntu1804: dovecot-core
+        pkgname@ubuntu2004: dovecot-core

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
@@ -32,3 +32,6 @@ template:
     name: package_removed
     vars:
         pkgname: openldap-clients
+        pkgname@ubuntu1604: ldap-utils
+        pkgname@ubuntu1804: ldap-utils
+        pkgname@ubuntu2004: ldap-utils

--- a/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
@@ -5,7 +5,11 @@ prodtype: rhel7,rhel8,rhel9,sle15
 title: 'Uninstall openldap-servers Package'
 
 description: |-
-    The openldap-servers RPM is not installed by default on a {{{ full_name }}}
+    {{% if 'ubuntu' not in product %}}
+    The openldap-servers package is not installed by default on a {{{ full_name }}}
+    {{% else %}}
+    The slapd package is not installed by default on a {{{ full_name }}}
+    {{% endif %}}
     system. It is needed only by the OpenLDAP server, not by the
     clients which use LDAP for authentication. If the system is not
     intended for use as an LDAP Server it should be removed.
@@ -36,11 +40,19 @@ references:
 ocil_clause: 'it does not'
 
 ocil: |-
+    {{% if 'ubuntu' not in product %}}
     To verify the <tt>openldap-servers</tt> package is not installed, run the
     following command:
     <pre>$ rpm -q openldap-servers</pre>
     The output should show the following:
     <pre>package openldap-servers is not installed</pre>
+    {{% else %}}
+    To verify the <tt>slapd</tt> package is not installed, run the
+    following command:
+    <pre>$ dpkg -l slapd</pre>
+    The output should show the following:
+    <pre>package slapd is not installed</pre>
+    {{% endif %}}
 
 template:
     name: package_removed

--- a/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
@@ -46,3 +46,6 @@ template:
     name: package_removed
     vars:
         pkgname: openldap-servers
+        pkgname@ubuntu1604: slapd
+        pkgname@ubuntu1804: slapd
+        pkgname@ubuntu2004: slapd

--- a/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
@@ -5,7 +5,11 @@ prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 title: 'Uninstall rsh Package'
 
 description: |-
+    {{% if 'ubuntu' not in product %}}
     The <tt>rsh</tt> package contains the client commands
+    {{% else %}}
+    The <tt>rsh-client</tt> package contains the client commands
+    {{% endif %}}
     for the rsh services
 
 rationale: |-
@@ -13,7 +17,11 @@ rationale: |-
     been replaced with the more secure SSH package. Even if the server is removed,
     it is best to ensure the clients are also removed to prevent users from
     inadvertently attempting to use these commands and therefore exposing
+    {{% if 'ubuntu' not in product %}}
     their credentials. Note that removing the <tt>rsh</tt> package removes
+    {{% else %}}
+    their credentials. Note that removing the <tt>rsh-client</tt> package removes
+    {{% endif %}}
     the clients for <tt>rsh</tt>,<tt>rcp</tt>, and <tt>rlogin</tt>.
 
 severity: unknown
@@ -29,9 +37,16 @@ references:
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
     iso27001-2013: A.8.2.3,A.13.1.1,A.13.2.1,A.13.2.3,A.14.1.2,A.14.1.3
 
+{{% if 'ubuntu' not in product %}}
 ocil: '{{{ describe_package_remove(package="rsh") }}}'
+{{% else %}}
+ocil: '{{{ describe_package_remove(package="rsh-client") }}}'
+{{% endif %}}
 
 template:
     name: package_removed
     vars:
         pkgname: rsh
+        pkgname@ubuntu1604: rsh-client
+        pkgname@ubuntu1804: rsh-client
+        pkgname@ubuntu2004: rsh-client

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -5,8 +5,13 @@ prodtype: debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wr
 title: 'Uninstall net-snmp Package'
 
 description: |-
+    {{% if pkg_manager != "apt_get" %}}
     The <tt>net-snmp</tt> package provides the snmpd service.
     {{{ describe_package_remove(package="net-snmp") }}}
+    {{% else %}}
+    The <tt>snmp</tt> package provides the snmpd service.
+    {{{ describe_package_remove(package="snmp") }}}
+    {{% endif %}}
 
 rationale: |-
     If there is no need to run SNMP server software,
@@ -18,11 +23,18 @@ severity: unknown
 identifiers:
     cce@rhel7: CCE-80275-1
 
+{{% if pkg_manager != "apt_get" %}}
 {{{ complete_ocil_entry_package(package="net-snmp") }}}
+{{% else %}}
+{{{ complete_ocil_entry_package(package="snmp") }}}
+{{% endif %}}
 
 template:
     name: package_removed
     vars:
+        pkgname: net-snmp
         pkgname@debian9: snmp
         pkgname@debian10: snmp
-        pkgname: net-snmp
+        pkgname@ubuntu1604: snmp
+        pkgname@ubuntu1804: snmp
+        pkgname@ubuntu2004: snmp

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
@@ -62,3 +62,6 @@ template:
     name: package_removed
     vars:
         pkgname: xorg-x11-server-common
+        pkgname@ubuntu1604: xserver-xorg
+        pkgname@ubuntu1804: xserver-xorg
+        pkgname@ubuntu2004: xserver-xorg

--- a/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
@@ -5,11 +5,19 @@ prodtype: fedora,rhel7,rhel8,rhel9,rhv4
 title: 'Remove the GDM Package Group'
 
 description: |-
+    {{% if 'ubuntu' not in product %}}
     By removing the <tt>gdm</tt> package, the system no longer has GNOME installed
+    {{% else %}}
+    By removing the <tt>gdm3</tt> package, the system no longer has GNOME installed
+    {{% endif %}}
     installed. If X Windows is not installed then the system cannot boot into graphical user mode.
     This prevents the system from being accidentally or maliciously booted into a <tt>graphical.target</tt>
     mode. To do so, run the following command:
+    {{% if 'ubuntu' not in product %}}
     <pre>$ sudo yum remove gdm</pre>
+    {{% else %}}
+    <pre>$ sudo apt remove gdm3</pre>
+    {{% endif %}}
 
 rationale: |-
     Unnecessary service packages must not be installed to decrease the attack surface of the system.
@@ -26,6 +34,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     srg: SRG-OS-000480-GPOS-00227
 
+{{% if 'ubuntu' not in product %}}
 ocil_clause: 'gdm has not been removed'
 
 ocil: |-
@@ -33,8 +42,22 @@ ocil: |-
     <pre>$ rpm -qi gdm</pre>
     The output should be:
     <pre>package gdm is not installed</pre>
+{{% else %}}
+ocil_clause: 'gdm3 has not been removed'
+
+ocil: |-
+    To ensure the gdm3 package group is removed, run the following command:
+    <pre>$ dpkg -l gdm3</pre>
+    The output should begin with:
+    <pre>rc gdm3</pre>
+    Or
+    <pre>dpkg-query: no packages found matching gdm3</pre>
+{{% endif %}}
 
 template:
     name: package_removed
     vars:
         pkgname: gdm
+        pkgname@ubuntu1604: gdm3
+        pkgname@ubuntu1804: gdm3
+        pkgname@ubuntu2004: gdm3

--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -25,6 +25,9 @@ package_gdm_installed:
   name: package_installed
   vars:
     pkgname: gdm
+    pkgname@ubuntu1604: gdm3
+    pkgname@ubuntu1804: gdm3
+    pkgname@ubuntu2004: gdm3
 
 package_pam_ldap_removed:
   name: package_removed

--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -2,6 +2,9 @@ package_avahi_installed:
   name: package_installed
   vars:
     pkgname: avahi
+    pkgname@ubuntu1604: avahi-daemon
+    pkgname@ubuntu1804: avahi-daemon
+    pkgname@ubuntu2004: avahi-daemon
 
 package_esc_installed:
   name: package_installed


### PR DESCRIPTION
#### Description:

This fixes various package names for Ubuntu, in rules that will be later required for CIS (see for instance #6416). Note that many of these rules lack Ubuntu prodtypes for the current moment. 

This is a fix brought upstream as a result of our internal CaC port. 