### PR TITLE
OCP4: The moderate profile requires the audit profile to be WriteRequestBodies

### DIFF
--- a/applications/openshift/logging/audit_profile_set/tests/ocp4/e2e.yml
+++ b/applications/openshift/logging/audit_profile_set/tests/ocp4/e2e.yml
@@ -1,2 +1,0 @@
----
-default_result: PASS

--- a/products/ocp4/profiles/moderate.profile
+++ b/products/ocp4/profiles/moderate.profile
@@ -55,6 +55,7 @@ selections:
     - banner_or_login_template_set
 
     # AU
+    - var_openshift_audit_profile=WriteRequestBodies
     - audit_profile_set
 
     # AU-9


### PR DESCRIPTION
This is needed to cover AU-3(1).

Unfortunately, our CI infra is not yet equipped to handle tests that
need different results for different benchmarks and in this case it
would be needed - CIS requires the Default audit profile to be used, so
the rule passes by default and doesn't need a remediation whereas
moderate checks for WriteRequestBodies so the rule fails by default and
needs to be remediated. Therefore the e2e test is removed for this rule
until we enhance the e2e test machinery.