### PR TITLE
Remove ospp profile from sshd_set_keepalive tests metadata

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/comment.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 SSHD_CONFIG="/etc/ssh/sshd_config"
 
 if grep -q "^ClientAliveCountMax" $SSHD_CONFIG; then

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 SSHD_CONFIG="/etc/ssh/sshd_config"
 
 if grep -q "^ClientAliveCountMax" $SSHD_CONFIG; then

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/line_not_there.fail.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 
 sed -i "/^ClientAliveCountMax.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 SSHD_CONFIG="/etc/ssh/sshd_config"
 
 if grep -q "^ClientAliveCountMax" $SSHD_CONFIG; then


### PR DESCRIPTION
#### Description:
The rhel8 ospp profile has `sshd_set_keepalive_0`. The `sshd_set_keepalive` rule is not used in the profile and thus the rule's test scenario metadata specifying ospp profile are not correct:
```
$ python3 tests/test_suite.py rule --libvirt qemu:///system test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml sshd_set_keepalive
Setting console output to log level INFO                                                                               
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - xccdf_org.ssgproject.content_rule_sshd_set_keepalive                                                            
ERROR - Script line_not_there.fail.sh using profile xccdf_org.ssgproject.content_profile_ospp found issue:
ERROR - Rule xccdf_org.ssgproject.content_rule_sshd_set_keepalive has not been evaluated! Wrong profile selected in test scenario?
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_sshd_set_keepalive'.
```

The `correct_value.pass.sh` test is removed because we actually don't know correct value. Testing of `ClientAliveCountMax 0` is performed in [sshd_set_keepalive_0](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/tests/correct_value.pass.sh)
