### PR TITLE
Add policy version number profile description

### DIFF
--- a/products/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/products/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel7/profiles/anssi_nt28_high.profile
+++ b/products/rhel7/profiles/anssi_nt28_high.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (high)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/products/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/products/rhel7/profiles/anssi_nt28_minimal.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel8/profiles/anssi_bp28_high.profile
+++ b/products/rhel8/profiles/anssi_bp28_high.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (high)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel8/profiles/anssi_bp28_minimal.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.


### PR DESCRIPTION


#### Description:

- Add policy version to the ANSSI profile's description.

#### Rationale:

- From the profile description it is not clear to what version the ANSSI profiles are aligned with.