### PR TITLE
remove broken links to support.ntp.org

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -31,9 +31,7 @@ rationale: |-
     maintaining accurate logs and auditing possible security breaches.
     <br /><br />
     The <tt>chronyd</tt> and <tt>ntpd</tt> NTP daemons offer all of the
-    functionality of <tt>ntpdate</tt>, which is now deprecated. Additional
-    information on this is available at
-    {{{ weblink(link="http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate") }}}
+    functionality of <tt>ntpdate</tt>, which is now deprecated.
 
 severity: medium
 

--- a/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
@@ -15,8 +15,7 @@ rationale: |-
     logs and auditing possible security breaches.
     <br /><br />
     The NTP daemon offers all of the functionality of <tt>ntpdate</tt>, which is now
-    deprecated.  Additional information on this is available at
-    {{{ weblink(link="http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate") }}}.
+    deprecated.
 
 severity: high
 

--- a/linux_os/guide/services/ntp/service_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntpd_enabled/rule.yml
@@ -15,8 +15,7 @@ rationale: |-
     logs and auditing possible security breaches.
     <br /><br />
     The NTP daemon offers all of the functionality of <tt>ntpdate</tt>, which is now
-    deprecated.  Additional information on this is available at
-    {{{ weblink(link="http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate") }}}.
+    deprecated.
 
 severity: medium
 


### PR DESCRIPTION
#### Description:

- Remove sentences referencing links to support.ntp.org. It was about deprecation of ntpdate.

#### Rationale:

- the site seems to have problems with correct connectivity for several weeks.
- fixes #7230 

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
