### PR TITLE
Move content-test-filtering github action job to a separate file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,28 +36,3 @@ jobs:
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
-
-  content-test-filtering:
-    name: Content Test Filtering on Ubuntu Latest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Deps
-        uses: mstksg/get-package@master
-        with:
-          apt-get: git python3-jinja2 python3-yaml python3-deepdiff python3-git python3-github python3-requests xmldiff
-      # TODO: Use action's checkout along with --local and --repository options of ctf
-      # See: https://github.community/t/how-to-commit-to-two-branches-from-an-action/17713/4
-      #- name: Checkout
-      #  uses: actions/checkout@v1
-      - name: Checkout (CTF)
-        uses: actions/checkout@v2
-        with:
-          repository: mildas/content-test-filtering
-          path: ctf
-      - name: Process (see the output for recommended tests)
-        run: python3 ./ctf/content_test_filtering.py pr --output-format markdown ${{ github.event.pull_request.number }} # > ctf.md
-      # TODO: We can't do this for now: github.token is incapable of writing to the PR, and we can't provide our own
-      # for PRs coming from forked repos
-      # TODO: mshick/add-pr-comment@v1 and alike won't work as well
-      #- name: Update the PR
-      #  run: python3 ./ctf/utility_scripts/comment_pr.py --token ${{ github.token }} --pr ${{ github.event.pull_request.number }} --comment ctf.md

--- a/.github/workflows/ctf.yaml
+++ b/.github/workflows/ctf.yaml
@@ -1,0 +1,29 @@
+name: Gating
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  content-test-filtering:
+    name: Content Test Filtering on Ubuntu Latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Deps
+        uses: mstksg/get-package@master
+        with:
+          apt-get: git python3-jinja2 python3-yaml python3-deepdiff python3-git python3-github python3-requests xmldiff
+      # TODO: Use action's checkout along with --local and --repository options of ctf
+      # See: https://github.community/t/how-to-commit-to-two-branches-from-an-action/17713/4
+      #- name: Checkout
+      #  uses: actions/checkout@v1
+      - name: Checkout (CTF)
+        uses: actions/checkout@v2
+        with:
+          repository: mildas/content-test-filtering
+          path: ctf
+      - name: Process (see the output for recommended tests)
+        run: python3 ./ctf/content_test_filtering.py pr --output-format markdown ${{ github.event.pull_request.number }} # > ctf.md
+      # TODO: We can't do this for now: github.token is incapable of writing to the PR, and we can't provide our own
+      # for PRs coming from forked repos
+      # TODO: mshick/add-pr-comment@v1 and alike won't work as well
+      #- name: Update the PR
+      #  run: python3 ./ctf/utility_scripts/comment_pr.py --token ${{ github.token }} --pr ${{ github.event.pull_request.number }} --comment ctf.md


### PR DESCRIPTION


#### Description:
- Move content-test-filtering github action job to a separate file.
  - This job is only valid for pull requests and we cannot keep at the same
file as regular builds that run every time a push to master happens.

#### Rationale:

- This job always fail when triggered by a push in `master` branch. e.g.: https://github.com/ComplianceAsCode/content/runs/3125776435?check_suite_focus=true
