### PR TITLE
OCP4: Add e2e test for scc_limit_container_allowed_capabilities

### DIFF
--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/tests/ocp4/e2e.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS


### PR DESCRIPTION
It was missing

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>