### PR TITLE
Remove FragmentPath check from service_disabled

### DIFF
--- a/shared/templates/service_disabled/oval.template
+++ b/shared/templates/service_disabled/oval.template
@@ -13,7 +13,6 @@
       <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
         <criterion comment="{{{ SERVICENAME }}} is not running" test_ref="test_service_not_running_{{{ SERVICENAME }}}" />
         <criterion comment="Property LoadState of service {{{ SERVICENAME }}} is masked" test_ref="test_service_loadstate_is_masked_{{{ SERVICENAME }}}" />
-        <criterion comment="Property FragmentPath of service {{{ SERVICENAME }}} is set to /dev/null" test_ref="test_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" />
       </criteria>
     </criteria>
   </definition>
@@ -39,18 +38,6 @@
   </linux:systemdunitproperty_object>
   <linux:systemdunitproperty_state id="state_service_loadstate_is_masked_{{{ SERVICENAME }}}" version="1" comment="LoadState is set to masked">
       <linux:value>masked</linux:value>
-  </linux:systemdunitproperty_state>
-
-  <linux:systemdunitproperty_test id="test_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" check="all" check_existence="any_exist" comment="Test that the property FragmentPath from the service {{{ SERVICENAME }}} is set to /dev/null" version="1">
-    <linux:object object_ref="obj_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}"/>
-    <linux:state state_ref="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}"/>
-  </linux:systemdunitproperty_test>
-  <linux:systemdunitproperty_object id="obj_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" comment="Retrieve the FragmentPath property of {{{ SERVICENAME }}}" version="1">
-    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)$</linux:unit>
-    <linux:property>FragmentPath</linux:property>
-  </linux:systemdunitproperty_object>
-  <linux:systemdunitproperty_state id="state_service_fragmentpath_is_dev_null_{{{ SERVICENAME }}}" version="1" comment="FragmentPath is set to /dev/null">
-      <linux:value>/dev/null</linux:value>
   </linux:systemdunitproperty_state>
 
 {{% else %}}


### PR DESCRIPTION
In https://github.com/systemd/systemd/issues/582, it is documented that
systemd could eventually replace `FragmentPath=/dev/null` (on masked
services) with the actual service path -- not the fully (symlink)
resolved path as is currently the case.

This matches the behavior currently seen in Ubuntu (all versions) and
RHEL 9/Fedora 34.

Per discussion with Gabriel, Matej, Richard, and Matt, it is best to
remove this check, especially since `ActiveState=Masked` suffices.

Resolves: #7280
Resolves: #7248

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`