### PR TITLE
Add  binary and system commands permission/ownership rules to SLE12

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Verify that system commands directories have root as a group owner'
 
-prodtype: sle15
+prodtype: sle12,sle15
 
 
 description: |-
@@ -36,11 +36,13 @@ rationale: |-
 severity: medium
 
 identifiers:
+    cce@sle12: CCE-83244-4
     cce@sle15: CCE-85743-3
 
 references:
     disa: CCI-001499
     nist: CM-5(6),CM-5(6).1
+    stigid@sle12: SLES-12-010883
     stigid@sle15: SLES-15-010362
     srgid: SRG-OS-000259-GPOS-00100 
 

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle12,sle15
 
 title: 'Verify that system commands directories have root ownership'
 
@@ -34,11 +34,13 @@ rationale: |-
 severity: medium
 
 identifiers:
+    cce@sle12: CCE-83242-8
     cce@sle15: CCE-85741-7
 
 references:
     nist: CM-5(6),CM-5(6).1
     disa: CCI-001499
+    stigid@sle12: SLES-15-010881
     stigid@sle15: SLES-15-010360
     srg: SRG-OS-000259-GPOS-00100
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15,rhel8,fedora
+prodtype: sle12,sle15,rhel8,fedora
 
 title: 'Verify that system commands files are group owned by root '
 
@@ -33,12 +33,14 @@ rationale: |-
 severity: medium
 
 identifiers:
+    cce@sle12: CCE-83243-6
     cce@sle15: CCE-85742-5
     cce@rhel8: CCE-86519-6
 
 references:
     disa: CCI-001499
     nist: CM-5(6),CM-5(6).1
+    stigid@sle12: SLES-12-010882
     stigid@sle15: SLES-15-010361
     stigid@rhel8: RHEL-08-010320
     srg: SRG-OS-000259-GPOS-00100

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
@@ -28,11 +28,11 @@ identifiers:
     cce@rhel7: CCE-82048-0
     cce@rhel8: CCE-80806-3
     cce@rhel9: CCE-83908-4
+    cce@sle12: CCE-83241-0
     cce@sle15: CCE-85730-0
 
 references:
-    nist: CM-6(a),AC-6(1)
-    nist@sle15: CM-5(6),CM-5(6).1
+    nist: CM-5(6),CM-5(6).1,CM-6(a),AC-6(1)
     cci@sle15: CCI-001499
     nist-csf: PR.AC-4,PR.DS-5
     isa-62443-2013: 'SR 2.1,SR 5.2'
@@ -41,6 +41,7 @@ references:
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     cis-csc: 12,13,14,15,16,18,3,5
     stigid@rhel8: RHEL-08-010310
+    stigid@sle12: SLES-15-010879
     stigid@sle15: SLES-15-010359
     srg: SRG-OS-000259-GPOS-00100
     disa: CCI-001499

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/rule.yml
@@ -33,7 +33,6 @@ identifiers:
 
 references:
     nist: CM-5(6),CM-5(6).1,CM-6(a),AC-6(1)
-    cci@sle15: CCI-001499
     nist-csf: PR.AC-4,PR.DS-5
     isa-62443-2013: 'SR 2.1,SR 5.2'
     isa-62443-2009: 4.3.3.7.3

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/rule.yml
@@ -28,12 +28,11 @@ identifiers:
     cce@rhel7: CCE-82040-7
     cce@rhel8: CCE-80809-7
     cce@rhel9: CCE-83911-8
+    cce@sle12: CCE-83240-2
     cce@sle15: CCE-85729-2
 
 references:
-    nist: CM-6(a),AC-6(1)
-    nist@sle15: CM-5(6),CM-5(6).1
-    cci@sle15: CCI-001499
+    nist: CM-5(6),CM-5(6).1,CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     isa-62443-2013: 'SR 2.1,SR 5.2'
     isa-62443-2009: 4.3.3.7.3
@@ -42,6 +41,7 @@ references:
     cis-csc: 12,13,14,15,16,18,3,5
     stigid@rhel8: RHEL-08-010300
     srg: SRG-OS-000259-GPOS-00100
+    stigid@sle12: SLES-12-010878
     stigid@sle15: SLES-15-010358
     disa: CCI-001499
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -161,6 +161,7 @@ selections:
     - dir_permissions_library_dirs
     - dir_perms_world_writable_sticky_bits
     - dir_perms_world_writable_system_owned_group
+    - dir_system_commands_group_root_owned
     - dir_system_commands_root_owned
     - disable_ctrlaltdel_reboot
     - display_login_attempts

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -169,6 +169,7 @@ selections:
     - ensure_rtc_utc_configuration
     - file_etc_security_opasswd
     - file_groupownership_home_directories
+    - file_ownership_binary_dirs
     - file_ownership_library_dirs
     - file_permissions_binary_dirs
     - file_permissions_home_directories

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -170,6 +170,7 @@ selections:
     - file_etc_security_opasswd
     - file_groupownership_home_directories
     - file_ownership_library_dirs
+    - file_permissions_binary_dirs
     - file_permissions_home_directories
     - file_permissions_sshd_private_key
     - file_permissions_sshd_pub_key

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -161,6 +161,7 @@ selections:
     - dir_permissions_library_dirs
     - dir_perms_world_writable_sticky_bits
     - dir_perms_world_writable_system_owned_group
+    - dir_system_commands_root_owned
     - disable_ctrlaltdel_reboot
     - display_login_attempts
     - enable_dconf_user_profile

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -170,6 +170,7 @@ selections:
     - ensure_rtc_utc_configuration
     - file_etc_security_opasswd
     - file_groupownership_home_directories
+    - file_groupownership_system_commands_dirs
     - file_ownership_binary_dirs
     - file_ownership_library_dirs
     - file_permissions_binary_dirs


### PR DESCRIPTION
#### Description:

- Add rules SLES-12-010878,SLES-12-010879,SLES-12-010881,SLES-12-010882,SLES-12-010883

#### Rationale:

- Map SLES-12-010878 to file_permissions_binary_dirs rule
- Map stig id  SLES-12-010879 to file_ownership_binary_dirs rule
- Map stig id SLES-15-010881 to dir_system_commands_root_owned
- Map stig id SLES-12-010882 to file_groupownership_system_commands_dirs
- Map stig id SLES-12-010883 to dir_system_commands_group_root_owned
