### PR TITLE
Fix remediation of accounts_password_pam_unix_remember

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel8_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel8_correct_value.pass.sh
@@ -14,7 +14,7 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
 		# option is not set, append to module
-		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/"
+		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/" $config_file
 	else
 		# option is set, replace value
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel8_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel8_wrong_value.fail.sh
@@ -14,7 +14,7 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
 		# option is not set, append to module
-		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/"
+		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/" $config_file
 	else
 		# option is set, replace value
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel8_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel8_correct_value.pass.sh
@@ -14,7 +14,7 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
 		# option is not set, append to module
-		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/"
+		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/"  $config_file
 	else
 		# option is set, replace value
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel8_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel8_wrong_value.fail.sh
@@ -14,7 +14,7 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
 		# option is not set, append to module
-		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/"
+		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/" $config_file
 	else
 		# option is set, replace value
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -5,14 +5,19 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("var_password_pam_unix_remember") }}}
 
-- name: "Do not allow users to reuse recent passwords - system-auth (change)"
+{{% macro ansible_pam_remember(path, module, control) %}}
+- name: "Do not allow users to reuse recent passwords ({{{ module }}}) - {{{ path }}} (change)"
   replace:
-    dest: /etc/pam.d/system-auth
-    regexp: '^(password\s+sufficient\s+pam_unix\.so\s.*remember\s*=\s*)(\S+)(.*)$'
+    dest: {{{ path }}}
+    regexp: '^(password\s+{{{ control }}}\s+{{{ module }}}\.so\s.*remember\s*=\s*)(\S+)(.*)$'
     replace: '\g<1>{{ var_password_pam_unix_remember }}\g<3>'
 
-- name: "Do not allow users to reuse recent passwords - system-auth (add)"
+- name: "Do not allow users to reuse recent passwords ({{{ module }}}) - {{{ path }}} (add)"
   replace:
-    dest: /etc/pam.d/system-auth
-    regexp: '^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$'
+    dest: {{{ path }}}
+    regexp: '^password\s+{{{ control }}}\s+{{{ module }}}\.so\s(?!.*remember\s*=\s*).*$'
     replace: '\g<0> remember={{ var_password_pam_unix_remember }}'
+{{%- endmacro -%}}
+
+{{{ ansible_pam_remember(path="/etc/pam.d/system-auth", module="pam_unix", control="sufficient") }}}
+{{{ ansible_pam_remember(path="/etc/pam.d/password-auth", module="pam_unix", control="sufficient") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -5,11 +5,15 @@
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"
 
+{{% macro bash_pam_remember(module, control) %}}
 for pamFile in "${AUTH_FILES[@]}"
 do
 	if grep -q "remember=" $pamFile; then
-		sed -i --follow-symlinks "s/\(^password.*sufficient.*pam_unix.so.*\)\(\(remember *= *\)[^ $]*\)/\1remember=$var_password_pam_unix_remember/" $pamFile
+		sed -i --follow-symlinks "s/\(^password.*{{{ control }}}.*{{{ module }}}.so.*\)\(\(remember *= *\)[^ $]*\)/\1remember=$var_password_pam_unix_remember/" $pamFile
 	else
-		sed -i --follow-symlinks "/^password[[:space:]]\+sufficient[[:space:]]\+pam_unix.so/ s/$/ remember=$var_password_pam_unix_remember/" $pamFile
+		sed -i --follow-symlinks "/^password[[:space:]]\+{{{ control }}}[[:space:]]\+{{{ module }}}.so/ s/$/ remember=$var_password_pam_unix_remember/" $pamFile
 	fi
 done
+{{%- endmacro -%}}
+
+{{{ bash_pam_remember(module="pam_unix", control="sufficient") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/rhel8_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/rhel8_correct_value.pass.sh
@@ -6,24 +6,24 @@ for auth_file in system-auth password-auth
 do
     config_file=/etc/pam.d/${auth_file}
 
-	# is 'password required|requisite pam_pwhistory.so' here?
-	if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+	# is 'password sufficient pam_unix.so' here?
+	if grep -q "^password.*pam_unix.so.*" $config_file; then
 		# is the remember option set?
-		option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
+		option=$(sed -rn 's/^(.*pam_unix\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 		if [[ -z $option ]]; then
 			# option is not set, append to module
-			sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/"
+			sed -i --follow-symlinks "/pam_unix.so/ s/$/ remember=$remember_cnt/" $config_file
 		else
 			# option is set, replace value
-			sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
+			sed -r -i --follow-symlinks "s/^(.*pam_unix\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 		fi
 		# ensure corect control is being used per os requirement
-		if ! grep -q "^password.*required.*pam_pwhistory.so.*" $config_file; then
+		if ! grep -q "^password.*sufficient*pam_unix.so.*" $config_file; then
 			#replace incorrect value
-			sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1required\3/" $config_file
+			sed -r -i --follow-symlinks "s/(^password.*)(sufficient)(.*pam_unix\.so.*)$/\1sufficient\3/" $config_file
 		fi
 	else
-		# no 'password required|requisite pam_pwhistory.so', add it
-		sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password required pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+		# no 'password sufficient pam_unix.so', add it
+		sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password sufficient pam_unix.so use_authtok remember=$remember_cnt" $config_file
 	fi
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/rhel8_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/rhel8_wrong_value.fail.sh
@@ -6,24 +6,24 @@ for auth_file in system-auth password-auth
 do
     config_file=/etc/pam.d/${auth_file}
 
-	# is 'password required|requisite pam_pwhistory.so' here?
-	if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+	# is 'password sufficient pam_unix.so' here?
+	if grep -q "^password.*pam_unix.so.*" $config_file; then
 		# is the remember option set?
-		option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
+		option=$(sed -rn 's/^(.*pam_unix\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 		if [[ -z $option ]]; then
 			# option is not set, append to module
-			sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$remember_cnt/"
+			sed -i --follow-symlinks "/pam_unix.so/ s/$/ remember=$remember_cnt/" $config_file
 		else
 			# option is set, replace value
-			sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
+			sed -r -i --follow-symlinks "s/^(.*pam_unix\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 		fi
 		# ensure corect control is being used per os requirement
-		if ! grep -q "^password.*required.*pam_pwhistory.so.*" $config_file; then
+		if ! grep -q "^password.*sufficient*pam_unix.so.*" $config_file; then
 			#replace incorrect value
-			sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1required\3/" $config_file
+			sed -r -i --follow-symlinks "s/(^password.*)(sufficient)(.*pam_unix\.so.*)$/\1sufficient\3/" $config_file
 		fi
 	else
-		# no 'password required|requisite pam_pwhistory.so', add it
-		sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password required pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+		# no 'password sufficient pam_unix.so', add it
+		sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password sufficient pam_unix.so use_authtok remember=$remember_cnt" $config_file
 	fi
 done


### PR DESCRIPTION
#### Description:

- Fix remediation of accounts_password_pam_unix_remember.
  - It needs to additionally account for pam_pwhistory with controls of kinds "requisite"
and "required" in both system-auth and password-auth.

- Fixes #7133
