### PR TITLE
OCP4: Fix kubelet cert/key matching rules

### DIFF
--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -39,6 +39,7 @@ ocil: |-
     Run the following command:
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["kubelet-client-certificate"]'</pre>
     The output should return <tt>/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt</tt>
+    or <tt>/etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.crt</tt>
 
 warnings:
 - general: |-
@@ -52,6 +53,6 @@ template:
     filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
     yamlpath: '.data["config.yaml"]'
     values:
-    - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt"\]'
+    - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt"\]'
       type: "string"
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -39,6 +39,7 @@ ocil: |-
     Run the following command:
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["kubelet-client-key"]'</pre>
     The output should return <tt>/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key</tt>
+    or <tt>/etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.key</tt>
 
 warnings:
 - general: |-
@@ -52,6 +53,6 @@ template:
     filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
     yamlpath: '.data["config.yaml"]'
     values:
-    - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key"\]'
+    - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key"\]'
       type: "string"
       operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -41,5 +41,5 @@ template:
         filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
         yamlpath: ".data['config.yaml']"
         values:
-          - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.crt"\]'
+          - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt"\]'
             operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -41,5 +41,5 @@ template:
         filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
         yamlpath: ".data['config.yaml']"
         values:
-          - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-resources/secrets/kubelet-client/tls.key"\]'
+          - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key"\]'
             operation: "pattern match"


### PR DESCRIPTION
The location for these changed in OCP 4.9, so this makes it portable.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>