### PR TITLE
ensure_pam_module_options now fix empty option value

### DIFF
--- a/shared/bash_remediation_functions/ensure_pam_module_options.sh
+++ b/shared/bash_remediation_functions/ensure_pam_module_options.sh
@@ -42,7 +42,7 @@ function ensure_pam_module_options {
 
 	# fix the value for 'option' if one exists but does not match '_valueRegex'
     if grep -q -P "^\\s*${_type}\\s+${_control}\\s+${_module}(\\s.+)?\\s+${_option}(?"'!'"${_valueRegex}(\\s|\$))" < "${_pamFile}" ; then
-		sed --follow-symlinks -i -E -e "s/^(\\s*${_type}\\s+${_control}\\s+${_module}(\\s.+)?\\s)${_option}=[^[:space:]]+/\\1${_option}${_defaultValue}/" "${_pamFile}"
+		sed --follow-symlinks -i -E -e "s/^(\\s*${_type}\\s+${_control}\\s+${_module}(\\s.+)?\\s)${_option}=[^[:space:]]*/\\1${_option}${_defaultValue}/" "${_pamFile}"
 
     # add 'option=default' if option is not set
 	elif grep -q -E "^\\s*${_type}\\s+${_control}\\s+${_module}" < "${_pamFile}" &&


### PR DESCRIPTION
Given a pam module option, this regexp will fix its value even if
there is no value associated previously (but the option exists).

For instance, for the module pam_tally2, option deny, this commit will allow
this script to fix 'deny=' adding a proper value like 'deny=3'.

Signed-off-by: Richard Maciel Costa <richard.maciel.costa@canonical.com>

#### Description:
Small change to the regexp responsible of the sed whose purpose is to fix the value of the option with the parameter `_defaultValue`.

#### Rationale:
If a pam module line has an option with `option=`, the bash script will fail to fix that option value.