### PR TITLE
OCP4: Add rule to verify networkpolicies exist for non-control plane namespaces

### DIFF
--- a/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
@@ -1,0 +1,94 @@
+<def-group>
+{{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies?limit=500' %}}
+{{% set namespaces_api_path = '/api/v1/namespaces?limit=500' %}}
+{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
+  <definition class="compliance" id="configure_network_policies_namespaces" version="1">
+    {{{ oval_metadata("Ensure that application Namespaces have Network Policies defined") }}}
+    <criteria>
+      <criterion comment="Make sure that the file '{{{ openshift_filtered_path(networkpolicies_api_path, networkpolicies_for_non_ctlplane_namespaces_filter) }}} exists."
+                 test_ref="test_file_for_configure_network_policies_namespaces"/>
+      <criterion comment="Make sure that the file '{{{ openshift_filtered_path(namespaces_api_path, non_ctlplane_namespaces_filter) }}}' exists."
+                 test_ref="test_file_for_configure_network_policies_filtered_namespaces"/>
+      <criterion comment="Make sure that all target elements exists for elements at path &#39;.items[:].spec.host&#39;"
+                 test_ref="test_elements_count_for_configure_network_policies_namespaces"/>
+    </criteria>
+  </definition>
+
+  <!-- OCP object file locations -->
+  <local_variable id="configure_network_policies_namespaces_file_location" datatype="string"
+                  comment="Path of file containing filtered non-ctlplane namespaces with network policies." version="1">
+    <concat>
+      <variable_component var_ref="ocp_data_root"/>
+      <literal_component>{{{ openshift_filtered_path(networkpolicies_api_path, networkpolicies_for_non_ctlplane_namespaces_filter) }}}</literal_component>
+    </concat>
+  </local_variable>
+
+  <local_variable id="configure_network_policies_filtered_namespaces_file_location" datatype="string"
+                  comment="Path of file containing filtered non-ctlplane namespaces." version="1">
+    <concat>
+      <variable_component var_ref="ocp_data_root"/>
+      <literal_component>{{{ openshift_filtered_path(namespaces_api_path, non_ctlplane_namespaces_filter) }}}</literal_component>
+    </concat>
+  </local_variable>
+
+  <!-- File existence checks -->
+  <unix:file_test id="test_file_for_configure_network_policies_namespaces" check="all" check_existence="only_one_exists"
+    comment="Find the file to be checked ('{{{ openshift_filtered_path(networkpolicies_api_path, networkpolicies_for_non_ctlplane_namespaces_filter) }}}')." version="1">
+    <unix:object object_ref="object_file_for_configure_network_policies_namespaces"/>
+  </unix:file_test>
+
+  <unix:file_object id="object_file_for_configure_network_policies_namespaces" version="1">
+    <unix:filepath var_ref="configure_network_policies_namespaces_file_location"/>
+  </unix:file_object>
+
+  <unix:file_test id="test_file_for_configure_network_policies_filtered_namespaces" check="all" check_existence="only_one_exists"
+    comment="Find the file to be checked ('{{{ openshift_filtered_path(namespaces_api_path, non_ctlplane_namespaces_filter) }}}')." version="1">
+    <unix:object object_ref="object_file_for_configure_network_policies_filtered_namespaces"/>
+  </unix:file_test>
+
+  <unix:file_object id="object_file_for_configure_network_policies_filtered_namespaces" version="1">
+    <unix:filepath var_ref="configure_network_policies_filtered_namespaces_file_location"/>
+  </unix:file_object>
+
+  <!-- Object gathering --> 
+  <ind:yamlfilecontent_object id="object_configure_network_policies_namespaces" version="1">
+    <ind:filepath var_ref="configure_network_policies_namespaces_file_location"/>
+    <ind:yamlpath>[:]</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+  <local_variable comment="Items counter" datatype="int" id="local_variable_counter_configure_network_policies_namespaces" version="1">
+    <count>
+      <object_component object_ref="object_configure_network_policies_namespaces" item_field="value" record_field="#"/>
+    </count>
+  </local_variable>
+
+  <ind:yamlfilecontent_object id="object_configure_network_policies_filtered_namespaces" version="1">
+    <ind:filepath var_ref="configure_network_policies_filtered_namespaces_file_location"/>
+    <ind:yamlpath>[:].metadata.name</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+  <local_variable comment="Items counter control" datatype="int" id="local_variable_counter_configure_network_policies_filtered_namespaces" version="1">
+    <count>
+      <object_component object_ref="object_configure_network_policies_filtered_namespaces" item_field="value" record_field="#"/>
+    </count>
+  </local_variable>
+  
+  <!-- Object counts -->
+  <ind:variable_test version="1" id="test_elements_count_for_configure_network_policies_namespaces" check="all"
+    comment="Count elements at both paths and compare">
+    <ind:object object_ref="object_elements_count_for_configure_network_policies_namespaces"/>
+    <ind:state state_ref="state_elements_count_for_configure_network_policies_namespaces"/>
+  </ind:variable_test>
+  
+  <ind:variable_object id="object_elements_count_for_configure_network_policies_namespaces" version="1">
+    <ind:var_ref>local_variable_counter_configure_network_policies_namespaces</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Comparison -->
+  <!-- This verifies that the filtered namespaces are equal to the namespaces with NetworkPolicies -->
+  <ind:variable_state id="state_elements_count_for_configure_network_policies_namespaces" version="1">
+    <ind:value var_ref="local_variable_counter_configure_network_policies_filtered_namespaces"/>
+  </ind:variable_state>
+  
+  <!-- OCP data root declaration -->
+  <external_variable comment="Root of OCP data dump" datatype="string" id="ocp_data_root" version="1" />
+</def-group>

--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -17,13 +17,32 @@ rationale: |-
 
 severity: high
 
+references:
+    cis@ocp4: 5.3.2
+    nist: AC-4,AC-4(21),CA-3(5),CM-6,CM-6(1),CM-7,CM-7(1),SC-7(3),SC-7(5),SC-7(8),SC-7(12),SC-7(13),SC-7(18)
+
+{{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies?limit=500' %}}
+{{% set namespaces_api_path = '/api/v1/namespaces?limit=500' %}}
+{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
+
 ocil_clause: 'Namespaced Network Policies needs review'
 
 ocil: |-
-    Verify on OpenShift namespaces that network policies are in use:
-    <pre>$ oc get networkpolicy --all-namespaces</pre>
-    Ensure that each namespace defined in the cluster has at least one NetworkPolicy.
+    Verify that the every non-control plane namespace has an appropriate
+    NetworkPolicy.
 
-references:
-    cis@ocp4: 5.3.2
-    nist: CM-6,CM-6(1)
+    To get all the non-control plane namespaces, you can do the
+    following command <tt>{{{ ocil_oc_pipe_jq_filter('namespaces', non_ctlplane_namespaces_filter) }}}</tt>
+
+    To get all the non-control plane namespaces with a NetworkPolicy, you can do the
+    following command <tt>{{{ ocil_oc_pipe_jq_filter('networkpolicies', networkpolicies_for_non_ctlplane_namespaces_filter, all_namespaces=true) }}}</tt>
+
+    Make sure that the namespaces displayed in the commands of the commands match.
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_cluster_setting({
+            networkpolicies_api_path: networkpolicies_for_non_ctlplane_namespaces_filter,
+            namespaces_api_path: non_ctlplane_namespaces_filter,
+        }) | indent(4) }}}

--- a/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+oc adm new-project e2e-test
+sleep 10
+# Deploy a single NetworkPolicy per non control plane namespace
+for NS in $(oc get namespaces -o json | jq -r '.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name'); do
+cat << EOF | oc apply -n "$NS" -f -
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-ingress
+spec:
+  podSelector: {}
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress
+EOF
+done

--- a/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -212,7 +212,7 @@ selections:
   #### 5.3 Network Policies and CNI
   # 5.3.1 Ensure that the CNI in use supports Network Policies (info)
     - configure_network_policies
-  # 5.3.2 Ensure that all Namespaces have Network Policies defined (info)
+  # 5.3.2 Ensure that all Namespaces have Network Policies defined
     - configure_network_policies_namespaces
   #### 5.4 Secrets Management
   # 5.4.1 Prefer using secrets as files over secrets as environment variables (info)

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -51,6 +51,13 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
 {{{ path }}}#{{{ (rule_id+path+filter)|sha256 }}}
 {{%- endmacro %}}
 
+{{#
+  Macro which generates a warning indicating how to make use of a
+#}}
+{{% macro ocil_oc_pipe_jq_filter(object, jqfilter, namespace=none, all_namespaces=false) -%}}
+oc get {{% if all_namespaces %}}--all-namespaces{{% elif namespace %}}-n {{{ namespace }}}{{% endif %}} {{{ object }}} -o json | jq '{{{ jqfilter }}}'
+{{%- endmacro %}}
+
 {{# Example usage: ocil_sshd_option(default="no", option="Banner", value="/etc/issue") #}}
 {{% macro ocil_sshd_option(default, option, value) -%}}
     To determine how the SSH daemon's <tt>{{{ option }}}</tt> option is set, run the following command:


### PR DESCRIPTION
This effectively verifies that there's a NetworkPolicy for each
non-control plane namespace.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>