### PR TITLE
add details about gpgkey package for rhel9

### DIFF
--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -13,10 +13,10 @@ init_system: "systemd"
 dconf_gdm_dir: "distro.d"
 
 # The fingerprints below are retrieved from https://access.redhat.com/security/team/key
-pkg_release: ""
-pkg_version: ""
-aux_pkg_release: ""
-aux_pkg_version: ""
+pkg_release: "4ae0493b"
+pkg_version: "fd431d51"
+aux_pkg_release: "5b32db75"
+aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"


### PR DESCRIPTION
#### Description:

- copy pkg versions and release numbers from rhel8 to rhel9

#### Rationale:

- the rule was incorrectly shown as not checked