### PR TITLE
Generate more reproducible remediations

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -302,8 +302,10 @@ class BashRemediation(Remediation):
         rule_specific_conditionals = [
             self.generate_platform_conditional(p) for p in rule_specific_platforms]
         # remove potential "None" from lists
-        inherited_conditionals = [p for p in inherited_conditionals if p is not None]
-        rule_specific_conditionals = [p for p in rule_specific_conditionals if p is not None]
+        inherited_conditionals = sorted([
+            p for p in inherited_conditionals if p is not None])
+        rule_specific_conditionals = sorted([
+            p for p in rule_specific_conditionals if p is not None])
 
         if inherited_conditionals or rule_specific_conditionals:
             wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]
@@ -478,8 +480,10 @@ class AnsibleRemediation(Remediation):
         rule_specific_conditionals = [
             self.generate_platform_conditional(p) for p in rule_specific_platforms]
         # remove potential "None" from lists
-        inherited_conditionals = [p for p in inherited_conditionals if p is not None]
-        rule_specific_conditionals = [p for p in rule_specific_conditionals if p is not None]
+        inherited_conditionals = sorted([
+            p for p in inherited_conditionals if p is not None])
+        rule_specific_conditionals = sorted([
+            p for p in rule_specific_conditionals if p is not None])
 
         # remove conditionals related to package CPEs if the updated task
         # collects package facts


### PR DESCRIPTION
#### Description & Rationale

We should sort the given generated conditionals of the remediations (Bash and Ansible) so that when we compare the datastreams, they're more similar by default.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`


----


When comparing datastreams, I saw a lot of entries like:

```
-if [ "$var_firewall_package" == "iptables" ] || [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
+if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ] || [ "$var_firewall_package" == "iptables" ]; then
```

These are exactly the same, just different ordering due to the set. IMO, the set is important, so we should sort it afterwards.

This helps to reduce noise in `compare-ds.py`. 