### PR TITLE
OCP4: Use minute notation for inactivity timeout setting

### DIFF
--- a/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/kubernetes/shared.yml
+++ b/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/kubernetes/shared.yml
@@ -5,4 +5,4 @@ metadata:
   name: cluster
 spec:
   tokenConfig:
-    accessTokenInactivityTimeout: 600s
+    accessTokenInactivityTimeout: 10m0s

--- a/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/rule.yml
@@ -24,7 +24,7 @@ description: |-
     ...
     spec:
        tokenConfig:
-         accessTokenInactivityTimeout: 400s 
+         accessTokenInactivityTimeout: 10m0s 
     </pre>
     For more information on configuring the OAuth server, consult the
     OpenShift documentation:

--- a/applications/openshift/authentication/var_oauth_inactivity_timeout.var
+++ b/applications/openshift/authentication/var_oauth_inactivity_timeout.var
@@ -11,5 +11,5 @@ operator: equals
 interactive: false
 
 options:
-    600s: "600s"
-    default: "600s"
+    10m0s: "10m0s"
+    default: "10m0s"

--- a/products/ocp4/profiles/moderate.profile
+++ b/products/ocp4/profiles/moderate.profile
@@ -39,7 +39,7 @@ description: |-
 
 selections:
     # AC-2(5)
-    - var_oauth_inactivity_timeout=600s
+    - var_oauth_inactivity_timeout=10m0s
     - oauth_or_oauthclient_inactivity_timeout
     # AC-2, AC-7
     - ocp_idp_no_htpasswd


### PR DESCRIPTION
We were setting `600s`, which equals to 10min, however **something** is
"prettifying" the setting to "10m0s", which makes the test fails and
contributes to the flakiness we've been seeing.

This uses the `10m0s` notation instead to fix this.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>