### PR TITLE
Fix bash remediation of sudo_defaults_option

### DIFF
--- a/shared/templates/sudo_defaults_option/bash.template
+++ b/shared/templates/sudo_defaults_option/bash.template
@@ -11,7 +11,7 @@
 {{% endif %}}
 if /usr/sbin/visudo -qcf /etc/sudoers; then
     cp /etc/sudoers /etc/sudoers.bak
-    if ! grep -P "^[\s]*Defaults.*\b{{{ OPTION_REGEX }}}\b.*$" /etc/sudoers; then
+    if ! grep -P '^[\s]*Defaults.*\b{{{ OPTION_REGEX }}}\b.*$' /etc/sudoers; then
         # sudoers file doesn't define Option {{{ OPTION }}}
         echo "Defaults {{{ OPTION_VALUE }}}" >> /etc/sudoers
     {{%- if not VARIABLE_NAME %}}


### PR DESCRIPTION

#### Description:

- Fix bash remediation of sudo_defaults_option.
  - Use single quotes in grep command so the regex input data
can freely use double quotes.


#### Rationale:

- Fixes #7101

Test results with bash remediation:
```
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/ggasparb/workspace/github/content/logs/rule-custom-2021-06-24-1428/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_sudo_custom_logfile
INFO - Script logfile_enabled.pass.sh using profile (all) OK
INFO - Script logfile_enabled_with_noexec.pass.sh using profile (all) OK
INFO - Script logfile_absent.fail.sh using profile (all) OK
INFO - Script logfile_enabled_dir.pass.sh using profile (all) OK
```
