### PR TITLE
Map SLES-12-010877 to file_permissions_system_commands_dirs rule

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/oval/shared.xml
@@ -16,7 +16,7 @@
   <unix:file_object comment="binary files" id="object_file_permissions_system_commands_files" version="1">
     <!-- Check that binary files under /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
          and /usr/local/sbin directories have safe permissions (go-w) -->
-    <unix:path operation="pattern match">^\/s?bin|^\/usr\/s?bin|^\/usr\/local\/s?bin</unix:path>
+    <unix:path operation="pattern match">^\/(s|)bin|^\/usr\/(s|)bin|^\/usr\/local\/(s|)bin</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
     <filter action="include">state_perms_system_commands_files_nogroupwrite_noworldwrite</filter>
     <filter action="exclude">state_perms_system_commands_files_symlink</filter>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle12,sle15
 
 title: 'Verify that system commands are protected from unauthorized access'
 
@@ -26,11 +26,13 @@ rationale: |-
 severity: medium
 
 identifiers:
+    cce@sle12: CCE-83239-4
     cce@sle15: CCE-85738-3
 
 references:
     disa: CCI-001499
     nist: CM-5(6),CM-5(6).1
+    stigid@sle12: SLES-12-010877
     stigid@sle15: SLES-15-010357
     srg: SRG-OS-000259-GPOS-00100
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -175,6 +175,7 @@ selections:
     - file_permissions_ungroupowned
     - file_permissions_library_dirs
     - file_permissions_local_var_log_messages
+    - file_permissions_system_commands_dirs
     - file_permission_user_init_files
     - ftp_present_banner
     - gnome_gdm_disable_automatic_login


### PR DESCRIPTION
#### Description:
- Map SLES-12-010877 to file_permissions_system_commands_dirs rule

#### Rationale:

- Add rule file_permissions_system_commands_dirs to sle12
- Made a patch in oval definition to make the regex more robust. Turns out the `?` qualifier does not behave ok on sle12,
  so changed to usage of `|` and tested on sle12 and sle15
