### PR TITLE
fix problems with variables in rhel7 cis

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1662,7 +1662,7 @@ controls:
     automated: yes
     rules:
     - sudo_custom_logfile
-    - var_sudo_logfile=default
+    - var_sudo_logfile=var_log_sudo_log
 
   - id: 5.3.1
     title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -13,4 +13,4 @@ interactive: false
 options:
     stig: hmac-sha2-512,hmac-sha2-256
     default: hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com
-    cis_rhel7: MACs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com
+    cis_rhel7: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com

--- a/linux_os/guide/system/software/sudo/var_sudo_logfile.var
+++ b/linux_os/guide/system/software/sudo/var_sudo_logfile.var
@@ -14,3 +14,4 @@ operator: equals
 
 options:
     default: "/var/log/sudo.log"
+    var_log_sudo_log: "/var/log/sudo.log"


### PR DESCRIPTION
#### Description:

- fix value of sshd_approved_macs for cis_rhel7
- create explicit variable value for "/var/log/sudo.log" and use it in rhel7 cis

#### Rationale:

fixes #7222 

fixes #7233 