### PR TITLE
Fix regex in dconf ansible remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME banner-message-enabled"
   lineinfile:
     path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/login-screen/banner-message-enable'
+    regexp: '^/org/gnome/login-screen/banner-message-enable$'
     line: '/org/gnome/login-screen/banner-message-enable'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 disablement of Login User List"
   lineinfile:
     path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/login-screen/disable-user-list'
+    regexp: '^/org/gnome/login-screen/disable-user-list$'
     line: '/org/gnome/login-screen/disable-user-list'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 disablement of Smartcard Authentication"
   lineinfile:
     path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/login-screen/enable-smartcard-authentication'
+    regexp: '^/org/gnome/login-screen/enable-smartcard-authentication$'
     line: '/org/gnome/login-screen/enable-smartcard-authentication'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 Login Number of Failures"
   lineinfile:
     path: /etc/dconf/db/gdm.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/login-screen/allowed-failures'
+    regexp: '^/org/gnome/login-screen/allowed-failures$'
     line: '/org/gnome/login-screen/allowed-failures'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 Automounting - automount"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/media-handling/automount'
+    regexp: '^/org/gnome/desktop/media-handling/automount$'
     line: '/org/gnome/desktop/media-handling/automount'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 Automounting - automount-open"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/media-handling/automount-open'
+    regexp: '^/org/gnome/desktop/media-handling/automount-open$'
     line: '/org/gnome/desktop/media-handling/automount-open'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 Automounting - autorun-never"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/media-handling/autorun-never'
+    regexp: '^/org/gnome/desktop/media-handling/autorun-never$'
     line: '/org/gnome/desktop/media-handling/autorun-never'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 Thumbnailers"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/thumbnailers/disable-all'
+    regexp: '^/org/gnome/desktop/thumbnailers/disable-all$'
     line: '/org/gnome/desktop/thumbnailers/disable-all'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/nm-applet/disable-wifi-create'
+    regexp: '^/org/gnome/nm-applet/disable-wifi-create$'
     line: '/org/gnome/nm-applet/disable-wifi-create'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/nm-applet/suppress-wireless-networks-available'
+    regexp: '^/org/gnome/nm-applet/suppress-wireless-networks-available$'
     line: '/org/gnome/nm-applet/suppress-wireless-networks-available'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 Credential Prompting for Remote Access"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/Vino/authentication-methods'
+    regexp: '^/org/gnome/Vino/authentication-methods$'
     line: '/org/gnome/Vino/authentication-methods'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME3 Encryption for Remote Access"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/Vino/require-encryption'
+    regexp: '^/org/gnome/Vino/require-encryption$'
     line: '/org/gnome/Vino/require-encryption'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME idle-activation-enabled"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled'
+    regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled$'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
@@ -6,7 +6,7 @@
 - name: "Prevent user modification of GNOME Screensaver idle-activation-enabled"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled'
+    regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled$'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -17,7 +17,7 @@
 - name: "Prevent user modification of GNOME idle-delay"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/session/idle-delay'
+    regexp: '^/org/gnome/desktop/session/idle-delay$'
     line: '/org/gnome/desktop/session/idle-delay'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME lock-delay"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/lock-delay'
+    regexp: '^/org/gnome/desktop/screensaver/lock-delay$'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -20,7 +20,7 @@
 - name: "Prevent user modification of GNOME lock-enabled"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/lock-enabled'
+    regexp: '^/org/gnome/desktop/screensaver/lock-enabled$'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
@@ -6,7 +6,7 @@
 - name: "Prevent user modification of GNOME Screensaver lock-enabled"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/lock-enabled'
+    regexp: '^/org/gnome/desktop/screensaver/lock-enabled$'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME picture-uri"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/picture-uri'
+    regexp: '^/org/gnome/desktop/screensaver/picture-uri$'
     line: '/org/gnome/desktop/screensaver/picture-uri'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME show-full-name-in-top-bar"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
+    regexp: '^/org/gnome/desktop/screensaver/show-full-name-in-top-bar$'
     line: '/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
@@ -6,7 +6,7 @@
 - name: "Prevent user modification of GNOME lock-delay"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/screensaver/lock-delay'
+    regexp: '^/org/gnome/desktop/screensaver/lock-delay$'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
@@ -7,7 +7,7 @@
 - name: "Prevent user modification of GNOME Session idle-delay"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/desktop/session/idle-delay'
+    regexp: '^/org/gnome/desktop/session/idle-delay$'
     line: '/org/gnome/desktop/session/idle-delay'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -15,7 +15,7 @@
 - name: "Prevent user modification of GNOME disablement of Ctrl-Alt-Del"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/settings-daemon/plugins/media-keys/logout'
+    regexp: '^/org/gnome/settings-daemon/plugins/media-keys/logout$'
     line: '/org/gnome/settings-daemon/plugins/media-keys/logout'
     create: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
@@ -23,14 +23,14 @@
 - name: "Prevent user modification of GNOME geolocation - location tracking"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/system/location/enabled'
+    regexp: '^/org/gnome/system/location/enabled$'
     line: '/org/gnome/system/location/enabled'
     create: yes
 
 - name: "Prevent user modification of GNOME geolocation - clock location tracking"
   lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
-    regexp: '^/org/gnome/clocks/geolocation'
+    regexp: '^/org/gnome/clocks/geolocation$'
     line: '/org/gnome/clocks/geolocation'
     create: yes
 

--- a/shared/templates/dconf_ini_file/ansible.template
+++ b/shared/templates/dconf_ini_file/ansible.template
@@ -39,7 +39,7 @@
 - name: "Prevent user modification {{{ PARAMETER }}} - default file"
   lineinfile:
     path: {{{ LOCK_PATH }}}/00-security-settings-lock
-    regexp: '^/{{{ SECTION }}}/{{{ PARAMETER }}}'
+    regexp: '^/{{{ SECTION }}}/{{{ PARAMETER }}}$'
     line: '/{{{ SECTION }}}/{{{ PARAMETER }}}'
     create: yes
   when: {{{ rule_id }}}_lock_files is defined and {{{ rule_id }}}_lock_files.matched == 0
@@ -47,7 +47,7 @@
 - name: "Prevent user modification {{{ PARAMETER }}} - existing files"
   lineinfile:
     path: "{{ item.path }}"
-    regexp: '^/{{{ SECTION }}}/{{{ PARAMETER }}}'
+    regexp: '^/{{{ SECTION }}}/{{{ PARAMETER }}}$'
     line: '/{{{ SECTION }}}/{{{ PARAMETER }}}'
     create: yes
   with_items: "{{ {{{ rule_id }}}_lock_files.files }}"


### PR DESCRIPTION
#### Description:

- Fix regex in dconf ansible remediation
  - Without the dollar sign it can happen that a match occurs when a
substring is found. In this case dconf_gnome_disable_automount would
match the same as dconf_gnome_disable_automount_open ansible
remediation.

#### Rationale

- Fixes partially https://bugzilla.redhat.com/show_bug.cgi?id=1976123
