### PR TITLE
Added RHEL9 kickstarts

### DIFF
--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
@@ -1,0 +1,163 @@
+# SCAP Security Guide ANSSI BP-028 (enhanced) profile kickstart for Red Hat Enterprise Linux 9
+# Version: 0.0.1
+# Date: 2021-07-13
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
+# Ensure /usr Located On Separate Partition
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+# Ensure /opt Located On Separate Partition
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /srv Located On Separate Partition
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
@@ -1,0 +1,167 @@
+# SCAP Security Guide ANSSI BP-028 (high) profile kickstart for Red Hat Enterprise Linux 9
+# Version: 0.0.1
+# Date: 2021-07-13
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
+# Ensure /usr Located On Separate Partition
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+# Ensure /opt Located On Separate Partition
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /srv Located On Separate Partition
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_high
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
@@ -1,0 +1,163 @@
+# SCAP Security Guide ANSSI BP-028 (intermediary) profile kickstart for Red Hat Enterprise Linux 9
+# Version: 0.0.1
+# Date: 2021-07-13
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
+# Ensure /usr Located On Separate Partition
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+# Ensure /opt Located On Separate Partition
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /srv Located On Separate Partition
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
@@ -1,0 +1,127 @@
+# SCAP Security Guide ANSSI BP-028 (minimal) profile kickstart for Red Hat Enterprise Linux 9
+# Version: 0.0.1
+# Date: 2021-07-13
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+autopart
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_minimal
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
@@ -1,0 +1,143 @@
+# SCAP Security Guide CIS profile kickstart for Red Hat Enterprise Linux 9 Server
+# Version: 0.0.1
+# Date: 2021-07-13
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$/0RYeeRdK70ynvYz$jH2ZN/80HM6DjndHMxfUF9KIibwipitvizzXDH1zW.fTjyD3RD3tkNdNUaND18B/XqfAUW3vy1uebkBybCuIm0
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+#
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=10240 --grow
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=LogVol02 --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=LogVol01 --vgname=VolGroup --size=1024 --fsoptions="nodev,noexec,nosuid"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=LogVol7 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=LogVol03 --vgname=VolGroup --size=3072
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=LogVol04 --vgname=VolGroup --size=1024
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=LogVol05 --vgname=VolGroup --size=512
+logvol swap --name=lv_swap --vgname=VolGroup --size=2016
+
+
+# Harden installation with CIS profile
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+%addon com_redhat_oscap
+        content-type = scap-security-guide
+        profile = xccdf_org.ssgproject.content_profile_cis
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
@@ -1,0 +1,164 @@
+# SCAP Security Guide CUI profile kickstart for Red Hat Enterprise Linux 9
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none"
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=10240 --grow
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_cui
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-e8-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-e8-ks.cfg
@@ -1,0 +1,122 @@
+# SCAP Security Guide Essential Eight profile kickstart for Red Hat Enterprise Linux 9 Server
+# Version: 0.0.1
+# Date: 2021-07-13
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$/0RYeeRdK70ynvYz$jH2ZN/80HM6DjndHMxfUF9KIibwipitvizzXDH1zW.fTjyD3RD3tkNdNUaND18B/XqfAUW3vy1uebkBybCuIm0
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+autopart
+
+# Harden installation with Essential Eight profile
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+%addon com_redhat_oscap
+        content-type = scap-security-guide
+        profile = xccdf_org.ssgproject.content_profile_e8
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-hipaa-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-hipaa-ks.cfg
@@ -1,0 +1,122 @@
+# SCAP Security Guide HIPAA profile kickstart for Red Hat Enterprise Linux 9 Server
+# Version: 0.0.1
+# Date: 2021-07-13
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$/0RYeeRdK70ynvYz$jH2ZN/80HM6DjndHMxfUF9KIibwipitvizzXDH1zW.fTjyD3RD3tkNdNUaND18B/XqfAUW3vy1uebkBybCuIm0
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+autopart
+
+# Harden installation with HIPAA profile
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+%addon com_redhat_oscap
+        content-type = scap-security-guide
+        profile = xccdf_org.ssgproject.content_profile_hipaa
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
@@ -1,0 +1,164 @@
+# SCAP Security Guide OSPP profile kickstart for Red Hat Enterprise Linux 9
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none"
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=10240 --grow
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_ospp
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-pci-dss-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-pci-dss-ks.cfg
@@ -1,0 +1,154 @@
+# SCAP Security Guide PCI-DSS profile kickstart for Red Hat Enterprise Linux 9
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url	        the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+network --onboot yes --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+#
+# PASSWORD TEMPORARILY DISABLED
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none"
+#bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=11264 --grow
+# CCE-26557-9: Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=LogVol02 --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# CCE-26435-8: Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=LogVol01 --vgname=VolGroup --size=1024 --fsoptions="nodev,noexec,nosuid"
+# CCE-26639-5: Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=LogVol03 --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# CCE-26215-4: Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=LogVol04 --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# CCE-26436-6: Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=LogVol05 --vgname=VolGroup --size=512 --fsoptions="nodev"
+logvol swap --name=lv_swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+        content-type = scap-security-guide
+        profile = xccdf_org.ssgproject.content_profile_pci-dss
+%end
+
+# Packages selection (%packages section is required)
+%packages
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
@@ -1,0 +1,165 @@
+# SCAP Security Guide STIG profile kickstart for Red Hat Enterprise Linux 9
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=10240 --grow
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=10240 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_stig
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
@@ -1,0 +1,165 @@
+# SCAP Security Guide STIG with GUI profile kickstart for Red Hat Enterprise Linux 9
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
+#       "--bootproto=static" must be used. For example:
+# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
+#
+network --onboot yes --bootproto dhcp
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow	enable shadowed passwords by default
+# --passalgo		hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512 --fsoptions="nodev,nosuid,noexec"
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=10240 --grow
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=10240 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
+#  The following keys are recognized by the add-on:
+#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
+#      - If the content-type is scap-security-guide, the add-on will use content provided by the
+#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
+#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
+#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
+#    xccdf-id - ID of the benchmark you want to use.
+#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
+#    profile - ID of the profile to be applied. Use default to apply the default profile.
+#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
+#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
+#
+#  The following is an example %addon com_redhat_oscap section which uses content from the
+#  scap-security-guide on the installation media: 
+%addon com_redhat_oscap
+	content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_stig_gui
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject


### PR DESCRIPTION
These kickstarts are based on RHEL8 kickstarts.
- The addon invocation has been changed to com_redhat_oscap,
  as the RHEL9 addon should support this.
- References to RHEL8 were updated except documentation, where
  backwards compatibility is assumed, as there is no RHEL9 doc available.