### PR TITLE
Fix possible issue in harden_openssl_crypto_policy remediation

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/bash/shared.sh
@@ -1,8 +1,9 @@
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora
 
 cp="Ciphersuites = TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
-file=/etc/crypto-policies/local.d/opensslcnf-ospp.config
+file="/etc/crypto-policies/local.d/opensslcnf-ospp.config"
+backend_file="/etc/crypto-policies/back-ends/opensslcnf.config"
 
-
-echo "$cp" >> "$file"
+sed -i "/Ciphersuites\s*=\s*/d" "$backend_file"
+printf "\n%s\n" "$cp" >> "$file"
 update-crypto-policies


### PR DESCRIPTION
#### Description:
The `harden_openssl_crypto_policy` remediation didn't work as expected:
```
$ python3 tests/test_suite.py rule --libvirt qemu:///system test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml harden_openssl_crypto_policy                                                                    
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/mlysonek/SCAP/content/logs/rule-custom-2021-06-30-1503/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_harden_openssl_crypto_policy
INFO - Script correct_followed_by_incorrect.fail.sh using profile (all) OK
ERROR - Rule evaluation resulted in error, instead of expected fixed during remediation stage 
ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_harden_openssl_crypto_policy'.
INFO - Script correct_commented.fail.sh using profile (all) OK
ERROR - Rule evaluation resulted in error, instead of expected fixed during remediation stage 
ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_harden_openssl_crypto_policy'.
...
```

In the `/etc/crypto-policies/back-ends/opensslcnf.config`, might already be `Ciphersuites = ...` line present. When the line is already there, `update-crypto-policies` rather adds a new `Ciphersuites = ` lines than updating the existing one. With removing the old line, we might prevent possible future issues.

I have also noticed, that `update-crypto-policies` actually doesn't update the openssl backend file when there isn't empty line before the `Ciphersuites` line. When the `Ciphersuites` line is not on the first line, then it works as expected and the backend file is correctly generated with `update-crypto-policies`.