### PR TITLE
Fix more applicabilities

### DIFF
--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/oval/shared.xml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_use_newer_protocol/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="snmpd_use_newer_protocol" version="2">
     {{{ oval_metadata("SNMP version 1 and 2c must not be enabled.") }}}
     <criteria operator="OR">
-      <extend_definition comment="SMNP installed" definition_ref="package_net-snmp_removed"/>
+      <extend_definition comment="SNMP installed" definition_ref="package_net-snmp_removed"/>
       <criterion comment="SNMP protocols" test_ref="test_snmp_versions" />
     </criteria>
   </definition>

--- a/products/debian10/product.yml
+++ b/products/debian10/product.yml
@@ -21,5 +21,10 @@ cpes:
 
 # Mapping of CPE platform to package
 platform_package_overrides:
-  net-snmp: "snmp"
+  gdm: gdm3
+  grub2: grub2-common
+  net-snmp: snmp
+  nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  shadow: login
+  sssd: sssd-common

--- a/products/debian9/product.yml
+++ b/products/debian9/product.yml
@@ -21,5 +21,10 @@ cpes:
 
 # Mapping of CPE platform to package
 platform_package_overrides:
-  net-snmp: "snmp"
+  gdm: gdm3
+  grub2: grub2-common
+  net-snmp: snmp
+  nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  shadow: login
+  sssd: sssd-common

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -21,4 +21,10 @@ cpes:
       check_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
+  gdm: gdm3
+  grub2: grub2-common
+  net-snmp: snmp
+  nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  shadow: login
+  sssd: sssd-common

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -20,4 +20,10 @@ cpes:
       check_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
+  gdm: gdm3
+  grub2: grub2-common
+  net-snmp: snmp
+  nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  shadow: login
+  sssd: sssd-common

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -20,4 +20,10 @@ cpes:
       check_id: installed_OS_is_ubuntu2004
 
 platform_package_overrides:
+  gdm: gdm3
+  grub2: grub2-common
+  net-snmp: snmp
+  nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  shadow: login
+  sssd: sssd-common

--- a/shared/checks/oval/installed_env_has_nss-pam-ldapd_package.xml
+++ b/shared/checks/oval/installed_env_has_nss-pam-ldapd_package.xml
@@ -30,7 +30,7 @@
     <linux:object object_ref="obj_env_has_nss-pam-ldapd_installed" />
   </linux:dpkginfo_test>
   <linux:dpkginfo_object id="obj_env_has_nss-pam-ldapd_installed" version="1">
-    <linux:name>nss-pam-ldapd</linux:name>
+    <linux:name>libpam-ldapd</linux:name>
   </linux:dpkginfo_object>
 {{% endif %}}
 


### PR DESCRIPTION
#### Description:

I keep forgetting that the Bash side population comes from the `platform_package_overrides` section in the `product.yml` file; I keep wishing it was closer to the CPEs themselves. I've now validated all `shared/checks/ovals/installed_env_has.*` (skipping `yum` and `zypher`) against Ubuntu and updated appropriately. This also builds and syncs a complete list of different packages (that we currently have) into all Ubuntu and Debian products. 

/cc @richardmaciel-canonical @dodys