### PR TITLE
Fix utilities after product move

### DIFF
--- a/utils/autoprodtyper.py
+++ b/utils/autoprodtyper.py
@@ -62,7 +62,7 @@ def main():
         msg = msg.format(args.product)
         raise ValueError(msg)
 
-    product_base = os.path.join(SSG_ROOT, args.product)
+    product_base = os.path.join(SSG_ROOT, "products", args.product)
     product_yaml = os.path.join(product_base, "product.yml")
     env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml)
 

--- a/utils/duplicated_prodtypes.py
+++ b/utils/duplicated_prodtypes.py
@@ -17,7 +17,7 @@ def _create_profile_cache(ssg_root):
 
     for product in product_list:
         found_obj_name = False
-        prod_profiles_dir = os.path.join(ssg_root, product, "profiles")
+        prod_profiles_dir = os.path.join(ssg_root, "products", product, "profiles")
         for _, dirs, files in os.walk(prod_profiles_dir):
             dirs.sort()
             files.sort()

--- a/utils/migrate_template_csv_to_rule.py
+++ b/utils/migrate_template_csv_to_rule.py
@@ -619,7 +619,7 @@ class ProductCSVData(object):
         self.product = product
         self.ssg_root = ssg_root  # Needed?
 
-        self.csv_dir = os.path.join(ssg_root, product, "templates/csv")
+        self.csv_dir = os.path.join(ssg_root, "products", product, "templates/csv")
         self.csv_files = self._identify_csv_files(self.csv_dir)
 
         self.csv_data = self._load_csv_files(self.csv_files)

--- a/utils/refchecker.py
+++ b/utils/refchecker.py
@@ -100,7 +100,7 @@ def main():
         msg = msg.format(args.product)
         raise ValueError(msg)
 
-    product_base = os.path.join(SSG_ROOT, args.product)
+    product_base = os.path.join(SSG_ROOT, "products", args.product)
     product_yaml = os.path.join(product_base, "product.yml")
     env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml)
 


### PR DESCRIPTION
After products were moved into a sub-folder, various utilities weren't
updated. Update them for the new location to ensure they still work
correctly post-move.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

----

@matejak Sorry, I didn't catch these prior to the merge :-)