### PR TITLE
Specify sshd_allow_only_protocol2 test scenarios platform

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6-configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6-configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+# platform = Red Hat Enterprise Linux 7
 
 # Test targeted to RHEL 7.4
 yum downgrade -y openssh-6.6.1p1 openssh-clients-6.6.1p1 openssh-server-6.6.1p1

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-6.6.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+# platform = Red Hat Enterprise Linux 7
 
 # Test targeted to RHEL 7.4
 yum downgrade -y openssh-6.6.1p1 openssh-clients-6.6.1p1 openssh-server-6.6.1p1

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 7
 # packages = openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1
 #
 


### PR DESCRIPTION
#### Description:
Specify rhel7 platform in tests that works with old `openssh` packages. These packages are not available in rhel8.

```
$ python3 tests/test_suite.py rule --libvirt qemu:///system test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml --remediate-using bash --profile "(all)" sshd_allow_only_protocol2
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
ERROR - Couldn't install required packages {'openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1'}: Command '('ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'root@192.168.122.10', 'yum install -y openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1')' returned non-zero exit status 1.
ERROR - Terminating due to error: Couldn't install required packages {'openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1'}.
ERROR - Nothing has been tested!
```