### PR TITLE
Ensure test scenarios and helper scripts are excutable

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -245,6 +245,8 @@ def _make_file_root_owned(tarinfo):
     if tarinfo:
         tarinfo.uid = 0
         tarinfo.gid = 0
+        # set permission to 775
+        tarinfo.mode = 509
     return tarinfo
 
 


### PR DESCRIPTION

#### Description:

- Ensure test scenarios and helper scripts are executable.

#### Rationale:

- After Jinja processing the test scenarios and test helper scripts they lose their original permissions. #7210 
  The helper scripts are called by test scenarios and they need to be executable.
- Fixes #7245
