### PR TITLE
Add service_pcscd_enabled to SLE15 PCI-DSS profile

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle15
 
 title: 'Enable the pcscd Service'
 
@@ -24,6 +24,7 @@ severity: medium
 identifiers:
     cce@rhel7: CCE-80569-7
     cce@rhel8: CCE-80881-6
+    cce@sle15: CCE-85844-9
 
 references:
     disa: CCI-001954

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -65,6 +65,7 @@ selections:
     - display_login_attempts
     - no_empty_passwords
     - service_auditd_enabled
+    - service_pcscd_enabled
     - sshd_set_idle_timeout
     - sshd_set_keepalive_0
 


### PR DESCRIPTION
#### Description:

- Add service_pcscd_enabled rule to SLE15 PCI-DSS profile

#### Rationale:

- Add rule service_pcscd_enabled and assign CCE id
