### PR TITLE
Add Jinja-based RHEL minor verison check

### DIFF
--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -27,6 +27,51 @@ cpes:
       title: "Red Hat Enterprise Linux 8"
       check_id: installed_OS_is_rhel8
 
+  - rhel8.0:
+      name: "cpe:/o:redhat:enterprise_linux:8.0"
+      title: "Red Hat Enterprise Linux 8.0"
+      check_id: installed_OS_is_rhel8_0
+
+  - rhel8.1:
+      name: "cpe:/o:redhat:enterprise_linux:8.1"
+      title: "Red Hat Enterprise Linux 8.1"
+      check_id: installed_OS_is_rhel8_1
+
+  - rhel8.2:
+      name: "cpe:/o:redhat:enterprise_linux:8.2"
+      title: "Red Hat Enterprise Linux 8.2"
+      check_id: installed_OS_is_rhel8_2
+
+  - rhel8.3:
+      name: "cpe:/o:redhat:enterprise_linux:8.3"
+      title: "Red Hat Enterprise Linux 8.3"
+      check_id: installed_OS_is_rhel8_3
+
+  - rhel8.4:
+      name: "cpe:/o:redhat:enterprise_linux:8.4"
+      title: "Red Hat Enterprise Linux 8.4"
+      check_id: installed_OS_is_rhel8_4
+
+  - rhel8.5:
+      name: "cpe:/o:redhat:enterprise_linux:8.5"
+      title: "Red Hat Enterprise Linux 8.5"
+      check_id: installed_OS_is_rhel8_5
+
+  - rhel8.6:
+      name: "cpe:/o:redhat:enterprise_linux:8.6"
+      title: "Red Hat Enterprise Linux 8.6"
+      check_id: installed_OS_is_rhel8_6
+
+  - rhel8.7:
+      name: "cpe:/o:redhat:enterprise_linux:8.7"
+      title: "Red Hat Enterprise Linux 8.7"
+      check_id: installed_OS_is_rhel8_7
+
+  - rhel8.8:
+      name: "cpe:/o:redhat:enterprise_linux:8.8"
+      title: "Red Hat Enterprise Linux 8.8"
+      check_id: installed_OS_is_rhel8_8
+
 # Mapping of CPE platform to package
 platform_package_overrides:
   login_defs: "shadow-utils"

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -72,6 +72,16 @@ cpes:
       title: "Red Hat Enterprise Linux 8.8"
       check_id: installed_OS_is_rhel8_8
 
+  - rhel8.9:
+      name: "cpe:/o:redhat:enterprise_linux:8.9"
+      title: "Red Hat Enterprise Linux 8.9"
+      check_id: installed_OS_is_rhel8_9
+
+  - rhel8.10:
+      name: "cpe:/o:redhat:enterprise_linux:8.10"
+      title: "Red Hat Enterprise Linux 8.10"
+      check_id: installed_OS_is_rhel8_10
+
 # Mapping of CPE platform to package
 platform_package_overrides:
   login_defs: "shadow-utils"

--- a/shared/checks/oval/installed_OS_is_rhel8.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8.xml
@@ -44,7 +44,7 @@
     <linux:name>redhat-release</linux:name>
   </linux:rpminfo_object>
 
-  {{% for minorversion in range(0, 9) %}}
+  {{% for minorversion in range(0, 11) %}}
   <definition class="inventory" id="installed_OS_is_rhel8_{{{ minorversion }}}" version="1">
     <metadata>
       <title>Red Hat Enterprise Linux 8.{{{ minorversion }}}</title>
@@ -52,13 +52,13 @@
         <platform>Red Hat Enterprise Linux 8.{{{ minorversion }}}</platform>
       </affected>
       <reference ref_id="cpe:/o:redhat:enterprise_linux:8.{{{ minorversion }}}" source="CPE" />
-      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.{{{  minorversion}}}</description>
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.{{{ minorversion }}}</description>
     </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.{{{ minorversion }}} is installed" test_ref="test_rhel8_{{{ minorversion }}}" />
+    </criteria>
   </definition>
 
-  <criteria>
-    <criterion comment="RHEL.{{{ minorversion }}} 8 is installed" test_ref="test_rhel8_{{{ minorversion }}}" />
-  </criteria>
 
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.{{{ minorversion }}}"
    id="test_rhel8_{{{ minorversion }}}" version="1">

--- a/shared/checks/oval/installed_OS_is_rhel8.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8.xml
@@ -44,6 +44,35 @@
     <linux:name>redhat-release</linux:name>
   </linux:rpminfo_object>
 
+  {{% for minorversion in range(0, 9) %}}
+  <definition class="inventory" id="installed_OS_is_rhel8_{{{ minorversion }}}" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.{{{ minorversion }}}</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.{{{ minorversion }}}</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.{{{ minorversion }}}" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.{{{  minorversion}}}</description>
+    </metadata>
+  </definition>
+
+  <criteria>
+    <criterion comment="RHEL.{{{ minorversion }}} 8 is installed" test_ref="test_rhel8_{{{ minorversion }}}" />
+  </criteria>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.{{{ minorversion }}}"
+   id="test_rhel8_{{{ minorversion }}}" version="1">
+    <linux:object object_ref="obj_rhel8_{{{ minorversion }}}" />
+    <linux:state state_ref="state_rhel8_{{{ minorversion }}}" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_{{{ minorversion }}}" version="1">
+    <linux:version operation="pattern match">^8.{{{ minorversion }}}*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_{{{ minorversion }}}" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+  {{% endfor %}}
+
   <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 8" id="test_rhevh_rhel8_version" version="1">
     <ind:object object_ref="obj_rhevh_rhel8_version" />
     <ind:state state_ref="state_rhevh_rhel8_version" />


### PR DESCRIPTION
#### Description:

Adds checks for minor versions of Red Hat Enterprise Linux.

#### Rationale:

Some of the DISA STIGs have checks that only apply to minor versions of RHEL 8.