### PR TITLE
Add implementation of dir_group_ownership_library_dirs rule

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/ansible/shared.yml
@@ -1,0 +1,23 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = medium
+# disruption = medium
+- name: "Read list libraries without root ownership"
+  find:
+    paths:
+      - "/usr/lib"
+      - "/usr/lib64"
+      - "/lib"
+      - "/lib64"
+    file_type: "directory"
+  register: library_dirs_not_group_owned_by_root
+
+- name: "Set group ownership of system library dirs to root"
+  file:
+    path: "{{ item.path }}"
+    group: "root"
+    state: "directory"
+    mode: "{{ item.mode }}"
+  with_items: "{{ library_dirs_not_group_owned_by_root.files }}"
+  when: library_dirs_not_group_owned_by_root.matched > 0

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="dir_group_ownership_library_dirs" version="1">
+    {{{ oval_metadata("
+        Checks that /lib, /lib64, /usr/lib, /usr/lib64, /lib/modules, and
+        directories therein, are group-owned by root.
+      ") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_dir_group_ownership_lib_dir" />
+    </criteria>
+  </definition>
+
+  <unix:file_test  check="all" check_existence="none_exist" comment="library directories gid root" id="test_dir_group_ownership_lib_dir" version="1">
+    <unix:object object_ref="object_dir_group_ownership_lib_dir" />
+  </unix:file_test>
+
+  <unix:file_object comment="library directories" id="object_dir_group_ownership_lib_dir" version="1">
+    <!-- Check that /lib, /lib64, /usr/lib, and /usr/lib64 directories belong to group with gid 0 (root) -->
+    <unix:path operation="pattern match">(^\/lib(|64)\/|^\/usr\/lib(|64)\/)</unix:path>
+    <unix:filename xsi:nil="true" />
+    <filter action="include">state_group_owner_library_dirs_not_root</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_group_owner_library_dirs_not_root" version="1">
+    <unix:group_id datatype="int" operation="not equal">0</unix:group_id>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
@@ -1,0 +1,50 @@
+documentation_complete: true
+
+title: 'Verify that Shared Library Directories Have Root Group Ownership'
+
+description: |-
+    System-wide shared library files, which are linked to executables
+    during process load time or run time, are stored in the following directories
+    by default:
+    <pre>/lib
+    /lib64
+    /usr/lib
+    /usr/lib64
+    </pre>
+    Kernel modules, which can be added to the kernel during runtime, are also
+    stored in <tt>/lib/modules</tt>. All files in these directories should be
+    group-owned by the <tt>root</tt> user. If the  directories, is found to be owned
+    by a user other than root correct its
+    ownership with the following command:
+    <pre>$ sudo chgrp root <i>DIR</i></pre>
+
+rationale: |-
+    Files from shared library directories are loaded into the address
+    space of processes (including privileged ones) or of the kernel itself at
+    runtime. Proper ownership of library directories is necessary to protect
+    the integrity of the system.
+
+severity: medium
+
+identifiers:
+    cce@sle12: CCE-83238-6
+    cce@sle15: CCE-85737-5
+
+references:
+    nist: CM-5(6),CM-5(6).1
+    srg: SRG-OS-000259-GPOS-00100
+    stigid@sle12: SLES-12-010876
+    stigid@sle15: SLES-15-010356
+    disa: CCI-001499
+
+ocil_clause: 'any of these directories are not group-owned by root'
+
+ocil: |-
+    Shared libraries are stored in the following directories:
+    <pre>/lib
+    /lib64
+    /usr/lib
+    /usr/lib64</pre>
+    For each of these directories, run the following command to find files not
+    owned by root:
+    <pre>$ sudo find -L <i>$DIR</i> ! -user root -type d -exec chgrp root {} \;</pre>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/tests/all_dirs_ok.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/tests/all_dirs_ok.pass.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+DIRS="/lib /lib64 /usr/lib /usr/lib64"
+for dirPath in $DIRS; do
+	find "$dirPath" -type d -exec chgrp root '{}' \;
+done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/tests/nobody_group_owned_dir_on_lib.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/tests/nobody_group_owned_dir_on_lib.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+DIRS="/lib /lib64"
+for dirPath in $DIRS; do
+	mkdir -p "$dirPath/testme" && chown root:nogroup "$dirPath/testme"
+done

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -157,6 +157,7 @@ selections:
     - dconf_gnome_login_banner_text
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_mode_blank
+    - dir_group_ownership_library_dirs
     - dir_ownership_library_dirs
     - dir_permissions_library_dirs
     - dir_perms_world_writable_sticky_bits

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -162,6 +162,7 @@ selections:
     - dconf_gnome_login_banner_text
     - dconf_gnome_screensaver_idle_delay
     - dconf_gnome_screensaver_mode_blank
+    - dir_group_ownership_library_dirs
     - dir_ownership_library_dirs
     - dir_permissions_library_dirs
     - dconf_gnome_screensaver_lock_enabled


### PR DESCRIPTION


#### Description:

- Add 'Verify that Shared Library Directories Have Root Group Ownership' rule

#### Rationale:

- Map rule to SLES-12-010876 and SLES-15-010356