### PR TITLE
Replace gpg keys to support Fedora 33 to 35

### DIFF
--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -18,20 +18,20 @@ cpes:
       check_id: installed_OS_is_fedora
 
 # The fingerprint and pkg_version are retrieved from https://getfedora.org/keys/
-future_version: 32
-future_release_fingerprint: "97A1AE57C3A2372CCA3A4ABA6C13026D12C944D0"
-future_pkg_version: "12c944d0"
-future_pkg_release: "5d5156ab"
+future_version: 35
+future_release_fingerprint: "787EA6AE1147EEE56C40B30CDB4639719867C58F"
+future_pkg_version: "9867c58f"
+future_pkg_release: "601c49ca"
 # Obtain the pkg_release like this:
 # sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-x86_64
 # rpm -q gpg-pubkey --qf '%{VERSION}-%{RELEASE}\n' | grep <pkg_version> | cut -f 2 -d -
 
-latest_version: 31
-latest_release_fingerprint: "7D22D5867F2A4236474BF7B850CB390B3C3359C4"
-latest_pkg_version: "3c3359c4"
-latest_pkg_release: "5c6ae44d"
+latest_version: 34
+latest_release_fingerprint: "8C5BA6990BDB26E19F2A1A801161AE6945719A39"
+latest_pkg_version: "45719a39"
+latest_pkg_release: "5f2c0192"
 
-previous_version: 30
-previous_release_fingerprint: "F1D8EC98F241AAF20DF69420EF3C111FCFC659B9"
-previous_pkg_version: "cfc659b9"
-previous_pkg_release: "5b6eac67"
+previous_version: 33
+previous_release_fingerprint: "963A2BEB02009608FE67EA4249FD77499570FF31"
+previous_pkg_version: "9570ff31"
+previous_pkg_release: "5e3006fb"


### PR DESCRIPTION
#### Description:

- Changed the GPG keys from Fedora 30-32 to Fedora 33-35, which are the current _previous, later and future_ versions.

#### Rationale:

- We are running openscap in our environments and the rule `xccdf_org.ssgproject.content_rule_ensure_fedora_gpgkey_installed` is failing due to the gpg fingerprint key for Fedora 33 is not defined.

Any guidance if this is indeed the fix or if there is a workaround to avoid this false positive will be really appreciated.