### PR TITLE
fix ansible of accounts_root_path_dirs_no_write

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml
@@ -6,7 +6,7 @@
 - name: "Print error message if user is not root"
   fail:
     msg: 'Root account required to read root $PATH'
-  when: ansible_user != "root"
+  when: ansible_env.USER != "root"
   ignore_errors: true
 
 - name: "Get root paths which are not symbolic links"
@@ -16,7 +16,7 @@
   failed_when: False
   register: root_paths
   with_items: "{{ ansible_env.PATH.split(':') }}"
-  when: ansible_user == "root"
+  when: ansible_env.USER == "root"
 
 - name: "Disable writability to root directories"
   file:

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/correct.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+( IFS=:
+  for p in $PATH; do
+    chmod go-w $p
+  done
+)

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/wrong.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+( IFS=:
+  for p in $PATH; do
+    chmod go+w $p
+  done
+)


### PR DESCRIPTION
#### Description:

- change ansible_user to ansible_env.USER in Ansible remediation for accounts_root_path_dirs_no_write
- add tests to this rule

#### Rationale:

fixes #7234 