### PR TITLE
Use quoted boolean for missing_parameter_pass

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
@@ -34,4 +34,4 @@ template:
     vars:
         filepath: /etc/motd
         filegid: '0'
-        missing_file_pass: true
+        missing_file_pass: 'true'

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
@@ -34,4 +34,4 @@ template:
     vars:
         filepath: /etc/motd
         fileuid: '0'
-        missing_file_pass: true
+        missing_file_pass: 'true'

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
@@ -34,4 +34,4 @@ template:
     vars:
         filepath: /etc/motd
         filemode: '0644'
-        missing_file_pass: true
+        missing_file_pass: 'true'


### PR DESCRIPTION
#### Description:

- Use quoted boolean for missing_parameter_pass.

#### Rationale:

- Fixes RHEL7 builds:
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/rhel7/build-scripts/build_templated_content.py", line 56, in <module>
    builder.build()
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/rhel7/ssg/templates.py", line 261, in build
    self.build_all_rules()
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/rhel7/ssg/templates.py", line 239, in build_all_rules
    rule = ssg.build_yaml.Rule.from_yaml(rule_path, self.env_yaml)
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/rhel7/ssg/build_yaml.py", line 1088, in from_yaml
    yaml_contents = open_and_macro_expand(yaml_file, env_yaml)
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/rhel7/ssg/yaml.py", line 102, in open_and_macro_expand
    return open_and_expand(yaml_file, substitutions_dict)
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/rhel7/ssg/yaml.py", line 85, in open_and_expand
    yaml_contents = _open_yaml(expanded_template, yaml_file, substitutions_dict)
  File "/home/jenkins/workspace/scap-security-guide-pull-requests/label/rhel7/ssg/yaml.py", line 70, in _open_yaml
    raise e
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/unicode'
  in "<unicode string>", line 39, column 64
```

This is related to this line: https://github.com/ComplianceAsCode/content/blob/master/ssg/yaml.py#L24
I don't know what would be the proper fix but quoting will solve it for now as we already use in other rules.

