### PR TITLE
modify platform and description of no_empty_passwords

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -13,6 +13,10 @@ description: |-
     <tt>/etc/pam.d/system-auth</tt>
     {{% endif %}}
     to prevent logins with empty passwords.
+    Note that this rule is not applicable for systems running within a
+    container. Having user with empty password within a container is not
+    considered a risk, because it should not be possible to directly login into
+    a container anyway.
 
 rationale: |-
     If an account has an empty password, anyone could log in and
@@ -20,6 +24,8 @@ rationale: |-
     empty passwords should never be used in operational environments.
 
 severity: high
+
+platform: machine
 
 identifiers:
     cce@rhel7: CCE-27286-4


### PR DESCRIPTION
#### Description:

- make the rule no_empty_passwords applicable only to "machine" platform
- extend description to explain the reason

#### Rationale:

- the rule does not make much sense within container environment, because it should not be possible to login into the container through external means anyway (ssh)

- fixes https://bugzilla.redhat.com/show_bug.cgi?id=1856466
- 