### PR TITLE
install_vm.py: add --console option

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,7 @@ To use Libvirt backend, you need to have:
   - `libvirt-daemon`
   - `python2-libvirt/python3-libvirt`
   - `virt-install`      (recommended, used by `install_vm.py` script)
+  - `expect`            (recommended, used by `install_vm.py` script with `--console` option)
   - `libvirt-client`    (optional, to manage VMs via console)
   - `virt-manager`      (optional, to manage VMs via GUI)
   - `virt-viewer`       (optional, to access graphical console of VMs)

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -100,6 +100,12 @@ def parse_args():
         action='store_true',
         help="Perform a GUI installation (default is installation without GUI)."
     )
+    parser.add_argument(
+        "--console",
+        dest="console",
+        action='store_true',
+        help="Connect to a serial console of the VM (to monitor installation progress)."
+    )
 
     return parser.parse_args()
 
@@ -181,11 +187,15 @@ def main():
             data.network = "network=default"
         else:
             data.network = "bridge=virbr0"
+    if data.console:
+        data.wait_opt = 0
+    else:
+        data.wait_opt = -1
 
     # The kernel option 'net.ifnames=0' is used to disable predictable network
     # interface names, for more details see:
     # https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} {inst_opt} ksdevice=eth0 net.ifnames=0 console=ttyS0,115200" --serial pty --graphics={graphics_opt} --noautoconsole --rng /dev/random --wait=-1 --location={url}'.format(**data.__dict__)
+    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} {inst_opt} ksdevice=eth0 net.ifnames=0 console=ttyS0,115200" --serial pty --graphics={graphics_opt} --noautoconsole --rng /dev/random --wait={wait_opt} --location={url}'.format(**data.__dict__)
     if data.uefi == "normal":
         command = command+" --boot uefi"
     if data.uefi == "secureboot":
@@ -198,6 +208,9 @@ nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd --features smm=on"
         print(command)
     else:
         os.system(command)
+        if data.console:
+            os.system("unbuffer virsh console {0}".format(data.domain))
+            os.system("virsh start {0}".format(data.domain))
 
     print("\nTo determine the IP address of the {0} VM use:".format(data.domain))
     if data.libvirt == "qemu:///system":


### PR DESCRIPTION
The new `--console` option allows to connect to a serial console of the VM
during installation which might be useful for monitoring installation progress
or for debugging installation issues.