### PR TITLE
OCP4: Re-enable usbguard rules

### DIFF
--- a/linux_os/guide/services/usbguard/package_usbguard_installed/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/package_usbguard_installed/kubernetes/shared.yml
@@ -1,6 +1,5 @@
 ---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
----
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/kubernetes/shared.yml
@@ -1,6 +1,5 @@
 ---
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
----
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:

--- a/products/rhcos4/profiles/moderate.profile
+++ b/products/rhcos4/profiles/moderate.profile
@@ -191,7 +191,7 @@ selections:
     #- package_openscap-scanner_installed
     #- package_policycoreutils_installed
     - package_sudo_installed
-    #- package_usbguard_installed
+    - package_usbguard_installed
     ####
     # Need to replace with fluentd checks
     #- package_audispd-plugins_installed
@@ -236,9 +236,9 @@ selections:
     #- sssd_run_as_sssd_user
 
     ### Configure USBGuard
-    #- service_usbguard_enabled
-    #- configure_usbguard_auditbackend
-    #- usbguard_allow_hid_and_hub
+    - service_usbguard_enabled
+    - configure_usbguard_auditbackend
+    - usbguard_allow_hid_and_hub
 
     ### Enable / Configure FIPS
     - enable_fips_mode


### PR DESCRIPTION
This also fixes the syntax errors introduced in-between when they were
disabled.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>