### PR TITLE
Kubernetes Remediations: Add YAML separator

### DIFF
--- a/applications/openshift/api-server/api_server_audit_log_maxsize/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp
 apiVersion: config.openshift.io/v1
 kind: APIServer

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp
 apiVersion: config.openshift.io/v1
 kind: APIServer

--- a/applications/openshift/api-server/api_server_encryption_provider_config/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_config/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp
 apiVersion: config.openshift.io/v1
 kind: APIServer

--- a/linux_os/guide/services/ntp/chronyd_client_only/kubernetes/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/kubernetes/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/kubernetes/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/kubernetes/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/kubernetes/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = false
 # strategy = restrict

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/kubernetes/shared.yml
@@ -1,2 +1,3 @@
+---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
 {{{ kubernetes_usbguard_set(["xccdf_org.ssgproject.content_rule_package_usbguard_installed"]) }}}

--- a/linux_os/guide/services/usbguard/package_usbguard_installed/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/package_usbguard_installed/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
 ---
 apiVersion: machineconfiguration.openshift.io/v1

--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
 ---
 apiVersion: machineconfiguration.openshift.io/v1

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos 
 {{% macro usbguard_hid_and_hub_config_source() %}}
 allow with-interface match-all { 03:*:* 09:00:* }

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/kubernetes/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/kubernetes/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/kubernetes/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/kubernetes/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/kubernetes/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_ocp,multi_platform_rhcos
 # reboot = true
 # strategy = disable

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 
 {{% set file_contents = """## Successful file delete

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_module_load/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_module_load/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/auditing/service_auditd_enabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/kubernetes/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_rhcos
 # reboot = true
 # strategy = restrict

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhcos,multi_platform_rhel,multi_platform_fedora
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/kubernetes/shared.yml
@@ -1,3 +1,4 @@
+---
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig


### PR DESCRIPTION
This ensures that a correct YAML separator is added to all kubernetes
remediations.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>