### PR TITLE
Map dir_ownership_library_dirs to SLES-12-010874

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
@@ -28,11 +28,13 @@ severity: medium
 
 identifiers:
     cce@sle15: CCE-85735-9
+    cce@sle12: CCE-83236-0
 
 references:
     nist: CM-5(6),CM-5(6).1
     srg: SRG-OS-000259-GPOS-00100
-    stigid@sle15: SLES-15-010353
+    stigid@sle15: SLES-12-010874
+    stigid@sle15: SLES-15-010354
     disa: CCI-001499
 
 ocil_clause: 'any of these directories are not owned by root'

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/rule.yml
@@ -33,7 +33,7 @@ identifiers:
 references:
     nist: CM-5(6),CM-5(6).1
     srg: SRG-OS-000259-GPOS-00100
-    stigid@sle15: SLES-12-010874
+    stigid@sle12: SLES-12-010874
     stigid@sle15: SLES-15-010354
     disa: CCI-001499
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -157,6 +157,7 @@ selections:
     - dconf_gnome_login_banner_text
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
+    - dir_ownership_library_dirs
     - dir_permissions_library_dirs
     - dir_perms_world_writable_sticky_bits
     - dir_perms_world_writable_system_owned_group


### PR DESCRIPTION

#### Description:

- Map dir_ownership_library_dirs to SLES-12-010874

#### Rationale:
- Added dir_ownership_library_dirs to sle12 stig profile
- Mapped cce id
- Fixed mapping of the rule to sles-15 id, done in previous PR, obviously done by mistake
