### PR TITLE
Minor updates to descriptions for Ubuntu

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -11,7 +11,11 @@ description: |-
     Storing the database, the configuration file <tt>/etc/aide.conf</tt>, and the binary
     <tt>/usr/sbin/aide</tt> (or hashes of these files), in a secure location (such as on read-only media) provides additional assurance about their integrity.
     The newly-generated database can be installed as follows:
+    {{% if 'ubuntu' not in product %}}
     <pre>$ sudo cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz</pre>
+    {{% else %}}
+    <pre>$ sudo cp /var/lib/aide/aide.db.new /var/lib/aide/aide.db</pre>
+    {{% endif %}}
     To initiate a manual check, run the following command:
     <pre>$ sudo /usr/sbin/aide --check</pre>
     If this check produces any unexpected output, investigate.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -62,6 +62,10 @@ ocil: |-
     To determine that periodic AIDE execution has been scheduled, run the following command:
     <pre>$ grep aide /etc/crontab</pre>
     The output should return something similar to the following:
+    {{% if 'ubuntu' not in product %}}
     <pre>05 4 * * * root /usr/sbin/aide --check</pre>
+    {{% else %}}
+    <pre>05 4 * * * root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
+    {{% endif %}}
 
     NOTE: The usage of special cron times, such as @daily or @weekly, is acceptable.

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -21,6 +21,9 @@ description: |-
     If the system is configured for online updates, invoking the following command will list available
     security updates:
     <pre>$ sudo zypper refresh &amp;&amp; sudo zypper list-patches -g security</pre>
+{{% elif 'ubuntu' in product %}}
+    If the system has an apt repository available, run the following command to install updates:
+    <pre>$ apt update &#38;&#38; apt full-upgrade</pre>
 {{% endif %}}
     <br /><br />
     NOTE: U.S. Defense systems are required to be patched within 30 days or sooner as local policy

--- a/shared/checks/oval/accounts_password_pam_pwquality.xml
+++ b/shared/checks/oval/accounts_password_pam_pwquality.xml
@@ -18,9 +18,17 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_password_pam_pwquality" version="1">
-    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:filepath var_ref="var_pam_pwquality_config_path" var_check="at least one" />
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_pwquality\.so.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <constant_variable id="var_pam_pwquality_config_path" version="1" datatype="string" comment="correct path for pam_pwquality.so check">
+    {{% if 'ubuntu' in product or 'debian' in product %}}
+    <value>/etc/pam.d/common-password</value>
+    {{% else %}}
+    <value>/etc/pam.d/system-auth</value>
+    {{% endif %}}
+  </constant_variable>
 
 </def-group>


### PR DESCRIPTION
#### Description:

This fixes various descriptions in rules that will be later required for CIS (see for instance #6416). Note that many of these rules lack Ubuntu prodtypes for the current moment. 

Also fixes a bug in the `accounts_password_pam_pwquality` package caused by an incorrect path on Debian-like systems. 

See also #7079.

This is a fix brought upstream as a result of our internal CaC port. 