### PR TITLE
Mark as machine rules that collect password_object

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
@@ -23,6 +23,9 @@ references:
     stigid@sle12: SLES-12-010640
     stigid@sle15: SLES-15-010230
 
+# The rule check uses password probe, which doesn't support offline mode
+platform: machine
+
 ocil_clause: 'a line is returned'
 
 ocil: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
@@ -34,6 +34,9 @@ references:
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     pcidss: Req-8.2.1
 
+# The rule check uses password probe, which doesn't support offline mode
+platform: machine
+
 ocil_clause: 'any stored hashes are found in /etc/passwd'
 
 ocil: |-

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -53,6 +53,9 @@ references:
     stigid@sle12: SLES-12-010690
     stigid@sle15: SLES-15-040400
 
+# The rule check uses password probe, which doesn't support offline mode
+platform: machine
+
 ocil_clause: 'files exist that are not owned by a valid user'
 
 ocil: |-


### PR DESCRIPTION
#### Description:

- Mark as machine rules that collect password_object

#### Rationale:

- The password probe doesn't support offline mode, and the rule results in unknown.
- Related to #7238
