### PR TITLE
Enable SSGTS into Github Actions

### DIFF
--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -20,17 +20,26 @@ jobs:
         with:
           repository: mildas/content-test-filtering
           path: ctf
-      - name: Process
+      - name: Detect content changes in the PR
         run: python3 ./ctf/content_test_filtering.py pr --output json ${{ github.event.pull_request.number }} > output.json
+      - name: Test if there are no content changes
+        run: echo "::set-output name=CTF_OUTPUT_SIZE::$(stat --printf="%s" output.json)"
+        id: ctf
+      - name: Print changes to content detected if any
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: cat output.json
       - name: Get product attribute
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
         uses: notiz-dev/github-action-json-property@release
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Build product
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ./build_product ${{steps.product.outputs.prop}} --datastream-only
       - uses: actions/upload-artifact@v2
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ssg-${{steps.product.outputs.prop}}-ds.xml
           path: build/ssg-${{steps.product.outputs.prop}}-ds.xml
@@ -45,82 +54,97 @@ jobs:
           apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml ansible-lint python3-github podman git python3-deepdiff python3-git python3-requests xmldiff jq
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Checkout (CTF)
+        uses: actions/checkout@v2
+        with:
+          repository: mildas/content-test-filtering
+          path: ctf
+      - name: Detect content changes in the PR
+        run: python3 ./ctf/content_test_filtering.py pr --output json ${{ github.event.pull_request.number }} > output.json
+      - name: Test if there are no content changes
+        run: echo "::set-output name=CTF_OUTPUT_SIZE::$(stat --printf="%s" output.json)"
+        id: ctf
+      - name: Print changes to content detected if any
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        run: cat output.json
       - name: Generate id_rsa key
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: ssh-keygen -N '' -t rsa -f ~/.ssh/id_rsa
       - name: Build test suite container
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-fedora
         working-directory: ./Dockerfiles
       - name: Get oscap-ssh
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |
           wget https://raw.githubusercontent.com/OpenSCAP/openscap/maint-1.2/utils/oscap-ssh
           sudo chmod 755 oscap-ssh
           sudo mv -v oscap-ssh /usr/local/bin
           sudo chown root:root /usr/local/bin/oscap-ssh
           rm -f oscap-ssh
-      - name: Checkout (CTF)
-        uses: actions/checkout@v2
-        with:
-          repository: mildas/content-test-filtering
-          path: ctf
-      - name: Process
-        run: python3 ./ctf/content_test_filtering.py pr --output json ${{ github.event.pull_request.number }} > output.json
       - name: Get rule ids to be tested
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
         uses: notiz-dev/github-action-json-property@release
         with:
           path: 'output.json'
           prop_path: 'rules'
       - name: Get product attribute
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
         uses: notiz-dev/github-action-json-property@release
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Get bash attribute
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
         uses: notiz-dev/github-action-json-property@release
         with:
           path: 'output.json'
           prop_path: 'bash'
       - name: Get ansible attribute
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
         uses: notiz-dev/github-action-json-property@release
         with:
           path: 'output.json'
           prop_path: 'ansible'
       - uses: actions/download-artifact@v2
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         with:
           name: ssg-${{steps.product.outputs.prop}}-ds.xml
       - name: Run tests in a container - Bash
-        if: ${{steps.bash.outputs.prop == 'True' }}
+        if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
       - name: Check for ERROR in logs
-        if: ${{steps.bash.outputs.prop == 'True' }}
+        if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
         id: check_results_bash
       - name: Upload logs in case of failure
-        if: ${{steps.bash.outputs.prop == 'True' && steps.check_results_bash.conclusion == 'success' }}
+        if: ${{steps.bash.outputs.prop == 'True' && steps.check_results_bash.conclusion == 'success' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         uses: actions/upload-artifact@v2
         with:
           name: logs_bash
           path: logs_bash/
       - name: Run tests in a container - Ansible
-        if: ${{ steps.ansible.outputs.prop == 'True' }}
+        if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
       - name: Check for ERROR in logs
-        if: ${{steps.ansible.outputs.prop == 'True' }}
+        if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log
         id: check_results_ansible
       - name: Upload logs in case of failure
-        if: ${{ steps.ansible.outputs.prop == 'True' && steps.check_results_ansible.conclusion == 'success' }}
+        if: ${{ steps.ansible.outputs.prop == 'True' && steps.check_results_ansible.conclusion == 'success' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         uses: actions/upload-artifact@v2
         with:
           name: logs_ansible
           path: logs_ansible/
       - name: Delete datastream artifact
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ssg-${{steps.product.outputs.prop}}-ds.xml
       - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
-        if: ${{ steps.check_results_bash.conclusion == 'success' || steps.check_results_ansible.conclusion == 'success' }}
+        if: ${{ (steps.check_results_bash.conclusion == 'success' || steps.check_results_ansible.conclusion == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: exit 1

--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -1,0 +1,126 @@
+name: SSGTS
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  build-content:
+    name: Build Content
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Install Deps
+        run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip
+      - name: Install deps python
+        run: pip install gitpython xmldiff
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout (CTF)
+        uses: actions/checkout@v2
+        with:
+          repository: mildas/content-test-filtering
+          path: ctf
+      - name: Process
+        run: python3 ./ctf/content_test_filtering.py pr --output json ${{ github.event.pull_request.number }} > output.json
+      - name: Get product attribute
+        id: product
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'output.json'
+          prop_path: 'product'
+      - name: Build product
+        run: ./build_product ${{steps.product.outputs.prop}} --datastream-only
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ssg-${{steps.product.outputs.prop}}-ds.xml
+          path: build/ssg-${{steps.product.outputs.prop}}-ds.xml
+  validate-ubuntu:
+    name: Run Tests
+    needs: build-content
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Deps
+        uses: mstksg/get-package@master
+        with:
+          apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml ansible-lint python3-github podman git python3-deepdiff python3-git python3-requests xmldiff jq
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate id_rsa key
+        run: ssh-keygen -N '' -t rsa -f ~/.ssh/id_rsa
+      - name: Build test suite container
+        run: podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-fedora
+        working-directory: ./Dockerfiles
+      - name: Get oscap-ssh
+        run: |
+          wget https://raw.githubusercontent.com/OpenSCAP/openscap/maint-1.2/utils/oscap-ssh
+          sudo chmod 755 oscap-ssh
+          sudo mv -v oscap-ssh /usr/local/bin
+          sudo chown root:root /usr/local/bin/oscap-ssh
+          rm -f oscap-ssh
+      - name: Checkout (CTF)
+        uses: actions/checkout@v2
+        with:
+          repository: mildas/content-test-filtering
+          path: ctf
+      - name: Process
+        run: python3 ./ctf/content_test_filtering.py pr --output json ${{ github.event.pull_request.number }} > output.json
+      - name: Get rule ids to be tested
+        id: rules
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'output.json'
+          prop_path: 'rules'
+      - name: Get product attribute
+        id: product
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'output.json'
+          prop_path: 'product'
+      - name: Get bash attribute
+        id: bash
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'output.json'
+          prop_path: 'bash'
+      - name: Get ansible attribute
+        id: ansible
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'output.json'
+          prop_path: 'ansible'
+      - uses: actions/download-artifact@v2
+        with:
+          name: ssg-${{steps.product.outputs.prop}}-ds.xml
+      - name: Run tests in a container - Bash
+        if: ${{steps.bash.outputs.prop == 'True' }}
+        run: tests/test_rule_in_container.sh --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
+      - name: Check for ERROR in logs
+        if: ${{steps.bash.outputs.prop == 'True' }}
+        run: grep -q "^ERROR" logs_bash/test_suite.log
+        id: check_results_bash
+      - name: Upload logs in case of failure
+        if: ${{steps.bash.outputs.prop == 'True' && steps.check_results_bash.conclusion == 'success' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs_bash
+          path: logs_bash/
+      - name: Run tests in a container - Ansible
+        if: ${{ steps.ansible.outputs.prop == 'True' }}
+        run: tests/test_rule_in_container.sh --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
+      - name: Check for ERROR in logs
+        if: ${{steps.ansible.outputs.prop == 'True' }}
+        run: grep -q "^ERROR" logs_ansible/test_suite.log
+        id: check_results_ansible
+      - name: Upload logs in case of failure
+        if: ${{ steps.ansible.outputs.prop == 'True' && steps.check_results_ansible.conclusion == 'success' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs_ansible
+          path: logs_ansible/
+      - name: Delete datastream artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ssg-${{steps.product.outputs.prop}}-ds.xml
+      - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
+        if: ${{ steps.check_results_bash.conclusion == 'success' || steps.check_results_ansible.conclusion == 'success' }}
+        run: exit 1

--- a/tests/test_rule_in_container.sh
+++ b/tests/test_rule_in_container.sh
@@ -5,6 +5,7 @@
 # ARG_OPTIONAL_SINGLE([scenarios],[s],[Regex to reduce selection of tested scenarios],[])
 # ARG_OPTIONAL_SINGLE([datastream],[d],[Path to the datastream to use in tests. Autodetected by default.])
 # ARG_OPTIONAL_SINGLE([remediate-using],[r],[What to remediate with],[oscap])
+# ARG_OPTIONAL_SINGLE([logdir],[l],[Directory where logs will be stored])
 # ARG_OPTIONAL_BOOLEAN([dontclean],[],[Dont remove HTML reports from the log directory.])
 # ARG_OPTIONAL_BOOLEAN([dry-run],[],[Just print the test suite command-line.])
 # ARG_POSITIONAL_SINGLE([rule],[The short rule ID. Wildcards are supported.])
@@ -55,6 +56,7 @@ _arg_name="ssg_test_suite"
 _arg_scenarios=""
 _arg_datastream=
 _arg_remediate_using="oscap"
+_arg_logdir=
 _arg_dontclean="off"
 _arg_dry_run="off"
 
@@ -68,6 +70,7 @@ print_help()
 	printf '\t%s\n' "-s, --scenarios: Regex to reduce selection of tested scenarios (default: '')"
 	printf '\t%s\n' "-d, --datastream: Path to the datastream to use in tests. Autodetected by default. (no default)"
 	printf '\t%s\n' "-r, --remediate-using: What to remediate with. Can be one of: 'oscap', 'bash' and 'ansible' (default: 'oscap')"
+	printf '\t%s\n' "-l, --logdir: Directory where logs will be stored"
 	printf '\t%s\n' "--dontclean: Dont remove HTML reports from the log directory."
 	printf '\t%s\n' "--dry-run: Just print the test suite command-line."
 	printf '\t%s\n' "-h, --help: Prints help"
@@ -124,6 +127,17 @@ parse_commandline()
 				;;
 			-r*)
 				_arg_remediate_using="$(remediations "${_key##-r}" "remediate-using")" || exit 1
+				;;
+			-l|--logdir)
+				test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+				_arg_logdir="$2"
+				shift
+				;;
+			--logdir=*)
+				_arg_logdir="${_key##--logdir=}"
+				;;
+			-l*)
+				_arg_logdir="${_key##-l}"
 				;;
 			--dontclean)
 				_arg_dontclean="on"
@@ -197,6 +211,8 @@ test -n "$_arg_scenarios" && additional_args+=(--scenario "'$_arg_scenarios'")
 test -n "$_arg_datastream" && additional_args+=(--datastream "$_arg_datastream")
 
 test -n "$_arg_remediate_using" && additional_args+=(--remediate-using "$_arg_remediate_using")
+
+test -n "$_arg_logdir" && additional_args+=(--logdir "$_arg_logdir")
 
 command=(python3 "${script_dir}/test_suite.py" rule --remove-machine-only "${additional_args[@]}" --add-platform "$test_image_cpe_product" --container "$_arg_name" -- "${_arg_rule}")
 if test "$_arg_dry_run" = on; then

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -285,6 +285,14 @@ def datastream_in_stash(current_location):
 
 
 def normalize_passed_arguments(options):
+    targets = []
+    for target in options.target:
+        if ',' in target:
+            targets.extend(target.split(","))
+        else:
+            targets.append(target)
+    options.target = targets
+
     if 'ALL' in options.target:
         options.target = ['ALL']
 


### PR DESCRIPTION
#### Description:

- Enable SSGTS in GH actions.
- This test uses content-test-filtering as input for which rules and remediation types should be tested. The product built is also provided by the CTF (content-test-filtering).
- Logs are uploaded in case of `ERROR` during tests execution. These logs can be downloaded and inspected locally.
- Content is built in a fedora:latest container because it contains latest version of OpenSCAP
- The rules are tested using the run_rule_in_container.sh script which overrides the cpe so it can be tested in the fedora container.
- Note: the tests are skipped in case there are no changes detected in the pull request. That's the case here, I've tested this PR with changes to the content but for the merge we need to keep it clean.
