### PR TITLE
add / fix remediations for audit rules wrt modules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_sle,multi_platform_rhel
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# Perform the remediation
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+fix_audit_watch_rule "auditctl" "/sbin/insmod" "x" "modules"
+fix_audit_watch_rule "augenrules" "/sbin/insmod" "x" "modules"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/ansible/shared.yml
@@ -1,42 +1,8 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
 
-- name: Service facts
-  service_facts:
-
-- name: Check the rules script being used
-  command:
-    grep '^ExecStartPost' /usr/lib/systemd/system/auditd.service
-  register: check_rules_scripts_result
-
-- name: Update modprobe in /etc/audit/rules.d/audit.rules
-  lineinfile:
-    path: /etc/audit/rules.d/audit.rules
-    line: '-w /sbin/modprobe -p x -k modules'
-    create: yes
-  when:
-    - '"auditd.service" in ansible_facts.services'
-    - '"augenrules" in check_rules_scripts_result.stdout'
-  register: augenrules_audit_rules_modprobe_update_result
-
-- name: Update modprobe in /etc/audit/audit.rules
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-w /sbin/modprobe -p x -k modules'
-    create: yes
-  when:
-    - '"auditd.service" in ansible_facts.services'
-    - '"auditctl" in check_rules_scripts_result.stdout'
-  register: auditctl_audit_rules_modprobe_update_result
-
-- name: Restart auditd.service
-  systemd:
-    name: auditd.service
-    state: restarted
-  when:
-    - (augenrules_audit_rules_modprobe_update_result.changed or
-       auditctl_audit_rules_modprobe_update_result.changed)
-    - ansible_facts.services["auditd.service"].state == "running"
+{{{ ansible_audit_augenrules_add_watch_rule(path='/sbin/modprobe', permissions='x', key='modules') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/sbin/modprobe', permissions='x', key='modules') }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_sle,multi_platform_rhel
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# Perform the remediation
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+fix_audit_watch_rule "auditctl" "/sbin/modprobe" "x" "modules"
+fix_audit_watch_rule "augenrules" "/sbin/modprobe" "x" "modules"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_sle,multi_platform_rhel
+
+# Include source function library.
+. /usr/share/scap-security-guide/remediation_functions
+
+# Perform the remediation
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+fix_audit_watch_rule "auditctl" "/sbin/rmmod" "x" "modules"
+fix_audit_watch_rule "augenrules" "/sbin/rmmod" "x" "modules"


### PR DESCRIPTION
#### Description:

- create bash remediations for audit_rules_privileged_commands_(insmod,modprobe,rmmod)
- make Ansible remediations applicable also for rhel for audit_rules_privileged_commands_(insmod,modprobe,rmmod)
- rewrite ansible remediation for audit_rules_privileged_commands_modprobe to use Jinja macros as other remediations

#### Rationale:

- rules were not remediated because they were missing Bash remediations
- the Ansible remediation of audit_rules_privileged_commands_modprobe was failing test scenarios
- fixes #7212 