### PR TITLE
Straighten platform metadata of Ansible playbooks

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/ansible/shared.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = multi_platform_all
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/ansible/shared.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_rhv,multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = multi_platform_all
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat OpenShift Container Platform 4,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat OpenShift Container Platform 4,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat OpenShift Container Platform 4,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Red Hat Enterprise Linux 7
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # complexity = low
 # disruption = low

--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Fedora,Oracle Linux 7,Oracle Linux 8,WRLinux 1019
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = high

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -1,5 +1,5 @@
 # and the regex_findall does not filter out configuration files the same as bash remediation does
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = high

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = unknown
 # complexity = low


### PR DESCRIPTION
When there is a single Ansible playbook for a rule, relax its set of applicable platforms.

See #7254 for details.