### PR TITLE
Switch log message to warning when there is nothing to test

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -687,7 +687,7 @@ class Checker(object):
 
     def finalize(self):
         if not self.executed_tests:
-            logging.error("Nothing has been tested!")
+            logging.warning("Nothing has been tested!")
 
         try:
             self.test_env.finalize()


### PR DESCRIPTION

#### Description:
- Switch log message to warning when there is nothing to test.
  - No need to log error in this case and this helps SSGTS integration with
GH to not falsely detect error when it just didn't have anything to
test.

#### Rationale:
Current output:
```
Run tests/test_rule_in_container.sh --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-rhel8-ds.xml enable_fips_mode
INFO - The base image option has been specified, choosing Podman-based test environment.
INFO - Logging into logs_ansible/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_enable_fips_mode
ERROR - Nothing has been tested!
Setting console output to log level INFO
```

Prevent this from erroring: https://github.com/ComplianceAsCode/content/pull/7318/checks?check_run_id=3225450673
