### PR TITLE
Fix SSG test suite support for setting variables

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -312,7 +312,7 @@ class RuleChecker(oscap.Checker):
         with open(script, 'r') as script_file:
             script_content = script_file.read()
             for parameter in params:
-                found = re.search(r'^# {0} = ([ =,_\.\-\w\(\)]*)$'.format(parameter),
+                found = re.search(r'^# {0} = (.*)$'.format(parameter),
                                   script_content,
                                   re.MULTILINE)
                 if found is None:


### PR DESCRIPTION
#### Description

When trying to set variables from within scripts, SSGTS has a very
limited regex for allowed variables and values:

    r'^# {0} = ([ =,_\.\-\w\(\)]*)$'.format(parameter)

This greatly restricted the ability to set certain non-word characters
such as quotes and percent signs (e.g., 25% remaining).

Loosen up the regex considerably to:

    r'^# {0} = (.*)$'.format(parameter)

This allows us to capture the entire value of this parameter, regardless
of its value. I feel this is safe because we explicitly check for

    # <parameter> =

Which should limit false-positives and is otherwise easy enough to work
around (remove spaces around the equals, remove initial leading space,
use two pound signs, &c).

Resolves: #7093

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

I came across this limitation on #7082 (which was since merged). I was trying to set a variable with literal double quote in it `"`. I also came across it internally today on a variable with a `%` in its value, causing me to actually investigate why :D 

Let me know if anyone disagrees with the change. 