### PR TITLE
Introduce automated CCE adder

### DIFF
--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -244,6 +244,68 @@ def rewrite_value_remove_prefix(line):
     return key + ": " + new_value
 
 
+class CCEFile:
+    def __init__(self, project_root):
+        self.project_root = project_root
+
+    @property
+    def absolute_path(self):
+        raise NotImplementedError()
+
+    def line_to_cce(self, line):
+        return line
+
+    def line_isnt_cce(self, cce, line):
+        return line != cce
+
+    def read_cces(self):
+        with open(self.absolute_path, "r") as f:
+            cces = f.read().splitlines()
+        return cces
+
+    def remove_cce_from_file(self, cce):
+        file_lines = self.read_cces()
+        lines_except_cce = [
+            line for line in file_lines
+            if self.line_isnt_cce(cce, line)
+        ]
+        with open(self.absolute_path, "w") as f:
+            f.write("\n".join(lines_except_cce) + "\n")
+
+    def random_cce(self):
+        cces = self.read_cces()
+        random.shuffle(cces)
+        return cces[0].strip()
+
+
+class RedhatCCEFile(CCEFile):
+    @property
+    def absolute_path(self):
+        return os.path.join(self.project_root, "shared", "references", "cce-redhat-avail.txt")
+
+
+def add_to_the_section(file_contents, yaml_contents, section, new_keys):
+    to_insert = []
+
+    sec_ranges = find_section_lines(file_contents, section)
+    if len(sec_ranges) != 1:
+        raise RuntimeError("Refusing to fix file: %s -- could not find one section: %d"
+                           % (path, sec_ranges))
+
+    begin, end = sec_ranges[0]
+    r_lines = set()
+
+    assert end > begin, "We need at least one identifier there already"
+    template_line = str(file_contents[end - 1])
+    print(f"{template_line}")
+    leading_whitespace = re.match(r"^\s*", template_line).group()
+    for key, value in new_keys.items():
+        to_insert.append(leading_whitespace + key + ": " + value)
+
+    new_contents = file_contents[:end] + to_insert + file_contents[end:]
+    return new_contents
+
+
 def rewrite_section_value(file_contents, yaml_contents, section, keys, transform):
     # For a given section, rewrite the keys in int_keys to be strings. Refuses to
     # operate if the given section appears more than once in the file. Assumes all
@@ -334,6 +396,33 @@ def fix_invalid_cce(file_contents, yaml_contents):
                     invalid_identifiers.append(i_type)
 
     return remove_section_keys(file_contents, yaml_contents, section, invalid_identifiers)
+
+
+def has_product_cce(yaml_contents, product):
+    section = 'identifiers'
+
+    invalid_identifiers = []
+
+    if not yaml_contents[section]:
+        return False
+
+    for i_type, i_value in yaml_contents[section].items():
+        if i_type[0:3] != 'cce' or "@" not in i_type:
+            continue
+
+        _, cce_product = i_type.split("@", 1)
+        if product == cce_product:
+            return True
+
+    return False
+
+
+def add_product_cce(file_contents, yaml_contents, product, cce):
+    section = 'identifiers'
+
+    return add_to_the_section(
+        file_contents, yaml_contents, section, {f"cce@{product}": f"{cce}"})
+
 
 
 def fix_int_identifier(file_contents, yaml_contents):

--- a/utils/fix-rules.py
+++ b/utils/fix-rules.py
@@ -13,6 +13,7 @@ import ssg
 
 
 _COMMANDS = dict()
+CCE_POOLS = dict()
 
 
 def command(name, description):
@@ -317,6 +318,9 @@ class RedhatCCEFile(CCEFile):
         return os.path.join(self.project_root, "shared", "references", "cce-redhat-avail.txt")
 
 
+CCE_POOLS["redhat"] = RedhatCCEFile
+
+
 def add_to_the_section(file_contents, yaml_contents, section, new_keys):
     to_insert = []
 
@@ -326,11 +330,9 @@ def add_to_the_section(file_contents, yaml_contents, section, new_keys):
                            % section)
 
     begin, end = sec_ranges[0]
-    r_lines = set()
 
     assert end > begin, "We need at least one identifier there already"
     template_line = str(file_contents[end - 1])
-    print(f"{template_line}")
     leading_whitespace = re.match(r"^\s*", template_line).group()
     for key, value in new_keys.items():
         to_insert.append(leading_whitespace + key + ": " + value)
@@ -476,9 +478,10 @@ def add_product_cce(file_contents, yaml_contents, product, cce):
     if section not in yaml_contents:
         return file_contents
 
-    return add_to_the_section(
+    new_contents = add_to_the_section(
         file_contents, yaml_contents, section, {f"cce@{product}": f"{cce}"})
-
+    new_contents = sort_section(new_contents, yaml_contents, section)
+    return new_contents
 
 
 def fix_int_identifier(file_contents, yaml_contents):
@@ -530,7 +533,6 @@ def fix_file(path, product_yaml, func):
     with open(path, 'w') as f:
         for line in new_file_contents:
             print(line, file=f)
-    print(new_file_contents)
     return True
 
 
@@ -563,33 +565,35 @@ def fix_file_prompt(path, product_yaml, func):
 
 def add_cce(args, product_yaml):
     directory = os.path.join(args.root, args.subdirectory)
-    return _add_cce(directory, args.rule, product_yaml)
+    cce_pool = CCE_POOLS[args.cce_pool]
+    return _add_cce(directory, cce_pool, args.rule, product_yaml)
 
 
-def _add_cce(directory, rules, product_yaml):
+def _add_cce(directory, cce_pool, rules, product_yaml):
     product = product_yaml["product"]
-    cces = RedhatCCEFile()
+    cce_pool = RedhatCCEFile()
 
     def is_relevant_rule(fname, _=None):
         for r in rules:
-            if fname.endswith(f"/{r}/rule.yml"):
+            if (
+                    fname.endswith(f"/{r}/rule.yml")
+                    and has_no_cce(fname, product_yaml)):
                 return True
         return False
 
     results = find_rules(directory, is_relevant_rule, product_yaml)
-    print("Number of rules without CCEs: %d" % len(results))
 
     for result in results:
         rule_path = result[0]
 
-        cce = cces.random_cce()
+        cce = cce_pool.random_cce()
 
         def fix_callback(file_contents, yaml_contents):
             return add_product_cce(file_contents, yaml_contents, product_yaml["product"], cce)
         changes = fix_file(rule_path, product_yaml, fix_callback)
 
         if changes:
-            cces.remove_cce_from_file(cce)
+            cce_pool.remove_cce_from_file(cce)
 
 
 @command("empty_identifiers", "check and fix rules with empty identifiers")
@@ -695,6 +699,12 @@ def create_parser_from_functions(subparsers):
         subparser.set_defaults(func=function)
 
 
+def create_other_parsers(subparsers):
+    subparser = subparsers.add_parser("add-cce", description="Add CCE to rule files")
+    subparser.add_argument("rule", nargs="+")
+    subparser.add_argument("--subdirectory", default="linux_os")
+    subparser.add_argument("--cce-pool", "-p", default="redhat", choices=list(CCE_POOLS.keys()))
+    subparser.set_defaults(func=add_cce)
 
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -705,6 +715,7 @@ def parse_args():
     parser.add_argument("--product", "-p", help="Path to the main product.yml")
     subparsers = parser.add_subparsers(title="command", help="What to perform.")
     create_parser_from_functions(subparsers)
+    create_other_parsers(subparsers)
     return parser.parse_args()
 
 


### PR DESCRIPTION
You can call e.g.

`python utils/fix-rules.py -p products/rhel9/product.yml add-cce sshd_disable_root_login service_ntpd_enabled`

and the script will make sure that all rules have RHEL9 CCEs.
- CCE is not assigned if the rule is not applicable for the given product or if it already has a CCE
- CCEs are picked randomly from the file. Support for CCE pools other than the redhat pool is there.

Aside from that, the script has been reworked to remove code that looked ugly.