### PR TITLE
Add oval check for bios_enable_execution_restrictions

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
@@ -1,8 +1,10 @@
 <def-group>
     <definition class="compliance" id="bios_enable_execution_restrictions" version="2">
         {{{ oval_metadata("The NX (no-execution) bit flag should be set on the system.") }}}
-        <criteria>
+        <criteria operator="AND">
             <criterion comment="NX bit is set" test_ref="test_NX_cpu_support" />
+            <criterion comment="No log messages about NX being disabled" test_ref="test_messages_nx_active" />
+            <criterion comment="NX is not disabled in the kernel command line" test_ref="test_noexec_cmd_line" />
         </criteria>
     </definition>
 
@@ -10,9 +12,29 @@
         <ind:object object_ref="obj_NX_cpu_support" />
     </ind:textfilecontent54_test>
 
+    <ind:textfilecontent54_test check="all" check_existence="none_exist" id="test_messages_nx_active" version="1" comment="No log messages about NX being disabled">
+        <ind:object object_ref="obj_messages_nx_active" />
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_test check="all" check_existence="none_exist" id="test_noexec_cmd_line" version="1" comment="NX is not disabled in the kernel command line">
+        <ind:object object_ref="obj_noexec_cmd_line" />
+    </ind:textfilecontent54_test>
+
     <ind:textfilecontent54_object id="obj_NX_cpu_support" version="1">
         <ind:filepath>/proc/cpuinfo</ind:filepath>
         <ind:pattern operation="pattern match">^flags[\s]+:.*[\s]+nx[\s]+.*$</ind:pattern>
+        <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_object id="obj_messages_nx_active" version="1">
+        <ind:filepath>/var/log/messages</ind:filepath>
+        <ind:pattern operation="pattern match">^.+protection: disabled.+</ind:pattern>
+        <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_object id="obj_noexec_cmd_line" version="1">
+        <ind:filepath>/proc/cmdline</ind:filepath>
+        <ind:pattern operation="pattern match">.+noexec[0-9]*=off.+</ind:pattern>
         <ind:instance datatype="int">1</ind:instance>
     </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
@@ -1,0 +1,18 @@
+<def-group>
+    <definition class="compliance" id="bios_enable_execution_restrictions" version="2">
+        {{{ oval_metadata("The NX (no-execution) bit flag should be set on the system.") }}}
+        <criteria>
+            <criterion comment="NX bit is set" test_ref="test_NX_cpu_support" />
+        </criteria>
+    </definition>
+
+    <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="CPUs support for NX bit" id="test_NX_cpu_support" version="1">
+        <ind:object object_ref="obj_NX_cpu_support" />
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_object id="obj_NX_cpu_support" version="1">
+        <ind:filepath>/proc/cpuinfo</ind:filepath>
+        <ind:pattern operation="pattern match">^flags[\s]+:.*[\s]+nx[\s]+.*$</ind:pattern>
+        <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -14,7 +14,7 @@ rationale: |-
     Computers with the ability to prevent this type of code execution frequently put an option in the BIOS that will
     allow users to turn the feature on or off at will.
 
-severity: unknown
+severity: medium
 
 identifiers:
     cce@rhel7: CCE-27099-1
@@ -31,5 +31,6 @@ references:
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
     nist: SC-39,CM-6(a)
     nist-csf: PR.IP-1
+    stig@rhel8: RHEL-08-010420
 
 platform: machine

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -260,6 +260,7 @@ selections:
     - package_opensc_installed
 
     # RHEL-08-010420
+    - bios_enable_execution_restrictions
 
     # RHEL-08-010421
     - grub2_page_poison_argument

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -74,6 +74,7 @@ selections:
 - auditd_log_format
 - auditd_name_format
 - banner_etc_issue
+- bios_enable_execution_restrictions
 - chronyd_client_only
 - chronyd_no_chronyc_network
 - chronyd_or_ntpd_set_maxpoll

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -85,6 +85,7 @@ selections:
 - auditd_log_format
 - auditd_name_format
 - banner_etc_issue
+- bios_enable_execution_restrictions
 - chronyd_client_only
 - chronyd_no_chronyc_network
 - chronyd_or_ntpd_set_maxpoll


### PR DESCRIPTION
#### Description:

Add oval check for bios_enable_execution_restrictions to if `nx` in the flags in `/proc/cpuinfo`

#### Rationale:

For DISA STIG RHEL-08-010420
