### PR TITLE
Fix kernel module disable template

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -191,6 +191,9 @@ else
     escaped_value="$(sed -e 's/\\/\\\\/g' <<< "{{{ value }}}")"
     if grep -q "^\\s*{{{ key }}}\\s*=" "${SETTINGSFILES[@]}"
     then
+        {{% if '/' in key %}}
+        {{{ raise("Key (" + key + ") uses sed path separator (/) in " + rule_id) }}}
+        {{% endif %}}
         sed -i "s/\\s*{{{ key }}}\\s*=\\s*.*/{{{ key }}}=${escaped_value}/g" "${SETTINGSFILES[@]}"
     else
         sed -i "\\|\\[{{{ path }}}\\]|a\\{{{ key }}}=${escaped_value}" "${SETTINGSFILES[@]}"
@@ -268,6 +271,11 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
 {{%- macro _put_into_firefox_cfg(config_item, key, value_varname, where, sed_separator) -%}}
 # If the key exists, change it. Otherwise, add it to the config_file.
 if LC_ALL=C grep -m 1 -q '^{{{ config_item }}}("{{{ key }}}", ' "{{{ where }}}"; then
+    {{% if sed_separator in config_item %}}
+    {{{ raise("config_item (" + config_item + ") uses sed path separator (" + sed_separator + ") in " + rule_id) }}}
+    {{% elif sed_separator in key %}}
+    {{{ raise("key (" + key + ") uses sed path separator (" + sed_separator + ") in " + rule_id) }}}
+    {{% endif %}}
     sed -i 's{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}".*{{{ sed_separator }}}{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}})"';{{{ sed_separator }}}g' "{{{ where }}}"
 else
     echo '{{{ config_item }}}("{{{ key }}}", '"${{{ value_varname }}}"');' >> "{{{ where }}}"
@@ -457,6 +465,9 @@ fi
     {{%- else -%}}
         {{%- set modifier="d" -%}}
     {{%- endif -%}}
+    {{% if '/' in regex %}}
+    {{{ raise("regex (" + regex + ") uses sed path separator (/) in " + rule_id) }}}
+    {{% endif %}}
 LC_ALL=C sed -i "/{{{ regex }}}/{{{ modifier }}}" "{{{ path }}}"
 {{%- endmacro -%}}
 
@@ -594,6 +605,11 @@ EOF
 # Try find '[{{{ section }}}]' and '{{{ key }}}' in '{{{ filename }}}', if it exists, set
 # to '{{{ value }}}', if it isn't here, add it, if '[{{{ section }}}]' doesn't exist, add it there
 if grep -qzosP '[[:space:]]*\[{{{ section }}}]([^\n\[]*\n+)+?[[:space:]]*{{{ key }}}' '{{{ filename }}}'; then
+    {{% if '/' in key %}}
+    {{{ raise("key (" + key + ") uses sed path separator (/) in " + rule_id) }}}
+    {{% elif '/' in value %}}
+    {{{ raise("value (" + value + ") uses sed path separator (/) in " + rule_id) }}}
+    {{% endif %}}
     sed -i 's/{{{ key }}}[^(\n)]*/{{{ key }}}={{{ value }}}/' '{{{ filename }}}'
 elif grep -qs '[[:space:]]*\[{{{ section }}}]' '{{{ filename }}}'; then
     sed -i '/[[:space:]]*\[{{{ section }}}]/a {{{ key }}}={{{ value }}}' '{{{ filename }}}'
@@ -632,6 +648,9 @@ DOMAIN_REGEX="[[:space:]]*\[domain\/[^]]*]"
 # if [domain/..] doesn't exist, add it here for default domain
 if grep -qvzosP $AD_REGEX $SSSD_CONF; then
         if grep -qzosP $LDAP_REGEX $SSSD_CONF; then
+                {{% if '#' in parameter %}}
+                {{{ raise("parameter (" + parameter + ") uses sed path separator (#) in " + rule_id) }}}
+                {{% endif %}}
                 sed -i "s#{{{ parameter }}}[^(\n)]*#{{{ parameter }}} = {{{ value }}}#" $SSSD_CONF
         elif grep -qs $DOMAIN_REGEX $SSSD_CONF; then
                 sed -i "/$DOMAIN_REGEX/a {{{ parameter }}} = {{{ value }}}" $SSSD_CONF
@@ -640,7 +659,7 @@ if grep -qvzosP $AD_REGEX $SSSD_CONF; then
                         echo -e "[domain/default]\n{{{ parameter }}} = {{{ value }}}" >> $SSSD_CONF
                 else
                         echo "Config file '$SSSD_CONF' doesnt exist, not remediating, assuming non-applicability." >&2
-                fi        
+                fi
         fi
 fi
 {{%- endmacro %}}

--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -1,6 +1,11 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 {{% if product in ["rhel7", "ol7"] %}}
+{{% if '/' in ARG_NAME %}}
+{{{ raise("ARG_NAME (" + ARG_NAME + ") uses sed path separator (/) in " + rule_id) }}}
+{{% elif '/' in ARG_NAME_VALUE %}}
+{{{ raise("ARG_NAME_VALUE (" + ARG_NAME_VALUE + ") uses sed path separator (/) in " + rule_id) }}}
+{{% endif %}}
 # Correct the form of default kernel command line in GRUB
 if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
 	# modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -10,7 +10,7 @@ if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/50-b
 fi
 {{% else %}}
 if LC_ALL=C grep -q -m 1 "^install {{{ KERNMODULE }}}" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
-	sed -i 's/^install {{{ KERNMODULE }}}.*/install {{{ KERNMODULE }}} /bin/true/g' /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+	sed -i 's#^install {{{ KERNMODULE }}}.*#install {{{ KERNMODULE }}} /bin/true#g' /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -10,6 +10,9 @@ if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/50-b
 fi
 {{% else %}}
 if LC_ALL=C grep -q -m 1 "^install {{{ KERNMODULE }}}" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
+	{{% if '#' in KERNMODULE %}}
+	{{{ raise("KERNMODULE (" + KERNMODULE + ") uses sed path separator (#) in " + rule_id) }}}
+	{{% endif %}}
 	sed -i 's#^install {{{ KERNMODULE }}}.*#install {{{ KERNMODULE }}} /bin/true#g' /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf

--- a/shared/templates/sudo_defaults_option/bash.template
+++ b/shared/templates/sudo_defaults_option/bash.template
@@ -20,6 +20,9 @@ if /usr/sbin/visudo -qcf /etc/sudoers; then
     else
         # sudoers file defines Option {{{ OPTION }}}, remediate if appropriate value is not set
         if ! grep -P "^[\s]*Defaults.*\b{{{ OPTION_VALUE }}}\b.*$" /etc/sudoers; then
+            {{% if '/' in OPTION %}}
+            {{{ raise("OPTION (" + OPTION + ") uses sed path separator (/) in " + rule_id) }}}
+            {{% endif %}}
             sed -Ei "s/(^[\s]*Defaults.*\b{{{ OPTION }}}=)\w+(\b.*$)/\1{{{ '${' ~ VARIABLE_NAME ~ '}' }}}\2/" /etc/sudoers
         fi
     fi

--- a/shared/templates/zipl_bls_entries_option/bash.template
+++ b/shared/templates/zipl_bls_entries_option/bash.template
@@ -7,5 +7,10 @@ grubby --update-kernel=ALL --args="{{{ ARG_NAME }}}={{{ ARG_VALUE }}}"
 if [ ! -f /etc/kernel/cmdline ]; then
     echo "{{{ ARG_NAME }}}={{{ ARG_VALUE }}}" > /etc/kernel/cmdline
 elif ! grep -q '^(.*\s)?{{{ ARG_NAME }}}={{{ ARG_VALUE }}}(\s.*)?$' /etc/kernel/cmdline; then
+    {{% if '/' in ARG_NAME %}}
+    {{{ raise("ARG_NAME (" + ARG_NAME + ") uses sed path separator (" + sed_separator + ") in " + rule_id) }}}
+    {{% elif '/' in ARG_VALUE %}}
+    {{{ raise("ARG_VALUE (" + ARG_VALUE + ") uses sed path separator (" + sed_separator + ") in " + rule_id) }}}
+    {{% endif %}}
     sed -Ei 's/^(.*)$/\1 {{{ ARG_NAME }}}={{{ ARG_VALUE }}}/' /etc/kernel/cmdline
 fi


### PR DESCRIPTION
#### Description:

Kernel module disabling includes `/bin/true` -- but we use `/` as the path separator in our `sed` invocation. 

Fix this bug and make sure we don't introduce similar in the future. 

--- 

Resolves: #6898 