### PR TITLE
OCP4: fips_mode_enabled rule relates to IA-7

### DIFF
--- a/applications/openshift/integrity/crypto/fips_mode_enabled/rule.yml
+++ b/applications/openshift/integrity/crypto/fips_mode_enabled/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 
 references:
   nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1,CIP-007-3 R7.1
-  nist: AC-17(2),SC-13
+  nist: AC-17(2),SC-13,IA-7
 
 ocil_clause: 'FIPS mode is not enabled'
 


### PR DESCRIPTION
#### Description:

- Just tags the fips_mode_enabled rule with IA-7

#### Rationale:

- book-keeping