### PR TITLE
OCP4: Add macro for filtered OCP and implement SCC capabilities rule

### DIFF
--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
@@ -38,3 +38,18 @@ ocil: |-
     Review each SCC and determine that only required capabilities are either
     completely added as a list entry under <tt>allowedCapabilities</tt>,
     or that all the un-required capabilities are dropped for containers and SCCs.
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_cluster_setting({'/apis/security.openshift.io/v1/securitycontextconstraints': '[.items[] | select(.metadata.name != "privileged")] | map(.allowedCapabilities == null)'}) | indent(4) }}}
+
+template:
+    name: yamlfile_value
+    vars:
+        ocp_data: "true"
+        filepath: "{{{ openshift_filtered_path('/apis/security.openshift.io/v1/securitycontextconstraints', '[.items[] | select(.metadata.name != \"privileged\")] | map(.allowedCapabilities == null)') }}}"
+        yamlpath: "[:]"
+        check_existence: "all_exist"
+        entity_check: "all"
+        values:
+          - value: "true"

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -3,11 +3,53 @@ ocil_clause: "the required value is not set"
 {{%- endmacro %}}
 
 
+{{#
+  Macro which generates a warning indicating how to make use of a
+  Kubernetes/OpenShift-related rule. This is used by the Compliance
+  Operator to automatically figure out what resources to fetch.
+    - endpoint (String/Array): The Kubernetes object path(s) to fetch
+#}}
 {{% macro openshift_cluster_setting(endpoint) -%}}
 This rule's check operates on the cluster configuration dump.
 Therefore, you need to use a tool that can query the OCP API, retrieve the {{% if endpoint is string %}}<code class="ocp-api-endpoint">{{{ endpoint }}}</code> API endpoint to the local <code class="ocp-dump-location">{{{ xccdf_value("ocp_data_root") }}}/{{{ endpoint.lstrip("/") }}}</code> file.{{% else %}}{{% for item in endpoint %}}<code class="ocp-api-endpoint">{{{ item }}}</code> API endpoint to the local <code class="ocp-dump-location">{{{ xccdf_value("ocp_data_root") }}}/{{{ item.lstrip("/") }}}</code> file{{% endfor %}}.{{% endif %}}
 {{%- endmacro %}}
 
+{{#
+  Macro which generates a warning indicating how to make use of a
+  Kubernetes/OpenShift-related rule as well as how to filter it. This
+  is used by the Compliance Operator to automatically figure
+  out what resources to fetch. The filtering directive can be used
+  by the jq command ( https://stedolan.github.io/jq/manual/ ).
+    - path_filter_pairs (dict): Kubernetes object path/filter directive pairs
+#}}
+{{% macro openshift_filtered_cluster_setting(path_filter_pairs) -%}}
+This rule's check operates on the cluster configuration dump.
+Therefore, you need to use a tool that can query the OCP API, retrieve the following:
+<ul>
+{{% for path, filter in path_filter_pairs.items() %}}
+  <li>
+    <code class="ocp-api-endpoint" id="{{{ (rule_id+path+filter)|sha256 }}}">{{{ path }}}</code>
+    API endpoint, filter with with the <code>jq</code> utility using the following filter
+    <code class="ocp-api-filter" id="filter-{{{ (rule_id+path+filter)|sha256 }}}">{{{ filter }}}</code>
+    and persist it to the local
+    <code class="ocp-dump-location" id="dump-{{{ (rule_id+path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ path.lstrip("/") }}}#{{{ (rule_id+path+filter)|sha256 }}}</code>
+    file.
+  </li>
+{{% endfor %}}
+</ul>
+{{%- endmacro %}}
+
+{{#
+  Macro which generates a unique path for a filtered Kubernetes
+  resource. The path and the filter are used to generate a unique
+  identifier in such a way that it won't conflict with unfiltered
+  resources
+    - path (String): The Kubernetes object path to fetch
+    - filter (String): A filtering directive
+#}}
+{{% macro openshift_filtered_path(path, filter) -%}}
+{{{ path }}}#{{{ (rule_id+path+filter)|sha256 }}}
+{{%- endmacro %}}
 
 {{# Example usage: ocil_sshd_option(default="no", option="Banner", value="/etc/issue") #}}
 {{% macro ocil_sshd_option(default, option, value) -%}}

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -26,7 +26,8 @@ from .utils import (required_key,
                     banner_anchor_wrap,
                     escape_id,
                     escape_regex,
-                    escape_yaml_key
+                    escape_yaml_key,
+                    sha256
                     )
 
 
@@ -97,6 +98,7 @@ def _get_jinja_environment(substitutions_dict):
         _get_jinja_environment.env.filters['escape_regex'] = escape_regex
         _get_jinja_environment.env.filters['escape_id'] = escape_id
         _get_jinja_environment.env.filters['escape_yaml_key'] = escape_yaml_key
+        _get_jinja_environment.env.filters['sha256'] = sha256
 
     return _get_jinja_environment.env
 

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -6,6 +6,7 @@ import errno
 import os
 import re
 from collections import namedtuple
+import hashlib
 
 from .constants import (FULL_NAME_TO_PRODUCT_MAPPING,
                         MAKEFILE_ID_TO_PRODUCT_MAP,
@@ -273,6 +274,10 @@ def escape_yaml_key(text):
     # them with '^' symbol.
     # myCamelCase^Key -> my^camel^case^^^key
     return re.sub(r'([A-Z^])', '^\\1', text).lower()
+
+
+def sha256(text):
+    return hashlib.sha256(text.encode('utf-8')).hexdigest()
 
 
 def banner_regexify(banner_text):


### PR DESCRIPTION
This adds a macro that implements filtering of kubernetes YAML manfiests
using jq. This is taken into use by the Compliance Operator.

It requires this PR to merge: https://github.com/openshift/compliance-operator/pull/658