### PR TITLE
Add RHEL-08-010590 STIG to existing rule

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -25,6 +25,10 @@ identifiers:
 
 references:
     anssi: BP28(R12)
+    stigid@rhel8: RHEL-08-010590
+    disa: CCI-000366
+    srg: SRG-OS-000480-GPOS-00227
+    nist: CM-6(b)
 
 platform: machine
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -341,6 +341,7 @@ selections:
     - mount_option_nodev_nonroot_local_partitions
 
     # RHEL-08-010590
+    - mount_option_home_noexec
 
     # RHEL-08-010600
     - mount_option_nodev_removable_partitions

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -156,6 +156,7 @@ selections:
 - mount_option_dev_shm_nodev
 - mount_option_dev_shm_noexec
 - mount_option_dev_shm_nosuid
+- mount_option_home_noexec
 - mount_option_home_nosuid
 - mount_option_nodev_nonroot_local_partitions
 - mount_option_nodev_remote_filesystems

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -167,6 +167,7 @@ selections:
 - mount_option_dev_shm_nodev
 - mount_option_dev_shm_noexec
 - mount_option_dev_shm_nosuid
+- mount_option_home_noexec
 - mount_option_home_nosuid
 - mount_option_nodev_nonroot_local_partitions
 - mount_option_nodev_remote_filesystems


### PR DESCRIPTION
#### Description:

* Adds the STIG id for RHEL 8 to mount_option_home_noexec
* Adds mount_option_home_noexec to the RHEL8 STIG
