### PR TITLE
SSGTS: Jinja enablement for test cases

### DIFF
--- a/ssg/products.py
+++ b/ssg/products.py
@@ -50,6 +50,10 @@ def _get_implied_properties(existing_properties):
     return result
 
 
+def product_yaml_path(ssg_root, product):
+    return os.path.join(ssg_root, "products", product, "product.yml")
+
+
 def load_product_yaml(product_yaml_path):
     """
     Reads a product data from disk and returns it.

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -59,7 +59,7 @@ def walk_through_benchmark_dirs(product=None):
     directories = _BENCHMARK_DIRS
     if product is not None:
         yaml_path = product_yaml_path(SSG_ROOT, product)
-        product_base = os.path.basename(yaml_path)
+        product_base = os.path.dirname(yaml_path)
         product_yaml = load_product_yaml(yaml_path)
         benchmark_root = os.path.join(product_base, product_yaml['benchmark_root'])
         directories = [os.path.abspath(benchmark_root)]
@@ -276,7 +276,6 @@ def template_tests(product=None):
         product_yaml = dict()
         if product:
             yaml_path = product_yaml_path(SSG_ROOT, product)
-            product_base = os.path.basename(yaml_path)
             product_yaml = load_product_yaml(yaml_path)
 
         # Below we could run into a DocumentationNotComplete error. However,

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -8,12 +8,17 @@ import functools
 import tarfile
 import tempfile
 import re
+import shutil
 
 from ssg.build_cpe import ProductCPEs
+from ssg.build_yaml import Rule as RuleYAML
 from ssg.constants import MULTI_PLATFORM_MAPPING
 from ssg.constants import FULL_NAME_TO_PRODUCT_MAPPING
 from ssg.constants import OSCAP_RULE
+from ssg.jinja import process_file
 from ssg.products import product_yaml_path, load_product_yaml
+from ssg.rules import get_rule_dir_yaml, is_rule_dir
+from ssg.rule_yaml import parse_prodtype
 from ssg_test_suite.log import LogHelper
 
 Scenario_run = namedtuple(
@@ -243,24 +248,151 @@ def _make_file_root_owned(tarinfo):
     return tarinfo
 
 
+def _rel_abs_path(current_path, base_path):
+    """
+    Return the value of the current path, relative to the base path, but
+    resolving paths absolutely first. This helps when walking a nested
+    directory structure and want to get the subtree relative to the original
+    path
+    """
+    tmp_path = os.path.abspath(current_path)
+    return os.path.relpath(current_path, base_path)
+
+
+def template_tests(product=None):
+    """
+    Create a temporary directory with test cases parsed via jinja using
+    product-specific context.
+    """
+    # Set up an empty temp directory
+    tmpdir = tempfile.mkdtemp()
+
+    # We want to remove the temporary directory on failure, but preserve
+    # it on success. Wrap in a try/except block and reraise the original
+    # exception after removing the temporary directory.
+    try:
+        # Load product's YAML file if present. This will allow us to parse
+        # tests in the context of the product we're executing under.
+        product_yaml = dict()
+        if product:
+            yaml_path = product_yaml_path(SSG_ROOT, product)
+            product_base = os.path.basename(yaml_path)
+            product_yaml = load_product_yaml(yaml_path)
+
+        # Below we could run into a DocumentationNotComplete error. However,
+        # because the test suite isn't executed in the context of a particular
+        # build (though, ideally it would be linked), we may not know exactly
+        # whether the top-level rule/profile we're testing is actually
+        # completed. Thus, forcibly set the required property to bypass this
+        # error.
+        product_yaml['cmake_build_type'] = 'Debug'
+
+        # Note that we're not exactly copying 1-for-1 the contents of the
+        # directory structure into the temporary one. Instead we want a
+        # flattened mapping with all rules in a single top-level directory
+        # and all tests immediately contained within it. That is:
+        #
+        # /group_a/rule_a/tests/something.pass.sh -> /rule_a/something.pass.sh
+        for dirpath, dirnames, _ in walk_through_benchmark_dirs(product):
+            # Skip anything that isn't obviously a rule.
+            if "tests" not in dirnames or not is_rule_dir(dirpath):
+                continue
+
+            # Load rule content in our environment. We use this to satisfy
+            # some implied properties that might be used in the test suite.
+            rule_path = get_rule_dir_yaml(dirpath)
+            rule = RuleYAML.from_yaml(rule_path, product_yaml)
+
+            # Note that most places would check prodtype, but we don't care
+            # about that here: if the rule is available to the product, we
+            # load and parse it anyways as we have no knowledge of the
+            # top-level profile or rule passed into the test suite.
+            prodtypes = parse_prodtype(rule.prodtype)
+
+            # Our local copy of env_yaml needs some properties from rule.yml
+            # for completeness.
+            local_env_yaml = dict()
+            local_env_yaml.update(product_yaml)
+            local_env_yaml['rule_id'] = rule.id_
+            local_env_yaml['rule_title'] = rule.title
+            local_env_yaml['products'] = prodtypes
+
+            # Create the destination directory.
+            dest_path = os.path.join(tmpdir, rule.id_)
+            os.mkdir(dest_path)
+
+            # Walk the test directory, writing all tests into the output
+            # directory, recursively.
+            tests_dir_path = os.path.join(dirpath, "tests")
+            tests_dir_path = os.path.abspath(tests_dir_path)
+            for dirpath, dirnames, filenames in os.walk(tests_dir_path):
+                for dirname in dirnames:
+                    # We want to recreate the correct path under the temporary
+                    # directory. Resolve it to a relative path from the tests/
+                    # directory.
+                    dir_path = _rel_abs_path(os.path.join(dirpath, dirname), tests_dir_path)
+                    assert '../' not in dir_path
+                    tmp_dir_path = os.path.join(dest_path, dir_path)
+                    os.mkdir(tmp_dir_path)
+
+                for filename in filenames:
+                    # We want to recreate the correct path under the temporary
+                    # directory. Resolve it to a relative path from the tests/
+                    # directory. Assumption: directories should be created
+                    # prior to recursing into them, so we don't need to handle
+                    # if a file's parent directory doesn't yet exist under the
+                    # destination.
+                    src_test_path = os.path.join(dirpath, filename)
+                    rel_test_path = _rel_abs_path(src_test_path, tests_dir_path)
+                    dest_test_path = os.path.join(dest_path, rel_test_path)
+
+                    # Rather than performing an OS-level copy, we need to
+                    # first parse the test with jinja and then write it back
+                    # out to the destination.
+                    parsed_test = process_file(src_test_path, local_env_yaml)
+                    with open(dest_test_path, 'w') as output_fp:
+                        print(parsed_test, file=output_fp)
+
+    except Exception as exp:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        raise exp
+
+    return tmpdir
+
+
 def create_tarball(product):
     """Create a tarball which contains all test scenarios for every rule.
     Tarball contains directories with the test scenarios. The name of the
     directories is the same as short rule ID. There is no tree structure.
     """
-    with tempfile.NamedTemporaryFile(
-            "wb", suffix=".tar.gz", delete=False) as fp:
-        with tarfile.TarFile.open(fileobj=fp, mode="w") as tarball:
-            tarball.add(_SHARED_DIR, arcname="shared", filter=_make_file_root_owned)
-            for dirpath, dirnames, _ in walk_through_benchmark_dirs(product):
-                rule_id = os.path.basename(dirpath)
-                if "tests" in dirnames:
-                    tests_dir_path = os.path.join(dirpath, "tests")
+    templated_tests = template_tests(product=product)
+
+    try:
+        with tempfile.NamedTemporaryFile(
+                "wb", suffix=".tar.gz", delete=False) as fp:
+            with tarfile.TarFile.open(fileobj=fp, mode="w") as tarball:
+                tarball.add(_SHARED_DIR, arcname="shared", filter=_make_file_root_owned)
+                for rule_id in os.listdir(templated_tests):
+                    # When a top-level directory exists under the temporary
+                    # templated tests directory, we've already validated that
+                    # it is a valid rule directory. Thus we can simply add it
+                    # to the tarball.
+                    absolute_dir = os.path.join(templated_tests, rule_id)
+                    if not os.path.isdir(absolute_dir):
+                        continue
+
                     tarball.add(
-                        tests_dir_path, arcname=rule_id,
+                        absolute_dir, arcname=rule_id,
                         filter=lambda tinfo: _exclude_garbage(_make_file_root_owned(tinfo))
                     )
-        return fp.name
+
+            # Since we've added the templated contents into the tarball, we
+            # can now delete the tree.
+            shutil.rmtree(templated_tests, ignore_errors=True)
+            return fp.name
+    except Exception as exp:
+        shutil.rmtree(templated_tests, ignore_errors=True)
+        raise exp
 
 
 def send_scripts(test_env):

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -67,6 +67,8 @@ class TestEnv(object):
         self.domain_ip = None
         self.ssh_additional_options = []
 
+        self.product = None
+
     def start(self):
         """
         Run the environment and

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -200,15 +200,7 @@ def parse_args():
                                        "in the profile will be evaluated against all its test "
                                        "scenarios."))
 
-    args = parser.parse_args()
-
-    if not args.product and args.datastream:
-        product_regex = re.compile(r'^.*ssg-([a-zA-Z0-9]*)-(ds|ds-1\.2)\.xml$')
-        match = product_regex.match(args.datastream)
-        if match:
-            args.product = match.group(1)
-
-    return args
+    return parser.parse_args()
 
 
 def get_logging_dir(options):
@@ -298,6 +290,15 @@ def normalize_passed_arguments(options):
 
     if not options.datastream:
         options.datastream = get_unique_datastream()
+
+    if not options.product and options.datastream:
+        product_regex = re.compile(r'^.*ssg-([a-zA-Z0-9]*)-(ds|ds-1\.2)\.xml$')
+        match = product_regex.match(options.datastream)
+        if not match:
+            msg = "Unable to detect product without explicit --product: "
+            msg += "datastream {0} lacks product name".format(datastream)
+            raise RuntimeError(msg)
+        options.product = match.group(1)
 
     if options.xccdf_id is None:
         options.xccdf_id = auto_select_xccdf_id(options.datastream,


### PR DESCRIPTION
#### Description:

This enables Jinja templating during test suite build time (precisely, prior to building the product tarball) via writing test scenarios out to a temporary directory.

We do require one semi-breaking API change to identify the target product; see the first commit message for more details:

```
Add --product argument to SSGTS

test_suite.py previously had no knowledge of which product was being
evaluated (from a content perspective). While it had a datastream and an
operating system image and thus could theoretically reverse back to a
content product based on the contents of either, doing so would be
difficult. Adding a parameter allows the caller to override
autodetection from datastream file name (which doesn't necessarily
always work).

Parameter: --product
Argument: name of a content product (e.g., rhel8, ubuntu2004, &c)
Notes: Automatically inferred from adequately named datastream file
       (e.g., ssg-<...product...>-ds*.xml)

Doing so will allow us to enable jinja macros for test cases (based on
product environment content) and later enable templated tests.
```

In my view, as long as a build datastream is specified in the pipelines and they're not renamed, this shouldn't be much of an issue. 

#### Rationale:

Existing tests try to be product independent but sometimes depend on properties about the operating system. While we have the `# product = ...` list, sometimes the differences in operating systems are already known to the build system (such as package managers or grub2 configuration path) and are more easily worked around in Jinja rather than creating separate files for each potential product.

Note: I mostly tested this against `file_owner_etc_shadow` and updated a test case to include `{{{ full_name }}}`; I've not run a complete battery of profile/... or against RHEL systems, so I'd appreciate some review on this PR in that department.

Later PRs would include updating some of the grub tests to use the relevant macro. Eventually I'd like to also include support for templated test cases, ~~but I've not yet gotten to adding it~~ -- see #7211 for a draft of this. Let me know what you think!