### PR TITLE
Improve OVAL and add bash for ensure_rtc_utc_configuration

### DIFF
--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/bash/shared.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+
+if timedatectl status | grep -i "time zone" | grep -iv 'UTC\|GMT'; then
+    timedatectl set-timezone UTC
+fi

--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/oval/shared.xml
@@ -17,7 +17,7 @@
   </unix:symlink_object>
   <unix:symlink_state comment="object_ensure_symlink_utc_configuration" id="object_ensure_symlink_utc_configuration" version="1">
     <unix:filepath>/etc/localtime</unix:filepath>
-    <unix:canonical_path operation="pattern match">^(/usr)?/share/zoneinfo/(GMT|UTC)$</unix:canonical_path>
+    <unix:canonical_path operation="pattern match">^(/usr)?/share/zoneinfo(/Etc)?/(GMT|UTC)$</unix:canonical_path>
   </unix:symlink_state>
 </def-group>
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- UTC/GMT symlink might be pointing to /usr/share/zoneinfo/Etc/(GTM/UTC), so extended the regex to include Etc
- Added bash script to set timezone to UTC.