### PR TITLE
Add Ubuntu to cron.allow, at.allow rules for CIS

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Verify Group Who Owns /etc/at.allow file'
+
+description: |-
+    If <tt>/etc/at.allow</tt> exists, it must be group-owned by <tt>root</tt>.
+    {{{ describe_file_group_owner(file="/etc/at.allow", group="root") }}}
+
+rationale: |-
+    If the owner of the at.allow file is not set to root, the possibility exists for an
+    unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 5.1.9
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/at.allow", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/at.allow", group="root") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/at.allow
+        missing_file_pass: 'true'
+        filegid: '0'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify Group Who Owns /etc/cron.allow file'
 
@@ -21,6 +21,7 @@ references:
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 5.1.8
     cis@sle15: 5.1.8
+    cis@ubuntu2004: 5.1.8
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
     disa: CCI-000366
     isa-62443-2009: 4.3.3.7.3

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_at_allow/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Verify User Who Owns /etc/at.allow file'
+
+description: |-
+    If <tt>/etc/at.allow</tt> exists, it must be owned by <tt>root</tt>.
+    {{{ describe_file_owner(file="/etc/at.allow", owner="root") }}}
+
+rationale: |-
+    If the owner of the at.allow file is not set to root, the possibility exists for an
+    unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 5.1.9
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/at.allow", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/at.allow", owner="root") }}}
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/at.allow
+        missing_file_pass: 'true'
+        fileuid: '0'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify User Who Owns /etc/cron.allow file'
 
@@ -21,6 +21,7 @@ references:
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 5.1.8
     cis@sle15: 5.1.8
+    cis@ubuntu2004: 5.1.8
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
     disa: CCI-000366
     isa-62443-2009: 4.3.3.7.3

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Verify Permissions on /etc/at.allow file'
+
+description: |-
+    If <tt>/etc/at.allow</tt> exists, it must have permissions <tt>0640</tt>
+    or more restrictive.
+
+    {{{ describe_file_permissions(file="/etc/at.allow", perms="0640") }}}
+
+rationale: |-
+    If the permissions of the at.allow file are not set to 0640 or more restrictive,
+    the possibility exists for an unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 5.1.9
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/at.allow", perms="-rw-r-----") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/at.allow", perms="-rw-r-----") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/at.allow
+        missing_file_pass: 'true'
+        filemode: '0640'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Verify Permissions on /etc/cron.allow file'
+
+description: |-
+    If <tt>/etc/cron.allow</tt> exists, it must have permissions <tt>0640</tt>
+    or more restrictive.
+
+    {{{ describe_file_permissions(file="/etc/cron.allow", perms="0640") }}}
+
+rationale: |-
+    If the permissions of the cron.allow file are not set to 0640 or more restrictive,
+    the possibility exists for an unauthorized user to view or edit sensitive information.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 5.1.8
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.allow", perms="-rw-r-----") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/cron.allow", perms="-rw-r-----") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/cron.allow
+        missing_file_pass: 'true'
+        filemode: '0640'

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -611,10 +611,14 @@ selections:
     - file_groupowner_cron_d
 
     ### 5.1.8 Ensure cron is restricted to authorized users (Automated)
-    # Needs rules
+    - file_permissions_cron_allow
+    - file_owner_cron_allow
+    - file_groupowner_cron_allow
 
     ### 5.1.9 Ensure at is restricted to authorized users (Automated)
-    # Needs rules
+    - file_permissions_at_allow
+    - file_owner_at_allow
+    - file_groupowner_at_allow
 
     ## 5.2 Configure SSH Server ##
     ### 5.2.1 Ensure permissions on /etc/ssh/sshd_config are configured (Automated)


### PR DESCRIPTION
#### Description:

I missed that `file_owner_cron_allow` and `file_groupowner_cron_allow` already existed in the project when I created the initial CIS profiles. I've also included the missing `file_permissions_cron_allow` rule and the corresponding `at.allow` equivalents of the `cron.allow` rules since they're all templated content.

I'm guessing other distros' CIS benchmarks include the same rules, so these should be generally useful to the community. 