### PR TITLE
Adding findutils to test_suite-fedora Dockerfile

### DIFF
--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -10,7 +10,7 @@ ARG ADDITIONAL_PACKAGES
 # Don't clean all, as the test scenario may require package install.
 RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
-		python3 \
+		python3 findutils \
 		$ADDITIONAL_PACKAGES \
         && true
 


### PR DESCRIPTION
#### Description:

- Adding the findutils package to the Fedora test-suite Dockerfile

#### Rationale:

- We have tests that use the `find` command, and this apparently is not standard on the fedora container, causing those tests to fail.