### PR TITLE
Prioritize install_smartcard_packages like package_*_installed

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -925,8 +925,11 @@ class Group(object):
         # The Rules are ordered in more logical way, and
         # remediation order is natural, first the package is installed, then configured.
         rules_in_group = list(self.rules.keys())
-        regex = r'(package_.*_(installed|removed))|(service_.*_(enabled|disabled))$'
-        priority_order = ["installed", "removed", "enabled", "disabled"]
+        regex = (r'(package_.*_(installed|removed))|' +
+                 r'(service_.*_(enabled|disabled))|' +
+                 r'install_smartcard_packages$')
+        priority_order = ["installed", "install_smartcard_packages", "removed",
+                          "enabled", "disabled"]
         rules_in_group = reorder_according_to_ordering(rules_in_group, priority_order, regex)
 
         # Add rules in priority order, first all packages installed, then removed,

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -70,7 +70,7 @@ def reorder_according_to_ordering(unordered, ordering, regex=None):
             if priority_type in item and item in unordered:
                 ordered.append(item)
                 unordered.remove(item)
-    ordered.extend(list(unordered))
+    ordered.extend(sorted(unordered))
     return ordered
 
 


### PR DESCRIPTION
#### Description:

Several smartcard rules have the problem that install_smartcard_packages
is not appropriately ordered. In #7208, we renamed the rule to match the
pattern of package_*_installed. However, this approach breaks any
existing tailoring and thus wasn't desired. Move to updating the Python
to order this rule as a special case.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`
