### PR TITLE
Enable templates for RHEL9

### DIFF
--- a/shared/templates/audit_rules_file_deletion_events/bash.template
+++ b/shared/templates/audit_rules_file_deletion_events/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/shared/templates/audit_rules_login_events/bash.template
+++ b/shared/templates/audit_rules_login_events/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/shared/templates/audit_rules_path_syscall/bash.template
+++ b/shared/templates/audit_rules_path_syscall/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/shared/templates/audit_rules_unsuccessful_file_modification/bash.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 {{% if product in ["rhel7", "ol7"] %}}
 {{% if '/' in ARG_NAME %}}

--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
 # reboot = true
 # strategy = disable
 # complexity = low

--- a/shared/templates/mount/anaconda.template
+++ b/shared/templates/mount/anaconda.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/mount_option/anaconda.template
+++ b/shared/templates/mount_option/anaconda.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/mount_option_removable_partitions/anaconda.template
+++ b/shared/templates/mount_option_removable_partitions/anaconda.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/zipl_bls_entries_option/ansible.template
+++ b/shared/templates/zipl_bls_entries_option/ansible.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # reboot = true
 # strategy = configure
 # complexity = medium

--- a/shared/templates/zipl_bls_entries_option/bash.template
+++ b/shared/templates/zipl_bls_entries_option/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 # Correct BLS option using grubby, which is a thin wrapper around BLS operations
 grubby --update-kernel=ALL --args="{{{ ARG_NAME }}}={{{ ARG_VALUE }}}"


### PR DESCRIPTION
Concerned templates are low-level, underlying components are stable.

I have updated some of the applicability metadata to include all RHELs.