### PR TITLE
SCE - shared/template support

### DIFF
--- a/build-scripts/build_sce.py
+++ b/build-scripts/build_sce.py
@@ -75,4 +75,4 @@ if __name__ == "__main__":
     template_builder = ssg.templates.Builder(
         env_yaml, empty, args.templates_dir, empty, empty)
     ssg.build_sce.checks(env_yaml, args.product_yaml, args.scedirs,
-        template_builder, args.output)
+                         template_builder, args.output)

--- a/build-scripts/build_sce.py
+++ b/build-scripts/build_sce.py
@@ -33,6 +33,7 @@ import argparse
 
 import ssg.build_sce
 import ssg.environment
+import ssg.templates
 
 
 def parse_args():
@@ -46,6 +47,11 @@ def parse_args():
         "--product-yaml", required=True,
         help="YAML file with information about the product we are building. "
         "e.g.: ~/scap-security-guide/rhel7/product.yml"
+    )
+    p.add_argument(
+        "--templates-dir", required=True,
+        help="Path to directory which contains content templates. "
+        "e.g.: ~/scap-security-guide/shared/templates"
     )
     p.add_argument(
         "--output", required=True)
@@ -65,4 +71,8 @@ if __name__ == "__main__":
 
     env_yaml = ssg.environment.open_environment(
         args.build_config_yaml, args.product_yaml)
-    ssg.build_sce.checks(env_yaml, args.product_yaml, args.scedirs, args.output)
+    empty = "/sce/empty/placeholder"
+    template_builder = ssg.templates.Builder(
+        env_yaml, empty, args.templates_dir, empty, empty)
+    ssg.build_sce.checks(env_yaml, args.product_yaml, args.scedirs,
+        template_builder, args.output)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -437,7 +437,7 @@ macro(ssg_build_sce PRODUCT)
         #    the Shorthand, so we'd have a dependency circle.
         add_custom_command(
             OUTPUT "${BUILD_CHECKS_DIR}/sce/metadata.json"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_sce.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --output "${BUILD_CHECKS_DIR}/sce" ${SCE_COMBINE_PATHS}
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_sce.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --templates-dir "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}/sce" ${SCE_COMBINE_PATHS}
             DEPENDS "${SSG_BUILD_SCRIPTS}/build_sce.py"
             COMMENT "[${PRODUCT}-content] generating sce/metadata.json"
         )

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -97,7 +97,7 @@
 <xsl:template match="xccdf:Rule">
   <xsl:copy>
     <!-- deal with the fact that oscap demands fixes stand only before checks -->
-    <xsl:apply-templates select="@*|node()[not(self::xccdf:check)]"/>
+    <xsl:apply-templates select="@*|node()[not(self::xccdf:check|self::xccdf:complex-check)]"/>
 
     <xsl:variable name="rule" select="."/>
     <xsl:variable name="rule_id" select="$rule/@id"/>
@@ -129,7 +129,7 @@
       </xsl:element>
     </xsl:for-each>
 
-    <xsl:apply-templates select="node()[self::xccdf:check]"/>
+    <xsl:apply-templates select="node()[self::xccdf:check|self::xccdf:complex-check]"/>
   </xsl:copy>
 </xsl:template>
 

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -51,12 +51,14 @@ class RuleStats(object):
             'id': rid,
             'oval': roval,
             'sce': rsce,
+            'check': None,
             'bash_fix': rbash_fix,
             'ansible_fix': ransible_fix,
             'ignition_fix': rignition_fix,
             'kubernetes_fix': rkubernetes_fix,
             'puppet_fix': rpuppet_fix,
             'anaconda_fix': ranaconda_fix,
+            'fix': None,
             'cce': rcce,
             'stig_id': stig_id,
             'cis_ref': cis_ref,
@@ -65,6 +67,24 @@ class RuleStats(object):
             'ospp_ref': ospp_ref,
             'cui_ref': cui_ref,
         }
+
+        if roval is not None:
+            self.dict['check'] = roval
+        elif rsce is not None:
+            self.dict['check'] = rsce
+
+        if rbash_fix is not None:
+            self.dict['fix'] = rbash_fix
+        elif ransible_fix is not None:
+            self.dict['fix'] = ransible_fix
+        elif rignition_fix is not None:
+            self.dict['fix'] = rignition_fix
+        elif rkubernetes_fix is not None:
+            self.dict['fix'] = rkubernetes_fix
+        elif rpuppet_fix is not None:
+            self.dict['fix'] = rpuppet_fix
+        elif ranaconda_fix is not None:
+            self.dict['fix'] = ranaconda_fix
 
 
 class XCCDFBenchmark(object):
@@ -128,6 +148,9 @@ class XCCDFBenchmark(object):
             'implemented_sces': [],
             'implemented_sces_pct': 0,
             'missing_sces': [],
+            'implemented_checks': [],
+            'implemented_checks_pct': 0,
+            'missing_checks': [],
             'implemented_bash_fixes': [],
             'implemented_bash_fixes_pct': 0,
             'implemented_ansible_fixes': [],
@@ -146,6 +169,9 @@ class XCCDFBenchmark(object):
             'missing_kubernetes_fixes': [],
             'missing_puppet_fixes': [],
             'missing_anaconda_fixes': [],
+            'implemented_fixes': [],
+            'implemented_fixes_pct': 0,
+            'missing_fixes': [],
             'assigned_cces': [],
             'assigned_cces_pct': 0,
             'missing_cces': [],
@@ -263,6 +289,14 @@ class XCCDFBenchmark(object):
         profile_stats['missing_sces'] = \
             [x.dict['id'] for x in rule_stats if x.dict['sce'] is None]
 
+        profile_stats['implemented_checks'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['check'] is not None]
+        profile_stats['implemented_checks_pct'] = \
+            float(len(profile_stats['implemented_checks'])) / \
+            profile_stats['rules_count'] * 100
+        profile_stats['missing_checks'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['check'] is None]
+
         profile_stats['implemented_bash_fixes'] = \
             [x.dict['id'] for x in rule_stats if x.dict['bash_fix'] is not None]
         profile_stats['implemented_bash_fixes_pct'] = \
@@ -305,6 +339,14 @@ class XCCDFBenchmark(object):
 
         profile_stats['implemented_anaconda_fixes'] = \
             [x.dict['id'] for x in rule_stats if x.dict['anaconda_fix'] is not None]
+
+        profile_stats['implemented_fixes'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['fix'] is not None]
+        profile_stats['implemented_fixes_pct'] = \
+            float(len(profile_stats['implemented_fixes'])) / \
+            profile_stats['rules_count'] * 100
+        profile_stats['missing_fixes'] = \
+            [x.dict['id'] for x in rule_stats if x.dict['fix'] is None]
 
         profile_stats['missing_stig_ids'] = []
         if 'stig' in profile_stats['profile_id']:
@@ -368,12 +410,14 @@ class XCCDFBenchmark(object):
         rules_count = profile_stats['rules_count']
         impl_ovals_count = len(profile_stats['implemented_ovals'])
         impl_sces_count = len(profile_stats['implemented_sces'])
+        impl_checks_count = len(profile_stats['implemented_checks'])
         impl_bash_fixes_count = len(profile_stats['implemented_bash_fixes'])
         impl_ansible_fixes_count = len(profile_stats['implemented_ansible_fixes'])
         impl_ignition_fixes_count = len(profile_stats['implemented_ignition_fixes'])
         impl_kubernetes_fixes_count = len(profile_stats['implemented_kubernetes_fixes'])
         impl_puppet_fixes_count = len(profile_stats['implemented_puppet_fixes'])
         impl_anaconda_fixes_count = len(profile_stats['implemented_anaconda_fixes'])
+        impl_fixes_count = len(profile_stats['implemented_fixes'])
         missing_stig_ids_count = len(profile_stats['missing_stig_ids'])
         missing_cis_refs_count = len(profile_stats['missing_cis_refs'])
         missing_hipaa_refs_count = len(profile_stats['missing_hipaa_refs'])
@@ -392,6 +436,9 @@ class XCCDFBenchmark(object):
                 print("* checks (SCE):       %d\t[%d%% complete]" %
                       (impl_sces_count,
                        profile_stats['implemented_sces_pct']))
+                print("* checks (any):       %d\t[%d%% complete]" %
+                      (impl_checks_count,
+                       profile_stats['implemented_checks_pct']))
 
                 print("* fixes (bash):       %d\t[%d%% complete]" %
                       (impl_bash_fixes_count,
@@ -411,6 +458,9 @@ class XCCDFBenchmark(object):
                 print("* fixes (anaconda):   %d\t[%d%% complete]" %
                       (impl_anaconda_fixes_count,
                        profile_stats['implemented_anaconda_fixes_pct']))
+                print("* fixes (any):        %d\t[%d%% complete]" %
+                      (impl_fixes_count,
+                       profile_stats['implemented_fixes_pct']))
 
                 print("* CCEs:               %d\t[%d%% complete]" %
                       (impl_cces_count,

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -470,7 +470,7 @@ def assert_that_check_ids_match_rule_id(checks, xccdf_rule):
 
 def check_that_oval_and_rule_id_match(xccdftree):
     for xccdfid, rule in rules_with_ids_generator(xccdftree):
-        checks = rule.find("./{%s}check" % XCCDF11_NS)
+        checks = rule.find(".//{%s}check" % XCCDF11_NS)
         if checks is None:
             print("Rule {0} doesn't have checks."
                   .format(xccdfid), file=sys.stderr)

--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -145,8 +145,8 @@ def checks(env_yaml, yaml_path, sce_dirs, template_builder, output):
             if _check_is_loaded(already_loaded, rule_id):
                 continue
 
-            output_file = open(os.path.join(output, filename), 'w')
-            print(sce_content, file=output_file)
+            with open(os.path.join(output, filename), 'w') as output_file:
+                print(sce_content, file=output_file)
 
             included_checks_count += 1
             already_loaded[rule_id] = metadata
@@ -172,17 +172,19 @@ def checks(env_yaml, yaml_path, sce_dirs, template_builder, output):
                 filename = rule_id + ext
 
                 # Load metadata and infer correct file name.
-                _, metadata = load_sce_and_metadata_parsed(raw_sce_content)
+                sce_content, metadata = load_sce_and_metadata_parsed(raw_sce_content)
                 metadata['filename'] = filename
 
                 # Skip the check if it isn't applicable for this product.
                 if not _check_is_applicable_for_product(metadata, product):
                     continue
 
+                with open(os.path.join(output, filename), 'w') as output_file:
+                    print(sce_content, file=output_file)
+
                 # Finally, include it in our loaded content
                 included_checks_count += 1
                 already_loaded[rule_id] = metadata
-                print(rule_id, metadata, file=sys.stderr)
 
     # Finally take any shared SCE checks and build them as well. Note that
     # there's no way for shorthand generation to include them if they do NOT
@@ -203,8 +205,8 @@ def checks(env_yaml, yaml_path, sce_dirs, template_builder, output):
             if _check_is_loaded(already_loaded, rule_id):
                 continue
 
-            output_file = open(os.path.join(output, filename), 'w')
-            print(sce_content, file=output_file)
+            with open(os.path.join(output, filename), 'w') as output_file:
+                print(sce_content, file=output_file)
 
             included_checks_count += 1
             already_loaded[rule_id] = metadata

--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -27,6 +27,7 @@ def load_sce_and_metadata(file_path, local_env_yaml):
     raw_content = process_file_with_macros(file_path, local_env_yaml)
     return load_sce_and_metadata_parsed(raw_content)
 
+
 def load_sce_and_metadata_parsed(raw_content):
     metadata = dict()
     sce_content = []

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1408,6 +1408,7 @@ class Rule(object):
         if main_ref.attrib:
             rule.append(main_ref)
 
+        ocil_parent = rule
         check_parent = rule
 
         if self.sce_metadata:
@@ -1417,6 +1418,30 @@ class Rule(object):
             #
             # Additionally, we build the content (check subelement) here rather
             # than in xslt due to the nature of our SCE metadata.
+            #
+            # Finally, before we begin, we might have an element with both SCE
+            # and OVAL. We have no way of knowing (right here) whether that is
+            # the case (due to a variety of issues, most notably, that linking
+            # hasn't yet occurred). So we must rely on the content author's
+            # good will, by annotating SCE content with a complex-check tag
+            # if necessary.
+
+            if 'complex-check' in self.sce_metadata:
+                # Here we have an issue: XCCDF allows EITHER one or more check
+                # elements OR a single complex-check. While we have an explicit
+                # case handling the OVAL-and-SCE interaction, OCIL entries have
+                # (historically) been alongside OVAL content and been in an
+                # "OR" manner -- preferring OVAL to SCE. In order to accomplish
+                # this, we thus need to add _yet another parent_ when OCIL data
+                # is present, and add update ocil_parent accordingly.
+                if self.ocil or self.ocil_clause:
+                    ocil_parent = ET.SubElement(ocil_parent, "complex-check")
+                    ocil_parent.set('operator', 'OR')
+
+                check_parent = ET.SubElement(ocil_parent, "complex-check")
+                check_parent.set('operator', self.sce_metadata['complex-check'])
+
+            # Now, add the SCE check element to the tree.
             check = ET.SubElement(check_parent, "check")
             check.set("system", SCE_SYSTEM)
 
@@ -1451,11 +1476,11 @@ class Rule(object):
             # TODO: This is pretty much a hack, oval ID will be the same as rule ID
             #       and we don't want the developers to have to keep them in sync.
             #       Therefore let's just add an OVAL ref of that ID.
-            oval_ref = ET.SubElement(rule, "oval")
+            oval_ref = ET.SubElement(check_parent, "oval")
             oval_ref.set("id", self.id_)
 
         if self.ocil or self.ocil_clause:
-            ocil = add_sub_element(rule, 'ocil', self.ocil if self.ocil else "")
+            ocil = add_sub_element(ocil_parent, 'ocil', self.ocil if self.ocil else "")
             if self.ocil_clause:
                 ocil.set("clause", self.ocil_clause)
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1408,17 +1408,7 @@ class Rule(object):
         if main_ref.attrib:
             rule.append(main_ref)
 
-        if self.oval_external_content:
-            check = ET.SubElement(rule, 'check')
-            check.set("system", "http://oval.mitre.org/XMLSchema/oval-definitions-5")
-            external_content = ET.SubElement(check, "check-content-ref")
-            external_content.set("href", self.oval_external_content)
-        else:
-            # TODO: This is pretty much a hack, oval ID will be the same as rule ID
-            #       and we don't want the developers to have to keep them in sync.
-            #       Therefore let's just add an OVAL ref of that ID.
-            oval_ref = ET.SubElement(rule, "oval")
-            oval_ref.set("id", self.id_)
+        check_parent = rule
 
         if self.sce_metadata:
             # TODO: This is pretty much another hack, just like the previous OVAL
@@ -1427,7 +1417,7 @@ class Rule(object):
             #
             # Additionally, we build the content (check subelement) here rather
             # than in xslt due to the nature of our SCE metadata.
-            check = ET.SubElement(rule, "check")
+            check = ET.SubElement(check_parent, "check")
             check.set("system", SCE_SYSTEM)
 
             if 'check-import' in self.sce_metadata:
@@ -1451,6 +1441,18 @@ class Rule(object):
             check_ref = ET.SubElement(check, "check-content-ref")
             href = self.current_product + "/checks/sce/" + self.sce_metadata['filename']
             check_ref.set("href", href)
+
+        if self.oval_external_content:
+            check = ET.SubElement(check_parent, 'check')
+            check.set("system", "http://oval.mitre.org/XMLSchema/oval-definitions-5")
+            external_content = ET.SubElement(check, "check-content-ref")
+            external_content.set("href", self.oval_external_content)
+        else:
+            # TODO: This is pretty much a hack, oval ID will be the same as rule ID
+            #       and we don't want the developers to have to keep them in sync.
+            #       Therefore let's just add an OVAL ref of that ID.
+            oval_ref = ET.SubElement(rule, "oval")
+            oval_ref.set("id", self.id_)
 
         if self.ocil or self.ocil_clause:
             ocil = add_sub_element(rule, 'ocil', self.ocil if self.ocil else "")

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -198,7 +198,7 @@ class Builder(object):
         Builds templated content for a given rule for a given language.
         Writes the output to the correct build directories.
         """
-        if lang not in templates[template_name].langs:
+        if lang not in templates[template_name].langs or lang.startswith("sce-"):
             return
 
         filled_template = self.build_lang_file(rule_id, template_name,

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -15,7 +15,8 @@ try:
 except ImportError:
     from urllib import quote
 
-languages = ["anaconda", "ansible", "bash", "oval", "puppet", "ignition", "kubernetes", "blueprint", "sce-bash"]
+languages = ["anaconda", "ansible", "bash", "oval", "puppet", "ignition",
+             "kubernetes", "blueprint", "sce-bash"]
 preprocessing_file_name = "template.py"
 lang_to_ext_map = {
     "anaconda": ".anaconda",

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     from urllib import quote
 
-languages = ["anaconda", "ansible", "bash", "oval", "puppet", "ignition", "kubernetes", "blueprint"]
+languages = ["anaconda", "ansible", "bash", "oval", "puppet", "ignition", "kubernetes", "blueprint", "sce-bash"]
 preprocessing_file_name = "template.py"
 lang_to_ext_map = {
     "anaconda": ".anaconda",
@@ -25,7 +25,8 @@ lang_to_ext_map = {
     "puppet": ".pp",
     "ignition": ".yml",
     "kubernetes": ".yml",
-    "blueprint": ".toml"
+    "blueprint": ".toml",
+    "sce-bash": ".sh",
 }
 
 
@@ -108,10 +109,10 @@ class Builder(object):
         self.output_dirs = dict()
         for lang in languages:
             lang_dir = lang
-            if lang == "oval":
-                # OVAL checks need to be put to a different directory because
-                # they are processed differently than remediations later in
-                # the build process
+            if lang == "oval" or lang.startswith("sce-"):
+                # OVAL and SCE checks need to be put to a different directory
+                # because they are processed differently than remediations
+                # later in the build process
                 output_dir = self.checks_dir
                 if lang.startswith("sce-"):
                     lang_dir = "sce"


### PR DESCRIPTION
#### Dependencies:

- [x] #7075 for base SCE support.
- [x] #7211 for some common `ssg/template.py` improvements/changes

This pull request will have to be rebased after those two PRs merge. 

#### Description & Rationale:

Sometimes support for SCE isn't enough; we'd like to use the information already in the template system when generating SCE content. This is most commonly typical for auditd rules: SCE allows us to audit the runtime auditd configuration (where OVAL only allows auditing of the content on disk). Rather than writing SCE content per-rule manually, we can use the template system to automatically generate Bash SCE content for auditing this.

Unlike generic SCE support, the template system requires knowledge of the target language. This is most frequently bash, so that's what we've added here, though in a manner that if future SCE languages are desired in the future, they could be added.

This also extends the profile tool to support SCE content. Let me know if you'd prefer that in a separate PR. 