### PR TITLE
Add SLES-12-030362 to sysctl_net_ipv6_conf_default_accept_source_route

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
@@ -24,13 +24,13 @@ identifiers:
     cce@rhel9: CCE-84130-4
     cce@rhcos4: CCE-82481-3
     cce@sle15: CCE-85653-4
+    cce@sle12: CCE-83227-9
 
 references:
     anssi: BP28(R22)
     cui: 3.1.20
     disa: CCI-000366
-    nist: CM-7(a),CM-7(b),CM-6(a)
-    nist@sle15: CM-6(b),CM-6.1(iv)
+    nist: CM-7(a),CM-7(b),CM-6(a),CM-6(b),CM-6.1(iv)
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.PT-4
     isa-62443-2013: 'SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 7.1,SR 7.6'
     isa-62443-2009: 4.2.3.4,4.3.3.4,4.4.3.3
@@ -39,6 +39,7 @@ references:
     cis-csc: 1,12,13,14,15,16,18,4,6,8,9
     srg: SRG-OS-000480-GPOS-00227
     stigid@sle15: SLES-15-040321
+    stigid@sle12: SLES-12-030362
     cis@rhel7: 3.3.1
     cis@rhel8: 3.2.1
     stigid@rhel8: RHEL-08-040250

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
@@ -19,8 +19,9 @@ identifiers:
 references:
     disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00227
-    nist@sle15: CM-6(b),CM-6.1(iv)
+    nist: CM-6(b),CM-6.1(iv)
     stigid@sle15: SLES-15-040382
+    stigid@sle12: SLES-12-030363
 
 ocil_clause: 'IPv6 Forwading is not disabled'
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -260,6 +260,7 @@ selections:
     - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
     - sysctl_net_ipv4_ip_forward
     - sysctl_net_ipv4_tcp_syncookies
+    - sysctl_net_ipv6_conf_all_accept_redirects
     - sysctl_net_ipv6_conf_all_accept_source_route
     - sysctl_net_ipv6_conf_default_accept_redirects
     - vlock_installed

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -260,8 +260,8 @@ selections:
     - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
     - sysctl_net_ipv4_ip_forward
     - sysctl_net_ipv4_tcp_syncookies
-    - sysctl_net_ipv6_conf_all_accept_redirects
     - sysctl_net_ipv6_conf_all_accept_source_route
+    - sysctl_net_ipv6_conf_default_accept_source_route
     - sysctl_net_ipv6_conf_default_accept_redirects
     - vlock_installed
     - wireless_disable_interfaces


### PR DESCRIPTION
#### Description:

- SLES-12-030362

#### Rationale:

- sysctl_net_ipv6_conf_default_accept_source_route
