### PR TITLE
Fix OVAL issues of the no_shelllogin_for_systemaccounts rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
@@ -4,8 +4,8 @@
       a login shell.") }}}
     <criteria operator="OR">
       <!-- If SYS_UID_MIN and SYS_UID_MAX is not defined in /etc/login.defs
-           perform the check that all /etc/passwd entries having shell defined
-           have UIDs outside the default <0, UID_MIN -1> range.
+           perform the check that any /etc/passwd entry with shell defined
+           has UID outside the default <0, UID_MIN -1> range.
            If at least one UID with shell defined exists within that range,
            the requirement isn't met -->
       <criteria operator="AND">
@@ -18,9 +18,9 @@
       </criteria>
       <!-- If both SYS_UID_MIN and SYS_UID_MAX are defined in /etc/login.defs
            perform both checks:
-           * That all /etc/passwd entries having shell defined have UIDs outside
+           * That any /etc/passwd entry with shell defined has UID outside
            the range for reserved system accounts <0, SYS_UID_MIN> range,
-           * That all /etc/passwd entries having shell defined have UIDs outside
+           * That any /etc/passwd entries with shell defined has UID outside
            the range for dynamically allocated system accounts <SYS_UID_MIN, SYS_UID_MAX>
            If at least one UID with shell defined exists within some of the two
            ranges, the requirement isn't met -->
@@ -71,14 +71,14 @@
   <!-- Get all /etc/passwd entries having shell defined as OVAL object -->
   <ind:textfilecontent54_object id="object_etc_passwd_entries" version="1">
     <ind:filepath>/etc/passwd</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!root).*:x:([\d]+):[\d]+:[^:]*:[^:]*:(?!\/usr\/sbin\/nologin|\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!root).*:x:([\d]+):[\d]+:[^:]*:[^:]*:(?!\/usr\/sbin\/nologin|\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt|\/bin\/false|\/usr\/bin\/false).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- FIRST CRITERION -->
   <!-- If both SYS_UID_MIN and SYS_UID_MAX aren't defined in /etc/login.defs
-       perform the check that all /etc/passwd entries having shell defined have
-       UIDs outside the <0, UID_MIN - 1> range -->
+       perform the check that any /etc/passwd entry with shell defined has
+       UID outside the <0, UID_MIN - 1> range -->
 
   <!-- Actual /etc/login.defs UID_MIN value as OVAL variable -->
   <local_variable id="variable_uid_min_value" datatype="int"
@@ -90,10 +90,10 @@
   </local_variable>
 
   <!-- Perform the default <0, UID_MIN - 1> UID range test itself -->
-  <!-- Thus check that all /etc/passwd entries having shell defined
-       have UID outside of <0, UID_MIN -1> range -->
+  <!-- Thus check that any /etc/passwd entry with shell defined
+       has UID outside of <0, UID_MIN -1> range -->
   <ind:textfilecontent54_test state_operator="OR" id="test_shell_defined_default_uid_range" check="all"
-  check_existence="all_exist" comment="&lt;0, UID_MIN - 1&gt; system UIDs having shell set"
+  check_existence="any_exist" comment="&lt;0, UID_MIN - 1&gt; system UIDs having shell set"
   version="1">
     <ind:object object_ref="object_etc_passwd_entries" />
     <ind:state state_ref="state_uid_less_than_zero" />
@@ -124,10 +124,10 @@
   <!-- SECOND CRITERION -->
   <!-- If both SYS_UID_MIN and SYS_UID_MAX are defined in /etc/login.defs,
        perform more advanced test:
-       * Check that all /etc/passwd entries having shell defined have UIDs
+       * Check that any /etc/passwd entry with shell defined has UID
        outside the range of reserved system UIDs, thus <0, SYS_UID_MIN>,
-       * Also check that all /etc/passwd entries having shell defined have
-       UIDs outside the range of dynamically allocated system UIDs, thus
+       * Also check that any /etc/passwd entry with shell defined has
+       UID outside the range of dynamically allocated system UIDs, thus
        <SYS_UID_MIN, SYS_UID_MAX>
   -->
 
@@ -150,8 +150,8 @@
   </local_variable>
 
   <!-- Perform the reserved UID range <0, SYS_UID_MIN> test itself -->
-  <!-- Thus check that all /etc/passwd entries having shell defined
-       have UID outside of <0, SYS_UID_MIN> range -->
+  <!-- Thus check that any /etc/passwd entry with shell defined
+       has UID outside of <0, SYS_UID_MIN> range -->
   <ind:textfilecontent54_test state_operator="OR" id="test_shell_defined_reserved_uid_range" check="all"
   check_existence="any_exist" comment="&lt;0, SYS_UID_MIN&gt; system UIDs having shell set"
   version="1">
@@ -165,8 +165,8 @@
   </ind:textfilecontent54_state>
 
   <!-- Perform the dynamically allocated UID range <SYS_UID_MIN, SYS_UID_MAX> test itself -->
-  <!-- Thus check that all /etc/passwd entries having shell defined
-       have UID outside of <SYS_UID_MIN, SYS_UID_MAX> range -->
+  <!-- Thus check that any /etc/passwd entry with shell defined
+       has UID outside of <SYS_UID_MIN, SYS_UID_MAX> range -->
   <ind:textfilecontent54_test state_operator="OR" id="test_shell_defined_dynalloc_uid_range" check="all"
   check_existence="any_exist" comment="&lt;SYS_UID_MIN, SYS_UID_MAX&gt; system UIDS having shell set"
   version="1">


### PR DESCRIPTION
- object_etc_passwd_entries was missing /usr/bin/false and /bin/false
  which are used by some system accounts in Ubuntu
- test_shell_defined_default_uid_range does not require object existence
  to pass anymore

Signed-off-by: Richard Maciel Costa <richard.maciel.costa@canonical.com>

#### Description:

This pull request fixes two problems found in the no_shelllogin_for_systemaccounts.

The first one was the lack of /usr/bin/false and /bin/false paths in the regular expression used by the object_etc_passwd_entries OVAL object. Since some Linux distros traditionally use the aforementioned paths, this test would fail on those systems.

Second one was the wrong use of check_existence=all_exist in the test_shell_defined_default_uid_range test. This could lead to false negatives when the system does not use SYS_UID_MIN and SYS_UID_MAX parameters in /etc/login.defs, because if the system doesn't have any user, the object_etc_passwd_entries will return 0 objects. With the all_exist modifier, the test_shell_defined_default_uid_range will fail, even if the system is in a valid state (i.e. no system user with a valid shell).
