### PR TITLE
Replace deprecated command in RHEL8/9 kickstart files

### DIFF
--- a/products/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
@@ -58,10 +58,10 @@ rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel9/kickstart/ssg-rhel9-pci-dss-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-pci-dss-ks.cfg
@@ -58,10 +58,10 @@ rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
@@ -67,10 +67,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -44,10 +44,10 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 firewall --enabled --ssh
 
 # Set up the authentication options for the system (required)
-# --enableshadow	enable shadowed passwords by default
-# --passalgo		hash / crypt algorithm for new passwords
-# See the manual page for authconfig for a complete list of possible options.
-authconfig --enableshadow --passalgo=sha512
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing


### PR DESCRIPTION

#### Description:
- Replace deprecated command in RHEL8/9 kickstart files.
  - The command authconfig is deprecated and authselect should be used
instead.


#### Rationale:

- Relates to #4977

Similar to what we already have in: https://github.com/ComplianceAsCode/content/blob/60539d75ee04f9e0a3fd6b4090b9c21327e38589/products/rhel8/kickstart/ssg-rhel8-cis-ks.cfg#L75
