### PR TITLE
Add option_regex_suffix to sudo_defaults_option template

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1773,7 +1773,7 @@ The remediations add the `Defaults` option  to `/etc/sudoers` file.
 -   Parameters:
 
     - **option** - name of sudo `Defaults` option to enable.
-    - **option_regex_suffix** - suffix to the pattern-match to use after **option**; defaults to `=(\w+)`.
+    - **option_regex_suffix** - suffix to the pattern-match to use after **option**; defaults to `=(\w+)\b`.
     - **parameter_variable** - name of the XCCDF variable to get the value for the option parameter.\
       (optional, if not set the check and remediation won't use parameters)
     - **default_is_enabled** -  set to `"true"` if the option is enabled by default for the product.

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1773,6 +1773,7 @@ The remediations add the `Defaults` option  to `/etc/sudoers` file.
 -   Parameters:
 
     - **option** - name of sudo `Defaults` option to enable.
+    - **option_regex_suffix** - suffix to the pattern-match to use after **option**; defaults to `=(\w+)`.
     - **parameter_variable** - name of the XCCDF variable to get the value for the option parameter.\
       (optional, if not set the check and remediation won't use parameters)
     - **default_is_enabled** -  set to `"true"` if the option is enabled by default for the product.

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
@@ -31,4 +31,5 @@ template:
     name: sudo_defaults_option
     vars:
         option: logfile
+        option_regex_suffix: '=(.*)'
         variable_name: var_sudo_logfile

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
@@ -31,5 +31,41 @@ template:
     name: sudo_defaults_option
     vars:
         option: logfile
-        option_regex_suffix: '=(.*)'
+        # Description of option_regex_suffix
+        # Outer capture group for the value (which we need to compare against an
+        # XCCDF variable).
+        #
+        # Inside it is an OR of two paths:
+        #
+        #  - Either we have a quoted value, or
+        #  - We don't have a quoted value.
+        #
+        # In the quoted path, we match the start and end quote (and therefore, the
+        # user running against this rule MUST specify quotes in the variable value
+        # if necessary!). Then we match (in between these quotes) any (potentially
+        # empty) group of character that:
+        #
+        #  - Is an escaped double quote,
+        #  - Is an escaped backslash,
+        #  - Or isn't one of those characters.
+        #
+        # Finally, we match on \B: since we know " is not a word character,
+        # it'll only match if the following character is also not a word
+        # character. This ensures we don't have a string such as "quoted"d, which
+        # would (presumably) be invalid in a sudoers entry.
+        #
+        # In the non-quoted path, we strictly match the value. However, we have a
+        # few more escaped characters to deal with. Thus we match any (potentially
+        # empty) group of characters that:
+        #
+        #  - Is an escaped comma,
+        #  - Is an escaped double quote,
+        #  - Is an escaped space (per `man sudoers`, this needs escaping without
+        #    double quotes),
+        #  - Is an escaped backslash,
+        #  - Or isn't one of those characters.
+        #
+        # Finally, we check for regular word boundary (with \b), ensuring the
+        # next character isn't yet another word character.
+        option_regex_suffix: '=("(?:\\"|\\\\|[^"\\\n])*"\B|[^"](?:(?:\\,|\\"|\\ |\\\\|[^", \\\n])*)\b)'
         variable_name: var_sudo_logfile

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+# Code taken from macro bash_sudo_remove_config()
+for f in $( ls /etc/sudoers /etc/sudoers.d/* 2> /dev/null ) ; do
+  matching_list=$(grep -P '^(?!#).*[\s]+logfile.*$' $f | uniq )
+  if ! test -z "$matching_list"; then
+    while IFS= read -r entry; do
+      # comment out "{{{ parameter }}}" matches to preserve user data
+      sed -i "s/^${entry}$/# &/g" $f
+    done <<< "$matching_list"
+
+    /usr/sbin/visudo -cf $f &> /dev/null || echo "Fail to validate $f with visudo"
+  fi
+done

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+echo "Defaults logfile=/var/log/sudo.log" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_dir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_dir.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+echo "Defaults logfile=/var/log/sudo.log" >> /etc/sudoers.d/enable_logfile

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_with_noexec.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_with_noexec.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+echo 'Defaults logfile=/var/log/sudo.log,noexec' >> /etc/sudoers

--- a/shared/templates/sudo_defaults_option/oval.template
+++ b/shared/templates/sudo_defaults_option/oval.template
@@ -13,7 +13,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ OPTION }}}_sudoers" version="1">
     <ind:filepath operation="pattern match">^/etc/sudoers(|\.d/.*)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*Defaults.*\b{{{ OPTION_REGEX }}}\b.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*Defaults.*\b{{{ OPTION_REGEX }}}.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal" >1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/sudo_defaults_option/template.py
+++ b/shared/templates/sudo_defaults_option/template.py
@@ -17,14 +17,14 @@ def preprocess(data, lang):
     if lang == "oval":
         if data.get("variable_name"):
             if 'option_regex_suffix' not in data:
-                data['option_regex_suffix'] = r"=(\w+)"
+                data['option_regex_suffix'] = r"=(\w+)\b"
             data["option_regex"] = data["option"] + data['option_regex_suffix']
         else:
             data["option_regex"] = data["option"]
     elif lang == "bash":
         if data.get("variable_name"):
             if 'option_regex_suffix' not in data:
-                data['option_regex_suffix'] = r"=\w+"
+                data['option_regex_suffix'] = r"=\w+\b"
             data["option_regex"] = data["option"] + data['option_regex_suffix']
             data["option_value"] = "{opt}=${{{var}}}".format(opt=data["option"],
                                                              var=data["variable_name"])

--- a/shared/templates/sudo_defaults_option/template.py
+++ b/shared/templates/sudo_defaults_option/template.py
@@ -16,12 +16,16 @@ def preprocess(data, lang):
 
     if lang == "oval":
         if data.get("variable_name"):
-            data["option_regex"] = data["option"] + r"=(\w+)"
+            if 'option_regex_suffix' not in data:
+                data['option_regex_suffix'] = r"=(\w+)"
+            data["option_regex"] = data["option"] + data['option_regex_suffix']
         else:
             data["option_regex"] = data["option"]
     elif lang == "bash":
         if data.get("variable_name"):
-            data["option_regex"] = data["option"] + r"=\w+"
+            if 'option_regex_suffix' not in data:
+                data['option_regex_suffix'] = r"=\w+"
+            data["option_regex"] = data["option"] + data['option_regex_suffix']
             data["option_value"] = "{opt}=${{{var}}}".format(opt=data["option"],
                                                              var=data["variable_name"])
         else:


### PR DESCRIPTION
#### Description

In the course of porting Ubuntu CIS tooling to CaC, we too used the
`sudo_defaults_option` template for the logfile rule. However, we found a
shortcoming in the existing template: `\w` matches word characters and
not `/` that many of the log file paths will use. Introduce an optional
template variable, `option_regex_suffix`, to control the regex portion
_after_ the option name in this template. This will allow us to specify
a different value in the `sudo_custom_logfile` rule.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

I was wanting to review the pull request prior to it merging but I forgot to assign myself as a reviewer and it got merged with this bug :D No matter. 

/cc @alexhaydock 
