### PR TITLE
Fix sshd service name in Ubuntu

### DIFF
--- a/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
@@ -51,6 +51,9 @@ template:
     name: service_enabled
     vars:
         servicename: sshd
+        servicename@ubuntu1604: ssh
+        servicename@ubuntu1804: ssh
+        servicename@ubuntu2004: ssh
         packagename: openssh-server
         packagename@sle12: openssh
         packagename@sle15: openssh


### PR DESCRIPTION
#### Description:

- sshd service name in Ubuntu is ssh