### PR TITLE
Fix bogus conflict resolution in cce-redhat-avail file.

### DIFF
--- a/shared/references/cce-redhat-avail.txt
+++ b/shared/references/cce-redhat-avail.txt
@@ -28,14 +28,6 @@ CCE-83463-0
 CCE-83464-8
 CCE-83466-3
 CCE-83468-9
-<<<<<<< HEAD
-CCE-83476-2
-CCE-83478-8
-CCE-83479-6
-CCE-83480-4
-=======
-CCE-83484-6
->>>>>>> d15794578 (moved changes to 2 new rules, rather than overwriting existing pam_unix_remember rule)
 CCE-83487-9
 CCE-83494-5
 CCE-83502-5


### PR DESCRIPTION
Bogus change overlooked during review of #7055

All CCEs are already being used by the content. So we just need to remove the lines.