### PR TITLE
change vim package name to vim-common

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_vim_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_vim_installed/rule.yml
@@ -5,7 +5,7 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
 title: 'Install vim Package'
 
 description: |-
-    {{{ describe_package_install(package="vim") }}}
+    {{{ describe_package_install(package="vim-common") }}}
 
 rationale: |-
     Vim (Vi IMproved) is an almost compatible version of the UNIX editor <tt>vi</tt>. 
@@ -18,9 +18,9 @@ identifiers:
 
 ocil_clause: 'the package is not installed'
 
-ocil: '{{{ ocil_package(package="vim") }}}'
+ocil: '{{{ ocil_package(package="vim-common") }}}'
 
 template:
     name: package_installed
     vars:
-        pkgname: vim
+        pkgname: vim-common


### PR DESCRIPTION
#### Description:

- the rule package_vim_installed uses package name of "vim", but this package actually does not exist. Change name to "vim-common".

#### Rationale:

The rule was reported as failing eventhough the application was installed.