### PR TITLE
Add some more tests

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/issue
+chgrp 0 /etc/issue

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/tests/incorrect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/tests/incorrect.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/issue
+chgrp 1 /etc/issue

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/motd
+chgrp 0 /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/tests/incorrect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/tests/incorrect.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/motd
+chgrp 1 /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/tests/missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/tests/missing.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+rm -rf /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/issue
+chown 0 /etc/issue

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/tests/incorrect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/tests/incorrect.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/issue
+chown 1 /etc/issue

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/motd
+chown 0 /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/tests/incorrect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/tests/incorrect.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/motd
+chown 1 /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/tests/missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/tests/missing.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+rm -rf /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/issue
+chmod 644 /etc/issue

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/tests/open.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/tests/open.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/issue
+chmod 777 /etc/issue

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/motd
+chmod 644 /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/tests/missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/tests/missing.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+rm -rf /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/tests/open.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/tests/open.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+touch /etc/motd
+chmod 777 /etc/motd

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/correct.pass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-chown 0:0 /boot/grub2/grub.cfg
+chown 0:0 {{{ grub2_boot_path }}}/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/wrong.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/tests/wrong.fail.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-chown 1:0 /boot/grub2/grub.cfg
+chown 1:0 {{{ grub2_boot_path }}}/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/correct.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/correct.pass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-chmod 0600 /boot/grub2/grub.cfg
+chmod 0600 {{{ grub2_boot_path }}}/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/wrong.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/tests/wrong.fail.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-chmod 0644 /boot/grub2/grub.cfg
+chmod 0644 {{{ grub2_boot_path }}}/grub.cfg

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/cramfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/cramfs.conf
-sed -i '/install cramfs/d' /etc/modprobe.d/cramfs.conf
+echo cramfs > /etc/modprobe.d/cramfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/freevxfs.conf ]; then
+    sed -i '/install freevxfs/d' /etc/modprobe.d/freevxfs.conf
+fi
+echo "# install freevxfs /bin/true" > /etc/modprobe.d/freevxfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install freevxfs /bin/true" > /etc/modprobe.d/freevxfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/freevxfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/freevxfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/freevxfs.conf
+sed -i '/install freevxfs/d' /etc/modprobe.d/freevxfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/freevxfs.conf
-sed -i '/install freevxfs/d' /etc/modprobe.d/freevxfs.conf
+echo freevxfs > /etc/modprobe.d/freevxfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/hfs.conf ]; then
+    sed -i '/install hfs/d' /etc/modprobe.d/hfs.conf
+fi
+echo "# install hfs /bin/true" > /etc/modprobe.d/hfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install hfs /bin/true" > /etc/modprobe.d/hfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/hfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/hfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/hfs.conf
-sed -i '/install hfs/d' /etc/modprobe.d/hfs.conf
+echo hfs > /etc/modprobe.d/hfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/hfs.conf
+sed -i '/install hfs/d' /etc/modprobe.d/hfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/hfsplus.conf ]; then
+    sed -i '/install hfsplus/d' /etc/modprobe.d/hfsplus.conf
+fi
+echo "# install hfsplus /bin/true" > /etc/modprobe.d/hfsplus.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install hfsplus /bin/true" > /etc/modprobe.d/hfsplus.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/hfsplus.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/hfsplus.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/hfsplus.conf
-sed -i '/install hfsplus/d' /etc/modprobe.d/hfsplus.conf
+echo hfsplus > /etc/modprobe.d/hfsplus.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/hfsplus.conf
+sed -i '/install hfsplus/d' /etc/modprobe.d/hfsplus.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/comment.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -f /etc/modprobe.d/jffs2.conf ]; then
+    sed -i '/install jffs2/d' /etc/modprobe.d/jffs2.conf
+fi
+echo "# install jffs2 /bin/true" > /etc/modprobe.d/jffs2.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "install jffs2 /bin/true" > /etc/modprobe.d/jffs2.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/jffs2.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/file_not_there.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/file_not_there.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -f /etc/modprobe.d/jffs2.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/wrong_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /etc/modprobe.d/jffs2.conf
+sed -i '/install jffs2/d' /etc/modprobe.d/jffs2.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/jffs2.conf
-sed -i '/install jffs2/d' /etc/modprobe.d/jffs2.conf
+echo jffs2 > /etc/modprobe.d/jffs2.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/squashfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/squashfs.conf
-sed -i '/install squashfs/d' /etc/modprobe.d/squashfs.conf
+echo squashfs > /etc/modprobe.d/squashfs.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/udf.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/udf.conf
-sed -i '/install udf/d' /etc/modprobe.d/udf.conf
+echo udf > /etc/modprobe.d/udf.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/empty.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/modprobe.d/usb-storage.conf

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/tests/wrong_value.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-touch /etc/modprobe.d/usb-storage.conf
-sed -i '/install usb-storage/d' /etc/modprobe.d/usb-storage.conf
+echo usb-storage > /etc/modprobe.d/usb-storage.conf

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-yum remove -y aide
+if command -v yum; then
+    yum remove -y aide
+elif command -v apt-get; then
+    DEBIAN_FRONTEND=noninteractive apt-get remove -y aide
+fi
 
 echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/installed.pass.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 # packages = aide
 
+if command -v yum; then
+    yum install -y aide
+elif command -v apt-get; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y aide
+fi

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/notinstalled.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/tests/notinstalled.fail.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-yum remove -y aide
+if command -v yum; then
+    yum remove -y aide
+elif command -v apt-get; then
+    DEBIAN_FRONTEND=noninteractive apt-get remove -y aide
+fi

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_absent.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+# Code taken from macro bash_sudo_remove_config()
+for f in $( ls /etc/sudoers /etc/sudoers.d/* 2> /dev/null ) ; do
+  matching_list=$(grep -P '^(?!#).*[\s]+use_pty.*$' $f | uniq )
+  if ! test -z "$matching_list"; then
+    while IFS= read -r entry; do
+      # comment out "{{{ parameter }}}" matches to preserve user data
+      sed -i "s/^${entry}$/# &/g" $f
+    done <<< "$matching_list"
+
+    /usr/sbin/visudo -cf $f &> /dev/null || echo "Fail to validate $f with visudo"
+  fi
+done

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+echo "Defaults use_pty" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled_dir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled_dir.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+echo "Defaults use_pty" >> /etc/sudoers.d/enable_use_pty


### PR DESCRIPTION
#### Description:

This pull requests adds some test cases into CaC for some rules which already exist. Let me know if any should be dropped. Some of these address issues w.r.t. `yum` vs `apt`.

The kernel tests (as pointed out by Richard) also didn't really have a "wrong value" -- any non-empty command would really suffice.  So we changed them to actually _loading_ the module (closet thing to a wrong value) and added an empty file test elsewhere. 

Not tested on RHEL or Fedora. Could someone check that please? :-) 