### PR TITLE
Add support for multiple profiles in TestSuite combined mode

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -81,7 +81,11 @@ class CombinedChecker(rule.RuleChecker):
     def _test_target(self, target):
         self.rules_not_tested_yet = set(target)
 
-        super(CombinedChecker, self)._test_target(target)
+        try:
+            super(CombinedChecker, self)._test_target(target)
+        except KeyboardInterrupt as exec_interrupt:
+            self.run_aborted = True
+            raise exec_interrupt
 
         if len(self.rules_not_tested_yet) != 0:
             not_tested = sorted(list(self.rules_not_tested_yet))
@@ -113,3 +117,5 @@ def perform_combined_check(options):
         target_rules = checker._generate_target_rules(profile)
 
         checker.test_target(target_rules)
+        if checker.run_aborted:
+            return

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -64,6 +64,20 @@ class CombinedChecker(rule.RuleChecker):
             params['profiles'] = [item for item in params['profiles'] if re.search(self.profile, item)]
         return params
 
+    def _generate_target_rules(self, profile):
+        # check if target is a complete profile ID, if not prepend profile prefix
+        if not profile.startswith(OSCAP_PROFILE):
+            profile = OSCAP_PROFILE + profile
+        logging.info("Performing combined test using profile: {0}".format(profile))
+
+        # Fetch target list from rules selected in profile
+        target_rules = xml_operations.get_all_rule_ids_in_profile(
+                self.datastream, self.benchmark_id,
+                profile, logging)
+        logging.debug("Profile {0} expanded to following list of "
+                      "rules: {1}".format(profile, target_rules))
+        return target_rules
+
     def _test_target(self, target):
         self.rules_not_tested_yet = set(target)
 
@@ -93,20 +107,9 @@ def perform_combined_check(options):
     checker.manual_debug = False
     checker.benchmark_cpes = options.benchmark_cpes
     checker.scenarios_regex = options.scenarios_regex
-    # Let's keep track of originaly targeted profile
-    checker.profile = options.target
+    for profile in options.target:
+        # Let's keep track of originaly targeted profile
+        checker.profile = profile
+        target_rules = checker._generate_target_rules(profile)
 
-    profile = options.target
-    # check if target is a complete profile ID, if not prepend profile prefix
-    if not profile.startswith(OSCAP_PROFILE):
-        profile = OSCAP_PROFILE+profile
-    logging.info("Performing combined test using profile: {0}".format(profile))
-
-    # Fetch target list from rules selected in profile
-    target_rules = xml_operations.get_all_rule_ids_in_profile(
-            options.datastream, options.benchmark_id,
-            profile, logging)
-    logging.debug("Profile {0} expanded to following list of "
-                  "rules: {1}".format(profile, target_rules))
-
-    checker.test_target(target_rules)
+        checker.test_target(target_rules)

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -112,7 +112,7 @@ def perform_combined_check(options):
     checker.benchmark_cpes = options.benchmark_cpes
     checker.scenarios_regex = options.scenarios_regex
     for profile in options.target:
-        # Let's keep track of originaly targeted profile
+        # Let's keep track of originally targeted profile
         checker.profile = profile
         target_rules = checker._generate_target_rules(profile)
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -195,9 +195,10 @@ def parse_args():
                                  default=None,
                                  help="Regular expression matching test scenarios to run")
     parser_combined.add_argument("target",
+                                 nargs="+",
                                  metavar="TARGET",
-                                 help=("Profile whose rules are to be tested. Each rule selected "
-                                       "in the profile will be evaluated against all its test "
+                                 help=("Profiles whose rules are to be tested. Each rule selected "
+                                       "in a profile will be evaluated against all its test "
                                        "scenarios."))
 
     return parser.parse_args()


### PR DESCRIPTION
#### Description:

- Add support for testing multiple profiles at once on combined mode.
  - The combined mode is the only Test Suite run mode that didn't support multiple inputs

#### Rationale:

- After #7218,  execution of combined mode got broken, specifically https://github.com/ComplianceAsCode/content/commit/17f46a62362 made the `options.target` a list, which `combined` mode did not support.
```shell
$ python3 test_suite.py combined --libvirt qemu:///session rhel84 --datastream ../build/ssg-rhel8-ds.xml ospp
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/wsato/git/content/tests/logs/combined-custom-2021-07-30-1619/test_suite.log
Traceback (most recent call last):
  File "/home/wsato/git/content/tests/test_suite.py", line 396, in <module>
    main()
  File "/home/wsato/git/content/tests/test_suite.py", line 392, in main
    options.func(options)
  File "/home/wsato/git/content/tests/ssg_test_suite/combined.py", line 101, in perform_combined_check
    if not profile.startswith(OSCAP_PROFILE):
AttributeError: 'list' object has no attribute 'startswith'
```

