### PR TITLE
Fix covscan shell findings

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
@@ -6,7 +6,10 @@
 SSSD_CONF="/etc/sssd/sssd.conf"
 SSSD_CONF_DIR="/etc/sssd/conf.d/*.conf"
 
-for f in $( ls $SSSD_CONF $SSSD_CONF_DIR 2> /dev/null ) ; do
+for f in $SSSD_CONF $SSSD_CONF_DIR; do
+	if [ ! -e "$f" ]; then
+		continue
+	fi
 	# finds all services entries under [sssd] configuration category, get a unique list so it doesn't add redundant fix
 	services_list=$( awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1}f' $f | grep -P '^services[ \t]*=' | uniq )
 

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
@@ -1,7 +1,10 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 found=false
-for f in $( ls /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf 2> /dev/null ) ; do
+for f in /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf; do
+	if [ ! -e "$f" ]; then
+		continue
+	fi
 	user=$( awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1} f{nu=gensub("^\\s*user\\s*=\\s*(\\S+).*","\\1",1); if($0!=nu){user=nu}} END{print user}' $f )
 	if [ -n "$user" ] ; then
 		if [ "$user" != sssd ] ; then

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -8,7 +8,7 @@ tmout_found=0
 for f in /etc/profile /etc/profile.d/*.sh; do
     if grep --silent '^\s*TMOUT' $f; then
         sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/\1TMOUT=$var_accounts_tmout\3/g" $f
-        $tmout_found=1
+        tmout_found=1
     fi
 done
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -19,7 +19,6 @@ if [ "$(getconf LONG_BIT)" = "64" ] ; then
   if grep --silent noexec {{{ grub2_boot_path }}}/grub*.cfg ; then
         sed -i "s/noexec.*//g" /etc/default/grub
         sed -i "s/noexec.*//g" /etc/grub.d/*
-        GRUBCFG={{{ grub2_boot_path }}}/*.cfg
-        grub2-mkconfig -o "$GRUBCFG"
+        grub2-mkconfig -o "{{{ grub2_boot_path }}}"/grub*.cfg
   fi
 fi

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/bash/shared.sh
@@ -16,7 +16,7 @@ do
 		config=$config"+sha512"
 	fi
 
-	for hash in ${forbidden_hashes[@]}
+	for hash in "${forbidden_hashes[@]}"
 	do
 		config=$(echo $config | sed "s/$hash//")
 	done

--- a/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/noexec_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/noexec_absent.fail.sh
@@ -2,7 +2,10 @@
 # platform = multi_platform_all
 
 # Code taken from macro bash_sudo_remove_config()
-for f in $( ls /etc/sudoers /etc/sudoers.d/* 2> /dev/null ) ; do
+for f in /etc/sudoers /etc/sudoers.d/*; do
+  if [ ! -e "$f" ]; then
+    continue
+  fi
   matching_list=$(grep -P '^(?!#).*[\s]+noexec.*$' $f | uniq )
   if ! test -z "$matching_list"; then
     while IFS= read -r entry; do

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
@@ -2,7 +2,10 @@
 # platform = multi_platform_all
 
 # Code taken from macro bash_sudo_remove_config()
-for f in $( ls /etc/sudoers /etc/sudoers.d/* 2> /dev/null ) ; do
+for f in /etc/sudoers /etc/sudoers.d/*; do
+  if [ ! -e "$f" ]; then
+    continue
+  fi
   matching_list=$(grep -P '^(?!#).*[\s]+logfile.*$' $f | uniq )
   if ! test -z "$matching_list"; then
     while IFS= read -r entry; do


### PR DESCRIPTION
#### Description:
```
Error: SHELLCHECK_WARNING (CWE-398):
/usr/share/scap-security-guide/bash/rhel7-script-anssi_nt28_enhanced.sh:1630:10: error[SC1066]: Don't use $ on the left side of assignments.
# 1628|       if grep --silent '^\s*TMOUT' $f; then
# 1629|           sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/\1TMOUT=$var_accounts_tmout\3/g" $f
# 1630|->         $tmout_found=1
# 1631|       fi
# 1632|   done
```

```
Error: SHELLCHECK_WARNING (CWE-88):
/usr/share/scap-security-guide/bash/rhel7-script-stig_gui.sh:191:14: error[SC2068]: Double quote array expansions to avoid re-splitting elements.
#  189|   	fi
#  190|   
#  191|-> 	for hash in ${forbidden_hashes[@]}
#  192|   	do
#  193|   		config=$(echo $config | sed "s/$hash//")
```

```
Error: SHELLCHECK_WARNING (CWE-398):
/usr/share/scap-security-guide/bash/rhel7-script-stig_gui.sh:1339:10: error[SC2045]: Iterating over ls output is fragile. Use globs.
# 1337|   (>&2 echo "Remediating rule 40/248: 'sudo_remove_nopasswd'")
# 1338|   
# 1339|-> for f in $( ls /etc/sudoers /etc/sudoers.d/* 2> /dev/null ) ; do
# 1340|     matching_list=$(grep -P '^(?!#).*[\s]+NOPASSWD[\s]*\:.*$' $f | uniq )
# 1341|     if ! test -z "$matching_list"; then
```

```
Error: SHELLCHECK_WARNING (CWE-398):
/usr/share/scap-security-guide/bash/rhel7-script-stig_gui.sh:19943:10: error[SC2045]: Iterating over ls output is fragile. Use globs.
#19941|   SSSD_CONF_DIR="/etc/sssd/conf.d/*.conf"
#19942|   
#19943|-> for f in $( ls $SSSD_CONF $SSSD_CONF_DIR 2> /dev/null ) ; do
#19944|   	# finds all services entries under [sssd] configuration category, get a unique list so it doesn't add redundant fix
#19945|   	services_list=$( awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1}f' $f | grep -P '^services[ \t]*=' | uniq )
```

```
Error: SHELLCHECK_WARNING (CWE-398):
/usr/share/scap-security-guide/bash/rhel8-script-anssi_bp28_high.sh:7011:17: warning[SC2125]: Brace expansions and globs are literal in assignments. Quote it or use an array.
# 7009|           sed -i "s/noexec.*//g" /etc/default/grub
# 7010|           sed -i "s/noexec.*//g" /etc/grub.d/*
# 7011|->         GRUBCFG=/boot/grub2/*.cfg
# 7012|           grub2-mkconfig -o "$GRUBCFG"
# 7013|     fi
```
