### PR TITLE
SSGTS-specific Jinja templates

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/service_disabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = avahi
+# packages = {{{- ssgts_package("avahi") -}}}
 #
 
 systemctl stop avahi-daemon.service

--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/socket_enabled.fail.sh
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/tests/socket_enabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = avahi
+# packages = {{{- ssgts_package("avahi") -}}}
 #
 
 systemctl unmask avahi-daemon

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = {{{- ssgts_package("pam_pwquality") -}}}
 
 sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf
 echo "minclass = 4" >> /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/line_not_there.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = {{{- ssgts_package("pam_pwquality") -}}}
 
 sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/wrong.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = {{{- ssgts_package("pam_pwquality") -}}}
 
 sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf
 echo "minclass = 0" >> /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/commented.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = {{{- ssgts_package("pam_pwquality") -}}}
 
 CONF_FILE="/etc/security/pwquality.conf"
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = {{{- ssgts_package("pam_pwquality") -}}}
 
 CONF_FILE="/etc/security/pwquality.conf"
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = {{{- ssgts_package("pam_pwquality") -}}}
 
 CONF_FILE="/etc/security/pwquality.conf"
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/short.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/short.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = {{{- ssgts_package("pam_pwquality") -}}}
 
 CONF_FILE="/etc/security/pwquality.conf"
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = audit
+# packages = {{{- ssgts_package("audit") -}}}
 
 mkdir -p /etc/audit/rules.d/
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/service_auditd_enabled/tests/disabled.fail.sh
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/tests/disabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = audit
+# packages = {{{- ssgts_package("audit") -}}}
 
 systemctl stop auditd
 systemctl disable auditd

--- a/linux_os/guide/system/auditing/service_auditd_enabled/tests/enabled.pass.sh
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/tests/enabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = audit
+# packages = {{{- ssgts_package("audit") -}}}
 
 systemctl start auditd
 systemctl enable auditd

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -22,6 +22,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
+  avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -22,6 +22,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
+  audit: auditd
   avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -28,5 +28,6 @@ platform_package_overrides:
   net-snmp: snmp
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  pam_pwquality: libpam-pwquality
   shadow: login
   sssd: sssd-common

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -27,5 +27,6 @@ platform_package_overrides:
   net-snmp: snmp
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  pam_pwquality: libpam-pwquality
   shadow: login
   sssd: sssd-common

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -21,6 +21,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
+  avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -21,6 +21,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
+  audit: auditd
   avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -31,5 +31,6 @@ platform_package_overrides:
   net-snmp: snmp
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
+  pam_pwquality: libpam-pwquality
   shadow: login
   sssd: sssd-common

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -25,6 +25,7 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/shared/macros-ssgts.jinja
+++ b/shared/macros-ssgts.jinja
@@ -1,0 +1,11 @@
+{{#
+  # Grabs the correct package from platform_package_overrides if present,
+  # else returns the supplied name.
+  #}}
+{{%- macro ssgts_package(name) -%}}
+{{%- if name in platform_package_overrides -%}}
+{{{- platform_package_overrides[name] -}}}
+{{%- else -%}}
+{{{- name -}}}
+{{%- endif -%}}
+{{%- endmacro -%}}

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -41,6 +41,8 @@ JINJA_MACROS_OVAL_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-oval.jinja")
 JINJA_MACROS_BASH_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
     __file__)), "shared", "macros-bash.jinja")
+JINJA_MACROS_SSGTS_DEFINITIONS = os.path.join(os.path.dirname(os.path.dirname(
+    __file__)), "shared", "macros-ssgts.jinja")
 
 xml_version = """<?xml version="1.0" encoding="UTF-8"?>"""
 

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -17,6 +17,7 @@ from .constants import (JINJA_MACROS_BASE_DEFINITIONS,
                         JINJA_MACROS_OVAL_DEFINITIONS,
                         JINJA_MACROS_IGNITION_DEFINITIONS,
                         JINJA_MACROS_KUBERNETES_DEFINITIONS,
+                        JINJA_MACROS_SSGTS_DEFINITIONS,
                         )
 from .utils import (required_key,
                     prodtype_to_name,
@@ -162,6 +163,7 @@ def load_macros(substitutions_dict=None):
             JINJA_MACROS_OVAL_DEFINITIONS,
             JINJA_MACROS_IGNITION_DEFINITIONS,
             JINJA_MACROS_KUBERNETES_DEFINITIONS,
+            JINJA_MACROS_SSGTS_DEFINITIONS,
         ]
         for filename in filenames:
             update_substitutions_dict(filename, substitutions_dict)


### PR DESCRIPTION
#### Description:

Introduces the infrastructure to have a SSGTS-specific file for jinja templates. As we get more usage of Jinja macros in SSGTS cases, we'll probably want this. For now, we introduce a single rule to get the package name, resolving for product specific differences.

Also updates Avahi to use this macro and then uses it in the various libpam-pwquality tests (which Ubuntu doesn't have installed by default). 

- Depends on #7211. 