### PR TITLE
SSGTS - add rhel9 install command, add rhel9 platform to crypto policy rule test scenarios

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/absent.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/absent.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = bind
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 
 BIND_CONF='/etc/named.conf'

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/bind_not_installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/bind_not_installed.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 yum remove -y bind || true

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/no_config_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/no_config_file.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = bind
 # 
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # We don't remediate anything if the config file is missing completely.
 # remediation = none
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/ok.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = bind
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 BIND_CONF='/etc/named.conf'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/overrides.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/overrides.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = bind
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 
 BIND_CONF='/etc/named.conf'

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_and_current_same_time.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 # IMPORTANT: This is a false negative scenario.
 # File /etc/crypto-policies/config can be newer than /etc/crypto-policies/state/current,

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_newer_than_current.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/config_newer_than_current.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 update-crypto-policies --set "DEFAULT"
 sleep 1s

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_nss_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_nss_config.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 sed -i "1d" /etc/crypto-policies/config

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_policy_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/missing_policy_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 rm /etc/crypto-policies/state/current

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_file.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_file.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_symlink.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/nss_config_as_symlink.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_nosha1_set.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_nosha1_set.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_e8
 
 update-crypto-policies --set "DEFAULT:NO-SHA1"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_set.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_set.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_standard
 
 update-crypto-policies --set "DEFAULT"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_fips_ospp_set.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_fips_ospp_set.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 update-crypto-policies --set "FIPS:OSPP"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/wrong_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/wrong_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp, xccdf_org.ssgproject.content_profile_standard
 
 sed -i "1s/.*/LEGACY/" /etc/crypto-policies/config

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_correct_policy.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_correct_policy.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 rm -f /etc/krb5.conf.d/crypto-policies
 ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_missing_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_missing_policy.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 rm -f /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_wrong_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/tests/kerberos_wrong_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 rm -f /etc/krb5.conf.d/crypto-policies
 ln -s /etc/crypto-policies/back-ends/openssh.config /etc/krb5.conf.d/crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/libreswan_not_installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/libreswan_not_installed.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 yum remove -y libreswan || true

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_commented.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = libreswan
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 
 cp ipsec.conf /etc

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_is_there.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_is_there.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = libreswan
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 
 cp ipsec.conf /etc

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/line_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = libreswan
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 
 cp ipsec.conf /etc

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = libreswan
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 
 cp ipsec.conf /etc

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/nothing.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/nothing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/ok.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/ok.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/section_not_include.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/section_not_include.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/wrong.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/wrong.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 . common.sh
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/absent.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/absent.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/comment.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/comment.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/no_config_file.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/no_config_file.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/overrides.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/overrides.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -473,6 +473,7 @@ INSTALL_COMMANDS = dict(
     fedora=("dnf", "install", "-y"),
     rhel7=("yum", "install", "-y"),
     rhel8=("yum", "install", "-y"),
+    rhel9=("yum", "install", "-y"),
     ubuntu=("DEBIAN_FRONTEND=noninteractive", "apt", "install", "-y"),
 )
 


### PR DESCRIPTION
The rhel9 install command is needed for preparation phase of SSGTS.

The crypto policy rules have rhel9 prodtype, so their test scenarios should be enabled on rhel9 too.