### PR TITLE
Multi-file templates: file_permissions/file_groupowner/file_owner

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1381,7 +1381,7 @@ the following to `rule.yml`:
 -   Parameters:
 
     -   **filepath** - File path to be checked. If the file path ends
-        with `/` it describes a directory.
+        with `/` it describes a directory. Can also be a list of paths.
 
     -   **filepath_is_regex** - If set to `"true"` the OVAL will
         consider the value of **filepath** as a regular expression.
@@ -1393,11 +1393,18 @@ the following to `rule.yml`:
         a directory specified by **filepath**. Can be set only if
         **filepath** parameter specifies a directory. Note: Applies to
         base name of files, so if a file `/foo/bar/file.txt` is
-        processed, only `file.txt` is tested against **file_regex**.
+        processed, only `file.txt` is tested against **file_regex**. Can
+        be a list of regexes.
 
     -   **filegid** - group ID (GID)
 
 -   Languages: Ansible, Bash, OVAL
+
+Note that the interaction between **filepath** and **file_regex** is as such:
+if **filepath** is a string, **file_regex** must also be a string; if **filepath**
+is a **list** and **file_regex** is a string, it gets extended to be the same regex
+for each path; if **filepath** and **file_regex** are both present and are lists,
+they must be of the same length.
 
 #### file_owner
 -   Check user that owns the given file.
@@ -1405,7 +1412,7 @@ the following to `rule.yml`:
 -   Parameters:
 
     -   **filepath** - File path to be checked. If the file path ends
-        with `/` it describes a directory.
+        with `/` it describes a directory. Can also be a list of paths.
 
     -   **filepath_is_regex** - If set to `"true"` the OVAL will
         consider the value of **filepath** as a regular expression.
@@ -1417,11 +1424,18 @@ the following to `rule.yml`:
         a directory specified by **filepath**. Can be set only if
         **filepath** parameter specifies a directory. Note: Applies to
         base name of files, so if a file `/foo/bar/file.txt` is
-        processed, only `file.txt` is tested against **file_regex**.
+        processed, only `file.txt` is tested against **file_regex**. Can
+        be a list of regexes.
 
     -   **fileuid** - user ID (UID)
 
 -   Languages: Ansible, Bash, OVAL
+
+Note that the interaction between **filepath** and **file_regex** is as such:
+if **filepath** is a string, **file_regex** must also be a string; if **filepath**
+is a **list** and **file_regex** is a string, it gets extended to be the same regex
+for each path; if **filepath** and **file_regex** are both present and are lists,
+they must be of the same length.
 
 #### file_permissions
 -   Checks permissions (mode) on a given file.
@@ -1429,7 +1443,7 @@ the following to `rule.yml`:
 -   Parameters:
 
     -   **filepath** - File path to be checked. If the file path ends
-        with `/` it describes a directory.
+        with `/` it describes a directory. Can also be a list of paths.
 
     -   **filepath_is_regex** - If set to `"true"` the OVAL will
         consider the value of **filepath** as a regular expression.
@@ -1441,7 +1455,8 @@ the following to `rule.yml`:
         a directory specified by **filepath**. Can be set only if
         **filepath** parameter specifies a directory. Note: Applies to
         base name of files, so if a file `/foo/bar/file.txt` is
-        processed, only `file.txt` is tested against **file_regex**.
+        processed, only `file.txt` is tested against **file_regex**. Can
+        be a list of regexes.
 
     -   **filemode** - File permissions in a hexadecimal format, eg.
         `'0640'`.
@@ -1451,6 +1466,12 @@ the following to `rule.yml`:
         Default value is `"true"`.
 
 -   Languages: Ansible, Bash, OVAL
+
+Note that the interaction between **filepath** and **file_regex** is as such:
+if **filepath** is a string, **file_regex** must also be a string; if **filepath**
+is a **list** and **file_regex** is a string, it gets extended to be the same regex
+for each path; if **filepath** and **file_regex** are both present and are lists,
+they must be of the same length.
 
 #### grub2_bootloader_argument
 -   Checks kernel command line arguments in GRUB 2 configuration.

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -4,11 +4,9 @@
 # complexity = low
 # disruption = low
 
-{{% if FILEPATH is not string %}}
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 
-  {{% if FILE_REGEX is not string %}}
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
   find:
     paths: "{{{ path }}}"
@@ -22,22 +20,6 @@
     group: "{{{ FILEGID }}}"
   with_items:
     - "{{ files_found.files }}"
-
-  {{% else %}}
-- name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
-  find:
-    paths: "{{{ FILEPATH }}}"
-    patterns: {{{ FILE_REGEX }}}
-    use_regex: yes
-  register: files_found
-
-- name: Ensure group owner on {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
-  file:
-    path: "{{ item.path }}"
-    group: "{{{ FILEGID }}}"
-  with_items:
-    - "{{ files_found.files }}"
-  {{% endif %}}
 
 {{% else %}}
 
@@ -54,33 +36,3 @@
 
 {{% endif %}}
 {{% endfor %}}
-{{% elif IS_DIRECTORY and FILE_REGEX %}}
-
-- name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
-  find:
-    paths: "{{{ FILEPATH }}}"
-    patterns: "{{{ FILE_REGEX }}}"
-    use_regex: yes
-  register: files_found
-
-- name: Ensure group owner on {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
-  file:
-    path: "{{ item.path }}"
-    group: "{{{ FILEGID }}}"
-  with_items:
-    - "{{ files_found.files }}"
-
-{{% else %}}
-
-- name: Test for existence {{{ FILEPATH }}}
-  stat:
-    path: "{{{ FILEPATH }}}"
-  register: file_exists
-
-- name: Ensure group owner {{{ FILEGID }}} on {{{ FILEPATH }}}
-  file:
-    path: "{{{ FILEPATH }}}"
-    group: "{{{ FILEGID }}}"
-  when: file_exists.stat is defined and file_exists.stat.exists
-
-{{% endif %}}

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -4,7 +4,57 @@
 # complexity = low
 # disruption = low
 
+{{% if FILEPATH is not string %}}
+{{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
+
+  {{% if FILE_REGEX is not string %}}
+- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
+  find:
+    paths: "{{{ path }}}"
+    patterns: {{{ FILE_REGEX[loop.index0] }}}
+    use_regex: yes
+  register: files_found
+
+- name: Ensure group owner on {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
+  file:
+    path: "{{ item.path }}"
+    group: "{{{ FILEGID }}}"
+  with_items:
+    - "{{ files_found.files }}"
+
+  {{% else %}}
+- name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
+  find:
+    paths: "{{{ FILEPATH }}}"
+    patterns: {{{ FILE_REGEX }}}
+    use_regex: yes
+  register: files_found
+
+- name: Ensure group owner on {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
+  file:
+    path: "{{ item.path }}"
+    group: "{{{ FILEGID }}}"
+  with_items:
+    - "{{ files_found.files }}"
+  {{% endif %}}
+
+{{% else %}}
+
+- name: Test for existence {{{ path }}}
+  stat:
+    path: "{{{ path }}}"
+  register: file_exists
+
+- name: Ensure group owner {{{ FILEGID }}} on {{{ path }}}
+  file:
+    path: "{{{ path }}}"
+    group: "{{{ FILEGID }}}"
+  when: file_exists.stat is defined and file_exists.stat.exists
+
+{{% endif %}}
+{{% endfor %}}
+{{% elif IS_DIRECTORY and FILE_REGEX %}}
 
 - name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
   find:

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -4,10 +4,27 @@
 # complexity = low
 # disruption = low
 
+{{% if FILEPATH is not string %}}
+{{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
+readarray -t files < <(find {{{ path }}})
+for file in "${files[@]}"; do
+    {{% if FILE_REGEX is not string %}}
+    if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
+    {{% else %}}
+    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
+    {{% endif %}}
+        chgrp {{{ FILEGID }}} $file
+    fi
+done
+{{% else %}}
+chgrp {{{ FILEGID }}} {{{ path }}}
+{{% endif %}}
+{{% endfor %}}
+{{% elif IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ FILEPATH }}})
 for file in "${files[@]}"; do
-    if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
+    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
         chgrp {{{ FILEGID }}} $file
     fi
 done

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -4,16 +4,11 @@
 # complexity = low
 # disruption = low
 
-{{% if FILEPATH is not string %}}
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
-    {{% if FILE_REGEX is not string %}}
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-    {{% else %}}
-    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
-    {{% endif %}}
         chgrp {{{ FILEGID }}} $file
     fi
 done
@@ -21,13 +16,3 @@ done
 chgrp {{{ FILEGID }}} {{{ path }}}
 {{% endif %}}
 {{% endfor %}}
-{{% elif IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ FILEPATH }}})
-for file in "${files[@]}"; do
-    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
-        chgrp {{{ FILEGID }}} $file
-    fi
-done
-{{% else %}}
-chgrp {{{ FILEGID }}} {{{ FILEPATH }}}
-{{% endif %}}

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -1,8 +1,16 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+   {{% if FILEPATH is not string %}}
+      {{{ oval_metadata("This test makes sure that FILEPATH is group owned by " + FILEGID + ".") }}}
+      <criteria>
+    {{% for filepath in FILEPATH %}}
+      <criterion comment="Check file group ownership of {{{ filepath }}}" test_ref="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" />
+    {{% endfor %}}
+   {{% else %}}
     {{{ oval_metadata("This test makes sure that " + FILEPATH + " is group owned by " + FILEGID + ".") }}}
     <criteria>
       <criterion comment="Check file group ownership of {{{ FILEPATH }}}" test_ref="test_file_groupowner{{{ FILEID }}}" />
+   {{% endif %}}
     </criteria>
   </definition>
   {{%- if MISSING_FILE_PASS -%}}
@@ -12,6 +20,33 @@
     {{# All defined files must exist. When using regex, at least one file must match #}}
     {{% set FILE_EXISTENCE = "all_exist" %}}
   {{%- endif -%}}
+
+
+  {{% if FILEPATH is not string %}}
+  {{% for filepath in FILEPATH %}}
+  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing group ownership of {{{ filepath }}}" id="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+    <unix:object object_ref="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" />
+    <unix:state state_ref="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}" />
+  </unix:file_test>
+  <unix:file_state id="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}" version="1">
+    <unix:group_id datatype="int">{{{ FILEGID }}}</unix:group_id>
+  </unix:file_state>
+  <unix:file_object comment="{{{ filepath }}}" id="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+    {{%- if IS_DIRECTORY -%}}
+      <unix:path>{{{ filepath }}}</unix:path>
+      {{%- if FILE_REGEX and FILE_REGEX is not string %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
+      {{%- elif FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else %}}
+      <unix:filename xsi:nil="true" />
+      {{%- endif %}}
+    {{%- else %}}
+      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
+    {{%- endif %}}
+  </unix:file_object>
+  {{% endfor %}}
+  {{% else %}}
   <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing group ownership of {{{ FILEPATH }}}" id="test_file_groupowner{{{ FILEID }}}" version="1">
     <unix:object object_ref="object_file_groupowner{{{ FILEID }}}" />
     <unix:state state_ref="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}" />
@@ -22,13 +57,14 @@
   <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_groupowner{{{ FILEID }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       <unix:path>{{{ FILEPATH }}}</unix:path>
-      {{%- if FILE_REGEX -%}}
-        <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
-      {{%- else -%}}
-        <unix:filename xsi:nil="true" />
-      {{%- endif -%}}
-    {{%- else -%}}
+      {{%- if FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else %}}
+      <unix:filename xsi:nil="true" />
+      {{%- endif %}}
+    {{%- else %}}
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
-    {{%- endif -%}}
+    {{%- endif %}}
   </unix:file_object>
+  {{% endif %}}
 </def-group>

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -22,7 +22,6 @@
   {{%- endif -%}}
 
 
-  {{% if FILEPATH is not string %}}
   {{% for filepath in FILEPATH %}}
   <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing group ownership of {{{ filepath }}}" id="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     <unix:object object_ref="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" />
@@ -34,10 +33,8 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       <unix:path>{{{ filepath }}}</unix:path>
-      {{%- if FILE_REGEX and FILE_REGEX is not string %}}
+      {{%- if FILE_REGEX %}}
       <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
-      {{%- elif FILE_REGEX %}}
-      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
       {{%- else %}}
       <unix:filename xsi:nil="true" />
       {{%- endif %}}
@@ -46,25 +43,4 @@
     {{%- endif %}}
   </unix:file_object>
   {{% endfor %}}
-  {{% else %}}
-  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing group ownership of {{{ FILEPATH }}}" id="test_file_groupowner{{{ FILEID }}}" version="1">
-    <unix:object object_ref="object_file_groupowner{{{ FILEID }}}" />
-    <unix:state state_ref="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}" />
-  </unix:file_test>
-  <unix:file_state id="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}" version="1">
-    <unix:group_id datatype="int">{{{ FILEGID }}}</unix:group_id>
-  </unix:file_state>
-  <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_groupowner{{{ FILEID }}}" version="1">
-    {{%- if IS_DIRECTORY -%}}
-      <unix:path>{{{ FILEPATH }}}</unix:path>
-      {{%- if FILE_REGEX %}}
-      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
-      {{%- else %}}
-      <unix:filename xsi:nil="true" />
-      {{%- endif %}}
-    {{%- else %}}
-      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
-    {{%- endif %}}
-  </unix:file_object>
-  {{% endif %}}
 </def-group>

--- a/shared/templates/file_groupowner/template.py
+++ b/shared/templates/file_groupowner/template.py
@@ -1,12 +1,21 @@
 from ssg.utils import parse_template_boolean_value
 
 def _file_owner_groupowner_permissions_regex(data):
-    data["is_directory"] = data["filepath"].endswith("/")
-    if "file_regex" in data and not data["is_directory"]:
-        raise ValueError(
-            "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-            "specify a directory. Append '/' to the filepath or remove the "
-            "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+    if isinstance(data["filepath"], list):
+        for f in data["filepath"]:
+            data["is_directory"] = f.endswith("/")
+            if "file_regex" in data and not data["is_directory"]:
+                raise ValueError(
+                    "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
+                    "specify a directory. Append '/' to the filepath or remove the "
+                    "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+    else:
+        data["is_directory"] = data["filepath"].endswith("/")
+        if "file_regex" in data and not data["is_directory"]:
+            raise ValueError(
+                "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
+                "specify a directory. Append '/' to the filepath or remove the "
+                "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
 
 
 def preprocess(data, lang):

--- a/shared/templates/file_groupowner/template.py
+++ b/shared/templates/file_groupowner/template.py
@@ -1,4 +1,4 @@
-from ssg.utils import parse_template_boolean_value
+from ssg.utils import parse_template_boolean_value, check_conflict_regex_directory
 
 def _file_owner_groupowner_permissions_regex(data):
     # this avoids code duplicates
@@ -19,20 +19,7 @@ def _file_owner_groupowner_permissions_regex(data):
                 "You should have one file_path per file_regex. Please check "
                 "rule '{0}'".format(data["_rule_id"]))
 
-    for f in data["filepath"]:
-        if "is_directory" in data and data["is_directory"] != f.endswith("/"):
-            raise ValueError(
-                "If passing a list of filepaths, all items need to be "
-                "either directories or files. Mixing is not possible. "
-                "Please fix rules '{0}' filepath '{1}'".format(data["_rule_id"], f))
-
-        data["is_directory"] = f.endswith("/")
-
-        if "file_regex" in data and not data["is_directory"]:
-            raise ValueError(
-                "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-                "specify a directory. Append '/' to the filepath or remove the "
-                "'file_regex' key.".format(data["_rule_id"], f))
+    check_conflict_regex_directory(data)
 
 
 def preprocess(data, lang):

--- a/shared/templates/file_groupowner/template.py
+++ b/shared/templates/file_groupowner/template.py
@@ -1,21 +1,38 @@
 from ssg.utils import parse_template_boolean_value
 
 def _file_owner_groupowner_permissions_regex(data):
-    if isinstance(data["filepath"], list):
-        for f in data["filepath"]:
-            data["is_directory"] = f.endswith("/")
-            if "file_regex" in data and not data["is_directory"]:
-                raise ValueError(
-                    "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-                    "specify a directory. Append '/' to the filepath or remove the "
-                    "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
-    else:
-        data["is_directory"] = data["filepath"].endswith("/")
+    # this avoids code duplicates
+    if isinstance(data["filepath"], str):
+        data["filepath"] = [ data["filepath"] ]
+
+    if "file_regex" in data:
+        # we can have a list of filepaths, but only one regex
+        # instead of declaring the same regex multiple times
+        if  isinstance(data["file_regex"], str):
+            data["file_regex"] = [ data["file_regex"] ] * len(data["filepath"])
+
+        # if the length of filepaths and file_regex are not the same, then error.
+        # in case we have multiple regexes for just one filepath, than we need
+        # to declare that filepath multiple times
+        if len(data["filepath"]) != len(data["file_regex"]):
+            raise ValueError(
+                "You should have one file_path per file_regex. Please check "
+                "rule '{0}'".format(data["_rule_id"]))
+
+    for f in data["filepath"]:
+        if "is_directory" in data and data["is_directory"] != f.endswith("/"):
+            raise ValueError(
+                "If passing a list of filepaths, all items need to be "
+                "either directories or files. Mixing is not possible. "
+                "Please fix rules '{0}' filepath '{1}'".format(data["_rule_id"], f))
+
+        data["is_directory"] = f.endswith("/")
+
         if "file_regex" in data and not data["is_directory"]:
             raise ValueError(
                 "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
                 "specify a directory. Append '/' to the filepath or remove the "
-                "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+                "'file_regex' key.".format(data["_rule_id"], f))
 
 
 def preprocess(data, lang):

--- a/shared/templates/file_groupowner/template.py
+++ b/shared/templates/file_groupowner/template.py
@@ -3,13 +3,13 @@ from ssg.utils import parse_template_boolean_value
 def _file_owner_groupowner_permissions_regex(data):
     # this avoids code duplicates
     if isinstance(data["filepath"], str):
-        data["filepath"] = [ data["filepath"] ]
+        data["filepath"] = [data["filepath"]]
 
     if "file_regex" in data:
         # we can have a list of filepaths, but only one regex
         # instead of declaring the same regex multiple times
-        if  isinstance(data["file_regex"], str):
-            data["file_regex"] = [ data["file_regex"] ] * len(data["filepath"])
+        if isinstance(data["file_regex"], str):
+            data["file_regex"] = [data["file_regex"]] * len(data["filepath"])
 
         # if the length of filepaths and file_regex are not the same, then error.
         # in case we have multiple regexes for just one filepath, than we need

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -4,7 +4,50 @@
 # complexity = low
 # disruption = low
 
+{{% if FILEPATH is not string %}}
+{{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
+
+  {{% if FILE_REGEX is not string %}}
+- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
+  find:
+    paths: "{{{ path }}}"
+    patterns: {{{ FILE_REGEX[loop.index0] }}}
+    use_regex: yes
+  register: files_found
+
+- name: Ensure group owner on {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
+  file:
+    path: "{{ item.path }}"
+    owner: "{{{ FILEUID }}}"
+  with_items:
+    - "{{ files_found.files }}"
+
+  {{% else %}}
+- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX }}}
+  find:
+    paths: "{{{ path }}}"
+    patterns: {{{ FILE_REGEX }}}
+    use_regex: yes
+  register: files_found
+  {{% endif %}}
+
+{{% else %}}
+
+- name: Test for existence {{{ path }}}
+  stat:
+    path: "{{{ path }}}"
+  register: file_exists
+
+- name: Ensure owner {{{ FILEUID }}} on {{{ path }}}
+  file:
+    path: "{{{ path }}}"
+    owner: "{{{ FILEUID }}}"
+  when: file_exists.stat is defined and file_exists.stat.exists
+
+{{% endif %}}
+{{% endfor %}}
+{{% elif IS_DIRECTORY and FILE_REGEX %}}
 
 - name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
   find:

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -4,11 +4,9 @@
 # complexity = low
 # disruption = low
 
-{{% if FILEPATH is not string %}}
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 
-  {{% if FILE_REGEX is not string %}}
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
   find:
     paths: "{{{ path }}}"
@@ -22,15 +20,6 @@
     owner: "{{{ FILEUID }}}"
   with_items:
     - "{{ files_found.files }}"
-
-  {{% else %}}
-- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX }}}
-  find:
-    paths: "{{{ path }}}"
-    patterns: {{{ FILE_REGEX }}}
-    use_regex: yes
-  register: files_found
-  {{% endif %}}
 
 {{% else %}}
 
@@ -47,33 +36,3 @@
 
 {{% endif %}}
 {{% endfor %}}
-{{% elif IS_DIRECTORY and FILE_REGEX %}}
-
-- name: Find {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
-  find:
-    paths: "{{{ FILEPATH }}}"
-    patterns: "{{{ FILE_REGEX }}}"
-    use_regex: yes
-  register: files_found
-
-- name: Ensure group owner on {{{ FILEPATH }}} file(s) matching {{{ FILE_REGEX }}}
-  file:
-    path: "{{ item.path }}"
-    owner: "{{{ FILEUID }}}"
-  with_items:
-    - "{{ files_found.files }}"
-
-{{% else %}}
-
-- name: Test for existence {{{ FILEPATH }}}
-  stat:
-    path: "{{{ FILEPATH }}}"
-  register: file_exists
-
-- name: Ensure owner {{{ FILEUID }}} on {{{ FILEPATH }}}
-  file:
-    path: "{{{ FILEPATH }}}"
-    owner: "{{{ FILEUID }}}"
-  when: file_exists.stat is defined and file_exists.stat.exists
-
-{{% endif %}}

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -4,16 +4,11 @@
 # complexity = low
 # disruption = low
 
-{{% if FILEPATH is not string %}}
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
-    {{% if FILE_REGEX is not string %}}
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-    {{% else %}}
-    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
-    {{% endif %}}
         chown {{{ FILEUID }}} $file
     fi
 done
@@ -21,13 +16,3 @@ done
 chown {{{ FILEUID }}} {{{ path }}}
 {{% endif %}}
 {{% endfor %}}
-{{% elif IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ FILEPATH }}})
-for file in "${files[@]}"; do
-    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
-        chown {{{ FILEUID }}} $file
-    fi
-done
-{{% else %}}
-chown {{{ FILEUID }}} {{{ FILEPATH }}}
-{{% endif %}}

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -4,10 +4,27 @@
 # complexity = low
 # disruption = low
 
+{{% if FILEPATH is not string %}}
+{{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
+readarray -t files < <(find {{{ path }}})
+for file in "${files[@]}"; do
+    {{% if FILE_REGEX is not string %}}
+    if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
+    {{% else %}}
+    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
+    {{% endif %}}
+        chown {{{ FILEUID }}} $file
+    fi
+done
+{{% else %}}
+chown {{{ FILEUID }}} {{{ path }}}
+{{% endif %}}
+{{% endfor %}}
+{{% elif IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ FILEPATH }}})
 for file in "${files[@]}"; do
-    if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
+    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
         chown {{{ FILEUID }}} $file
     fi
 done

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -21,7 +21,6 @@
     {{% set FILE_EXISTENCE = "all_exist" %}}
   {{%- endif -%}}
 
-  {{% if FILEPATH is not string %}}
   {{% for filepath in FILEPATH %}}
   <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing user ownership of {{{ filepath }}}" id="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     <unix:object object_ref="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" />
@@ -33,10 +32,8 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       <unix:path>{{{ filepath }}}</unix:path>
-      {{%- if FILE_REGEX and FILE_REGEX is not string %}}
+      {{%- if FILE_REGEX %}}
       <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
-      {{%- elif FILE_REGEX %}}
-      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
       {{%- else %}}
       <unix:filename xsi:nil="true" />
       {{%- endif %}}
@@ -45,25 +42,4 @@
     {{%- endif %}}
   </unix:file_object>
   {{% endfor %}}
-  {{% else %}}
-  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing user ownership of {{{ FILEPATH }}}" id="test_file_owner{{{ FILEID }}}" version="1">
-    <unix:object object_ref="object_file_owner{{{ FILEID }}}" />
-    <unix:state state_ref="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}" />
-  </unix:file_test>
-  <unix:file_state id="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}" version="1">
-    <unix:user_id datatype="int">{{{ FILEUID }}}</unix:user_id>
-  </unix:file_state>
-  <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_owner{{{ FILEID }}}" version="1">
-    {{%- if IS_DIRECTORY -%}}
-      <unix:path>{{{ FILEPATH }}}</unix:path>
-      {{%- if FILE_REGEX %}}
-      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
-      {{%- else %}}
-      <unix:filename xsi:nil="true" />
-      {{%- endif %}}
-    {{%- else %}}
-      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
-    {{%- endif %}}
-  </unix:file_object>
-  {{% endif %}}
 </def-group>

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -1,8 +1,16 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+  {{% if FILEPATH is not string %}}
+    {{{ oval_metadata("This test makes sure that FILEPATH is owned by " + FILEUID + ".") }}}
+     <criteria>
+   {{% for filepath in FILEPATH %}}
+     <criterion comment="Check file ownership of {{{ filepath }}}" test_ref="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" />
+   {{% endfor %}}
+  {{% else %}}
     {{{ oval_metadata("This test makes sure that " + FILEPATH + " is owned by " + FILEUID + ".") }}}
     <criteria>
       <criterion comment="Check file ownership of {{{ FILEPATH }}}" test_ref="test_file_owner{{{ FILEID }}}" />
+  {{% endif %}}
     </criteria>
   </definition>
   {{%- if MISSING_FILE_PASS -%}}
@@ -12,6 +20,32 @@
     {{# All defined files must exist. When using regex, at least one file must match #}}
     {{% set FILE_EXISTENCE = "all_exist" %}}
   {{%- endif -%}}
+
+  {{% if FILEPATH is not string %}}
+  {{% for filepath in FILEPATH %}}
+  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing user ownership of {{{ filepath }}}" id="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+    <unix:object object_ref="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" />
+    <unix:state state_ref="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}_{{{ loop.index0 }}}" />
+  </unix:file_test>
+  <unix:file_state id="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}_{{{ loop.index0 }}}" version="1">
+    <unix:user_id datatype="int">{{{ FILEUID }}}</unix:user_id>
+  </unix:file_state>
+  <unix:file_object comment="{{{ filepath }}}" id="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+    {{%- if IS_DIRECTORY -%}}
+      <unix:path>{{{ filepath }}}</unix:path>
+      {{%- if FILE_REGEX and FILE_REGEX is not string %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
+      {{%- elif FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else %}}
+      <unix:filename xsi:nil="true" />
+      {{%- endif %}}
+    {{%- else %}}
+      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
+    {{%- endif %}}
+  </unix:file_object>
+  {{% endfor %}}
+  {{% else %}}
   <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing user ownership of {{{ FILEPATH }}}" id="test_file_owner{{{ FILEID }}}" version="1">
     <unix:object object_ref="object_file_owner{{{ FILEID }}}" />
     <unix:state state_ref="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}" />
@@ -22,13 +56,14 @@
   <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_owner{{{ FILEID }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       <unix:path>{{{ FILEPATH }}}</unix:path>
-      {{%- if FILE_REGEX -%}}
-        <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
-      {{%- else -%}}
-        <unix:filename xsi:nil="true" />
-      {{%- endif -%}}
-    {{%- else -%}}
+      {{%- if FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else %}}
+      <unix:filename xsi:nil="true" />
+      {{%- endif %}}
+    {{%- else %}}
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
-    {{%- endif -%}}
+    {{%- endif %}}
   </unix:file_object>
+  {{% endif %}}
 </def-group>

--- a/shared/templates/file_owner/template.py
+++ b/shared/templates/file_owner/template.py
@@ -3,13 +3,13 @@ from ssg.utils import parse_template_boolean_value
 def _file_owner_groupowner_permissions_regex(data):
     # this avoids code duplicates
     if isinstance(data["filepath"], str):
-        data["filepath"] = [ data["filepath"] ]
+        data["filepath"] = [data["filepath"]]
 
     if "file_regex" in data:
         # we can have a list of filepaths, but only one regex
         # instead of declaring the same regex multiple times
         if isinstance(data["file_regex"], str):
-            data["file_regex"] = [ data["file_regex"] ] * len(data["filepath"])
+            data["file_regex"] = [data["file_regex"]] * len(data["filepath"])
 
         # if the length of filepaths and file_regex are not the same, then error.
         # in case we have multiple regexes for just one filepath, than we need

--- a/shared/templates/file_owner/template.py
+++ b/shared/templates/file_owner/template.py
@@ -1,21 +1,38 @@
 from ssg.utils import parse_template_boolean_value
 
 def _file_owner_groupowner_permissions_regex(data):
-    if isinstance(data["filepath"], list):
-        for f in data["filepath"]:
-            data["is_directory"] = f.endswith("/")
-            if "file_regex" in data and not data["is_directory"]:
-                raise ValueError(
-                    "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-                    "specify a directory. Append '/' to the filepath or remove the "
-                    "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
-    else:
-        data["is_directory"] = data["filepath"].endswith("/")
+    # this avoids code duplicates
+    if isinstance(data["filepath"], str):
+        data["filepath"] = [ data["filepath"] ]
+
+    if "file_regex" in data:
+        # we can have a list of filepaths, but only one regex
+        # instead of declaring the same regex multiple times
+        if isinstance(data["file_regex"], str):
+            data["file_regex"] = [ data["file_regex"] ] * len(data["filepath"])
+
+        # if the length of filepaths and file_regex are not the same, then error.
+        # in case we have multiple regexes for just one filepath, than we need
+        # to declare that filepath multiple times
+        if len(data["filepath"]) != len(data["file_regex"]):
+            raise ValueError(
+                "You should have one file_path per file_regex. Please check "
+                "rule '{0}'".format(data["_rule_id"]))
+
+    for f in data["filepath"]:
+        if "is_directory" in data and data["is_directory"] != f.endswith("/"):
+            raise ValueError(
+                "If passing a list of filepaths, all of them need to be "
+                "either directories or files. Mixing is not possible. "
+                "Please fix rules '{0}' filepath '{1}'".format(data["_rule_id"], f))
+
+        data["is_directory"] = f.endswith("/")
+
         if "file_regex" in data and not data["is_directory"]:
             raise ValueError(
                 "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
                 "specify a directory. Append '/' to the filepath or remove the "
-                "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+                "'file_regex' key.".format(data["_rule_id"], f))
 
 
 def preprocess(data, lang):

--- a/shared/templates/file_owner/template.py
+++ b/shared/templates/file_owner/template.py
@@ -1,4 +1,4 @@
-from ssg.utils import parse_template_boolean_value
+from ssg.utils import parse_template_boolean_value, check_conflict_regex_directory
 
 def _file_owner_groupowner_permissions_regex(data):
     # this avoids code duplicates
@@ -19,20 +19,7 @@ def _file_owner_groupowner_permissions_regex(data):
                 "You should have one file_path per file_regex. Please check "
                 "rule '{0}'".format(data["_rule_id"]))
 
-    for f in data["filepath"]:
-        if "is_directory" in data and data["is_directory"] != f.endswith("/"):
-            raise ValueError(
-                "If passing a list of filepaths, all of them need to be "
-                "either directories or files. Mixing is not possible. "
-                "Please fix rules '{0}' filepath '{1}'".format(data["_rule_id"], f))
-
-        data["is_directory"] = f.endswith("/")
-
-        if "file_regex" in data and not data["is_directory"]:
-            raise ValueError(
-                "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-                "specify a directory. Append '/' to the filepath or remove the "
-                "'file_regex' key.".format(data["_rule_id"], f))
+    check_conflict_regex_directory(data)
 
 
 def preprocess(data, lang):

--- a/shared/templates/file_owner/template.py
+++ b/shared/templates/file_owner/template.py
@@ -1,12 +1,21 @@
 from ssg.utils import parse_template_boolean_value
 
 def _file_owner_groupowner_permissions_regex(data):
-    data["is_directory"] = data["filepath"].endswith("/")
-    if "file_regex" in data and not data["is_directory"]:
-        raise ValueError(
-            "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-            "specify a directory. Append '/' to the filepath or remove the "
-            "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+    if isinstance(data["filepath"], list):
+        for f in data["filepath"]:
+            data["is_directory"] = f.endswith("/")
+            if "file_regex" in data and not data["is_directory"]:
+                raise ValueError(
+                    "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
+                    "specify a directory. Append '/' to the filepath or remove the "
+                    "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+    else:
+        data["is_directory"] = data["filepath"].endswith("/")
+        if "file_regex" in data and not data["is_directory"]:
+            raise ValueError(
+                "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
+                "specify a directory. Append '/' to the filepath or remove the "
+                "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
 
 
 def preprocess(data, lang):

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -4,7 +4,6 @@
 # complexity = low
 # disruption = low
 
-{{% if FILEPATH is not string %}}
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 
@@ -41,33 +40,3 @@
 
 {{% endif %}}
 {{% endfor %}}
-{{% elif IS_DIRECTORY and FILE_REGEX %}}
-
-- name: Find {{{ FILEPATH }}} file(s)
-  find:
-    paths: "{{{ FILEPATH }}}"
-    patterns: "{{{ FILE_REGEX }}}"
-    use_regex: yes
-  register: files_found
-
-- name: Set permissions for {{{ FILEPATH }}} file(s)
-  file:
-    path: "{{ item.path }}"
-    mode: "{{{ FILEMODE }}}"
-  with_items:
-    - "{{ files_found.files }}"
-
-{{% else %}}
-
-- name: Test for existence {{{ FILEPATH }}}
-  stat:
-    path: "{{{ FILEPATH }}}"
-  register: file_exists
-  
-- name: Ensure permission {{{ FILEMODE }}} on {{{ FILEPATH }}}
-  file:
-    path: "{{{ FILEPATH }}}"
-    mode: "{{{ FILEMODE }}}"
-  when: file_exists.stat is defined and file_exists.stat.exists
-
-{{% endif %}}

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -3,7 +3,45 @@
 # strategy = configure
 # complexity = low
 # disruption = low
+
+{{% if FILEPATH is not string %}}
+{{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
+
+- name: Find {{{ path }}} file(s)
+  find:
+    paths: "{{{ path }}}"
+    {{% if FILE_REGEX is not string %}}
+    patterns: {{{ FILE_REGEX[loop.index0] }}}
+    {{% else %}}
+    patterns: {{{ FILE_REGEX }}}
+    {{% endif %}}
+    use_regex: yes
+  register: files_found
+
+- name: Set permissions for {{{ path }}} file(s)
+  file:
+    path: "{{ item.path }}"
+    mode: "{{{ FILEMODE }}}"
+  with_items:
+    - "{{ files_found.files }}"
+
+{{% else %}}
+
+- name: Test for existence {{{ path }}}
+  stat:
+    path: "{{{ path }}}"
+  register: file_exists
+  
+- name: Ensure permission {{{ FILEMODE }}} on {{{ path }}}
+  file:
+    path: "{{{ path }}}"
+    mode: "{{{ FILEMODE }}}"
+  when: file_exists.stat is defined and file_exists.stat.exists
+
+{{% endif %}}
+{{% endfor %}}
+{{% elif IS_DIRECTORY and FILE_REGEX %}}
 
 - name: Find {{{ FILEPATH }}} file(s)
   find:

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -4,13 +4,21 @@
 # complexity = low
 # disruption = low
 
+{{% if FILEPATH is not string %}}
+{{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ FILEPATH }}})
+readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
-    if basename $file | grep -q '{{{ FILE_REGEX }}}'; then
+    {{% if FILE_REGEX is not string %}}
+    if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
+    {{% else %}}
+    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
+    {{% endif %}}
         chmod {{{ FILEMODE }}} $file
     fi    
 done
 {{% else %}}
-chmod {{{ FILEMODE }}} {{{ FILEPATH }}}
+chmod {{{ FILEMODE }}} {{{ path }}}
 {{% endif %}}
+{{% endfor %}}
+{{% elif IS_DIRECTORY and FILE_REGEX %}}

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -4,16 +4,11 @@
 # complexity = low
 # disruption = low
 
-{{% if FILEPATH is not string %}}
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
-    {{% if FILE_REGEX is not string %}}
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-    {{% else %}}
-    if basename $file | grep -qE '{{{ FILE_REGEX }}}'; then
-    {{% endif %}}
         chmod {{{ FILEMODE }}} $file
     fi    
 done
@@ -21,4 +16,3 @@ done
 chmod {{{ FILEMODE }}} {{{ path }}}
 {{% endif %}}
 {{% endfor %}}
-{{% elif IS_DIRECTORY and FILE_REGEX %}}

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -24,7 +24,6 @@
     </criteria>
   </definition>
 
-  {{% if FILEPATH is not string %}}
   {{% for filepath in FILEPATH %}}
   <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing mode of {{{ filepath }}}" id="test_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="2">
     <unix:object object_ref="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" />
@@ -37,10 +36,8 @@
 
     {{%- if IS_DIRECTORY %}}
       <unix:path>{{{ filepath }}}</unix:path>
-      {{%- if FILE_REGEX and FILE_REGEX is not string %}}
+      {{%- if FILE_REGEX %}}
       <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
-      {{%- elif FILE_REGEX %}}
-      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
       {{%- else %}}
       <unix:filename xsi:nil="true" />
       {{%- endif %}}
@@ -58,35 +55,4 @@
     {{%- endif %}}
   </unix:file_object>
   {{% endfor %}}
-  {{% else %}}
-      <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing mode of {{{ FILEPATH }}}" id="test_file_permissions{{{ FILEID }}}" version="2">
-      <unix:object object_ref="object_file_permissions{{{ FILEID }}}" />
-      <unix:state state_ref="state_file_permissions{{{ FILEID }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}" />
-    </unix:file_test>
-    <unix:file_state id="state_file_permissions{{{ FILEID }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}"{{{ ' operator="OR"' if ALLOW_STRICTER_PERMISSIONS }}} version="2">
-      {{{ STATEMODE | indent(6) }}}
-    </unix:file_state>
-    <unix:file_object comment="{{{ FILEPATH }}}" id="object_file_permissions{{{ FILEID }}}" version="1">
-
-    {{%- if IS_DIRECTORY %}}
-      <unix:path>{{{ FILEPATH }}}</unix:path>
-      {{%- if FILE_REGEX %}}
-      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
-      {{%- else %}}
-      <unix:filename xsi:nil="true" />
-      {{%- endif %}}
-    {{%- else %}}
-      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ FILEPATH }}}</unix:filepath>
-    {{%- endif %}}
-
-    {{%- if ALLOW_STRICTER_PERMISSIONS %}}
-      {{#
-          This filter is required because of an issue in OpenSCAP. The issue has been fixed in:
-          https://github.com/OpenSCAP/openscap/pull/1709 but this line should be kept until the
-          fix is widely available. The fix is expected to be part of OpenSCAP >= 1.3.5.
-      #}}
-      <filter action="include">state_file_permissions{{{ FILEID }}}_mode_not_{{{ FILEMODE }}}</filter>
-    {{%- endif %}}
-
-    </unix:file_object>
 </def-group>

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -16,11 +16,21 @@
 {{%- endif -%}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
-    {{{ oval_metadata("This test makes sure that " + FILEPATH + " has mode " + FILEMODE + ".
+  {{% if FILEPATH is not string %}}
+    {{{ oval_metadata("This test makes sure that FILEPATH has mode " + FILEMODE + ".
+      If the target file or directory has an extended ACL, then it will fail the mode check.
+      ") }}}
+    <criteria>
+  {{% for filepath in FILEPATH %}}
+      <criterion comment="Check file mode of {{{ filepath }}}" test_ref="test_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}"{{{ ' negate="true"' if ALLOW_STRICTER_PERMISSIONS }}}/>
+  {{% endfor %}}
+  {{% else %}}
+    {{{ oval_metadata("This test makes sure that " +  FILEPATH + " has mode " + FILEMODE + ".
       If the target file or directory has an extended ACL, then it will fail the mode check.
       ") }}}
     <criteria>
       <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_file_permissions{{{ FILEID }}}"{{{ ' negate="true"' if ALLOW_STRICTER_PERMISSIONS }}}/>
+  {{% endif %}}
     </criteria>
   </definition>
 

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -23,6 +23,42 @@
       <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_file_permissions{{{ FILEID }}}"{{{ ' negate="true"' if ALLOW_STRICTER_PERMISSIONS }}}/>
     </criteria>
   </definition>
+
+  {{% if FILEPATH is not string %}}
+  {{% for filepath in FILEPATH %}}
+  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing mode of {{{ filepath }}}" id="test_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="2">
+    <unix:object object_ref="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" />
+    <unix:state state_ref="state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}" />
+  </unix:file_test>
+  <unix:file_state id="state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}"{{{ ' operator="OR"' if ALLOW_STRICTER_PERMISSIONS }}} version="2">
+      {{{ STATEMODE | indent(6) }}}
+  </unix:file_state>
+  <unix:file_object comment="{{{ filepath }}}" id="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+
+    {{%- if IS_DIRECTORY %}}
+      <unix:path>{{{ filepath }}}</unix:path>
+      {{%- if FILE_REGEX and FILE_REGEX is not string %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
+      {{%- elif FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX }}}</unix:filename>
+      {{%- else %}}
+      <unix:filename xsi:nil="true" />
+      {{%- endif %}}
+    {{%- else %}}
+      <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
+    {{%- endif %}}
+
+    {{%- if ALLOW_STRICTER_PERMISSIONS %}}
+      {{#
+          This filter is required because of an issue in OpenSCAP. The issue has been fixed in:
+          https://github.com/OpenSCAP/openscap/pull/1709 but this line should be kept until the
+          fix is widely available. The fix is expected to be part of OpenSCAP >= 1.3.5.
+      #}}
+      <filter action="include">state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_not_{{{ FILEMODE }}}</filter>
+    {{%- endif %}}
+  </unix:file_object>
+  {{% endfor %}}
+  {{% else %}}
       <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing mode of {{{ FILEPATH }}}" id="test_file_permissions{{{ FILEID }}}" version="2">
       <unix:object object_ref="object_file_permissions{{{ FILEID }}}" />
       <unix:state state_ref="state_file_permissions{{{ FILEID }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}" />

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -3,13 +3,13 @@ from ssg.utils import parse_template_boolean_value
 def _file_owner_groupowner_permissions_regex(data):
     # this avoids code duplicates
     if isinstance(data["filepath"], str):
-        data["filepath"] = [ data["filepath"] ]
+        data["filepath"] = [data["filepath"]]
 
     if "file_regex" in data:
         # we can have a list of filepaths, but only one regex
         # instead of declaring the same regex multiple times
         if isinstance(data["file_regex"], str):
-            data["file_regex"] = [ data["file_regex"] ] * len(data["filepath"])
+            data["file_regex"] = [data["file_regex"]] * len(data["filepath"])
 
         # if the length of filepaths and file_regex are not the same, then error.
         # in case we have multiple regexes for just one filepath, than we need

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -1,4 +1,4 @@
-from ssg.utils import parse_template_boolean_value
+from ssg.utils import parse_template_boolean_value, check_conflict_regex_directory
 
 def _file_owner_groupowner_permissions_regex(data):
     # this avoids code duplicates
@@ -19,20 +19,7 @@ def _file_owner_groupowner_permissions_regex(data):
                 "You should have one file_path per file_regex. Please check "
                 "rule '{0}'".format(data["_rule_id"]))
 
-    for f in data["filepath"]:
-        if "is_directory" in data and data["is_directory"] != f.endswith("/"):
-            raise ValueError(
-                "If passing a list of filepaths, all of them need to be "
-                "either directories or files. Mixing is not possible. "
-                "Please fix rules '{0}' filepath '{1}'".format(data["_rule_id"], f))
-
-        data["is_directory"] = f.endswith("/")
-
-        if "file_regex" in data and not data["is_directory"]:
-            raise ValueError(
-                "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-                "specify a directory. Append '/' to the filepath or remove the "
-                "'file_regex' key.".format(data["_rule_id"], f))
+    check_conflict_regex_directory(data)
 
 
 def preprocess(data, lang):

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -1,12 +1,38 @@
 from ssg.utils import parse_template_boolean_value
 
 def _file_owner_groupowner_permissions_regex(data):
-    data["is_directory"] = data["filepath"].endswith("/")
-    if "file_regex" in data and not data["is_directory"]:
-        raise ValueError(
-            "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
-            "specify a directory. Append '/' to the filepath or remove the "
-            "'file_regex' key.".format(data["_rule_id"], data["filepath"]))
+    # this avoids code duplicates
+    if isinstance(data["filepath"], str):
+        data["filepath"] = [ data["filepath"] ]
+
+    if "file_regex" in data:
+        # we can have a list of filepaths, but only one regex
+        # instead of declaring the same regex multiple times
+        if isinstance(data["file_regex"], str):
+            data["file_regex"] = [ data["file_regex"] ] * len(data["filepath"])
+
+        # if the length of filepaths and file_regex are not the same, then error.
+        # in case we have multiple regexes for just one filepath, than we need
+        # to declare that filepath multiple times
+        if len(data["filepath"]) != len(data["file_regex"]):
+            raise ValueError(
+                "You should have one file_path per file_regex. Please check "
+                "rule '{0}'".format(data["_rule_id"]))
+
+    for f in data["filepath"]:
+        if "is_directory" in data and data["is_directory"] != f.endswith("/"):
+            raise ValueError(
+                "If passing a list of filepaths, all of them need to be "
+                "either directories or files. Mixing is not possible. "
+                "Please fix rules '{0}' filepath '{1}'".format(data["_rule_id"], f))
+
+        data["is_directory"] = f.endswith("/")
+
+        if "file_regex" in data and not data["is_directory"]:
+            raise ValueError(
+                "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
+                "specify a directory. Append '/' to the filepath or remove the "
+                "'file_regex' key.".format(data["_rule_id"], f))
 
 
 def preprocess(data, lang):

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -303,3 +303,25 @@ def parse_template_boolean_value(data, parameter, default_value):
         raise ValueError(
             "Template parameter {} used in rule {} cannot accept the "
             "value {}".format(parameter, data["_rule_id"], value))
+
+
+def check_conflict_regex_directory(data):
+    """
+    Validate that either all path are directories OR file_regex exists.
+
+    Throws ValueError.
+    """
+    for f in data["filepath"]:
+        if "is_directory" in data and data["is_directory"] != f.endswith("/"):
+            raise ValueError(
+                "If passing a list of filepaths, all of them need to be "
+                "either directories or files. Mixing is not possible. "
+                "Please fix rules '{0}' filepath '{1}'".format(data["_rule_id"], f))
+
+        data["is_directory"] = f.endswith("/")
+
+        if "file_regex" in data and not data["is_directory"]:
+            raise ValueError(
+                "Used 'file_regex' key in rule '{0}' but filepath '{1}' does not "
+                "specify a directory. Append '/' to the filepath or remove the "
+                "'file_regex' key.".format(data["_rule_id"], f))


### PR DESCRIPTION
(@dodys is the author of these changes; he's out on PTO and agreed to let me upstream them in the mean time).

#### Description:

As discussed on Gitter and in the comments on several previous pull requests, this introduces changes to the three main file ACL checking templates (`file_permissions`, `file_groupowner`, and `file_owner`) to support changing ACLs on multiple paths. 

All forms of these rules (concrete path and regex) have been extended.

The behavior is as follows:

 - One or more concrete path is allowed.
 - Using a glob, either:
    - Multiple paths under a single regex,
    - a 1:1 correspondence of paths to regexes (first path with first regex, second path with second regex, &c).

This means that one path with multiple regexes still needs the path explicitly duplicated each time. 

In order to simplify the logic, we use `template.py` to coerce regex and filepath to a list of the same length (and abort if of different sizes), and then the templates can strictly handle the multiple-option path.  

#### Rationale:

Many of the new SUSE rules around STIG compliance apply to multiple files/directories. These rules are generally useful across platforms (including for RHEL and Ubuntu content) -- but hand-writing custom Bash/OVAL/... for each platform isn't generally worth the time. Writing a jinja macro could've sufficed, but since we already have templates for this, we might as well leverage them instead. 

---

We can either open this PR as-is and then update rules in another PR, or I can include one or more rules using the updated form of this template in this PR. I'll leave it up to the maintainers to decide. 

/cc @dodys @richardmaciel-canonical 