### PR TITLE
Map file_ownership_library_dirs to SLES-12-010873

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
@@ -33,7 +33,7 @@ identifiers:
     cce@sle15: CCE-85756-5
 
 references:
-    nist:  CM-5(6),CM-5(6).1,CM-6(a),AC-6(1)
+    nist: CM-5(6),CM-5(6).1,CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     isa-62443-2013: 'SR 2.1,SR 5.2'
     isa-62443-2009: 4.3.3.7.3

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
@@ -29,10 +29,11 @@ identifiers:
     cce@rhel7: CCE-82021-7
     cce@rhel8: CCE-80807-1
     cce@rhel9: CCE-83907-6
+    cce@sle12: CCE-83235-2
     cce@sle15: CCE-85756-5
 
 references:
-    nist: CM-6(a),AC-6(1)
+    nist:  CM-5(6),CM-5(6).1,CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     isa-62443-2013: 'SR 2.1,SR 5.2'
     isa-62443-2009: 4.3.3.7.3
@@ -41,9 +42,8 @@ references:
     cis-csc: 12,13,14,15,16,18,3,5
     stigid@rhel8: RHEL-08-010340
     srg: SRG-OS-000259-GPOS-00100
+    stigid@sle12: SLES-12-010873
     stigid@sle15: SLES-15-010353
-    disa: CCI-001499
-    nist@sle15: CM-5(6),CM-5(6).1
     disa: CCI-001499
 
 ocil_clause: 'any of these files are not owned by root'

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -168,6 +168,7 @@ selections:
     - ensure_rtc_utc_configuration
     - file_etc_security_opasswd
     - file_groupownership_home_directories
+    - file_ownership_library_dirs
     - file_permissions_home_directories
     - file_permissions_sshd_private_key
     - file_permissions_sshd_pub_key


### PR DESCRIPTION
#### Description:

-  Map file_ownership_library_dirs to SLES-12-010873

#### Rationale:

- Add rule file_ownership_library_dirs to sle12 stig profile
- Optimize references in the file_ownership_library_dirs rule, removed duplicates and per prodtype nist references merged