### PR TITLE
Add single quotes to dconf value "lock-screen" (RHEL-08-020050)

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/rule.yml
@@ -7,12 +7,12 @@ title: 'Enable the GNOME3 Screen Locking On Smartcard Removal'
 description: |-
     In the default graphical environment, screen locking on smartcard removal
     can be enabled by setting <tt>removal-action</tt>
-    to <tt>lock-screen</tt>.
+    to <tt>'lock-screen'</tt>.
     <br /><br />
     To enable, add or edit <tt>removal-action</tt> to
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/settings-daemon/peripherals/smartcard]
-    removal-action=lock-screen</pre>
+    removal-action='lock-screen'</pre>
     Once the setting has been added, add a lock to
     <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.
     For example:
@@ -38,7 +38,7 @@ ocil_clause: 'removal-action has not been configured'
 ocil: |-
     To ensure screen locking on smartcard removal is enabled, run the following command:
     <pre>$ grep removal-action /etc/dconf/db/local.d/*</pre>
-    The output should be <tt>lock-screen</tt>.
+    The output should be <tt>'lock-screen'</tt>.
     To ensure that users cannot disable screen locking on smartcard removal, run the following:
     <pre>$ grep removal-action /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/settings-daemon/peripherals/smartcard/removal-action</tt>
@@ -49,6 +49,6 @@ template:
     name: dconf_ini_file
     vars:
         parameter: removal-action
-        value: "lock-screen"
+        value: "'lock-screen'"
         section: "org/gnome/settings-daemon/peripherals/smartcard"
         path: /etc/dconf/db/local.d/

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/tests/correct_value.pass.sh
@@ -5,7 +5,7 @@
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "lock-screen" "local.d" "00-security-settings"
+add_dconf_setting "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "'lock-screen'" "local.d" "00-security-settings"
 add_dconf_lock "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "local.d" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/tests/wrong_value.fail.sh
@@ -5,7 +5,7 @@
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "wrong_value" "local.d" "00-security-settings"
+add_dconf_setting "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "'wrong_value'" "local.d" "00-security-settings"
 add_dconf_lock "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "local.d" "00-security-settings-lock"
 
 dconf update


### PR DESCRIPTION
#### Description:

- Add single quotes to dconf value "lock-screen" (RHEL-08-020050)

#### Rationale:

- Value without the single quotes is not accepted and `dconf update` fails.

