### PR TITLE
Add rule_id to env_yml when jinja processing yaml rule files.

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1085,13 +1085,16 @@ class Rule(object):
     def from_yaml(cls, yaml_file, env_yaml=None):
         yaml_file = os.path.normpath(yaml_file)
 
-        yaml_contents = open_and_macro_expand(yaml_file, env_yaml)
-        if yaml_contents is None:
-            return None
-
         rule_id, ext = os.path.splitext(os.path.basename(yaml_file))
         if rule_id == "rule" and ext == ".yml":
             rule_id = get_rule_dir_id(yaml_file)
+
+        if env_yaml:
+            env_yaml["rule_id"] = rule_id
+
+        yaml_contents = open_and_macro_expand(yaml_file, env_yaml)
+        if yaml_contents is None:
+            return None
 
         rule = cls(rule_id)
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1080,6 +1080,7 @@ class Rule(object):
         self.cpe_names = set()
         self.inherited_platforms = [] # platforms inherited from the group
         self.template = None
+        self.local_env_yaml = None
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None):
@@ -1089,14 +1090,20 @@ class Rule(object):
         if rule_id == "rule" and ext == ".yml":
             rule_id = get_rule_dir_id(yaml_file)
 
+        local_env_yaml = None
         if env_yaml:
-            env_yaml["rule_id"] = rule_id
+            local_env_yaml = dict()
+            local_env_yaml.update(env_yaml)
+            local_env_yaml["rule_id"] = rule_id
 
-        yaml_contents = open_and_macro_expand(yaml_file, env_yaml)
+        yaml_contents = open_and_macro_expand(yaml_file, local_env_yaml)
         if yaml_contents is None:
             return None
 
         rule = cls(rule_id)
+
+        if local_env_yaml:
+            rule.local_env_yaml = local_env_yaml
 
         try:
             rule._set_attributes_from_dict(yaml_contents)


### PR DESCRIPTION
#### Description:

- Add rule_id to env_yml when jinja processing yaml rule files.

#### Rationale:

- `rule_id` can be used within YAML rule files.

