### PR TITLE
Fix a python2 issue with STIG overlay generation.

### DIFF
--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -107,7 +107,12 @@ def new_stig_overlay(xccdftree, ssgtree, outfile, quiet):
     lines = new_stig_overlay.findall("overlay")
     new_stig_overlay[:] = sorted(lines, key=getkey)
 
-    dom = xml.dom.minidom.parseString(ET.tostring(new_stig_overlay, encoding="UTF-8", xml_declaration=True))
+    try:
+        et_str = ET.tostring(new_stig_overlay, encoding="UTF-8", xml_declaration=True)
+    except TypeError:
+        et_str = ET.tostring(new_stig_overlay, encoding="UTF-8")
+
+    dom = xml.dom.minidom.parseString(et_str)
     pretty_xml_as_string = dom.toprettyxml(indent='  ', encoding="UTF-8")
 
     overlay_directory = os.path.dirname(outfile)


### PR DESCRIPTION
#### Description:

- Fix a python2 issue with STIG overlay generation
  - `xml_declaration` does not exist in python2 so we cannot use it.
  - This also manifests on python < 3.8

#### Rationale:

- Relates to: https://github.com/ComplianceAsCode/content/pull/7315#issuecomment-891105967

Fixes the following problem:

`$python2 utils/create-stig-overlay.py --disa-xccdf=shared/references/disa-stig-rhel8-v1r2-xccdf-manual.xml --ssg-xccdf=build/ssg-rhel8-xccdf.xml -o products/rhel8/overlays/stig_overlay.xml`
```
Traceback (most recent call last):
  File "utils/create-stig-overlay.py", line 180, in <module>
    main()
  File "utils/create-stig-overlay.py", line 176, in main
    new_stig_overlay(disa_xccdftree, ssg_xccdftree, args.output_file, args.quiet)
  File "utils/create-stig-overlay.py", line 110, in new_stig_overlay
    dom = xml.dom.minidom.parseString(ET.tostring(new_stig_overlay, encoding="UTF-8", xml_declaration=True))
TypeError: tostring() got an unexpected keyword argument 'xml_declaration'
```
