### PR TITLE
enable levels to override variables of inheriting levels

### DIFF
--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -214,17 +214,19 @@ class ControlsManager():
                     if len(variables) == 0:
                         eligible_controls.append(c)
                         continue
+                    variables_to_remove = [] # contains list of variables which are already defined and should be removed from the control
                     for var in variables:
                         if var in defined_variables:
-                            # if it is, create new instance of the control and remove the variable
-                            # we are going from the top level to the bottom
-                            # so we don't want to overwrite variables
-                            new_c = copy.deepcopy(c)
-                            del new_c.variables[var]
-                            eligible_controls.append(new_c)
+                            variables_to_remove.append(var)
                         else:
                             defined_variables.append(var)
-                            eligible_controls.append(c)
+                    if len(variables_to_remove) == 0:
+                        eligible_controls.append(c)
+                    else:
+                        new_c = copy.deepcopy(c)
+                        for var in variables_to_remove:
+                            del new_c.variables[var]
+                        eligible_controls.append(new_c)
         return eligible_controls
 
     def get_all_controls(self, policy_id):

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -152,17 +152,17 @@ class Policy():
             )
             raise ValueError(msg)
 
-    def get_level_with_ancestors(self, level_id):
+    def get_level_with_ancestors_sequence(self, level_id):
         # use OrderedDict for Python2 compatibility instead of ordered set
         levels = collections.OrderedDict()
         level = self.get_level(level_id)
         levels[level] = ""
         if level.inherits_from:
             for lv in level.inherits_from:
-                eligible_levels = [l for l in self.get_level_with_ancestors(lv).keys() if l not in levels.keys()]
+                eligible_levels = [l for l in self.get_level_with_ancestors_sequence(lv) if l not in levels.keys()]
                 for l in eligible_levels:
                     levels[l] = ""
-        return levels
+        return list(levels.keys())
 
 
 class ControlsManager():
@@ -200,34 +200,36 @@ class ControlsManager():
 
     def get_all_controls_of_level(self, policy_id, level_id):
         policy = self._get_policy(policy_id)
-        levels = policy.get_level_with_ancestors(level_id)
+        levels = policy.get_level_with_ancestors_sequence(level_id)
         all_policy_controls = self.get_all_controls(policy_id)
         eligible_controls = []
-        defined_variables = []
+        already_defined_variables = set()
         # we will go level by level, from top to bottom
         # this is done to enable overriding of variables by higher levels
-        for lv in levels.keys():
-            for c in all_policy_controls:
-                if lv.id in c.levels:
-                    # if the control has a variable, check if it is not already defined
-                    variables = list(c.variables.keys())
-                    if len(variables) == 0:
-                        eligible_controls.append(c)
-                        continue
-                    variables_to_remove = [] # contains list of variables which are already defined and should be removed from the control
-                    for var in variables:
-                        if var in defined_variables:
-                            variables_to_remove.append(var)
-                        else:
-                            defined_variables.append(var)
-                    if len(variables_to_remove) == 0:
-                        eligible_controls.append(c)
-                    else:
-                        new_c = copy.deepcopy(c)
-                        for var in variables_to_remove:
-                            del new_c.variables[var]
-                        eligible_controls.append(new_c)
+        for lv in levels:
+            for control in all_policy_controls:
+                if lv.id not in control.levels:
+                    continue
+
+                variables = set(control.variables.keys())
+
+                variables_to_remove = variables.intersection(already_defined_variables)
+                already_defined_variables.update(variables)
+
+                new_c = self._get_control_without_variables(variables_to_remove, control)
+                eligible_controls.append(new_c)
+
         return eligible_controls
+
+    @staticmethod
+    def _get_control_without_variables(variables_to_remove, control):
+        if not variables_to_remove:
+            return control
+
+        new_c = copy.deepcopy(control)
+        for var in variables_to_remove:
+            del new_c.variables[var]
+        return new_c
 
     def get_all_controls(self, policy_id):
         policy = self._get_policy(policy_id)

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -198,42 +198,42 @@ class ControlsManager():
             raise ValueError(msg)
         return policy
 
-    def get_all_controls_of_level(self, policy_id, level_id):
+    def get_all_controls_of_level(self, policy_id, level_id, override_vars=True):
+        # if override_vars is enabled, then variables from higher levels will
+        # override variables efined in controls of lower levels
         policy = self._get_policy(policy_id)
         levels = policy.get_level_with_ancestors(level_id)
-        print ("getting levels of " + level_id)
-        print ([ l.id for l in levels.keys()])
         # we use OrderedDict here with empty values instead of ordered set
         # cause we want to be compatible with python 2
         level_ids = collections.OrderedDict()
         for lv in levels.keys():
             level_ids[lv.id] = ""
-        print (level_ids.keys())
         all_policy_controls = self.get_all_controls(policy_id)
         eligible_controls = []
         defined_variables = []
         # we will go level by level, from top to bottom
         # this is done to enable overriding of variables by higher levels
         for lv in level_ids.keys():
-            print ("going through level " +lv)
             for c in all_policy_controls:
-                print (c.levels)
                 if lv in c.levels:
-                    # if the control has a variable, check if it is not already defined
-                    variables = list(c.variables.keys())
-                    if len(variables) == 0:
+                    if override_vars == False:
                         eligible_controls.append(c)
-                    for var in variables:
-                        if var in defined_variables:
-                            # if it is, create new instance of the control and remove the variable
-                            # we are going from the top level to the bottom
-                            # so we don't want to overwrite variables
-                            new_c = copy.deepcopy(c)
-                            del new_c.variables[var]
-                            eligible_controls.append(new_c)
-                        else:
-                            defined_variables.append(var)
+                    else:
+                        # if the control has a variable, check if it is not already defined
+                        variables = list(c.variables.keys())
+                        if len(variables) == 0:
                             eligible_controls.append(c)
+                        for var in variables:
+                            if var in defined_variables:
+                                # if it is, create new instance of the control and remove the variable
+                                # we are going from the top level to the bottom
+                                # so we don't want to overwrite variables
+                                new_c = copy.deepcopy(c)
+                                del new_c.variables[var]
+                                eligible_controls.append(new_c)
+                            else:
+                                defined_variables.append(var)
+                                eligible_controls.append(c)
         return eligible_controls
 
     def get_all_controls(self, policy_id):

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -200,7 +200,7 @@ class ControlsManager():
 
     def get_all_controls_of_level(self, policy_id, level_id, override_vars=True):
         # if override_vars is enabled, then variables from higher levels will
-        # override variables efined in controls of lower levels
+        # override variables defined in controls of lower levels
         policy = self._get_policy(policy_id)
         levels = policy.get_level_with_ancestors(level_id)
         # we use OrderedDict here with empty values instead of ordered set

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -201,19 +201,14 @@ class ControlsManager():
     def get_all_controls_of_level(self, policy_id, level_id):
         policy = self._get_policy(policy_id)
         levels = policy.get_level_with_ancestors(level_id)
-        # we use OrderedDict here with empty values instead of ordered set
-        # cause we want to be compatible with python 2
-        level_ids = collections.OrderedDict()
-        for lv in levels.keys():
-            level_ids[lv.id] = ""
         all_policy_controls = self.get_all_controls(policy_id)
         eligible_controls = []
         defined_variables = []
         # we will go level by level, from top to bottom
         # this is done to enable overriding of variables by higher levels
-        for lv in level_ids.keys():
+        for lv in levels.keys():
             for c in all_policy_controls:
-                if lv in c.levels:
+                if lv.id in c.levels:
                     # if the control has a variable, check if it is not already defined
                     variables = list(c.variables.keys())
                     if len(variables) == 0:

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -202,9 +202,16 @@ class ControlsManager():
 
         all_policy_controls = self.get_all_controls(policy_id)
         eligible_controls = []
-        for c in all_policy_controls:
-            if len(level_ids.intersection(c.levels)) > 0:
-                eligible_controls.append(c)
+        defined_variables = []
+        # we will go level by level, from top to bottom
+        # this is done to enable overriding of variables by higher levels
+        for lv in level_ids:
+            for c in all_policy_controls:
+                if lv in c.levels:
+                    # if the control has a variable, check if it is not already defined
+                    if c.variables.keys().isdisjoint(defined_variables):
+                        eligible_controls.append(c)
+                        defined_variables += [*c.variables.keys()]
         return eligible_controls
 
     def get_all_controls(self, policy_id):

--- a/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
@@ -25,8 +25,6 @@ controls:
   - id: S3
     levels:
     - medium
-    rules:
-      - var_password_pam_minlen=2
 
   - id: S4
     title: Configure authentication
@@ -41,4 +39,4 @@ controls:
         levels:
         - high
         rules:
-          - var_password_pam_minlen=3
+          - var_password_pam_minlen=2

--- a/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
@@ -19,10 +19,14 @@ controls:
   - id: S2
     levels:
     - low
+    rules:
+      - var_password_pam_minlen=1
 
   - id: S3
     levels:
     - medium
+    rules:
+      - var_password_pam_minlen=2
 
   - id: S4
     title: Configure authentication
@@ -36,3 +40,5 @@ controls:
         title: Enforce password quality standards
         levels:
         - high
+        rules:
+          - var_password_pam_minlen=3

--- a/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd-levels.yml
@@ -21,6 +21,7 @@ controls:
     - low
     rules:
       - var_password_pam_minlen=1
+      - var_some_variable=1
 
   - id: S3
     levels:
@@ -40,3 +41,4 @@ controls:
         - high
         rules:
           - var_password_pam_minlen=2
+          - var_some_variable=3

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -87,6 +87,11 @@ def test_controls_levels():
     assert len(low_controls) == 4
     assert len(medium_controls) == 5
 
+    # test overriding of variables in levels
+    assert c_2.variables["var_password_pam_minlen"] == "1"
+    assert c_3.variables["var_password_pam_minlen"] == "2"
+    assert c_4b.variables["var_password_pam_minlen"] == "3"
+
 
 def test_controls_load_product():
     ssg_root = \

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -89,8 +89,20 @@ def test_controls_levels():
 
     # test overriding of variables in levels
     assert c_2.variables["var_password_pam_minlen"] == "1"
-    assert c_3.variables["var_password_pam_minlen"] == "2"
-    assert c_4b.variables["var_password_pam_minlen"] == "3"
+    assert "var_password_pam_minlen" not in c_3.variables.keys()
+    assert c_4b.variables["var_password_pam_minlen"] == "2"
+
+    for c in low_controls:
+        if "var_password_pam_minlen" in c.variables.keys():
+            assert c.variables["var_password_pam_minlen"] == "1"
+
+    for c in medium_controls:
+        if "var_password_pam_minlen" in c.variables.keys():
+            assert c.variables["var_password_pam_minlen"] == "1"
+
+    for c in high_controls:
+        if "var_password_pam_minlen" in c.variables.keys():
+            assert c.variables["var_password_pam_minlen"] == "2"
 
 
 def test_controls_load_product():

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -104,6 +104,25 @@ def test_controls_levels():
         if "var_password_pam_minlen" in c.variables.keys():
             assert c.variables["var_password_pam_minlen"] == "2"
 
+    # now test if controls of lower level has the variable definition correctly removed
+    # because it is overriden by higher level controls
+    s2_high = [c for c in high_controls if c.id == "S2"]
+    assert len(s2_high) == 1
+    assert "var_some_variable" not in s2_high[0].variables.keys()
+    assert "var_password_pam_minlen" not in s2_high[0].variables.keys()
+    s4b_high = [c for c in high_controls if c.id == "S4.b"]
+    assert len(s4b_high) == 1
+    assert s4b_high[0].variables["var_some_variable"] == "3"
+    assert s4b_high[0].variables["var_password_pam_minlen"] == "2"
+
+    # check that in low level the variable is correctly placed there in S2
+    s2_low = [c for c in low_controls if c.id == "S2"]
+    assert len(s2_low) == 1
+    assert s2_low[0].variables["var_some_variable"] == "1"
+    assert s2_low[0].variables["var_password_pam_minlen"] == "1"
+
+
+
 
 def test_controls_load_product():
     ssg_root = \


### PR DESCRIPTION
#### Description:

- modify build system
- while getting list of controls of a certain level, make sure that only the top-most level variable definition is used


#### Rationale:

- this modification allows for example CIS level 2 profile to have a different variable than CIS level 1 profile