### PR TITLE
Disable ctrl-alt-del.target before masking it

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -4,6 +4,7 @@
 # The process to disable ctrl+alt+del has changed in RHEL7. 
 # Reference: https://access.redhat.com/solutions/1123873
 {{% endif %}}
+systemctl disable --now ctrl-alt-del.target
 systemctl mask --now ctrl-alt-del.target
 {{%- else -%}}
 # If system does not contain control-alt-delete.override,


### PR DESCRIPTION

#### Description:

- Disable `ctrl-alt-del.target` before masking it.

#### Rationale:
- From 8.5, the target is enabled and cannot be simply masked.
- Fixes #7213

