### PR TITLE
Fix links to repo: SSG->CaC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ message(STATUS "")
 # discourage our users from using them
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "In-source builds are not supported! Please use out of source builds:\n"
-       "$ cd scap-security-guide\n"
+       "$ cd content\n"
        "$ rm CMakeCache.txt\n"
        "$ cd build\n"
        "$ cmake ../\n"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Nightly 5.10 ZIP Status](https://jenkins.complianceascode.io/job/scap-security-guide-nightly-oval510-zip/badge/icon?subject=Nightly%20OVAL-5.10%20ZIP&status=Download)](https://jenkins.complianceascode.io/job/scap-security-guide-nightly-oval510-zip/lastSuccessfulBuild/artifact/scap-security-guide-nightly-oval-510.zip)
 [![Link-checker Status](https://jenkins.complianceascode.io/job/scap-security-guide-linkcheck/badge/icon?subject=Link%20Checker)](https://jenkins.complianceascode.io/job/scap-security-guide-linkcheck/)
 [![CentOS CI Status](https://ci.centos.org/job/openscap-scap-security-guide/badge/icon?subject=CentOS%20CI%20Build)](https://ci.centos.org/job/openscap-scap-security-guide/)
-[![Travis CI Build Status](https://img.shields.io/travis/OpenSCAP/scap-security-guide/master.svg?label=Travis%20CI%20Build)](https://travis-ci.org/OpenSCAP/scap-security-guide)
+[![Travis CI Build Status](https://img.shields.io/travis/ComplianceAsCode/content/master.svg?label=Travis%20CI%20Build)](https://travis-ci.org/ComplianceAsCode/content)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ComplianceAsCode/content/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ComplianceAsCode/content/?branch=master)
 [![Profile Statistics](https://jenkins.complianceascode.io/job/scap-security-guide-stats/badge/icon?subject=Statistics)](https://jenkins.complianceascode.io/job/scap-security-guide-stats/Statistics/)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Nightly 5.10 ZIP Status](https://jenkins.complianceascode.io/job/scap-security-guide-nightly-oval510-zip/badge/icon?subject=Nightly%20OVAL-5.10%20ZIP&status=Download)](https://jenkins.complianceascode.io/job/scap-security-guide-nightly-oval510-zip/lastSuccessfulBuild/artifact/scap-security-guide-nightly-oval-510.zip)
 [![Link-checker Status](https://jenkins.complianceascode.io/job/scap-security-guide-linkcheck/badge/icon?subject=Link%20Checker)](https://jenkins.complianceascode.io/job/scap-security-guide-linkcheck/)
 [![CentOS CI Status](https://ci.centos.org/job/openscap-scap-security-guide/badge/icon?subject=CentOS%20CI%20Build)](https://ci.centos.org/job/openscap-scap-security-guide/)
-[![Travis CI Build Status](https://img.shields.io/travis/ComplianceAsCode/content/master.svg?label=Travis%20CI%20Build)](https://travis-ci.org/ComplianceAsCode/content)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ComplianceAsCode/content/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ComplianceAsCode/content/?branch=master)
 [![Profile Statistics](https://jenkins.complianceascode.io/job/scap-security-guide-stats/badge/icon?subject=Statistics)](https://jenkins.complianceascode.io/job/scap-security-guide-stats/Statistics/)
 

--- a/build-scripts/sds_move_ocil_to_checks.py
+++ b/build-scripts/sds_move_ocil_to_checks.py
@@ -18,8 +18,8 @@
 # check system should be placed into <ds:checks> element when building a datastream
 #
 # The current oscap behaviour leads to:
-# * [3] https://github.com/OpenSCAP/scap-security-guide/issues/1101 and
-# * [4] https://github.com/OpenSCAP/scap-security-guide/issues/1100
+# * [3] https://github.com/ComplianceAsCode/content/issues/1101 and
+# * [4] https://github.com/ComplianceAsCode/content/issues/1100
 # issues when validating the produced datastream using the NIST SCAP content
 # test suite
 #

--- a/docs/man_page_template.jinja
+++ b/docs/man_page_template.jinja
@@ -54,7 +54,7 @@ oscap xccdf eval --profile ospp \
 /usr/share/xml/scap/ssg/content/ssg-{product}-xccdf.xml
 .PP
 Additional details can be found on the projects wiki page:
-https://www.github.com/OpenSCAP/scap-security-guide/wiki
+https://www.github.com/ComplianceAsCode/content/wiki
 
 
 .SH FILES

--- a/docs/manual/user_guide.adoc
+++ b/docs/manual/user_guide.adoc
@@ -297,15 +297,15 @@ If you need content for RHV based on el7, use the Red Hat Enterprise Linux 7 (`r
 
 |Webmin
 |-
-| link:https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.38[SSG 0.1.38]
+| link:https://github.com/ComplianceAsCode/content/releases/tag/v0.1.38[SSG 0.1.38]
 
 |Red Hat Enterprise Virtualization Manager 3
 |September 30, 2018
-| link:https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.38[SSG 0.1.38]
+| link:https://github.com/ComplianceAsCode/content/releases/tag/v0.1.38[SSG 0.1.38]
 
 |JBoss EAP 5
 |November 30, 2016
-| link:https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.35[SSG 0.1.35]
+| link:https://github.com/ComplianceAsCode/content/releases/tag/v0.1.35[SSG 0.1.35]
 
 |JBoss EAP 6
 |June 30, 2019
@@ -314,7 +314,7 @@ If you need content for RHV based on el7, use the Red Hat Enterprise Linux 7 (`r
 
 |Red Hat Enterprise Linux 5
 |March 31, 2017
-| link:https://github.com/OpenSCAP/scap-security-guide/releases/tag/v0.1.34[SSG 0.1.34]
+| link:https://github.com/ComplianceAsCode/content/releases/tag/v0.1.34[SSG 0.1.34]
 
 |Ubuntu 14.04
 |April 30, 2019

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -33,8 +33,8 @@
 <xsl:variable name="osppuri">https://www.niap-ccevs.org/Profile/PP.cfm</xsl:variable>
 <xsl:variable name="pcidssuri">https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf</xsl:variable>
 <xsl:variable name="nerc-cipuri">https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx</xsl:variable>
-<xsl:variable name="ssg-benchmark-latest-uri">https://github.com/OpenSCAP/scap-security-guide/releases/latest</xsl:variable>
-<xsl:variable name="ssg-contributors-uri">https://github.com/OpenSCAP/scap-security-guide/wiki/Contributors</xsl:variable>
+<xsl:variable name="ssg-benchmark-latest-uri">https://github.com/ComplianceAsCode/content/releases/latest</xsl:variable>
+<xsl:variable name="ssg-contributors-uri">https://github.com/ComplianceAsCode/content/wiki/Contributors</xsl:variable>
 <xsl:variable name="ssg-project-name">SCAP Security Guide Project</xsl:variable>
 
 <!-- misc language URI's -->

--- a/shared/transforms/shared_shorthand2xccdf.xslt
+++ b/shared/transforms/shared_shorthand2xccdf.xslt
@@ -321,7 +321,7 @@
           </xsl:if>
           <xsl:if test="$refsource = 'cis'">
             <!-- Precaution for repeated occurrence of issue:
-                 https://github.com/OpenSCAP/scap-security-guide/issues/1288 -->
+                 https://github.com/ComplianceAsCode/content/issues/1288 -->
             <xsl:if test="$cisuri != 'empty'">
               <xsl:value-of select="$cisuri" />
             </xsl:if>

--- a/shared/transforms/xccdf-ocilcheck2ref.xslt
+++ b/shared/transforms/xccdf-ocilcheck2ref.xslt
@@ -15,8 +15,8 @@
   <!-- Remove OCIL <check-export> nodes since they were used only to append the appropriate question
        to OCIL <check-content> nodes by previous run of $(SHARED)/$(TRANS)/xccdf-create-ocil.xslt.
        But at this state of building the content this has been already finished.
-       Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1189
-       Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1190 -->
+       Fixes: https://github.com/ComplianceAsCode/content/issues/1189
+       Fixes: https://github.com/ComplianceAsCode/content/issues/1190 -->
   <xsl:template match="xccdf:check-export[@value-id='conditional_clause']"/>
 
   <!-- Remove the "conditional_clause" <xccdf:Value> since it was required only to expand OCIL macros

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -92,8 +92,8 @@ def oval_entities_are_identical(firstelem, secondelem):
        Return: True if identical, False otherwise
        Based on: http://stackoverflow.com/a/24349916"""
 
-    # Per https://github.com/OpenSCAP/scap-security-guide/pull/1343#issuecomment-234541909
-    # and https://github.com/OpenSCAP/scap-security-guide/pull/1343#issuecomment-234545296
+    # Per https://github.com/ComplianceAsCode/content/pull/1343#issuecomment-234541909
+    # and https://github.com/ComplianceAsCode/content/pull/1343#issuecomment-234545296
     # ignore the differences in 'comment', 'version', 'state_operator', and
     # 'deprecated' attributes. Also ignore different nsmap, since all these
     # don't affect the semantics of the OVAL entities
@@ -173,7 +173,7 @@ def append(element, newchild):
                 sys.exit(1)
         # ID is identical, but OVAL entities are semantically difference =>
         # report and error and exit with failure
-        # Fixes: https://github.com/OpenSCAP/scap-security-guide/issues/1275
+        # Fixes: https://github.com/ComplianceAsCode/content/issues/1275
         else:
             if not oval_entity_is_extvar(existing) and \
               not oval_entity_is_extvar(newchild):
@@ -182,7 +182,7 @@ def append(element, newchild):
                 # we might evaluate wrong requirement for the second entity
                 # => report an error and exit with failure in that case
                 # See
-                #   https://github.com/OpenSCAP/scap-security-guide/issues/1275
+                #   https://github.com/ComplianceAsCode/content/issues/1275
                 # for a reproducer and what could happen in this case
                 sys.stderr.write("ERROR: it's not possible to use the " +
                                  "same ID: %s " % newid + "for two " +

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -70,7 +70,7 @@ cui_ns = 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.p
 stig_refs = 'https://public.cyber.mil/stigs/'
 disa_cciuri = "https://public.cyber.mil/stigs/cci/"
 ssg_version_uri = \
-    "https://github.com/OpenSCAP/scap-security-guide/releases/latest"
+    "https://github.com/ComplianceAsCode/content/releases/latest"
 OSCAP_VENDOR = "org.ssgproject"
 OSCAP_DS_STRING = "xccdf_%s.content_benchmark_" % OSCAP_VENDOR
 OSCAP_PROFILE = "xccdf_%s.content_profile_" % OSCAP_VENDOR
@@ -249,11 +249,11 @@ CENTOS_NOTICE = \
     "\n" \
     "<p>Members of the <i>CentOS</i> community are invited to participate in " \
     "<a href=\"http://open-scap.org\">OpenSCAP</a> and " \
-    "<a href=\"https://github.com/OpenSCAP/scap-security-guide\">" \
+    "<a href=\"https://github.com/ComplianceAsCode/content\">" \
     "SCAP Security Guide</a> development. Bug reports and patches " \
     "can be sent to GitHub: " \
-    "<a href=\"https://github.com/OpenSCAP/scap-security-guide\">" \
-    "https://github.com/OpenSCAP/scap-security-guide</a>. " \
+    "<a href=\"https://github.com/ComplianceAsCode/content\">" \
+    "https://github.com/ComplianceAsCode/content</a>. " \
     "The mailing list is at " \
     "<a href=\"https://fedorahosted.org/mailman/listinfo/scap-security-guide\">" \
     "https://fedorahosted.org/mailman/listinfo/scap-security-guide</a>" \
@@ -289,11 +289,11 @@ SL_NOTICE = \
     "\n" \
     "<p>Members of the <i>Scientifc Linux</i> community are invited to participate in " \
     "<a href=\"http://open-scap.org\">OpenSCAP</a> and " \
-    "<a href=\"https://github.com/OpenSCAP/scap-security-guide\">" \
+    "<a href=\"https://github.com/ComplianceAsCode/content\">" \
     "SCAP Security Guide</a> development. Bug reports and patches " \
     "can be sent to GitHub: " \
-    "<a href=\"https://github.com/OpenSCAP/scap-security-guide\">" \
-    "https://github.com/OpenSCAP/scap-security-guide</a>. " \
+    "<a href=\"https://github.com/ComplianceAsCode/content\">" \
+    "https://github.com/ComplianceAsCode/content</a>. " \
     "The mailing list is at " \
     "<a href=\"https://fedorahosted.org/mailman/listinfo/scap-security-guide\">" \
     "https://fedorahosted.org/mailman/listinfo/scap-security-guide</a>" \


### PR DESCRIPTION
#### Description:

A lot of links were using the `OpenSCAP/scap-security-guide` name rather than `ComplianceAsCode/content`; update the links for the future.
