### PR TITLE
Make FIPS mode check idempotent

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -4,5 +4,12 @@
 # complexity = medium
 # disruption = medium
 
-- name: enable fips mode
+- name: Check to see the current status of FIPS mode
+  command: /usr/bin/fips-mode-setup --check
+  register: is_fips_enabled
+  changed_when: false
+
+- name: Enable FIPS mode
   command: /usr/bin/fips-mode-setup --enable
+  when:
+    - is_fips_enabled.stdout.find('FIPS mode is enabled.') == -1


### PR DESCRIPTION
#### Description:

Checks the status of FIPS mode before setting FIPS mode, to make the play idempotent.

#### Rationale:

Makes the play idempotent so it only is marked changed if a change to FIPS mode occurred.

- Fixes #7314 
