### PR TITLE
Fix gdm3 package name in installed_env_has_gdm_package

### DIFF
--- a/shared/checks/oval/installed_env_has_gdm_package.xml
+++ b/shared/checks/oval/installed_env_has_gdm_package.xml
@@ -30,7 +30,7 @@
     <linux:object object_ref="obj_env_has_gdm_installed" />
   </linux:dpkginfo_test>
   <linux:dpkginfo_object id="obj_env_has_gdm_installed" version="1">
-    <linux:name>gdm</linux:name>
+    <linux:name>gdm3</linux:name>
   </linux:dpkginfo_object>
 {{% endif %}}
 


### PR DESCRIPTION
Like mentioned in #7079, Debian and Ubuntu use the gdm3 package name
rather than gdm. Fix this also in the shared OVAL check (used for CPEs).

Caught when talking with Eduardo Barretto about this.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

I went through all the CPEs we use in CIS and the rest seem correct. :-) We don't use some of the other CPEs, so I'm inclined to leave it alone. 