### PR TITLE
Add option to avoid cleanup in SSGTS

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -68,6 +68,7 @@ class TestEnv(object):
         self.ssh_additional_options = []
 
         self.product = None
+        self.cleanup = True
 
     def start(self):
         """
@@ -217,6 +218,9 @@ class VMTestEnv(TestEnv):
         virt.reboot_domain(self.domain, self.domain_ip, self.ssh_port)
 
     def finalize(self):
+        if not self.cleanup:
+            return
+
         self._delete_saved_state(self._origin)
         # self.domain.shutdown()
         # logging.debug('Shut the domain off')
@@ -260,6 +264,9 @@ class ContainerTestEnv(TestEnv):
         super().start()
 
     def finalize(self):
+        if not self.cleanup:
+            return
+
         self._terminate_current_running_container_if_applicable()
 
     def image_stem2fqn(self, stem):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -136,6 +136,11 @@ def parse_args():
         "otherwise, executes one test per template type"
     )
 
+    common_parser.add_argument(
+        "--no-cleanup", dest="cleanup", action="store_false",
+        help="Don't cleanup destination machine state in event of fatal error "
+        "(useful for debugging)")
+
     subparsers = parser.add_subparsers(dest="subparser_name",
                                        help="Subcommands: profile, rule, combined")
     subparsers.required = True
@@ -406,6 +411,7 @@ def normalize_passed_arguments(options):
     # test environment type so we do it after creation.
     options.test_env.product = options.product
     options.test_env.duplicate_templates = options.duplicate_templates
+    options.test_env.cleanup = options.cleanup
 
     try:
         benchmark_cpes = xml_operations.benchmark_get_applicable_platforms(


### PR DESCRIPTION
When debugging failed test cases in SSGTS, it is frequently helpful
to save the state of the VM with provisioned test cases.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`

---

How do we want to document this? Is there anything else we should do here? I've only been able to test with libvirt based deployments, but it might be nice for someone to test container based deployments as well. 

Also, unlike `--debug`, we quit executing the test suite entirely and leave cleanup to the operator. This means they can debug about as much as they want and not have to worry about resuming the test suite later. They can revert to the origin snapshot and then remove it. 