### PR TITLE
SSGTS - testing "ALL" rules must selects all rules from current benchmark

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -213,6 +213,10 @@ class RuleChecker(oscap.Checker):
 
     def _rule_should_be_tested(self, rule, rules_to_be_tested):
         if 'ALL' in rules_to_be_tested:
+            # don't select rules that are not present in benchmark
+            if not xml_operations.find_rule_in_benchmark(
+                    self.datastream, self.benchmark_id, rule.id):
+                return False
             return True
         else:
             for rule_to_be_tested in rules_to_be_tested:


### PR DESCRIPTION
#### Description:
When `ALL` rules are being tested, we want to test all rules from selected benchmark. It's not possible to test rules that are not in selected benchmark, thus those should not be selected at all.

Currently, there is flood of error messages that `a rule isn't present in benchmark`:
```
$ python3 tests/test_suite.py rule --libvirt qemu:///system test_suite_vm --datastream build/ssg-rhel8-ds.xml --remediate-using bash                 --profile "(all)" ALL
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /tmp/tmp.mRPpBpjNzu/logs/rule-ALL-2021-05-21-0542/test_suite.log
ERROR - Rule 'xccdf_org.ssgproject.content_rule_ntpd_configure_restrictions' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in '/tmp/ssgts-ds-6w7ndqre'
ERROR - Rule 'xccdf_org.ssgproject.content_rule_ntpd_run_as_ntp_user' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in '/tmp/ssgts-ds-6w7ndqre'
ERROR - Rule 'xccdf_org.ssgproject.content_rule_configure_etc_hosts_deny' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in '/tmp/ssgts-ds-6w7ndqre'
ERROR - Rule 'xccdf_org.ssgproject.content_rule_sshd_use_approved_ciphers_ordered_stig' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in '/tmp/ssgts-ds-6w7ndqre'
ERROR - Rule 'xccdf_org.ssgproject.content_rule_sshd_use_approved_macs_ordered_stig' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in '/tmp/ssgts-ds-6w7ndqre'
ERROR - Rule 'xccdf_org.ssgproject.content_rule_sshd_use_strong_ciphers' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in '/tmp/ssgts-ds-6w7ndqre'
ERROR - Rule 'xccdf_org.ssgproject.content_rule_sshd_use_strong_macs' isn't present in benchmark 'xccdf_org.ssgproject.content_benchmark_RHEL-8' in '/tmp/ssgts-ds-6w7ndqre'
```
The error message is useful when a specific rule is selected. But it is not when `ALL` are selected.
With this update, no error about "not in benchmark" is printed for the `ALL` rules alias.