### PR TITLE
Bug 1857179 - Improved ansible fix for banner files. Replace files on…

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/ansible/shared.yml
@@ -5,13 +5,7 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("login_banner_text") }}}
 
-- name: "{{{ rule_title }}} - remove incorrect banner"
-  file:
-    state: absent
-    path: /etc/issue
-
-- name: "{{{ rule_title }}} - add correct banner"
-  lineinfile:
+- name: "{{{ rule_title }}} - ensure correct banner"
+  copy:
     dest: /etc/issue
-    line: '{{{ ansible_deregexify_banner_etc_issue("login_banner_text") }}}'
-    create: yes
+    content: '{{{ ansible_deregexify_banner_etc_issue("login_banner_text") }}}'

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/ansible/shared.yml
@@ -5,13 +5,7 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("login_banner_text") }}}
 
-- name: "{{{ rule_title }}} - remove incorrect banner"
-  file:
-    state: absent
-    path: /etc/motd
-
-- name: "{{{ rule_title }}} - add correct banner"
-  lineinfile:
+- name: "{{{ rule_title }}} - ensure correct banner"
+  copy:
     dest: /etc/motd
-    line: '{{{ ansible_deregexify_banner_etc_issue("login_banner_text") }}}'
-    create: yes
+    content: '{{{ ansible_deregexify_banner_etc_issue("login_banner_text") }}}'


### PR DESCRIPTION
#### Description:

This patch fix the Bug 1857179 - https://bugzilla.redhat.com/show_bug.cgi?id=1857179
The files / etc / issue and / etc / motd are replaced by the Ansible playbook, even if they are already correct, impacting the efficiency and integrity of the files once a new inode is created.
This patch improves the playbook using the copy module, which ensures that the file is only updated if the current content is different from the desired content.

#### Rationale:

This patch achieve the same goal with less code and more efficiency.
The copy module is part of ansible-base and included in all Ansible installations.
