### PR TITLE
Fix chrony maxpoll description, include peer in bash check

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -14,3 +14,8 @@ sed -i "s/^\(server.*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpo
 grep "^server" "$config_file" | grep -v maxpoll | while read -r line ; do
         sed -i "s/$line/& maxpoll $var_time_service_set_maxpoll/" "$config_file"
 done
+
+# Add maxpoll to peer entries without maxpoll
+grep "^peer" "$config_file" | grep -v maxpoll | while read -r line ; do
+        sed -i "s/$line/& maxpoll $var_time_service_set_maxpoll/" "$config_file"
+done

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -9,7 +9,7 @@ description: |-
     {{{ xccdf_value("var_time_service_set_maxpoll") }}} in <tt>/etc/ntp.conf</tt> or
     <tt>/etc/chrony.conf</tt> to continuously poll time servers. To configure
     <tt>maxpoll</tt> in <tt>/etc/ntp.conf</tt> or <tt>/etc/chrony.conf</tt>
-    add the following:
+    add the following after each `server` entry:
     <pre>maxpoll {{{ xccdf_value("var_time_service_set_maxpoll") }}}</pre>
     {{% if product == "rhcos4" %}}
     <p>
@@ -102,5 +102,5 @@ ocil_clause: 'it does not exist or maxpoll has not been set to the expected valu
 ocil: |-
     To verify that <tt>maxpoll</tt> has been set properly, perform the following:
     <pre>$ sudo grep maxpoll /etc/ntp.conf /etc/chrony.conf</pre>
-    The output should return
+    The output should return:
     <pre>maxpoll {{{ xccdf_value("var_time_service_set_maxpoll") }}}</pre>.


### PR DESCRIPTION
#### Description:

As reported by @mralph-rh, the description text is vague and makes it sound like `maxpoll` goes on its own line; it doesn't.

Additionally `peer` is a valid keyword and should also contain `maxpoll` entries. 


cc: @dodys -- this will affect Ubuntu as well. Curious what your thoughts on about 20.04 STIG as it doesn't appear to include `peer` entries. 